### PR TITLE
Revert #1066

### DIFF
--- a/.github/workflows/update_eu_policies.yml
+++ b/.github/workflows/update_eu_policies.yml
@@ -25,6 +25,8 @@ jobs:
           branch: master
           title: Update EU_Policies with latest changes from master
           body: Automatically updating the EU_Policies branch on master merge.
+          branch-suffix: random
+          delete-branch: true
           draft: true
           labels: READY-FOR-REVIEW
       - name: Check outputs


### PR DESCRIPTION
Reverts changes from #1066 .  This is required because we can't resolve conflicts with a `master` -> `EU_Policies` PR (Example in https://github.com/flexera-public/policy_templates/pull/1067 )