### PR TITLE
Fix: Disable random branch suffix on Actions Workflow

### DIFF
--- a/.github/workflows/update_eu_policies.yml
+++ b/.github/workflows/update_eu_policies.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - bryankaraffa/* # For dev only
+
 jobs:
   EU_PoliciesPromotion:
     runs-on: ubuntu-latest

--- a/.github/workflows/update_eu_policies.yml
+++ b/.github/workflows/update_eu_policies.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - bryankaraffa/* # For dev only
 jobs:
   EU_PoliciesPromotion:
     runs-on: ubuntu-latest
@@ -24,8 +25,6 @@ jobs:
           branch: master
           title: Update EU_Policies with latest changes from master
           body: Automatically updating the EU_Policies branch on master merge.
-          branch-suffix: random
-          delete-branch: true
           draft: true
           labels: READY-FOR-REVIEW
       - name: Check outputs


### PR DESCRIPTION
### Description

Modifies the GitHub Actions workflow that creates a "Release Candidate" Pull Request to sync changes from `master` branch into `EU_Policies` branch.

Disabling random branch creation will reduce the amount of Pull Requests that are created by this automation and disable the amount of manual cleanup necessary.  Using alternative branching strategies like random is also [not recommended by the actions developer](https://github.com/peter-evans/create-pull-request#alternative-strategy---always-create-a-new-pull-request-branch).