### PR TITLE
ITAM Policy: VMs Without Host ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ Reference
 
 - [FlexNet Manager Licenses At Risk](./compliance/fnms/fnms_licenses_at_risk/)
 - [FlexNet Manager Low Available Licenses](./compliance/fnms/fnms_low_licenses_available)
+- [FlexNet Manager VMs Missing Host ID](./compliance/fnms/vms_missing_hostid)
 - [GitHub.com Available Seats](./compliance/github/available_seats/)
 - [GitHub.com Unpermitted Outside Collaborators](./compliance/github/outside_collaborators/)
 - [GitHub.com Unpermitted Repository Names](./compliance/github/repository_naming/)

--- a/README.md
+++ b/README.md
@@ -296,7 +296,6 @@ Reference
 
 - [FlexNet Manager Licenses At Risk](./compliance/fnms/fnms_licenses_at_risk/)
 - [FlexNet Manager Low Available Licenses](./compliance/fnms/fnms_low_licenses_available)
-- [FlexNet Manager VMs Missing Host ID](./compliance/fnms/vms_missing_hostid)
 - [GitHub.com Available Seats](./compliance/github/available_seats/)
 - [GitHub.com Unpermitted Outside Collaborators](./compliance/github/outside_collaborators/)
 - [GitHub.com Unpermitted Repository Names](./compliance/github/repository_naming/)
@@ -304,6 +303,7 @@ Reference
 - [GitHub.com Unpermitted Sized Repositories](./compliance/github/repository_size/)
 - [GitHub.com Repository Branches without Protection](./compliance/github/repository_branch_protection/)
 - [GitHub.com Repositories without Admin Team](./compliance/github/repository_admin_team/)
+- [ITAM VMs Missing Host ID](./compliance/fnms/vms_missing_hostid)
 - [Policy Update Notification](./compliance/policy_update_notification/)
 
 ### Operational

--- a/compliance/fnms/vms_missing_hostid/CHANGELOG.md
+++ b/compliance/fnms/vms_missing_hostid/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v2.0
+
+- Initial Release

--- a/compliance/fnms/vms_missing_hostid/README.md
+++ b/compliance/fnms/vms_missing_hostid/README.md
@@ -1,8 +1,8 @@
-# FlexNet Manager VMs Missing Host ID
+# ITAM VMs Missing Host ID
 
 ## What it does
 
-This policy uses the FlexNet Manager Inventories API to look up virtual machines and raises an incident if any are found without a Host ID assigned to them. The incident provides a detailed list of the affected machines.
+This policy uses the ITAM Inventories API to look up virtual machines and raises an incident if any are found without a Host ID assigned to them. The incident provides a detailed list of the affected machines.
 
 ## Input Parameters
 

--- a/compliance/fnms/vms_missing_hostid/README.md
+++ b/compliance/fnms/vms_missing_hostid/README.md
@@ -1,8 +1,8 @@
-# ITAM VMs Missing Host ID
+# FlexNet Manager VMs Missing Host ID
 
 ## What it does
 
-This policy uses the ITAM Inventories API to look up virtual machines and raises an incident if any are found without a Host ID assigned to them. The incident provides a detailed list of the affected machines.
+This policy uses the FlexNet Manager Inventories API to look up virtual machines and raises an incident if any are found without a Host ID assigned to them. The incident provides a detailed list of the affected machines.
 
 ## Input Parameters
 

