### PR TITLE
FINOPS-112 Use AWS Pricing API for AWS Unused IP Addresses

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,6 +25,7 @@
     "fknop",
     "Flexera",
     "formulahendry",
+    "fromjson",
     "githubusercontent",
     "iops",
     "jamesls",

--- a/cost/aws/unused_ip_addresses/CHANGELOG.md
+++ b/cost/aws/unused_ip_addresses/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1
+
+- Improve savings calculations by using the AWS Pricing API which is significantly faster and more memory efficient than retrieving the AWS price sheet JSON file
+
 ## v3.0
 
 - applying data normalization updates for spend recommendations api. this change breaks current iterations expecting specific output types being pushed.

--- a/cost/aws/unused_ip_addresses/README.md
+++ b/cost/aws/unused_ip_addresses/README.md
@@ -55,7 +55,8 @@ Required permissions in the provider:
       "Action": [
         "ec2:DescribeAddresses",
         "ec2:ReleaseAddress",
-        "ec2:DescribeRegions"
+        "ec2:DescribeRegions",
+        "pricing:GetProducts"
       ],
       "Resource": "*"
     }

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-    version: "3.0",
+    version: "3.1",
     provider: "AWS",
     service: "EC2",
     policy_set: "Unused IP Addresses"
@@ -64,7 +64,7 @@ end
 
 auth "auth_rs", type: "rightscale"
 
-pagination "aws_pagination" do
+pagination "pagination_aws" do
   get_page_marker do
     body_path "//DescribeAddressesResponse/nextToken"
   end
@@ -73,11 +73,20 @@ pagination "aws_pagination" do
   end
 end
 
+pagination "pagination_aws_products" do
+  get_page_marker do
+    body_path "NextToken"
+  end
+  set_page_marker do
+    body_field "NextToken"
+  end
+end
+
 ###############################################################################
 # Datasources
 ###############################################################################
 
-#Get list of enabled regions for an account
+# Get list of enabled regions for an account
 datasource "ds_regions_list" do
   request do
     auth $auth_aws
@@ -104,7 +113,7 @@ datasource "ds_aws_elastic_ip_address" do
   iterate $ds_regions
   request do
     auth $auth_aws
-    pagination $aws_pagination
+    pagination $pagination_aws
     host join(["ec2.",val(iter_item,"region"), ".amazonaws.com"])
     path "/"
     query "Action", "DescribeAddresses"
@@ -147,13 +156,23 @@ datasource "ds_get_caller_identity" do
   end
 end
 
-datasource "ds_get_aws_offer_page" do
+datasource "ds_aws_products" do
   request do
     auth $auth_aws
-    verb "GET"
-    host "pricing.us-east-1.amazonaws.com"
-    path "/offers/v1.0/aws/AmazonEC2/current/us-east-1/index.json"
-    header "User-Agent", "RS Policies"
+    pagination $pagination_aws_products
+    host "api.pricing.us-east-1.amazonaws.com"
+    verb "POST"
+    path "/"
+    header "Content-Type", "application/x-amz-json-1.1"
+    header "X-Amz-Target", "AWSPriceListService.GetProducts"
+    body_field "Filters", [{Field: "productFamily", Type: "TERM_MATCH", Value: "IP Address"}]
+    body_field "ServiceCode", "AmazonEC2"
+  end
+  result do
+    collect jq(response, '.PriceList[] | fromjson | select(.product.attributes.usagetype | test("ElasticIP:IdleAddress"))') do
+      field 'price_per_unit', jq(col_item, '.terms.OnDemand[].priceDimensions[] | select(.description | test("Elastic IP address not attached to a running instance per hour")).pricePerUnit.USD')
+      field 'region', jq(col_item, '.product.attributes.regionCode')
+    end
   end
 end
 
@@ -162,7 +181,7 @@ datasource "ds_filter_ip" do
 end
 
 datasource "ds_ip_cost_mapping" do
