### PR TITLE
Azure CIS 3.10/3.11 Ensure Storage logging is Enabled for Blob/Table Service for 'Read', 'Write', and 'Delete' requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,9 @@ Reference
 ###### CIS Policies
 
 - [Azure Ensure Blob Containers Set To Private](./security/azure/private_blob_containers/)
+- [Azure Ensure Storage Logging Enabled For Blob Service](./security/azure/blob_storage_logging/)
 - [Azure Ensure Storage Logging Enabled For Queue Service](./security/azure/queue_storage_logging/)
+- [Azure Ensure Storage Logging Enabled For Table Service](./security/azure/table_storage_logging/)
 - [Azure Ensure Secure Transfer Required](./security/azure/secure_transfer_required/)
 
 ##### Security

--- a/security/azure/blob_storage_logging/CHANGELOG.md
+++ b/security/azure/blob_storage_logging/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v2.0
+
+- initial release

--- a/security/azure/blob_storage_logging/README.md
+++ b/security/azure/blob_storage_logging/README.md
@@ -1,8 +1,8 @@
-# Azure Ensure Storage Logging Enabled For Queue Service
+# Azure Ensure Storage Logging Enabled For Blob Service
 
 ## What it does
 
-This policy checks all Azure storage accounts that use the queue service to ensure that they are configured to log read, write, and delete requests. An incident is raised with the offending storage accounts if any are found that don't.
+This policy checks all Azure storage accounts that use the blob service to ensure that they are configured to log read, write, and delete requests. An incident is raised with the offending storage accounts if any are found that don't.
 
 ## Functional Details
 

