### PR TITLE
feat: DescribeRegions filter out not-opted-in

### DIFF
--- a/compliance/aws/disallowed_regions/CHANGELOG.md
+++ b/compliance/aws/disallowed_regions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.7
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.6
 
 - Flipped parameter to enable user to specify which reasons to allow instead of which to disallow.

--- a/compliance/aws/disallowed_regions/aws_disallowed_regions.pt
+++ b/compliance/aws/disallowed_regions/aws_disallowed_regions.pt
@@ -82,25 +82,9 @@ end
 # Datasources
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -109,26 +93,25 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"
-    collect xpath(response, "//DescribeRegionsResponse/regionInfo/item") do
-      field "regionName", xpath(col_item, "regionName")
-      field "regionEndpoint", xpath(col_item, "regionEndpoint")
+    collect xpath(response, "//DescribeRegionsResponse/regionInfo/item", "array") do
+      field "region", xpath(col_item, "regionName")
     end
   end
 end
 
-# Generates list of Regions which User input.
-datasource "ds_regions_list" do
-  run_script $js_regions_map, $ds_all_regions, $param_allowed_regions
+# Get only SCP enabled regions
+datasource "ds_regions" do
+  run_script $js_regions, $param_allowed_regions, $ds_regions_list
 end
-
 # Get the list of all EC2 Instances across all regions.
 # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html
 datasource "ds_disallowed_instances_list" do
-  iterate $ds_regions_list
+  iterate $ds_regions
   request do
     auth $auth_aws
     pagination $aws_pagination_xml
@@ -163,26 +146,36 @@ end
 # Scripts
 ###############################################################################
 
-script "js_regions_map", type: "javascript" do
-  parameters "ds_all_regions", "param_allowed_regions"
-  result "regions_map"
+script "js_regions", type:"javascript" do
+  parameters "user_entered_regions", "all_regions"
+  result "regions"
   code <<-EOS