-  run_script $js_ip_cost_mapping, $ds_filter_ip, $ds_get_caller_identity, $ds_get_aws_offer_page
+  run_script $js_ip_cost_mapping, $ds_filter_ip, $ds_get_caller_identity, $ds_aws_products
 end
 
 ###############################################################################
@@ -238,32 +257,20 @@ script "js_filter_ip_response", type: "javascript" do
 end
 
 script "js_ip_cost_mapping", type:"javascript" do
-  parameters  "ip_list", "ds_get_caller_identity", "offer_page"
+  parameters "ip_list", "ds_get_caller_identity", "aws_products"
   result "result"
   code <<-EOS
-    var result = {};
-    var unused_ip_list=[];
-    var message='';
-    var doc_rate=0;
+    // map the prices by region for easy lookup
+    var regions = {}, prices_by_region = {};
+    _.each(ip_list, function (ip) {
+      regions[ip.region] = true;
+    });
+    _.each(aws_products, function (product) {
+      if (regions[product.region]) {
+        prices_by_region[product.region] = parseFloat(product.price_per_unit);
+      }
+    });
     var total_savings = 0;
-    var savings_per_resource = 0;
-    var sku = '';
-    var sku_obj = _.find(offer_page.products, function(product){
-                    if(product.productFamily == 'IP Address' && product.attributes.usagetype.indexOf('ElasticIP:IdleAddress')!= -1){
-                      return product;
-                    }
-                  })
-    sku = sku_obj['sku'];
-    var obj= offer_page.terms.OnDemand[sku]
-    _.each(obj, function(item){
-      price_dim = item.priceDimensions;
-      _.each(price_dim, function(price_item){
-        if(price_item.description.indexOf('Elastic IP address not attached to a running instance per hour') != -1){
-          doc_curr_val=_.values(price_item.pricePerUnit);
-          doc_rate=doc_curr_val[0];
-        }
-      })
-    })
     function formatNumber(number, separator){
       var numString =number.toString();
       var values=numString.split(".");
@@ -281,25 +288,25 @@ script "js_ip_cost_mapping", type:"javascript" do
       }
       return result+"."+values[1];
     }
+    // The savings is calculated and displayed in USD
     var cur = "$"
     var separator = ","
-    //The savings is calculated and displayed in USD
-    savings_per_resource = Math.round((doc_rate * 24 * 30) * 1000) / 1000;
-    total_savings = savings_per_resource * ip_list.length;
-    total_savings = cur + ' '+formatNumber((Math.round((total_savings) * 100) / 100) , separator);
-    savings_per_resource = savings_per_resource;
-    message = "The total estimated monthly savings are "+ total_savings;
-    _.each(ip_list, function(ip){
-      ip['service']="EC2";
-      ip['savings']=savings_per_resource;
-      ip['savings_currency']=cur
+    var unused_ip_list = _.map(ip_list, function(ip){
+      ip = _.clone(ip);
+      var costs = prices_by_region[ip.region] * 24 * 30;
+      ip.service = 'EC2';
+      ip.savings = Math.round(costs * 1000) / 1000;
+      ip.savings_currency = cur;
+      total_savings += costs;
+      return ip;
     })
-    result={
-      "ip_list": ip_list,
+    var total_savings_string = cur + ' ' + formatNumber(Math.round(total_savings * 100) / 100, separator);
+    var message = "The total estimated monthly savings are " + total_savings_string;
+    var result = {
+      "ip_list": _.sortBy(unused_ip_list, "region"),
       "message": message,
-      "accountID": ds_get_caller_identity[0]['account']
-    }
-    result.ip_list=_.sortBy(result.ip_list,"region")
+      "accountID": ds_get_caller_identity[0]['account'],
+    };
   EOS
 end
 


### PR DESCRIPTION
### Description

- Improve savings calculations by using the AWS Pricing API which is significantly faster and more memory efficient than retrieving the AWS price sheet JSON file

### Issues Resolved

FINOPS-112

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
