### PR TITLE
POL-611 Invert AWS Disallowed Regions Policy

### DIFF
--- a/compliance/aws/disallowed_regions/CHANGELOG.md
+++ b/compliance/aws/disallowed_regions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.6
+
+- Flipped parameter to enable user to specify which reasons to allow instead of which to disallow.
+
 ## v2.5
 
 - Added default to aws_account_number parameter to enable existing API users.

--- a/compliance/aws/disallowed_regions/README.md
+++ b/compliance/aws/disallowed_regions/README.md
@@ -2,11 +2,11 @@
 
 ## What it does
 
-This policy checks all instances in a set of disallowed regions. The user is given the option to Terminate the instance after approval.
+This policy checks all instances outside of a set of allowed regions. The user is given the option to Terminate the instance after approval.
 
 ## Functional Details
 
-- The policy leverages the AWS API to check all instances that exist in a disallowed region.
+- The policy leverages the AWS API to check all instances that exist outside of an allowed region.
 - When an EC2 instance in disallowed region is detected, an email action is triggered automatically to notify the specified users of the incident. Users then have the option to terminate instances after manual approval if needed.
 
 ## Input Parameters
@@ -14,7 +14,7 @@ This policy checks all instances in a set of disallowed regions. The user is giv
 - *Email addresses to notify* - Email addresses of the recipients you wish to notify when new incidents are created.
 - *Account Number* - The Account number for use with the AWS STS Cross Account Role. Leave blank when using AWS IAM Access key and secret. It only needs to be passed when the desired AWS account is different than the one associated with the Flexera One credential. [more](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1123608)
 - *Exclusion Tag* - List of tags that will exclude EC2 instances from being evaluated by this policy. Multiple tags are evaluated as an 'OR' condition. Tag keys or key/value pairs can be listed. Example: 'test,env=dev'.
-- *Disallowed Regions(s)* - List of regions to disallow.
+- *Allowed Regions(s)* - List of regions to allow.
 - *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).
 
 Note:Refer Region column under Amazon Elastic Compute Cloud (Amazon EC2) in below link for AWS supported regions \n See the [README](https://docs.aws.amazon.com/general/latest/gr/rande.html).

--- a/compliance/aws/disallowed_regions/aws_disallowed_regions.pt
+++ b/compliance/aws/disallowed_regions/aws_disallowed_regions.pt
@@ -151,8 +151,6 @@ script "js_regions_map", type: "javascript" do
   code <<-EOS
   regions_map = []
 
-  param_disallowed_regions = []
-
   _.each(ds_all_regions, function(region) {
     disallowed = true
 
@@ -163,12 +161,8 @@ script "js_regions_map", type: "javascript" do
     })
 
     if (disallowed) {
-      param_disallowed_regions.push(region)
+      regions_map.push(region)
     }
-  })
-
-  _.each(param_disallowed_regions, function(disallowed_region) {
-    regions_map.push(disallowed_region)
   })
 EOS
 end

--- a/compliance/aws/disallowed_regions/aws_disallowed_regions.pt
+++ b/compliance/aws/disallowed_regions/aws_disallowed_regions.pt
@@ -1,12 +1,13 @@
 name "AWS Disallowed Regions"
 rs_pt_ver 20180301
 type "policy"