--- a/security/azure/blob_storage_logging/README.md
+++ b/security/azure/blob_storage_logging/README.md
@@ -1,0 +1,39 @@
+# Azure Ensure Storage Logging Enabled For Queue Service
+
+## What it does
+
+This policy checks all Azure storage accounts that use the queue service to ensure that they are configured to log read, write, and delete requests. An incident is raised with the offending storage accounts if any are found that don't.
+
+## Functional Details
+
+The Azure Resource Manager API is used to get a list of subscriptions and storage accounts within those subscriptions. The policy then gathers the storage service properties of each storage account in order to verify that logging is properly enabled.
+
+## Input Parameters
+
+This policy has the following input parameters required when launching the policy.
+
+- *Email addresses to notify* - Email addresses of the recipients you wish to notify when new incidents are created
+- *Azure Endpoint* - Azure Endpoint to access resources
+
+## Prerequisites
+
+This policy uses [credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for connecting to the cloud -- in order to apply this policy you must have a credential registered in the system that is compatible with this policy. If there are no credentials listed when you apply the policy, please contact your cloud admin and ask them to register a credential that is compatible with this policy. The information below should be consulted when creating the credential.
+
+### Credential configuration
+
+For administrators [creating and managing credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) to use with this policy, the following information is needed:
+
+Provider tag values to match this policy: `azure_rm`, `azure_storage`
+
+Required permissions in the provider:
+
+- Microsoft.Resources/subscriptions/read
+- Microsoft.Storage/storageAccounts/read
+
+## Supported Clouds
+
+- Azure Resource Manager
+
+## Cost
+
+This Policy Template does not incur any cloud costs.

--- a/security/azure/blob_storage_logging/blob_storage_logging.pt
+++ b/security/azure/blob_storage_logging/blob_storage_logging.pt
@@ -1,0 +1,242 @@
+name "Azure Ensure Storage Logging Enabled For Queue Service"
+rs_pt_ver 20180301
+type "policy"
+short_description "Report if any storage queue accounts are not configured to log read, write, and delete requests. \n See the [README](https://github.com/flexera/policy_templates/tree/master/security/azure/queue_storage_logging) and [docs.rightscale.com/policies](https://docs.rightscale.com/policies/) to learn more."
+long_description ""
+category "Security"
+severity "high"
+default_frequency "daily"
+info(
+  version: "2.0",
+  provider: "Azure",
+  service: "Storage",
+  policy_set: "CIS",
+  cce_id: "",
+  benchmark_control: "3.3",
+  benchmark_version: "1.4.0",
+  cis_controls: "[\"8.5v8\", \"6.3v7\"]",
+  nist: "AU-3"
+)
+
+###############################################################################
+# Parameters
+###############################################################################
+
+parameter "param_email" do
+  type "list"
+  label "Email addresses of the recipients you wish to notify"
+end
+
+parameter "param_azure_endpoint" do
+  type "string"
+  label "Azure Endpoint"
+  allowed_values "management.azure.com", "management.chinacloudapi.cn"
+  default "management.azure.com"
+end
+
+###############################################################################
+# Authentication
+###############################################################################
+
+credentials "azure_auth" do
+  schemes "oauth2"
+  label "Azure"
+  description "Select the Azure Resource Manager Credential from the list."
+  tags "provider=azure_rm"
+end
+
+credentials "azure_storage_auth" do
+  schemes "oauth2"
+  label "Azure"
+  description "Select the Azure Storage Credential from the list."
+  tags "provider=azure_storage"
+end
+
+###############################################################################
+# Pagination
+###############################################################################
+
+pagination "azure_pagination" do
+  get_page_marker do
+    body_path "nextLink"
+  end
+  set_page_marker do
+    uri true
+  end
+end
+
+###############################################################################
+# Datasources
+###############################################################################
+
+datasource "ds_subscriptions" do
+  request do
+    auth $azure_auth
+    pagination $azure_pagination
+    host $param_azure_endpoint
+    path "/subscriptions/"
+    query "api-version", "2019-06-01"
+    header "User-Agent", "RS Policies"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "value[*]") do
+      field "id", jmes_path(col_item, "subscriptionId")
+      field "displayName", jmes_path(col_item, "displayName")
+      field "state", jmes_path(col_item, "state")
+    end
+  end
+end
+
+datasource "ds_storage_accounts" do
+  iterate $ds_subscriptions
+  request do
+    auth $azure_auth
+    pagination $azure_pagination
+    host $param_azure_endpoint
+    path join(["/subscriptions/", val(iter_item, "id"), "/providers/Microsoft.Storage/storageAccounts"])
+    query "api-version", "2021-04-01"
+    header "User-Agent", "RS Policies"
+    header "Content-Type", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "value[*]") do
+      field "id", jmes_path(col_item, "id")
+      field "kind", jmes_path(col_item, "kind")
+      field "location", jmes_path(col_item, "location")
+      field "name", jmes_path(col_item, "name")
+      field "accessTier", jmes_path(col_item, "properties.accessTier")
+      field "creationTime", jmes_path(col_item, "properties.creationTime")
+      field "primaryLocation", jmes_path(col_item, "properties.primaryLocation")
+      field "provisioningState", jmes_path(col_item, "properties.provisioningState")
+      field "statusOfPrimary", jmes_path(col_item, "properties.statusOfPrimary")
+      field "secure_transfer", jmes_path(col_item, "properties.supportsHttpsTrafficOnly")
+      field "encryption", jmes_path(col_item, "properties.encryption")
+      field "keyCreationTime", jmes_path(col_item, "properties.keyCreationTime")
+      field "networkAcls", jmes_path(col_item, "properties.networkAcls")
+      field "primaryEndpoints", jmes_path(col_item, "properties.primaryEndpoints")
+      field "queueEndpoint", jmes_path(col_item, "properties.primaryEndpoints.queue")
+      field "subscriptionId", val(iter_item, "id")
+      field "subscriptionName", val(iter_item, "displayName")
+    end
+  end
+end
+
+datasource "ds_storage_accounts_with_queues" do
+  run_script $js_storage_accounts_with_queues, $ds_storage_accounts
+end
+
+datasource "ds_storage_queues" do
+  iterate $ds_storage_accounts_with_queues
+  request do
+    auth $azure_storage_auth
+    host val(iter_item, "queueHost")
+    query "restype", "service"
+    query "comp", "properties"
+    header "User-Agent", "RS Policies"
+    header "x-ms-version", "2018-03-28"
+  end
+  result do
+    encoding "xml"
+    collect xpath(response, "//StorageServiceProperties/Logging") do
+      field "id", val(iter_item, "id")
+      field "name", val(iter_item, "name")
+      field "location", val(iter_item, "location")
+      field "kind", val(iter_item, "kind")
+      field "accessTier", val(iter_item, "accessTier")
+      field "queueHost", val(iter_item, "queueHost")
+      field "loggingVersion", xpath(col_item, "Version")
+      field "loggingRead", xpath(col_item, "Read")
+      field "loggingWrite", xpath(col_item, "Write")
+      field "loggingDelete", xpath(col_item, "Delete")
+    end
+  end
+end
+
+datasource "ds_bad_storage_queues" do
+  run_script $js_bad_storage_queues, $ds_storage_queues
+end
+
+###############################################################################
+# Scripts
+###############################################################################
+
+script "js_storage_accounts_with_queues", type: "javascript" do
+  parameters "ds_storage_accounts"
+  result "result"
+  code <<-EOS
+  result = []
+
+  _.each(ds_storage_accounts, function(account) {
+    if (account['queueEndpoint'] != null) {
+      account['queueHost'] = account['queueEndpoint'].split('//')[1].split('.')[0] + '.queue.core.windows.net'
+      result.push(account)
+    }
+  })
+
+EOS
+end
+
+script "js_bad_storage_queues", type: "javascript" do
+  parameters "ds_storage_queues"
+  result "result"
+  code <<-EOS
+  result = []
+
+  _.each(ds_storage_queues, function(queue) {
+    if (queue['loggingRead'] != "true" || queue['loggingWrite'] != "true" || queue['loggingDelete'] != "true") {
+      result.push(queue)
+    }
+  })
+EOS
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "policy_storage_queue_logging" do
+  validate $ds_bad_storage_queues do
+    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} Azure Storage Account(s) That Don't Have Storage Logging Enabled For Queue Service"
+    escalate $esc_email
+    check eq(size(data),0)
+    export do
+      field "name" do
+        label "Name"
+      end
+      field "kind" do
+        label "Kind"
+      end
+      field "location" do
+        label "Location"
+      end
+      field "accessTier" do
+        label "Access Tier"
+      end
+      field "loggingRead" do
+        label "Read Logging"
+      end
+      field "loggingWrite" do
+        label "Write Logging"
+      end
+      field "loggingDelete" do
+        label "Delete Logging"
+      end
+      field "id" do
+        label "Resource ID"
+      end
+    end
+  end
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end