-  regions_map = []
+    if(_.isEmpty(user_entered_regions)){
+      regions = all_regions;
+    }else{
+      //Filter unique regions
+      var uniqueRegions = _.uniq(user_entered_regions);
+      var all_regions_list = [];
+      all_regions.forEach(function(all_region){
+        all_regions_list.push(all_region.region)
+      })
 
-  _.each(ds_all_regions, function(region) {
-    disallowed = true
+      //Filter valid regions
+      var valid_regions = [];
+      _.map(uniqueRegions, function(uniqueRegion){
+        if(all_regions_list.indexOf(uniqueRegion) > -1){
+          valid_regions.push({"region": uniqueRegion})
+        }
+      })
 
-    _.each(param_allowed_regions, function(allowed_region) {
-      if (region['regionName'].trim() == allowed_region.trim()) {
-        disallowed = false
+      //Throw an error if no valid regions found
+      if (_.isEmpty(valid_regions)) {
+        regions = all_regions;
+      }else{
+        regions = valid_regions
       }
-    })
-
-    if (disallowed) {
-      regions_map.push(region)
     }
-  })
-EOS
+  EOS
 end
 
 script "js_filter_aws_instances", type: "javascript" do

--- a/compliance/aws/disallowed_regions/aws_disallowed_regions.pt
+++ b/compliance/aws/disallowed_regions/aws_disallowed_regions.pt
@@ -7,7 +7,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "2.6",
+  version: "2.7",
   provider: "AWS",
   service: "EC2",
   policy_set: "Disallowed Regions"
@@ -82,16 +82,34 @@ end
 # Datasources
 ###############################################################################
 
-# Get a list of all active AWS regions on the account
-datasource "ds_all_regions" do
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
+datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
-    pagination $aws_pagination_xml
     verb "GET"
     host "ec2.amazonaws.com"
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/compliance/aws/ecs_unused/CHANGELOG.md
+++ b/compliance/aws/ecs_unused/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.8
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.7
 
 - Added default to aws_account_number parameter to enable existing API users.

--- a/compliance/aws/ecs_unused/aws_unused_ecs_clusters.pt
+++ b/compliance/aws/ecs_unused/aws_unused_ecs_clusters.pt
@@ -6,7 +6,7 @@ long_description ""
 category "Compliance"
 severity "low"
 info(
-  version: "2.7",
+  version: "2.8",
   provider: "AWS",
   service: "ECS",
   policy_set: ""
@@ -66,8 +66,25 @@ end
 # Datasources
 ###############################################################################
 
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -75,6 +92,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/compliance/aws/ecs_unused/aws_unused_ecs_clusters.pt
+++ b/compliance/aws/ecs_unused/aws_unused_ecs_clusters.pt
@@ -66,25 +66,9 @@ end
 # Datasources
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -93,7 +77,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/compliance/aws/instances_without_fnm_agent/CHANGELOG.md
+++ b/compliance/aws/instances_without_fnm_agent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.9
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.8
 
 - Added default to aws_account_number parameter to enable existing API users.

--- a/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent.pt
+++ b/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent.pt
@@ -6,7 +6,7 @@ long_description ""
 severity "medium"
 category "Compliance"
 info(
-  version: "2.8",
+  version: "2.9",
   provider: "AWS",
   service: "EC2",
   policy_set: "Instances not running FlexNet Inventory Agent"
@@ -92,8 +92,25 @@ end
 # Datasources
 ###############################################################################
 
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -101,6 +118,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent.pt
+++ b/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent.pt
@@ -92,25 +92,9 @@ end
 # Datasources
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -119,7 +103,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/compliance/aws/long_stopped_instances/CHANGELOG.md
+++ b/compliance/aws/long_stopped_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.8
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.7
 
 - Added default to aws_account_number parameter to enable existing API users.

--- a/compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt
+++ b/compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt
@@ -6,7 +6,7 @@ long_description ""
 category "Compliance"
 severity "low"
 info(
-  version: "2.7",
+  version: "2.8",
   provider: "AWS",
   service: "EC2",
   policy_set: "Long Stopped Instances"
@@ -87,8 +87,25 @@ end
 # Datasources
 ###############################################################################
 
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -96,6 +113,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt
+++ b/compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt
@@ -87,25 +87,9 @@ end
 # Datasources
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -114,7 +98,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/compliance/aws/untagged_resources/CHANGELOG.md
+++ b/compliance/aws/untagged_resources/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.7
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.6
 
 - Added default to aws_account_number parameter to enable existing API users.

--- a/compliance/aws/untagged_resources/aws_untagged_resources.pt
+++ b/compliance/aws/untagged_resources/aws_untagged_resources.pt
@@ -6,7 +6,7 @@ long_description ""
 category "Compliance"
 severity "low"
 info(
-  version: "2.6",
+  version: "2.7",
   provider: "AWS",
   service: "",
   policy_set:"Untagged resources"
@@ -71,8 +71,25 @@ end
 # Datasources
 ###############################################################################
 
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -80,6 +97,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/compliance/aws/untagged_resources/aws_untagged_resources.pt
+++ b/compliance/aws/untagged_resources/aws_untagged_resources.pt
@@ -71,25 +71,9 @@ end
 # Datasources
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -98,7 +82,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/cost/aws/burstable_instance_cloudwatch_credit_utilization/CHANGELOG.md
+++ b/cost/aws/burstable_instance_cloudwatch_credit_utilization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.11
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.10
 
 - Added default to aws_account_number parameter to enable existing API users.

--- a/cost/aws/burstable_instance_cloudwatch_credit_utilization/aws_burstable_instance_cloudwatch_credit_utilization.pt
+++ b/cost/aws/burstable_instance_cloudwatch_credit_utilization/aws_burstable_instance_cloudwatch_credit_utilization.pt
@@ -109,25 +109,9 @@ datasource "ds_get_caller_identity" do
   end
 end
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -136,7 +120,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/cost/aws/burstable_instance_cloudwatch_credit_utilization/aws_burstable_instance_cloudwatch_credit_utilization.pt
+++ b/cost/aws/burstable_instance_cloudwatch_credit_utilization/aws_burstable_instance_cloudwatch_credit_utilization.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.10",
+  version: "2.11",
   provider: "AWS",
   service: "EC2",
   policy_set: ""
@@ -109,8 +109,25 @@ datasource "ds_get_caller_identity" do
   end
 end
 
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -118,6 +135,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/cost/aws/elb/clb_unused/CHANGELOG.md
+++ b/cost/aws/elb/clb_unused/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.16
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.15
 
 - Added default to aws_account_number parameter to enable existing API users.

--- a/cost/aws/elb/clb_unused/aws_delete_unused_clb.pt
+++ b/cost/aws/elb/clb_unused/aws_delete_unused_clb.pt
@@ -78,25 +78,9 @@ auth "auth_rs", type: "rightscale"
 # Datasources
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -105,7 +89,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/cost/aws/elb/clb_unused/aws_delete_unused_clb.pt
+++ b/cost/aws/elb/clb_unused/aws_delete_unused_clb.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.15",
+  version: "2.16",
   provider: "AWS",
   service: "ELB",
   policy_set: ""
@@ -78,8 +78,25 @@ auth "auth_rs", type: "rightscale"
 # Datasources
 ###############################################################################
 
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -87,6 +104,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/cost/aws/gp3_volume_upgrade/CHANGELOG.md
+++ b/cost/aws/gp3_volume_upgrade/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.6
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.5
 
 - Added default to aws_account_number parameter to enable existing API users.

--- a/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume.pt
+++ b/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume.pt
@@ -109,25 +109,9 @@ end
 # Datasource
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -136,7 +120,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume.pt
+++ b/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.5",
+  version: "2.6",
   provider: "AWS",
   service: "EBS",
   policy_set: "GP3 Volumes"
@@ -109,8 +109,25 @@ end
 # Datasource
 ###############################################################################
 
-# Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -118,6 +135,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/cost/aws/idle_compute_instances/CHANGELOG.md
+++ b/cost/aws/idle_compute_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.6
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v3.5
 
 - GetMetricData is now used to gather metrics data in batches for faster policy execution.

--- a/cost/aws/idle_compute_instances/idle_compute_instances.pt
+++ b/cost/aws/idle_compute_instances/idle_compute_instances.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "3.5",
+  version: "3.6",
   provider: "AWS",
   service: "EC2",
   policy_set: "Idle Compute Instances"
@@ -169,7 +169,25 @@ datasource "ds_aws_account" do
   run_script $js_aws_account, $ds_get_caller_identity
 end
 
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -177,6 +195,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/cost/aws/idle_compute_instances/idle_compute_instances.pt
+++ b/cost/aws/idle_compute_instances/idle_compute_instances.pt
@@ -169,25 +169,9 @@ datasource "ds_aws_account" do
   run_script $js_aws_account, $ds_get_caller_identity
 end
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -196,7 +180,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/cost/aws/instance_cloudwatch_utilization/CHANGELOG.md
+++ b/cost/aws/instance_cloudwatch_utilization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.15
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.14
 
 - Added default to aws_account_number parameter to enable existing API users.

--- a/cost/aws/instance_cloudwatch_utilization/aws_instance_cloudwatch_utilization.pt
+++ b/cost/aws/instance_cloudwatch_utilization/aws_instance_cloudwatch_utilization.pt
@@ -126,25 +126,9 @@ datasource "ds_get_caller_identity" do
   end
 end
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -153,7 +137,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/cost/aws/instance_cloudwatch_utilization/aws_instance_cloudwatch_utilization.pt
+++ b/cost/aws/instance_cloudwatch_utilization/aws_instance_cloudwatch_utilization.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.14",
+  version: "2.15",
   provider: "AWS",
   service: "EC2",
   policy_set: "Inefficient Instance Usage"
@@ -126,8 +126,25 @@ datasource "ds_get_caller_identity" do
   end
 end
 
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -135,6 +152,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/cost/aws/old_snapshots/CHANGELOG.md
+++ b/cost/aws/old_snapshots/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.5
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v3.4
 
 - Modified Image (AMI) datasource collection to improve policy efficiency

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -191,25 +191,9 @@ datasource "ds_snapshot_costs" do
   end
 end
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -218,7 +202,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "3.4",
+  version: "3.5",
   provider: "AWS",
   service: "EBS",
   policy_set: "Old Snapshots"
@@ -191,8 +191,25 @@ datasource "ds_snapshot_costs" do
   end
 end
 
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -200,6 +217,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/cost/aws/rds_instance_cloudwatch_utilization/CHANGELOG.md
+++ b/cost/aws/rds_instance_cloudwatch_utilization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.13
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.12
 
 - Added default to aws_account_number parameter to enable existing API users.

--- a/cost/aws/rds_instance_cloudwatch_utilization/rds_instance_cloudwatch_utilization.pt
+++ b/cost/aws/rds_instance_cloudwatch_utilization/rds_instance_cloudwatch_utilization.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.12",
+  version: "2.13",
   provider: "AWS",
   service: "RDS",
   policy_set: "RightSize Database Services"
@@ -111,8 +111,25 @@ datasource "ds_get_caller_identity" do
   end
 end
 
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -120,6 +137,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/cost/aws/rds_instance_cloudwatch_utilization/rds_instance_cloudwatch_utilization.pt
+++ b/cost/aws/rds_instance_cloudwatch_utilization/rds_instance_cloudwatch_utilization.pt
@@ -111,25 +111,9 @@ datasource "ds_get_caller_identity" do
   end
 end
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -138,7 +122,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/cost/aws/rds_instance_license_info/CHANGELOG.md
+++ b/cost/aws/rds_instance_license_info/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.9
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.8
 
 - Added default to aws_account_number parameter to enable existing API users.

--- a/cost/aws/rds_instance_license_info/rds_instance_license_info.pt
+++ b/cost/aws/rds_instance_license_info/rds_instance_license_info.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.8",
+  version: "2.9",
   provider: "AWS",
   service: "RDS",
   policy_set: ""
@@ -76,8 +76,25 @@ datasource "ds_get_caller_identity" do
   end
 end
 
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -85,6 +102,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/cost/aws/rds_instance_license_info/rds_instance_license_info.pt
+++ b/cost/aws/rds_instance_license_info/rds_instance_license_info.pt
@@ -76,25 +76,9 @@ datasource "ds_get_caller_identity" do
   end
 end
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -103,7 +87,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/cost/aws/schedule_instance/CHANGELOG.md
+++ b/cost/aws/schedule_instance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.11
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.10
 
 - Added default to aws_account_number parameter to enable existing API users.

--- a/cost/aws/schedule_instance/aws_schedule_instance.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.10",
+  version: "2.11",
   provider: "AWS",
   service: "EC2",
   policy_set:"Schedule Instance"
@@ -97,8 +97,25 @@ datasource "ds_get_caller_identity" do
   end
 end
 
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -106,6 +123,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/cost/aws/schedule_instance/aws_schedule_instance.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance.pt
@@ -97,25 +97,9 @@ datasource "ds_get_caller_identity" do
   end
 end
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -124,7 +108,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/cost/aws/unused_ip_addresses/CHANGELOG.md
+++ b/cost/aws/unused_ip_addresses/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.5
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v3.4
 
 - updated savings_currency to savingsCurrency

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-    version: "3.4",
+    version: "3.5",
     provider: "AWS",
     service: "EC2",
     policy_set: "Unused IP Addresses"
@@ -94,8 +94,25 @@ end
 # Datasources
 ###############################################################################
 
-# Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -103,6 +120,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
@@ -94,25 +94,9 @@ end
 # Datasources
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -121,7 +105,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/cost/aws/unused_rds/CHANGELOG.md
+++ b/cost/aws/unused_rds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.6
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v3.5
 
 - Improved accuracy of metric collection by using a different Statistic to identify idle resources

--- a/cost/aws/unused_rds/unused_rds.pt
+++ b/cost/aws/unused_rds/unused_rds.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "3.5",
+  version: "3.6",
   provider: "AWS",
   service: "RDS",
   policy_set: "Unused Database Services"
@@ -91,8 +91,25 @@ end
 # Datasources
 ###############################################################################
 
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -100,6 +117,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/cost/aws/unused_rds/unused_rds.pt
+++ b/cost/aws/unused_rds/unused_rds.pt
@@ -91,25 +91,9 @@ end
 # Datasources
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -118,7 +102,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/cost/aws/unused_volumes/CHANGELOG.md
+++ b/cost/aws/unused_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.7
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v3.6
 
 - Refactored datasources from `cloudwatch:GetMetricStatistics` to `cloudwatch:GetMetricData` to improve efficiency of metric data collection

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "3.6",
+  version: "3.7",
   provider: "AWS",
   service: "EBS",
   policy_set: "Unused Volumes"
@@ -132,8 +132,25 @@ end
 # Datasources
 ###############################################################################
 
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -141,6 +158,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
@@ -132,25 +132,9 @@ end
 # Datasources
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -159,7 +143,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/operational/aws/instance_scheduled_events/CHANGELOG.md
+++ b/operational/aws/instance_scheduled_events/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.8
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.7
 
 - Added default to aws_account_number parameter to enable existing API users.

--- a/operational/aws/instance_scheduled_events/aws_instance_scheduled_events.pt
+++ b/operational/aws/instance_scheduled_events/aws_instance_scheduled_events.pt
@@ -6,7 +6,7 @@ long_description ""
 category "Operational"
 severity "medium"
 info(
-  version: "2.7",
+  version: "2.8",
   provider: "AWS",
   service: "EC2",
   policy_set: ""
@@ -72,9 +72,25 @@ end
 # Datasources
 ###############################################################################
 
-#Generates list of Regions.
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -82,6 +98,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/operational/aws/instance_scheduled_events/aws_instance_scheduled_events.pt
+++ b/operational/aws/instance_scheduled_events/aws_instance_scheduled_events.pt
@@ -72,25 +72,9 @@ end
 # Datasources
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -99,7 +83,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/operational/aws/lambda_functions_with_high_error_rate/CHANGELOG.md
+++ b/operational/aws/lambda_functions_with_high_error_rate/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.4
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.3
 
 - Added default to aws_account_number parameter to enable existing API users.

--- a/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate.pt
+++ b/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate.pt
@@ -7,7 +7,7 @@ category "Operational"
 severity "high"
 default_frequency "hourly"
 info(
-  version: "2.3",
+  version: "2.4",
   provider: "AWS",
   service: "Lambda",
   policy_set: ""
@@ -77,9 +77,25 @@ end
 # Datasources
 ###############################################################################
 
-#Generates list of Regions
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -87,6 +103,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate.pt
+++ b/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate.pt
@@ -77,25 +77,9 @@ end
 # Datasources
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -104,7 +88,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/operational/aws/long_running_instances/CHANGELOG.md
+++ b/operational/aws/long_running_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.9
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.8
 
 - Added default to aws_account_number parameter to enable existing API users.

--- a/operational/aws/long_running_instances/long_running_instances.pt
+++ b/operational/aws/long_running_instances/long_running_instances.pt
@@ -89,25 +89,9 @@ end
 # Datasources
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -116,7 +100,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/operational/aws/long_running_instances/long_running_instances.pt
+++ b/operational/aws/long_running_instances/long_running_instances.pt
@@ -6,7 +6,7 @@ long_description ""
 severity "low"
 category "Operational"
 info(
-  version: "2.8",
+  version: "2.9",
   provider: "AWS",
   service: "EC2",
   policy_set: "Long Running Instances"
@@ -89,8 +89,25 @@ end
 # Datasources
 ###############################################################################
 
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -98,6 +115,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/operational/aws/subnet_name_sync/CHANGELOG.md
+++ b/operational/aws/subnet_name_sync/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.9
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.8
 
 - Added default to aws_account_number parameter to enable existing API users.

--- a/operational/aws/subnet_name_sync/aws_subnet_name_sync.pt
+++ b/operational/aws/subnet_name_sync/aws_subnet_name_sync.pt
@@ -7,7 +7,7 @@ severity "medium"
 category "Operational"
 info(
   publish: "false",
-  version: "2.8",
+  version: "2.9",
   provider: "AWS",
   service: "VPC",
   policy_set: "",
@@ -96,8 +96,25 @@ end
 # Datasources
 ###############################################################################
 
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -105,6 +122,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/operational/aws/subnet_name_sync/aws_subnet_name_sync.pt
+++ b/operational/aws/subnet_name_sync/aws_subnet_name_sync.pt
@@ -96,25 +96,9 @@ end
 # Datasources
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -123,7 +107,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/operational/aws/vpc_name_sync/CHANGELOG.md
+++ b/operational/aws/vpc_name_sync/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.9
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.8
 
 - Added default to aws_account_number parameter to enable existing API users.

--- a/operational/aws/vpc_name_sync/aws_vpc_name_sync.pt
+++ b/operational/aws/vpc_name_sync/aws_vpc_name_sync.pt
@@ -98,25 +98,9 @@ end
 # Datasources
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -125,7 +109,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/operational/aws/vpc_name_sync/aws_vpc_name_sync.pt
+++ b/operational/aws/vpc_name_sync/aws_vpc_name_sync.pt
@@ -7,7 +7,7 @@ severity "medium"
 category "Operational"
 info(
   publish: "false",
-  version: "2.8",
+  version: "2.9",
   provider: "AWS",
   service: "VPC",
   policy_set: "",
@@ -98,8 +98,25 @@ end
 # Datasources
 ###############################################################################
 
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -107,6 +124,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/operational/dbaas/aws/rds_backup/CHANGELOG.md
+++ b/operational/dbaas/aws/rds_backup/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.6
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.5
 
 - updated README.md rightscale documentation links with docs.flexera documentation links

--- a/operational/dbaas/aws/rds_backup/aws_rds_backup.pt
+++ b/operational/dbaas/aws/rds_backup/aws_rds_backup.pt
@@ -78,25 +78,9 @@ end
 # Datasources
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -105,7 +89,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/operational/dbaas/aws/rds_backup/aws_rds_backup.pt
+++ b/operational/dbaas/aws/rds_backup/aws_rds_backup.pt
@@ -6,7 +6,7 @@ long_description ""
 severity "medium"
 category "Operational"
 info(
-  version: "2.5",
+  version: "2.6",
   provider: "AWS",
   service: "RDS",
   policy_set: ""
@@ -78,8 +78,25 @@ end
 # Datasources
 ###############################################################################
 
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -87,6 +104,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/security/aws/aws_config_enabled/CHANGELOG.md
+++ b/security/aws/aws_config_enabled/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.0
 
 - initial release

--- a/security/aws/aws_config_enabled/aws_config_enabled.pt
+++ b/security/aws/aws_config_enabled/aws_config_enabled.pt
@@ -7,7 +7,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "2.0",
+  version: "2.1",
   provider: "AWS",
   service: "Config",
   policy_set: "CIS",
@@ -44,8 +44,25 @@ end
 # Datasources
 ###############################################################################
 
-# Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -53,6 +70,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/security/aws/aws_config_enabled/aws_config_enabled.pt
+++ b/security/aws/aws_config_enabled/aws_config_enabled.pt
@@ -44,25 +44,9 @@ end
 # Datasources
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -71,7 +55,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/security/aws/clb_unencrypted/CHANGELOG.md
+++ b/security/aws/clb_unencrypted/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.9
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.8
 
 - Added default to aws_account_number parameter to enable existing API users.

--- a/security/aws/clb_unencrypted/aws_clb_encryption.pt
+++ b/security/aws/clb_unencrypted/aws_clb_encryption.pt
@@ -6,7 +6,7 @@ long_description ""
 category "Security"
 severity "medium"
 info(
-  version: "2.8",
+  version: "2.9",
   provider: "AWS",
   service: "ELB",
   policy_set: ""
@@ -71,8 +71,25 @@ end
 # Datasources
 ###############################################################################
 
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -80,6 +97,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/security/aws/clb_unencrypted/aws_clb_encryption.pt
+++ b/security/aws/clb_unencrypted/aws_clb_encryption.pt
@@ -71,25 +71,9 @@ end
 # Datasources
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -98,7 +82,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/security/aws/ebs_ensure_encryption_default/CHANGELOG.md
+++ b/security/aws/ebs_ensure_encryption_default/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.1
 
 - updated README.md rightscale documentation links with docs.flexera documentation links

--- a/security/aws/ebs_ensure_encryption_default/ebs_ensure_encryption_default.pt
+++ b/security/aws/ebs_ensure_encryption_default/ebs_ensure_encryption_default.pt
@@ -52,25 +52,9 @@ end
 # Datasources
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -79,7 +63,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/security/aws/ebs_ensure_encryption_default/ebs_ensure_encryption_default.pt
+++ b/security/aws/ebs_ensure_encryption_default/ebs_ensure_encryption_default.pt
@@ -7,7 +7,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "2.1",
+  version: "2.2",
   provider: "AWS",
   service: "DBS",
   policy_set: "CIS",
@@ -52,8 +52,25 @@ end
 # Datasources
 ###############################################################################
 
-# Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -61,6 +78,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/security/aws/ebs_unencrypted_volumes/CHANGELOG.md
+++ b/security/aws/ebs_unencrypted_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.9
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.8
 
 - Added default to aws_account_number parameter to enable existing API users.

--- a/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes.pt
+++ b/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes.pt
@@ -6,7 +6,7 @@ long_description ""
 category "Security"
 severity "low"
 info(
-  version: "2.8",
+  version: "2.9",
   provider: "AWS",
   service: "EBS",
   policy_set: ""
@@ -72,8 +72,25 @@ end
 # Datasource
 ###############################################################################
 
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -81,6 +98,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes.pt
+++ b/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes.pt
@@ -72,25 +72,9 @@ end
 # Datasource
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -99,7 +83,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/security/aws/elb_unencrypted/CHANGELOG.md
+++ b/security/aws/elb_unencrypted/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.9
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.8
 
 - Added default to aws_account_number parameter to enable existing API users.

--- a/security/aws/elb_unencrypted/aws_elb_encryption.pt
+++ b/security/aws/elb_unencrypted/aws_elb_encryption.pt
@@ -6,7 +6,7 @@ long_description ""
 category "Security"
 severity "medium"
 info(
-  version: "2.8",
+  version: "2.9",
   provider: "AWS",
   service: "ELB",
   policy_set: ""
@@ -80,9 +80,25 @@ end
 # Datasources
 ###############################################################################
 
-#Generates list of Regions
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -90,6 +106,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/security/aws/elb_unencrypted/aws_elb_encryption.pt
+++ b/security/aws/elb_unencrypted/aws_elb_encryption.pt
@@ -80,25 +80,9 @@ end
 # Datasources
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -107,7 +91,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/security/aws/kms_rotation/CHANGELOG.md
+++ b/security/aws/kms_rotation/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.0
 
 - initial release

--- a/security/aws/kms_rotation/kms_rotation.pt
+++ b/security/aws/kms_rotation/kms_rotation.pt
@@ -7,7 +7,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "2.0",
+  version: "2.1",
   provider: "AWS",
   service: "KMS",
   policy_set: "CIS",
@@ -44,7 +44,25 @@ end
 # Datasources
 ###############################################################################
 
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -52,6 +70,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/security/aws/kms_rotation/kms_rotation.pt
+++ b/security/aws/kms_rotation/kms_rotation.pt
@@ -44,25 +44,9 @@ end
 # Datasources
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -71,7 +55,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/security/aws/loadbalancer_internet_facing/CHANGELOG.md
+++ b/security/aws/loadbalancer_internet_facing/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.9
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.8
 
 - Added default to aws_account_number parameter to enable existing API users.

--- a/security/aws/loadbalancer_internet_facing/aws_internet-facing_elbs.pt
+++ b/security/aws/loadbalancer_internet_facing/aws_internet-facing_elbs.pt
@@ -6,7 +6,7 @@ long_description ""
 category "Security"
 severity "high"
 info(
-  version: "2.8",
+  version: "2.9",
   provider: "AWS",
   service: "ELB",
   policy_set: ""
@@ -79,7 +79,25 @@ end
 # Datasources
 ###############################################################################
 
-datasource "ds_region_list" do
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
+datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -87,6 +105,8 @@ datasource "ds_region_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/security/aws/loadbalancer_internet_facing/aws_internet-facing_elbs.pt
+++ b/security/aws/loadbalancer_internet_facing/aws_internet-facing_elbs.pt
@@ -79,25 +79,9 @@ end
 # Datasources
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -106,7 +90,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/security/aws/loadbalancer_internet_facing/aws_internet-facing_elbs.pt
+++ b/security/aws/loadbalancer_internet_facing/aws_internet-facing_elbs.pt
@@ -107,13 +107,13 @@ datasource "ds_regions" do
 end
 
 #Generates list of Regions with Load Balancer type and API version.
-datasource "ds_regions_list" do
+datasource "ds_regions_map" do
   run_script $js_regions_map, $ds_regions
 end
 
 #Get the list of all Classic and application load Balancers
 datasource "ds_elb_list" do
-  iterate $ds_regions_list
+  iterate $ds_regions_map
   request do
     run_script $js_elb_list, val(iter_item,"region"), val(iter_item,"API_version")
   end

--- a/security/aws/loadbalancer_internet_facing/aws_internet-facing_elbs.pt
+++ b/security/aws/loadbalancer_internet_facing/aws_internet-facing_elbs.pt
@@ -103,7 +103,7 @@ end
 
 # Get only SCP enabled regions
 datasource "ds_regions" do
-  run_script $js_regions, $param_allowed_regions, $ds_region_list
+  run_script $js_regions, $param_allowed_regions, $ds_regions_list
 end
 
 #Generates list of Regions with Load Balancer type and API version.

--- a/security/aws/rds_publicly_accessible/CHANGELOG.md
+++ b/security/aws/rds_publicly_accessible/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.9
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.8
 
 - Added default to aws_account_number parameter to enable existing API users.

--- a/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances.pt
+++ b/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances.pt
@@ -6,7 +6,7 @@ long_description ""
 category "Security"
 severity "high"
 info(
-  version: "2.8",
+  version: "2.9",
   provider: "AWS",
   service: "RDS",
   policy_set: "Public Database Access"
@@ -79,8 +79,25 @@ end
 # Datasources
 ###############################################################################
 
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -88,6 +105,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances.pt
+++ b/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances.pt
@@ -79,25 +79,9 @@ end
 # Datasources
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -106,7 +90,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/security/aws/rds_unencrypted/CHANGELOG.md
+++ b/security/aws/rds_unencrypted/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.10
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.9
 
 - Added default to aws_account_number parameter to enable existing API users.

--- a/security/aws/rds_unencrypted/aws_unencrypted_rds_instances.pt
+++ b/security/aws/rds_unencrypted/aws_unencrypted_rds_instances.pt
@@ -7,7 +7,7 @@ category "Security"
 severity "medium"
 default_frequency "daily"
 info(
-  version: "2.9",
+  version: "2.10",
   provider: "AWS",
   service: "RDS",
   policy_set: "CIS",
@@ -85,9 +85,25 @@ end
 # Datasources
 ###############################################################################
 
-#Generates list of Regions
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -95,6 +111,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/security/aws/rds_unencrypted/aws_unencrypted_rds_instances.pt
+++ b/security/aws/rds_unencrypted/aws_unencrypted_rds_instances.pt
@@ -85,25 +85,9 @@ end
 # Datasources
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -112,7 +96,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/security/aws/vpcs_without_flow_logs_enabled/CHANGELOG.md
+++ b/security/aws/vpcs_without_flow_logs_enabled/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.4
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.3
 
 - Added default to aws_account_number parameter to enable existing API users.

--- a/security/aws/vpcs_without_flow_logs_enabled/aws_vpcs_without_flow_logs_enabled.pt
+++ b/security/aws/vpcs_without_flow_logs_enabled/aws_vpcs_without_flow_logs_enabled.pt
@@ -71,25 +71,9 @@ end
 # Datasources
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -98,7 +82,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"

--- a/security/aws/vpcs_without_flow_logs_enabled/aws_vpcs_without_flow_logs_enabled.pt
+++ b/security/aws/vpcs_without_flow_logs_enabled/aws_vpcs_without_flow_logs_enabled.pt
@@ -7,7 +7,7 @@ category "Security"
 severity "medium"
 default_frequency "daily"
 info(
-  version: "2.3",
+  version: "2.4",
   provider: "AWS",
   service: "VPC",
   policy_set: "AWS Config"
@@ -71,9 +71,25 @@ end
 # Datasources
 ###############################################################################
 
-#Generates list of Regions
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -81,6 +97,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/tools/instance_types/CHANGELOG.md
+++ b/tools/instance_types/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2
+
+- Added filter for DescribeRegion to only return regions that are `opted-in` or `opt-in-not-required` [exclude `not-opted-in`] in the current AWS account.
+
 ## v2.1
 
 - updated README.md rightscale documentation links with docs.flexera documentation links

--- a/tools/instance_types/check_new_instance_types.pt
+++ b/tools/instance_types/check_new_instance_types.pt
@@ -6,7 +6,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "2.1",
+  version: "2.2",
   provider: "",
   service: "",
   policy_set: "New Instance Types",
@@ -90,8 +90,25 @@ end
 # Datasource
 ###############################################################################
 
-#Get list of enabled regions for an account
+# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
+datasource "ds_opt_in_params" do
+  run_script $js_opt_in_params
+end
+
+# js_opt_in_params takes no parameters and returns list of 2 strings
+script "js_opt_in_params", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = ["opt-in-not-required", "opted-in"];
+EOS
+end
+
+# ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
+  # iterate through opt-in-status param values and collect list of regions
+  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -99,6 +116,8 @@ datasource "ds_regions_list" do
     path "/"
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", iter_item
   end
   result do
     encoding "xml"

--- a/tools/instance_types/check_new_instance_types.pt
+++ b/tools/instance_types/check_new_instance_types.pt
@@ -90,25 +90,9 @@ end
 # Datasource
 ###############################################################################
 
-# ds_opt_in_params contains list of opt-in-status param values needed to get all regions except "not-opted-in"
-datasource "ds_opt_in_params" do
-  run_script $js_opt_in_params
-end
-
-# js_opt_in_params takes no parameters and returns list of 2 strings
-script "js_opt_in_params", type:"javascript" do
-  result "result"
-  code <<-EOS
-  result = ["opt-in-not-required", "opted-in"];
-EOS
-end
-
 # ds_region_list is a list of regions that are opted-in or opt-in-not-required
 datasource "ds_regions_list" do
-  # iterate through opt-in-status param values and collect list of regions
-  # Effectively `iterate: ["opt-in-not-required", "opted-in"]` but policy template requires iterate over datasource (ds_opt_in_params)
   # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
-  iterate $ds_opt_in_params
   request do
     auth $auth_aws
     verb "GET"
@@ -117,7 +101,8 @@ datasource "ds_regions_list" do
     query "Action", "DescribeRegions"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", iter_item
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
   end
   result do
     encoding "xml"


### PR DESCRIPTION
### Description

[`ec2:DescribeRegions`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html) returns all regions by default -- even those not opted into yet.  New regions by default are not opted into as well, so this combination has resulted increased policy template errors when running without specifying region whitelist [`param_allowed_regions`].  

This change filters only regions that are `opted-in` or `opt-in-not-required` in the current account

### Contribution Check List

- [x] All tests pass.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
