### PR TITLE
Fix: Add `auth: $$auth_rs` for authentication to policy sync template

### DIFF
--- a/tools/policy_sync/CHANGELOG.md
+++ b/tools/policy_sync/CHANGELOG.md
@@ -1,6 +1,5 @@
 # CHANGELOG
 
-
 ## v1.14
 
 - Add `auth: $$auth_rs` to `upload_template()` definition

--- a/tools/policy_sync/CHANGELOG.md
+++ b/tools/policy_sync/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+
+## v1.14
+
+- Add `auth: $$auth_rs` to `upload_template()` definition
+
 ## v1.13
 
 - updating for flexera-public

--- a/tools/policy_sync/policy_sync.pt
+++ b/tools/policy_sync/policy_sync.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Operational"
 default_frequency "15 minutes"
 info(
-  version: "1.13",
+  version: "1.14",
   publish: "false",
   provider: "Flexera",
   service: "Policy Engine",

--- a/tools/policy_sync/policy_sync.pt
+++ b/tools/policy_sync/policy_sync.pt
@@ -183,6 +183,7 @@ define upload_template($data, $project_id, $param_governance_host, $param_publis
       $file_name = last(split($item["file_name"],'/'))
 
       $create_response = http_request(
+        auth: $$auth_rs,
         verb: "post",
         https: true,
         host: $param_governance_host,
@@ -199,6 +200,7 @@ define upload_template($data, $project_id, $param_governance_host, $param_publis
       end
       if $create_response["code"] == 409
         $update_response = http_request(
+          auth: $$auth_rs,
           verb: "put",
           https: true,
           host: $param_governance_host,
@@ -212,6 +214,7 @@ define upload_template($data, $project_id, $param_governance_host, $param_publis
       end
       if ( $param_publish == 1 ) && ( $item["name"] != "Policy Template Synchronization" )
         $publish_response = http_request(
+          auth: $$auth_rs,
           verb: "post",
           https: true,
           host: $param_governance_host,
@@ -222,6 +225,7 @@ define upload_template($data, $project_id, $param_governance_host, $param_publis
         $response_array << $publish_response
         if $publish_response["code"] == 409
           $upublish_response = http_request(
+            auth: $$auth_rs,
             verb: "put",
             https: true,
             host: $param_governance_host,


### PR DESCRIPTION
### Description

Adds `auth: $$auth_rs` to the Flexera API requests in CWF definition.  Currently actions are receiving unauthorized and this is the reason EU Policies are not being published/updated as expected.