--- a/security/azure/blob_storage_logging/blob_storage_logging.pt
+++ b/security/azure/blob_storage_logging/blob_storage_logging.pt
@@ -1,7 +1,7 @@
-name "Azure Ensure Storage Logging Enabled For Queue Service"
+name "Azure Ensure Storage Logging Enabled For Blob Service"
 rs_pt_ver 20180301
 type "policy"
-short_description "Report if any storage queue accounts are not configured to log read, write, and delete requests. \n See the [README](https://github.com/flexera/policy_templates/tree/master/security/azure/queue_storage_logging) and [docs.rightscale.com/policies](https://docs.rightscale.com/policies/) to learn more."
+short_description "Report if any blob storage accounts are not configured to log read, write, and delete requests. \n See the [README](https://github.com/flexera/policy_templates/tree/master/security/azure/blob_storage_logging) and [docs.rightscale.com/policies](https://docs.rightscale.com/policies/) to learn more."
 long_description ""
 category "Security"
 severity "high"
@@ -12,7 +12,7 @@ info(
   service: "Storage",
   policy_set: "CIS",
   cce_id: "",
-  benchmark_control: "3.3",
+  benchmark_control: "3.10",
   benchmark_version: "1.4.0",
   cis_controls: "[\"8.5v8\", \"6.3v7\"]",
   nist: "AU-3"
@@ -116,22 +116,22 @@ datasource "ds_storage_accounts" do
       field "keyCreationTime", jmes_path(col_item, "properties.keyCreationTime")
       field "networkAcls", jmes_path(col_item, "properties.networkAcls")
       field "primaryEndpoints", jmes_path(col_item, "properties.primaryEndpoints")
-      field "queueEndpoint", jmes_path(col_item, "properties.primaryEndpoints.queue")
+      field "blobEndpoint", jmes_path(col_item, "properties.primaryEndpoints.blob")
       field "subscriptionId", val(iter_item, "id")
       field "subscriptionName", val(iter_item, "displayName")
     end
   end
 end
 
-datasource "ds_storage_accounts_with_queues" do
-  run_script $js_storage_accounts_with_queues, $ds_storage_accounts
+datasource "ds_storage_accounts_with_blobs" do
+  run_script $js_storage_accounts_with_blobs, $ds_storage_accounts
 end
 
-datasource "ds_storage_queues" do
-  iterate $ds_storage_accounts_with_queues
+datasource "ds_storage_blobs" do
+  iterate $ds_storage_accounts_with_blobs
   request do
     auth $azure_storage_auth
-    host val(iter_item, "queueHost")
+    host val(iter_item, "blobHost")
     query "restype", "service"
     query "comp", "properties"
     header "User-Agent", "RS Policies"
@@ -145,7 +145,7 @@ datasource "ds_storage_queues" do
       field "location", val(iter_item, "location")
       field "kind", val(iter_item, "kind")
       field "accessTier", val(iter_item, "accessTier")
-      field "queueHost", val(iter_item, "queueHost")
+      field "blobHost", val(iter_item, "blobHost")
       field "loggingVersion", xpath(col_item, "Version")
       field "loggingRead", xpath(col_item, "Read")
       field "loggingWrite", xpath(col_item, "Write")
@@ -154,39 +154,41 @@ datasource "ds_storage_queues" do
   end
 end
 
-datasource "ds_bad_storage_queues" do
-  run_script $js_bad_storage_queues, $ds_storage_queues
+datasource "ds_bad_storage_blobs" do
+  run_script $js_bad_storage_blobs, $ds_storage_blobs
 end
 
 ###############################################################################
 # Scripts
 ###############################################################################
 
-script "js_storage_accounts_with_queues", type: "javascript" do
+script "js_storage_accounts_with_blobs", type: "javascript" do
   parameters "ds_storage_accounts"
   result "result"
   code <<-EOS
   result = []
 
   _.each(ds_storage_accounts, function(account) {
-    if (account['queueEndpoint'] != null) {
-      account['queueHost'] = account['queueEndpoint'].split('//')[1].split('.')[0] + '.queue.core.windows.net'
+    if (account['blobEndpoint'] != null) {
+      account['blobHost'] = account['blobEndpoint'].split('//')[1].split('.')[0] + '.blob.core.windows.net'
       result.push(account)
     }
   })
 
+  result = result.slice(0,10)
+
 EOS
 end
 
-script "js_bad_storage_queues", type: "javascript" do
-  parameters "ds_storage_queues"
+script "js_bad_storage_blobs", type: "javascript" do
+  parameters "ds_storage_blobs"
   result "result"
   code <<-EOS
   result = []
 
-  _.each(ds_storage_queues, function(queue) {
-    if (queue['loggingRead'] != "true" || queue['loggingWrite'] != "true" || queue['loggingDelete'] != "true") {
-      result.push(queue)
+  _.each(ds_storage_blobs, function(blob) {
+    if (blob['loggingRead'] != "true" || blob['loggingWrite'] != "true" || blob['loggingDelete'] != "true") {
+      result.push(blob)
     }
   })
 EOS
@@ -196,9 +198,9 @@ end
 # Policy
 ###############################################################################
 
-policy "policy_storage_queue_logging" do
-  validate $ds_bad_storage_queues do
-    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} Azure Storage Account(s) That Don't Have Storage Logging Enabled For Queue Service"
+policy "policy_storage_blob_logging" do
+  validate $ds_bad_storage_blobs do
+    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} Azure Storage Account(s) That Don't Have Storage Logging Enabled For Blob Service"
     escalate $esc_email
     check eq(size(data),0)
     export do

--- a/security/azure/table_storage_logging/CHANGELOG.md
+++ b/security/azure/table_storage_logging/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v2.0
+
+- initial release

--- a/security/azure/table_storage_logging/README.md
+++ b/security/azure/table_storage_logging/README.md
@@ -1,8 +1,8 @@
-# Azure Ensure Storage Logging Enabled For Queue Service
+# Azure Ensure Storage Logging Enabled For Table Service
 
 ## What it does
 
-This policy checks all Azure storage accounts that use the queue service to ensure that they are configured to log read, write, and delete requests. An incident is raised with the offending storage accounts if any are found that don't.
+This policy checks all Azure storage accounts that use the table service to ensure that they are configured to log read, write, and delete requests. An incident is raised with the offending storage accounts if any are found that don't.
 
 ## Functional Details
 

--- a/security/azure/table_storage_logging/README.md
+++ b/security/azure/table_storage_logging/README.md
@@ -1,0 +1,39 @@
+# Azure Ensure Storage Logging Enabled For Queue Service
+
+## What it does
+
+This policy checks all Azure storage accounts that use the queue service to ensure that they are configured to log read, write, and delete requests. An incident is raised with the offending storage accounts if any are found that don't.
+
+## Functional Details
+
+The Azure Resource Manager API is used to get a list of subscriptions and storage accounts within those subscriptions. The policy then gathers the storage service properties of each storage account in order to verify that logging is properly enabled.
+
+## Input Parameters
+
+This policy has the following input parameters required when launching the policy.
+
+- *Email addresses to notify* - Email addresses of the recipients you wish to notify when new incidents are created
+- *Azure Endpoint* - Azure Endpoint to access resources
+
+## Prerequisites
+
+This policy uses [credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for connecting to the cloud -- in order to apply this policy you must have a credential registered in the system that is compatible with this policy. If there are no credentials listed when you apply the policy, please contact your cloud admin and ask them to register a credential that is compatible with this policy. The information below should be consulted when creating the credential.
+
+### Credential configuration
+
+For administrators [creating and managing credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) to use with this policy, the following information is needed:
+
+Provider tag values to match this policy: `azure_rm`, `azure_storage`
+
+Required permissions in the provider:
+
+- Microsoft.Resources/subscriptions/read
+- Microsoft.Storage/storageAccounts/read
+
+## Supported Clouds
+
+- Azure Resource Manager
+
+## Cost
+
+This Policy Template does not incur any cloud costs.

--- a/security/azure/table_storage_logging/table_storage_logging.pt
+++ b/security/azure/table_storage_logging/table_storage_logging.pt
@@ -1,7 +1,7 @@
-name "Azure Ensure Storage Logging Enabled For Queue Service"
+name "Azure Ensure Storage Logging Enabled For Table Service"
 rs_pt_ver 20180301
 type "policy"
-short_description "Report if any storage queue accounts are not configured to log read, write, and delete requests. \n See the [README](https://github.com/flexera/policy_templates/tree/master/security/azure/queue_storage_logging) and [docs.rightscale.com/policies](https://docs.rightscale.com/policies/) to learn more."
+short_description "Report if any storage table accounts are not configured to log read, write, and delete requests. \n See the [README](https://github.com/flexera/policy_templates/tree/master/security/azure/table_storage_logging) and [docs.rightscale.com/policies](https://docs.rightscale.com/policies/) to learn more."
 long_description ""
 category "Security"
 severity "high"
@@ -116,22 +116,22 @@ datasource "ds_storage_accounts" do
       field "keyCreationTime", jmes_path(col_item, "properties.keyCreationTime")
       field "networkAcls", jmes_path(col_item, "properties.networkAcls")
       field "primaryEndpoints", jmes_path(col_item, "properties.primaryEndpoints")
-      field "queueEndpoint", jmes_path(col_item, "properties.primaryEndpoints.queue")
+      field "tableEndpoint", jmes_path(col_item, "properties.primaryEndpoints.table")
       field "subscriptionId", val(iter_item, "id")
       field "subscriptionName", val(iter_item, "displayName")
     end
   end
 end
 
-datasource "ds_storage_accounts_with_queues" do
-  run_script $js_storage_accounts_with_queues, $ds_storage_accounts
+datasource "ds_storage_accounts_with_tables" do
+  run_script $js_storage_accounts_with_tables, $ds_storage_accounts
 end
 
-datasource "ds_storage_queues" do
-  iterate $ds_storage_accounts_with_queues
+datasource "ds_storage_tables" do
+  iterate $ds_storage_accounts_with_tables
   request do
     auth $azure_storage_auth
-    host val(iter_item, "queueHost")
+    host val(iter_item, "tableHost")
     query "restype", "service"
     query "comp", "properties"
     header "User-Agent", "RS Policies"
@@ -145,7 +145,7 @@ datasource "ds_storage_queues" do
       field "location", val(iter_item, "location")
       field "kind", val(iter_item, "kind")
       field "accessTier", val(iter_item, "accessTier")
-      field "queueHost", val(iter_item, "queueHost")
+      field "tableHost", val(iter_item, "table")
       field "loggingVersion", xpath(col_item, "Version")
       field "loggingRead", xpath(col_item, "Read")
       field "loggingWrite", xpath(col_item, "Write")
@@ -154,23 +154,23 @@ datasource "ds_storage_queues" do
   end
 end
 
-datasource "ds_bad_storage_queues" do
-  run_script $js_bad_storage_queues, $ds_storage_queues
+datasource "ds_bad_storage_tables" do
+  run_script $js_bad_storage_tables, $ds_storage_tables
 end
 
 ###############################################################################
 # Scripts
 ###############################################################################
 
-script "js_storage_accounts_with_queues", type: "javascript" do
+script "js_storage_accounts_with_tables", type: "javascript" do
   parameters "ds_storage_accounts"
   result "result"
   code <<-EOS
   result = []
 
   _.each(ds_storage_accounts, function(account) {
-    if (account['queueEndpoint'] != null) {
-      account['queueHost'] = account['queueEndpoint'].split('//')[1].split('.')[0] + '.queue.core.windows.net'
+    if (account['tableEndpoint'] != null) {
+      account['tableHost'] = account['tableEndpoint'].split('//')[1].split('.')[0] + '.table.core.windows.net'
       result.push(account)
     }
   })
@@ -178,15 +178,15 @@ script "js_storage_accounts_with_queues", type: "javascript" do
 EOS
 end
 
-script "js_bad_storage_queues", type: "javascript" do
-  parameters "ds_storage_queues"
+script "js_bad_storage_tables", type: "javascript" do
+  parameters "ds_storage_tables"
   result "result"
   code <<-EOS
   result = []
 
-  _.each(ds_storage_queues, function(queue) {
-    if (queue['loggingRead'] != "true" || queue['loggingWrite'] != "true" || queue['loggingDelete'] != "true") {
-      result.push(queue)
+  _.each(ds_storage_tables, function(table) {
+    if (table['loggingRead'] != "true" || table['loggingWrite'] != "true" || table['loggingDelete'] != "true") {
+      result.push(table)
     }
   })
 EOS
@@ -196,9 +196,9 @@ end
 # Policy
 ###############################################################################
 
-policy "policy_storage_queue_logging" do
-  validate $ds_bad_storage_queues do
-    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} Azure Storage Account(s) That Don't Have Storage Logging Enabled For Queue Service"
+policy "policy_storage_table_logging" do
+  validate $ds_bad_storage_tables do
+    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} Azure Storage Account(s) That Don't Have Storage Logging Enabled For Table Service"
     escalate $esc_email
     check eq(size(data),0)
     export do

--- a/security/azure/table_storage_logging/table_storage_logging.pt
+++ b/security/azure/table_storage_logging/table_storage_logging.pt
@@ -1,0 +1,242 @@
+name "Azure Ensure Storage Logging Enabled For Queue Service"
+rs_pt_ver 20180301
+type "policy"
+short_description "Report if any storage queue accounts are not configured to log read, write, and delete requests. \n See the [README](https://github.com/flexera/policy_templates/tree/master/security/azure/queue_storage_logging) and [docs.rightscale.com/policies](https://docs.rightscale.com/policies/) to learn more."
+long_description ""
+category "Security"
+severity "high"
+default_frequency "daily"
+info(
+  version: "2.0",
+  provider: "Azure",
+  service: "Storage",
+  policy_set: "CIS",
+  cce_id: "",
+  benchmark_control: "3.3",
+  benchmark_version: "1.4.0",
+  cis_controls: "[\"8.5v8\", \"6.3v7\"]",
+  nist: "AU-3"
+)
+
+###############################################################################
+# Parameters
+###############################################################################
+
+parameter "param_email" do
+  type "list"
+  label "Email addresses of the recipients you wish to notify"
+end
+
+parameter "param_azure_endpoint" do
+  type "string"
+  label "Azure Endpoint"
+  allowed_values "management.azure.com", "management.chinacloudapi.cn"
+  default "management.azure.com"
+end
+
+###############################################################################
+# Authentication
+###############################################################################
+
+credentials "azure_auth" do
+  schemes "oauth2"
+  label "Azure"
+  description "Select the Azure Resource Manager Credential from the list."
+  tags "provider=azure_rm"
+end
+
+credentials "azure_storage_auth" do
+  schemes "oauth2"
+  label "Azure"
+  description "Select the Azure Storage Credential from the list."
+  tags "provider=azure_storage"
+end
+
+###############################################################################
+# Pagination
+###############################################################################
+
+pagination "azure_pagination" do
+  get_page_marker do
+    body_path "nextLink"
+  end
+  set_page_marker do
+    uri true
+  end
+end
+
+###############################################################################
+# Datasources
+###############################################################################
+
+datasource "ds_subscriptions" do
+  request do
+    auth $azure_auth
+    pagination $azure_pagination
+    host $param_azure_endpoint
+    path "/subscriptions/"
+    query "api-version", "2019-06-01"
+    header "User-Agent", "RS Policies"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "value[*]") do
+      field "id", jmes_path(col_item, "subscriptionId")
+      field "displayName", jmes_path(col_item, "displayName")
+      field "state", jmes_path(col_item, "state")
+    end
+  end
+end
+
+datasource "ds_storage_accounts" do
+  iterate $ds_subscriptions
+  request do
+    auth $azure_auth
+    pagination $azure_pagination
+    host $param_azure_endpoint
+    path join(["/subscriptions/", val(iter_item, "id"), "/providers/Microsoft.Storage/storageAccounts"])
+    query "api-version", "2021-04-01"
+    header "User-Agent", "RS Policies"
+    header "Content-Type", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "value[*]") do
+      field "id", jmes_path(col_item, "id")
+      field "kind", jmes_path(col_item, "kind")
+      field "location", jmes_path(col_item, "location")
+      field "name", jmes_path(col_item, "name")
+      field "accessTier", jmes_path(col_item, "properties.accessTier")
+      field "creationTime", jmes_path(col_item, "properties.creationTime")
+      field "primaryLocation", jmes_path(col_item, "properties.primaryLocation")
+      field "provisioningState", jmes_path(col_item, "properties.provisioningState")
+      field "statusOfPrimary", jmes_path(col_item, "properties.statusOfPrimary")
+      field "secure_transfer", jmes_path(col_item, "properties.supportsHttpsTrafficOnly")
+      field "encryption", jmes_path(col_item, "properties.encryption")
+      field "keyCreationTime", jmes_path(col_item, "properties.keyCreationTime")
+      field "networkAcls", jmes_path(col_item, "properties.networkAcls")
+      field "primaryEndpoints", jmes_path(col_item, "properties.primaryEndpoints")
+      field "queueEndpoint", jmes_path(col_item, "properties.primaryEndpoints.queue")
+      field "subscriptionId", val(iter_item, "id")
+      field "subscriptionName", val(iter_item, "displayName")
+    end
+  end
+end
+
+datasource "ds_storage_accounts_with_queues" do
+  run_script $js_storage_accounts_with_queues, $ds_storage_accounts
+end
+
+datasource "ds_storage_queues" do
+  iterate $ds_storage_accounts_with_queues
+  request do
+    auth $azure_storage_auth
+    host val(iter_item, "queueHost")
+    query "restype", "service"
+    query "comp", "properties"
+    header "User-Agent", "RS Policies"
+    header "x-ms-version", "2018-03-28"
+  end
+  result do
+    encoding "xml"
+    collect xpath(response, "//StorageServiceProperties/Logging") do
+      field "id", val(iter_item, "id")
+      field "name", val(iter_item, "name")
+      field "location", val(iter_item, "location")
+      field "kind", val(iter_item, "kind")
+      field "accessTier", val(iter_item, "accessTier")
+      field "queueHost", val(iter_item, "queueHost")
+      field "loggingVersion", xpath(col_item, "Version")
+      field "loggingRead", xpath(col_item, "Read")
+      field "loggingWrite", xpath(col_item, "Write")
+      field "loggingDelete", xpath(col_item, "Delete")
+    end
+  end
+end
+
+datasource "ds_bad_storage_queues" do
+  run_script $js_bad_storage_queues, $ds_storage_queues
+end
+
+###############################################################################
+# Scripts
+###############################################################################
+
+script "js_storage_accounts_with_queues", type: "javascript" do
+  parameters "ds_storage_accounts"
+  result "result"
+  code <<-EOS
+  result = []
+
+  _.each(ds_storage_accounts, function(account) {
+    if (account['queueEndpoint'] != null) {
+      account['queueHost'] = account['queueEndpoint'].split('//')[1].split('.')[0] + '.queue.core.windows.net'
+      result.push(account)
+    }
+  })
+
+EOS
+end
+
+script "js_bad_storage_queues", type: "javascript" do
+  parameters "ds_storage_queues"
+  result "result"
+  code <<-EOS
+  result = []
+
+  _.each(ds_storage_queues, function(queue) {
+    if (queue['loggingRead'] != "true" || queue['loggingWrite'] != "true" || queue['loggingDelete'] != "true") {
+      result.push(queue)
+    }
+  })
+EOS
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "policy_storage_queue_logging" do
+  validate $ds_bad_storage_queues do
+    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} Azure Storage Account(s) That Don't Have Storage Logging Enabled For Queue Service"
+    escalate $esc_email
+    check eq(size(data),0)
+    export do
+      field "name" do
+        label "Name"
+      end
+      field "kind" do
+        label "Kind"
+      end
+      field "location" do
+        label "Location"
+      end
+      field "accessTier" do
+        label "Access Tier"
+      end
+      field "loggingRead" do
+        label "Read Logging"
+      end
+      field "loggingWrite" do
+        label "Write Logging"
+      end
+      field "loggingDelete" do
+        label "Delete Logging"
+      end
+      field "id" do
+        label "Resource ID"
+      end
+    end
+  end
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end


### PR DESCRIPTION
Azure CIS 3.10/3.11 Ensure Storage logging is Enabled for Blob/Table Service for 'Read', 'Write', and 'Delete' requests

tested and working

(Two policies in one pull request because they are extremely similar to one another)