--- a/compliance/fnms/vms_missing_hostid/README.md
+++ b/compliance/fnms/vms_missing_hostid/README.md
@@ -1,0 +1,23 @@
+# ITAM VMs Missing Host ID
+
+## What it does
+
+This policy uses the ITAM Inventories API to look up virtual machines and raises an incident if any are found without a Host ID assigned to them. The incident provides a detailed list of the affected machines.
+
+## Input Parameters
+
+This policy has the following input parameters required when launching the policy.
+
+- *Email addresses of the recipients you wish to notify* - A list of email address(es) to notify
+
+## Policy Actions
+
+- Send an email report
+
+## Prerequisites
+
+This policy uses [credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for connecting to the cloud -- in order to apply this policy you must have a credential registered in the system that is compatible with this policy. If there are no credentials listed when you apply the policy, please contact your cloud admin and ask them to register a credential that is compatible with this policy. The information below should be consulted when creating the credential.
+
+## Cost
+
+This Policy Template does not incur any additional cloud costs.

--- a/compliance/fnms/vms_missing_hostid/vms_missing_hostid.pt
+++ b/compliance/fnms/vms_missing_hostid/vms_missing_hostid.pt
@@ -1,0 +1,134 @@
+name "ITAM VMs Missing Host ID"
+rs_pt_ver 20180301
+type "policy"
+short_description "Looks for machines that are active but missing a Host ID.  See the [README](https://github.com/flexera/policy_templates/tree/master/compliance/fnms/missing_active_machines/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+long_description ""
+severity "medium"
+category "Compliance"
+info(
+  version: "2.0",
+  provider: "Flexera ITAM",
+  service: "",
+  policy_set: "ITAM"
+)
+
+###############################################################################
+# Parameters
+###############################################################################
+
+parameter "param_email" do
+  type "list"
+  label "Email addresses of the recipients you wish to notify"
+  description "A list of email addresse(s) to notify"
+end
+
+###############################################################################
+# Authentication
+###############################################################################
+
+credentials "auth_flexeraone" do
+  schemes "oauth2"
+  label "flexera"
+  description "Select FlexeraOne OAuth2 credentials"
+  tags "provider=flexera"
+end
+
+###############################################################################
+# Pagination
+###############################################################################
+
+pagination "itam_pagination" do
+  get_page_marker do
+    body_path jq(response, "if .total == 0 then null else .offset + 10000 end")
+  end
+  set_page_marker do
+    query "offset"
+  end
+end
+
+###############################################################################
+# Datasources
+###############################################################################
+
+datasource "ds_inventories" do
+  request do
+    auth $auth_flexeraone
+    host "api.flexera.com"
+    path join(["/fnms/v1/orgs/", rs_org_id, "/inventories"])
+    header "Api-Version", "0.1"
+    header "User-Agent", "RS Policies"
+    query "status", "Active"
+    query "limit", "10000"
+    pagination $itam_pagination
+  end
+end
+
+datasource "ds_missing_hostid", type: "javascript" do
+  run_script $js_missing_hostid, $ds_inventories
+end
+
+###############################################################################
+# Scripts
+###############################################################################
+
+script "js_missing_hostid", type: "javascript" do
+  parameters "ds_inventories"
+  result "result"
+  code <<-EOF
+  var result = []
+
+  _.each(ds_inventories[0].values, function(asset) {
+    if (asset['deviceType'] == "Virtual Machine") {
+      if (asset['hostId'] == null || asset['hostId'] == undefined || asset['hostId'] == '') {
+        result.push(asset)
+      }
+    }
+  })
+EOF
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy 'itam_policy' do
+  validate $ds_missing_hostid do
+    summary_template 'FlexNet Manager - Virtual Machines Without Host ID'
+    escalate $send_report
+    check eq(size(data),0)
+    export do
+      field "name"
+      field "serialNumber"
+      field "os"
+      field "LastInventoryDate" do
+        path "inventorySourceData.lastInventoryDate"
+      end
+      field "LastInventorySource" do
+        path "inventorySourceData.lastInventorySource"
+      end
+      field "complianceStatus"
+      field "computerId"
+      field "deviceType"
+      field "inventorySourceData"
+      field "ipAddress"
+      field "macAddresses"
+      field "manufacturer"
+      field "model"
+      field "ownership"
+      field "processorType"
+      field "ram"
+      field "userData"
+    end
+  end
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
+escalation "send_report" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end

--- a/compliance/fnms/vms_missing_hostid/vms_missing_hostid.pt
+++ b/compliance/fnms/vms_missing_hostid/vms_missing_hostid.pt
@@ -5,6 +5,7 @@ short_description "Looks for machines that are active but missing a Host ID.  Se
 long_description ""
 severity "medium"
 category "Compliance"
+default_frequency "daily"
 info(
   version: "2.0",
   provider: "Flexera ITAM",

--- a/compliance/fnms/vms_missing_hostid/vms_missing_hostid.pt
+++ b/compliance/fnms/vms_missing_hostid/vms_missing_hostid.pt
@@ -1,4 +1,4 @@
-name "FlexNet Manager VMs Missing Host ID"
+name "ITAM VMs Missing Host ID"
 rs_pt_ver 20180301
 type "policy"
 short_description "Looks for machines that are active but missing a Host ID.  See the [README](https://github.com/flexera/policy_templates/tree/master/compliance/fnms/vms_missing_hostid/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."

--- a/compliance/fnms/vms_missing_hostid/vms_missing_hostid.pt
+++ b/compliance/fnms/vms_missing_hostid/vms_missing_hostid.pt
@@ -1,4 +1,4 @@
-name "ITAM VMs Missing Host ID"
+name "FlexNet Manager VMs Missing Host ID"
 rs_pt_ver 20180301
 type "policy"
 short_description "Looks for machines that are active but missing a Host ID.  See the [README](https://github.com/flexera/policy_templates/tree/master/compliance/fnms/vms_missing_hostid/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."

--- a/compliance/fnms/vms_missing_hostid/vms_missing_hostid.pt
+++ b/compliance/fnms/vms_missing_hostid/vms_missing_hostid.pt
@@ -1,7 +1,7 @@
 name "ITAM VMs Missing Host ID"
 rs_pt_ver 20180301
 type "policy"
-short_description "Looks for machines that are active but missing a Host ID.  See the [README](https://github.com/flexera/policy_templates/tree/master/compliance/fnms/missing_active_machines/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "Looks for machines that are active but missing a Host ID.  See the [README](https://github.com/flexera/policy_templates/tree/master/compliance/fnms/vms_missing_hostid/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 severity "medium"
 category "Compliance"

--- a/compliance/fnms/vms_missing_hostid/vms_missing_hostid.pt
+++ b/compliance/fnms/vms_missing_hostid/vms_missing_hostid.pt
@@ -20,7 +20,7 @@ info(
 parameter "param_email" do
   type "list"
   label "Email addresses of the recipients you wish to notify"
-  description "A list of email addresse(s) to notify"
+  description "A list of email address(es) to notify"
 end
 
 ###############################################################################


### PR DESCRIPTION
ITAM Policy to find VMs without a Host ID. Policy has been tested and works as expected.