-short_description "Check for instances that are in a disallowed region with the option to terminate them. \n See the [README](https://github.com/flexera/policy_templates/tree/master/compliance/aws/disallowed_regions) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "Check for instances that are outside of an allowed region with the option to terminate them. \n See the [README](https://github.com/flexera/policy_templates/tree/master/compliance/aws/disallowed_regions) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 category "Compliance"
 severity "low"
+default_frequency "weekly"
 info(
-  version: "2.5",
+  version: "2.6",
   provider: "AWS",
   service: "EC2",
   policy_set: "Disallowed Regions"
@@ -36,11 +37,11 @@ parameter "param_exclude_tags" do
   description "List of tags that will exclude EC2 instances from being evaluated by this policy. Multiple tags are evaluated as an 'OR' condition. Tag keys or key/value pairs can be listed. Example: 'test,env=dev'."
 end
 
-parameter "param_disallowed_region" do
+parameter "param_allowed_regions" do
   type "list"
-  label "Disallowed Regions(s)"
+  label "Allowed Regions(s)"
   allowed_pattern /([a-z])+\-([a-z])+\-([\d]?)+/
-  description "List of regions to disallow."
+  description "List of regions to allow."
 end
 
 parameter "param_automatic_action" do
@@ -82,7 +83,7 @@ end
 
 #Generates list of Regions which User input.
 datasource "ds_regions_list" do
-  run_script $js_regions_map,$param_disallowed_region
+  run_script $js_regions_map, $param_allowed_regions
 end
 
 #Get the list of all EC2 Instances across all regions.
@@ -166,21 +167,42 @@ script "js_filter_aws_instances", type: "javascript" do
 end
 
 script "js_regions_map", type: "javascript" do
-  parameters "param_disallowed_region"
+  parameters "param_allowed_regions"
   result "regions_map"
   code <<-EOS
-  regions_map=[]
-  var param_disallowed_region_lower=[];
-    for(var i=0; i < param_disallowed_region.length; i++){
-      param_disallowed_region_lower[i]=param_disallowed_region[i].toString().toLowerCase();
+  all_regions = [
+    "us-east-1", "us-east-2", "us-west-1", "us-west-2", "af-south-1",
+    "ap-east-1", "ap-southeast-3", "ap-south-1", "ap-northeast-3",
+    "ap-northeast-2", "ap-southeast-1", "ap-southeast-2",
+    "ap-northeast-1", "ca-central-1", "eu-central-1", "eu-west-1",
+    "eu-west-2", "eu-south-1", "eu-west-3", "eu-north-1",
+    "me-south-1", "sa-east-1", "us-gov-east-1", "us-gov-west-1"
+  ]
+
+  regions_map = []
+
+  param_disallowed_regions = []
+
+  _.each(all_regions, function(region) {
+    disallowed = true
+
+    _.each(param_allowed_regions, function(allowed_region) {
+      if (region == allowed_region.trim()) {
+        disallowed = false
+      }
+    })
+
+    if (disallowed) {
+      param_disallowed_regions.push(region.trim())
     }
-    for (var j = 0; j < param_disallowed_region_lower.length; j++){
-      disallowed_region = param_disallowed_region_lower[j];
-      regions_map.push({
-        "region": disallowed_region
-      })
-    }
-  EOS
+  })
+
+  _.each(param_disallowed_regions, function(disallowed_region) {
+    regions_map.push({
+      "region": disallowed_region
+    })
+  })
+EOS
 end
 
 ###############################################################################

--- a/compliance/aws/disallowed_regions/aws_disallowed_regions.pt
+++ b/compliance/aws/disallowed_regions/aws_disallowed_regions.pt
@@ -35,6 +35,7 @@ parameter "param_exclude_tags" do
   category "User Inputs"
   label "Exclusion Tag"
   description "List of tags that will exclude EC2 instances from being evaluated by this policy. Multiple tags are evaluated as an 'OR' condition. Tag keys or key/value pairs can be listed. Example: 'test,env=dev'."
+  default []
 end
 
 parameter "param_allowed_regions" do
@@ -49,6 +50,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Terminate Instances"]
+  default []
 end
 
 ###############################################################################
@@ -81,31 +83,51 @@ end
 # Datasources
 ###############################################################################
 
-#Generates list of Regions which User input.
-datasource "ds_regions_list" do
-  run_script $js_regions_map, $param_allowed_regions
+# Get a list of all active AWS regions on the account
+datasource "ds_all_regions" do
+  request do
+    auth $auth_aws
+    pagination $aws_pagination_xml
+    verb "GET"
+    host "ec2.amazonaws.com"
+    path "/"
+    query "Action", "DescribeRegions"
+    query "Version", "2016-11-15"
+  end
+  result do
+    encoding "xml"
+    collect xpath(response, "//DescribeRegionsResponse/regionInfo/item") do
+      field "regionName", xpath(col_item, "regionName")
+      field "regionEndpoint", xpath(col_item, "regionEndpoint")
+    end
+  end
 end
 
-#Get the list of all EC2 Instances across all regions.
-#https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html
+# Generates list of Regions which User input.
+datasource "ds_regions_list" do
+  run_script $js_regions_map, $ds_all_regions, $param_allowed_regions
+end
+
+# Get the list of all EC2 Instances across all regions.
+# https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html
 datasource "ds_disallowed_instances_list" do
   iterate $ds_regions_list
   request do
     auth $auth_aws
-  pagination $aws_pagination_xml
+    pagination $aws_pagination_xml
     verb "GET"
-    host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
+    host val(iter_item, "regionEndpoint")
     path "/"
     query "Action", "DescribeInstances"
     query "Version", "2016-11-15"
   end
   result do
     encoding "xml"
-    collect xpath(response, "//DescribeInstancesResponse/reservationSet/item/instancesSet/item","array") do
+    collect xpath(response, "//DescribeInstancesResponse/reservationSet/item/instancesSet/item", "array") do
       field "instance_id", xpath(col_item, "instanceId")
-      field "region", val(iter_item,"region")
+      field "region", val(iter_item, "regionName")
       field "instance_state", xpath(col_item, "instanceState/name")
-      field "instance_type", xpath(col_item,"instanceType")
+      field "instance_type", xpath(col_item, "instanceType")
       field "tags" do
         collect xpath(col_item, "tagSet/item") do
           field "tagKey", xpath(col_item, "key")
@@ -117,12 +139,40 @@ datasource "ds_disallowed_instances_list" do
 end
 
 datasource "ds_list_aws_instances" do
-  run_script $js_filter_aws_instances,$ds_disallowed_instances_list,$param_exclude_tags
+  run_script $js_filter_aws_instances, $ds_disallowed_instances_list, $param_exclude_tags
 end
 
 ###############################################################################
 # Scripts
 ###############################################################################
+
+script "js_regions_map", type: "javascript" do
+  parameters "ds_all_regions", "param_allowed_regions"
+  result "regions_map"
+  code <<-EOS
+  regions_map = []
+
+  param_disallowed_regions = []
+
+  _.each(ds_all_regions, function(region) {
+    disallowed = true
+
+    _.each(param_allowed_regions, function(allowed_region) {
+      if (region['regionName'].trim() == allowed_region.trim()) {
+        disallowed = false
+      }
+    })
+
+    if (disallowed) {
+      param_disallowed_regions.push(region)
+    }
+  })
+
+  _.each(param_disallowed_regions, function(disallowed_region) {
+    regions_map.push(disallowed_region)
+  })
+EOS
+end
 
 script "js_filter_aws_instances", type: "javascript" do
   parameters "ds_disallowed_instances_list","param_exclude_tags"
@@ -166,45 +216,6 @@ script "js_filter_aws_instances", type: "javascript" do
   EOS
 end
 
-script "js_regions_map", type: "javascript" do
-  parameters "param_allowed_regions"
-  result "regions_map"
-  code <<-EOS
-  all_regions = [
-    "us-east-1", "us-east-2", "us-west-1", "us-west-2", "af-south-1",
-    "ap-east-1", "ap-southeast-3", "ap-south-1", "ap-northeast-3",
-    "ap-northeast-2", "ap-southeast-1", "ap-southeast-2",
-    "ap-northeast-1", "ca-central-1", "eu-central-1", "eu-west-1",
-    "eu-west-2", "eu-south-1", "eu-west-3", "eu-north-1",
-    "me-south-1", "sa-east-1", "us-gov-east-1", "us-gov-west-1"
-  ]
-
-  regions_map = []
-
-  param_disallowed_regions = []
-
-  _.each(all_regions, function(region) {
-    disallowed = true
-
-    _.each(param_allowed_regions, function(allowed_region) {
-      if (region == allowed_region.trim()) {
-        disallowed = false
-      }
-    })
-
-    if (disallowed) {
-      param_disallowed_regions.push(region.trim())
-    }
-  })
-
-  _.each(param_disallowed_regions, function(disallowed_region) {
-    regions_map.push({
-      "region": disallowed_region
-    })
-  })
-EOS
-end
-
 ###############################################################################
 # Escalations
 ###############################################################################
@@ -228,7 +239,7 @@ end
 ###############################################################################
 
 policy "pol_list_aws_instances" do
-  validate $ds_list_aws_instances do
+  validate $ds_all_regions do
     summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} AWS Instances in Disallowed regions"
     export do
       resource_level true
@@ -258,7 +269,7 @@ end
 # Cloud Workflow
 ###############################################################################
 
-#https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TerminateInstances.html
+# https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TerminateInstances.html
 define terminate_instances($data) return $all_responses do
   $$debug=true
   $all_responses = []

--- a/compliance/aws/disallowed_regions/aws_disallowed_regions.pt
+++ b/compliance/aws/disallowed_regions/aws_disallowed_regions.pt
@@ -50,7 +50,6 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Terminate Instances"]
-  default []
 end
 
 ###############################################################################
@@ -239,8 +238,8 @@ end
 ###############################################################################
 
 policy "pol_list_aws_instances" do
-  validate $ds_all_regions do
-    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} AWS Instances in Disallowed regions"
+  validate $ds_list_aws_instances do
+    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} AWS Instance(s) in Disallowed regions"
     export do
       resource_level true
       field "id" do


### PR DESCRIPTION
This is a modification of the AWS Disallowed Regions Policy. The user now has to specify a list of regions to allow rather than a list of regions to disallow. There's also been some general cleanup to bring the policy more in line with our current best practices.

Tested and works as expected.