### PR TITLE
Tag cardinality

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ Reference
 - [AWS Long Running Instances](./operational/aws/long_running_instances/)
 - [AWS Instance Scheduled Events](./operational/aws/instance_scheduled_events)
 - [AWS Lambda Functions with high error rate](./operational/aws/lambda_functions_with_high_error_rate/)
+- [AWS Tag Cardinality Report](./operational/aws/tag_cardinality/)
 - [AWS Usage Report - Number of Instance Hours Used](./operational/aws/total_instance_hours/)
 - [AWS Usage Report - Number of Instance vCPUs Used](./operational/aws/total_instance_vcpus/)
 - [AWS Usage Forecast - Number of Instance Hours Used](./operational/aws/total_instance_hours_forecast/)
@@ -400,6 +401,7 @@ Reference
 - [AzureAD Group Sync](./operational/azure/azuread_group_sync/)
 - [Azure Sync Tags with Optima](./operational/azure/sync_tags_with_optima/)
 - [Azure SQL Databases without Elastic Pools](./operational/azure/azure_sql_using_elastic_pool/)
+- [Azure Tag Cardinality Report](./operational/azure/tag_cardinality/)
 
 #### VMWare
 

--- a/operational/aws/tag_cardinality/CHANGELOG.md
+++ b/operational/aws/tag_cardinality/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v2.0
+
+- initial release

--- a/operational/aws/tag_cardinality/README.md
+++ b/operational/aws/tag_cardinality/README.md
@@ -1,0 +1,60 @@
+# AWS Tag Cardinality Report
+
+## What it does
+
+This Policy Template is used to generate a tag cardinality (how frequently each tag value occurs) report for AWS. The report includes cardinality for all tag values for both AWS resources and AWS accounts.
+
+## Functional Details
+
+This policy performs the following action:
+
+- Connect to the AWS Organizations API to get a list of AWS accounts and their tags.
+- Connect to the AWS Tagging API to get a list of AWS resources and their tags.
+
+## Input Parameters
+
+This policy has the following input parameter required when launching the policy.
+
+- *Email addresses of the recipients you wish to notify* - A list of email addresses to notify
+
+## Policy Actions
+
+This read-only policy is purely for reporting purposes and takes no action.
+
+## Prerequisites
+
+This policy uses [credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for connecting to the cloud -- in order to apply this policy you must have a credential registered in the system that is compatible with this policy. If there are no credentials listed when you apply the policy, please contact your cloud admin and ask them to register a credential that is compatible with this policy. The information below should be consulted when creating the credential.
+
+### Credential configuration
+
+For administrators [creating and managing credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) to use with this policy, the following information is needed:
+
+Provider tag value to match this policy: `aws` , `aws_sts`
+
+Required permissions in the provider:
+
+```javascript
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "tag:GetResources",
+        "ec2:DescribeRegions",
+        "organizations:ListAccounts",
+        "organizations:ListTagsForResource"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+## Supported Clouds
+
+- AWS
+
+## Cost
+
+This Policy Template does not incur any cloud costs.

--- a/operational/aws/tag_cardinality/aws_tag_cardinality.pt
+++ b/operational/aws/tag_cardinality/aws_tag_cardinality.pt
@@ -216,7 +216,7 @@ script "js_tag_lister", type: "javascript" do
     _.each(Object.keys(tags[key]), function(value) {
       result.push({
         'type': tag_type,
-        'id': key,
+        'key': key,
         'value': value,
         'cardinality': tags[key][value]
       })
@@ -249,7 +249,7 @@ policy "pol_aws_tag_cardinality_report" do
       field "type" do
         label "Type"
       end
-      field "id" do
+      field "key" do
         label "Key"
       end
       field "value" do

--- a/operational/aws/tag_cardinality/aws_tag_cardinality.pt
+++ b/operational/aws/tag_cardinality/aws_tag_cardinality.pt
@@ -1,13 +1,16 @@
 name "AWS Tag Cardinality Report"
 rs_pt_ver 20180301
 type "policy"
-short_description "Report on AWS tag cardinality in the account"
+short_description "Generates a tag cardinality report for AWS accounts and resources. See the [README](https://github.com/flexera-public/policy_templates/tree/master/operational/aws/tag_cardinality) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
-category "Onboarding"
 severity "low"
+category "Operational"
 default_frequency "weekly"
 info(
-  version: "2.0"
+  version: "2.0",
+  provider: "AWS",
+  service: "Tags",
+  policy_set: "Tag Cardinality"
 )
 
 ###############################################################################
@@ -119,7 +122,7 @@ datasource "ds_aws_resources" do
   request do
     auth $auth_aws
     pagination $aws_pagination
-    host join(["tagging.",val(iter_item, "region"),".amazonaws.com"])
+    host join(["tagging.", val(iter_item, "region"), ".amazonaws.com"])
     verb "POST"
     path "/"
     header "X-Amz-Target", "ResourceGroupsTaggingAPI_20170126.GetResources"

--- a/operational/aws/tag_cardinality/aws_tag_cardinality.pt
+++ b/operational/aws/tag_cardinality/aws_tag_cardinality.pt
@@ -1,0 +1,270 @@
+name "AWS Tag Cardinality Report"
+rs_pt_ver 20180301
+type "policy"
+short_description "Report on AWS tag cardinality in the account"
+long_description ""
+category "Onboarding"
+severity "low"
+default_frequency "weekly"
+info(
+  version: "2.0"
+)
+
+###############################################################################
+# Parameters
+###############################################################################
+
+parameter "param_email" do
+  type "list"
+  label "Email addresses to notify"
+  description "Email addresses of the recipients you wish to notify"
+end
+
+###############################################################################
+# Authentication
+###############################################################################
+
+credentials "auth_aws" do
+  schemes "aws","aws_sts"
+  label "AWS"
+  description "Select the AWS credential."
+  tags "provider=aws"
+end
+
+###############################################################################
+# Pagination
+###############################################################################
+
+pagination "aws_pagination" do
+  get_page_marker do
+    body_path jmes_path(response, "NextToken")
+  end
+  set_page_marker do
+    body_field "NextToken"
+  end
+end
+
+###############################################################################
+# Datasources
+###############################################################################
+
+datasource "ds_aws_accounts_without_tags" do
+  request do
+    auth $auth_aws
+    pagination $aws_pagination
+    host "organizations.us-east-1.amazonaws.com"
+    path '/'
+    verb "POST"
+    header "User-Agent", "RS Policies"
+    header "X-Amz-Target", "AWSOrganizationsV20161128.ListAccounts"
+    header "Content-Type", "application/x-amz-json-1.1"
+    body "{}"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "Accounts") do
+      field "org_arn", jmes_path(col_item, "Arn")
+      field "account_id", jmes_path(col_item, "Id")
+      field "account_name", jmes_path(col_item, "Name")
+      field "account_status", jmes_path(col_item, "Status")
+    end
+  end
+end
+
+datasource "ds_aws_accounts" do
+  iterate $ds_aws_accounts_without_tags
+  request do
+    auth $auth_aws
+    pagination $aws_pagination
+    host "organizations.us-east-1.amazonaws.com"
+    path '/'
+    verb "POST"
+    header "User-Agent", "RS Policies"
+    header "X-Amz-Target", "AWSOrganizationsV20161128.ListTagsForResource"
+    header "Content-Type", "application/x-amz-json-1.1"
+    body_field "ResourceId", val(iter_item, "account_id")
+  end
+  result do
+    encoding "json"
+    field "org_arn", val(iter_item, "org_arn")
+    field "account_id", val(iter_item, "account_id")
+    field "account_name", val(iter_item, "account_name")
+    field "account_status", val(iter_item, "account_status")
+    field "tags_unsorted", jmes_path(response, "Tags")
+  end
+end
+
+datasource "ds_regions" do
+  request do
+    auth $auth_aws
+    verb "GET"
+    host "ec2.amazonaws.com"
+    path "/"
+    query "Action", "DescribeRegions"
+    query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
+  end
+  result do
+    encoding "xml"
+    collect xpath(response, "//DescribeRegionsResponse/regionInfo/item", "array") do
+      field "region", xpath(col_item, "regionName")
+    end
+  end
+end
+
+datasource "ds_aws_resources" do
+  iterate $ds_regions
+  request do
+    auth $auth_aws
+    pagination $aws_pagination
+    host join(["tagging.",val(iter_item, "region"),".amazonaws.com"])
+    verb "POST"
+    path "/"
+    header "X-Amz-Target", "ResourceGroupsTaggingAPI_20170126.GetResources"
+    header "Content-Type", "application/x-amz-json-1.1"
+    body_field "ExcludeCompliantResources", "false"
+    body_field "IncludeComplianceDetails", "true"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "ResourceTagMappingList[*]") do
+      field "complianceDetails", val(iter_item, "ComplianceDetails")
+      field "arn", jmes_path(col_item, "ResourceARN")
+      field "tags_unsorted", jmes_path(col_item, "Tags")
+    end
+  end
+end
+
+datasource "ds_aws_accounts_sorted" do
+  run_script $js_tag_sorter, $ds_aws_accounts
+end
+
+datasource "ds_aws_resources_sorted" do
+  run_script $js_tag_sorter, $ds_aws_resources
+end
+
+datasource "ds_aws_accounts_tag_list" do
+  run_script $js_tag_lister, $ds_aws_accounts, "Account"
+end
+
+datasource "ds_aws_resources_tag_list" do
+  run_script $js_tag_lister, $ds_aws_resources, "Resource"
+end
+
+datasource "ds_tag_report" do
+  run_script $js_tag_report, $ds_aws_accounts_tag_list, $ds_aws_resources_tag_list
+end
+
+###############################################################################
+# Scripts
+###############################################################################
+
+script "js_tag_sorter", type: "javascript" do
+  parameters "tagged_list"
+  result "result"
+  code <<-EOS
+  result = []
+
+  _.each(tagged_list, function(item) {
+    sorted_tags = {}
+
+    _.each(item['tags_unsorted'], function(tag) {
+      sorted_tags[tag['Key']] = tag['Value']
+    })
+
+    item['tags'] = sorted_tags
+
+    result.push(item)
+  })
+EOS
+end
+
+script "js_tag_lister", type: "javascript" do
+  parameters "tagged_list", "tag_type"
+  result "result"
+  code <<-EOS
+  tags = {}
+  result = []
+
+  _.each(tagged_list, function(item) {
+    if (item['tags'] != undefined && item['tags'] != null) {
+      _.each(Object.keys(item['tags']), function(key) {
+        value = item['tags'][key]
+        if (value == "" || value == null || value == undefined) {
+          value = "[Empty Value]"
+        }
+
+        if (tags[key] == undefined || tags[key] == null) {
+          tags[key] = {}
+        }
+
+        if (tags[key][value] == undefined || tags[key][value] == null) {
+          tags[key][value] = 1
+        } else {
+          tags[key][value] += 1
+        }
+      })
+    }
+  })
+
+  _.each(Object.keys(tags), function(key) {
+    _.each(Object.keys(tags[key]), function(value) {
+      result.push({
+        'type': tag_type,
+        'id': key,
+        'value': value,
+        'cardinality': tags[key][value]
+      })
+    })
+  })
+
+  result = _.sortBy(result, 'cardinality').reverse()
+EOS
+end
+
+script "js_tag_report", type: "javascript" do
+  parameters "ds_aws_accounts_tag_list", "ds_aws_resources_tag_list"
+  result "result"
+  code <<-EOS
+  result = ds_aws_accounts_tag_list.concat(ds_aws_resources_tag_list)
+EOS
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "pol_aws_tag_cardinality_report" do
+  validate $ds_tag_report do
+    summary_template "AWS Tag Cardinality Report"
+    check eq(1, 0)
+    escalate $email
+    export do
+      resource_level true
+      field "type" do
+        label "Type"
+      end
+      field "id" do
+        label "Key"
+      end
+      field "value" do
+        label "Value"
+      end
+      field "cardinality" do
+        label "Cardinality"
+      end
+    end
+  end
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
+escalation "email" do
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end

--- a/operational/aws/tag_cardinality/aws_tag_cardinality.pt
+++ b/operational/aws/tag_cardinality/aws_tag_cardinality.pt
@@ -1,7 +1,7 @@
 name "AWS Tag Cardinality Report"
 rs_pt_ver 20180301
 type "policy"
-short_description "Generates a tag cardinality report for AWS accounts and resources. See the [README](https://github.com/flexera-public/policy_templates/tree/master/operational/aws/tag_cardinality) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "Generates a tag cardinality report for AWS Accounts and Resources. See the [README](https://github.com/flexera-public/policy_templates/tree/master/operational/aws/tag_cardinality) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 severity "low"
 category "Operational"
@@ -243,7 +243,7 @@ policy "pol_aws_tag_cardinality_report" do
   validate $ds_tag_report do
     summary_template "AWS Tag Cardinality Report"
     check eq(1, 0)
-    escalate $email
+    escalate $esc_email
     export do
       resource_level true
       field "type" do
@@ -266,7 +266,7 @@ end
 # Escalations
 ###############################################################################
 
-escalation "email" do
+escalation "esc_email" do
   label "Send Email"
   description "Send incident email"
   email $param_email

--- a/operational/aws/tag_cardinality/aws_tag_cardinality.pt
+++ b/operational/aws/tag_cardinality/aws_tag_cardinality.pt
@@ -245,7 +245,7 @@ policy "pol_aws_tag_cardinality_report" do
     check eq(1, 0)
     escalate $esc_email
     export do
-      resource_level true
+      resource_level false
       field "type" do
         label "Type"
       end

--- a/operational/azure/tag_cardinality/CHANGELOG.md
+++ b/operational/azure/tag_cardinality/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v2.0
+
+- initial release

--- a/operational/azure/tag_cardinality/README.md
+++ b/operational/azure/tag_cardinality/README.md
@@ -1,15 +1,14 @@
-# AWS Tag Cardinality Report
+# Azure Tag Cardinality Report
 
 ## What it does
 
-This Policy Template is used to generate a tag cardinality (how frequently each tag value occurs) report for AWS. The report includes cardinality for all tag values for both AWS Accounts and Resources.
+This Policy Template is used to generate a tag cardinality (how frequently each tag value occurs) report for Azure. The report includes cardinality for all tag values for Azure Subscriptions, Resource Groups, and Resources.
 
 ## Functional Details
 
 This policy performs the following action:
 
-- Connect to the AWS Organizations API to get a list of AWS Accounts and their tags.
-- Connect to the AWS Tagging API to get a list of AWS Resources and their tags.
+- Connect to the Azure Resource Manager API to get a list of Azure Subscriptions, Resource Groups, and Resources, along with their tags.
 
 ## Input Parameters
 
@@ -29,31 +28,19 @@ This policy uses [credentials](https://docs.flexera.com/flexera/EN/Automation/Ma
 
 For administrators [creating and managing credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) to use with this policy, the following information is needed:
 
-Provider tag value to match this policy: `aws` , `aws_sts`
+Provider tag value to match this policy: `azure_rm`
 
 Required permissions in the provider:
 
-```javascript
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "tag:GetResources",
-        "ec2:DescribeRegions",
-        "organizations:ListAccounts",
-        "organizations:ListTagsForResource"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-```
+- Microsoft.Resources/subscriptions/resources/read
+- Microsoft.Resources/subscriptions/providers/read
+- Microsoft.Resources/subscriptions/read
+- Microsoft.Resources/resourceGroups/read
+- Microsoft.Resources/tags/read
 
 ## Supported Clouds
 
-- AWS
+- Azure
 
 ## Cost
 

--- a/operational/azure/tag_cardinality/azure_tag_cardinality.pt
+++ b/operational/azure/tag_cardinality/azure_tag_cardinality.pt
@@ -186,7 +186,7 @@ script "js_tag_lister", type: "javascript" do
     _.each(Object.keys(tags[key]), function(value) {
       result.push({
         'type': tag_type,
-        'id': key,
+        'key': key,
         'value': value,
         'cardinality': tags[key][value]
       })
@@ -219,7 +219,7 @@ policy "pol_azure_tag_cardinality_report" do
       field "type" do
         label "Type"
       end
-      field "id" do
+      field "key" do
         label "Key"
       end
       field "value" do

--- a/operational/azure/tag_cardinality/azure_tag_cardinality.pt
+++ b/operational/azure/tag_cardinality/azure_tag_cardinality.pt
@@ -215,7 +215,7 @@ policy "pol_azure_tag_cardinality_report" do
     check eq(1, 0)
     escalate $esc_email
     export do
-      resource_level true
+      resource_level false
       field "type" do
         label "Type"
       end

--- a/operational/azure/tag_cardinality/azure_tag_cardinality.pt
+++ b/operational/azure/tag_cardinality/azure_tag_cardinality.pt
@@ -1,0 +1,240 @@
+name "Azure Tag Cardinality Report"
+rs_pt_ver 20180301
+type "policy"
+short_description "Report on Azure tag cardinality in the account"
+long_description ""
+category "Onboarding"
+severity "low"
+default_frequency "weekly"
+info(
+  version: "2.0"
+)
+
+###############################################################################
+# Parameters
+###############################################################################
+
+parameter "param_email" do
+  type "list"
+  label "Email addresses to notify"
+  description "Email addresses of the recipients you wish to notify"
+end
+
+###############################################################################
+# Authentication
+###############################################################################
+
+credentials "auth_azure" do
+  schemes "oauth2"
+  label "Azure"
+  description "Select the Azure Resource Manager Credential from the list."
+  tags "provider=azure_rm"
+end
+
+###############################################################################
+# Pagination
+###############################################################################
+
+pagination "azure_pagination" do
+  get_page_marker do
+    body_path "nextLink"
+  end
+  set_page_marker do
+    uri true
+  end
+end
+
+###############################################################################
+# Datasources
+###############################################################################
+
+datasource "ds_azure_subscriptions_tagless" do
+  request do
+    auth $auth_azure
+    pagination $azure_pagination
+    host "management.azure.com"
+    path "/subscriptions/"
+    query "api-version","2018-06-01"
+    header "User-Agent", "RS Policies"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "value[*]") do
+      field "id", jmes_path(col_item,"subscriptionId")
+      field "name", jmes_path(col_item,"displayName")
+    end
+  end
+end
+
+datasource "ds_azure_subscriptions" do
+  iterate $ds_azure_subscriptions_tagless
+  request do
+    auth $auth_azure
+    pagination $azure_pagination
+    host "management.azure.com"
+    path join(["/subscriptions/", val(iter_item, "id"), "/providers/Microsoft.Resources/tags/default"])
+    query "api-version","2021-04-01"
+    header "User-Agent", "RS Policies"
+  end
+  result do
+    encoding "json"
+    field "id", val(iter_item, "id")
+    field "name", val(iter_item, "name")
+    field "tags", jmes_path(response, "properties.tags")
+  end
+end
+
+datasource "ds_azure_resource_groups" do
+  iterate $ds_azure_subscriptions_tagless
+  request do
+    auth $auth_azure
+    pagination $azure_pagination
+    host "management.azure.com"
+    path join(["/subscriptions/", val(iter_item, "id"), "/resourcegroups"])
+    query "api-version","2021-04-01"
+    header "User-Agent", "RS Policies"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "value[*]") do
+      field "subscriptionName", val(iter_item, "name")
+      field "subscriptionId", val(iter_item, "id")
+      field "id", jmes_path(col_item, "id")
+      field "location", jmes_path(col_item, "location")
+      field "name", jmes_path(col_item, "name")
+      field "tags", jmes_path(col_item, "tags")
+    end
+  end
+end
+
+datasource "ds_azure_resources" do
+  iterate $ds_azure_subscriptions_tagless
+  request do
+    auth $auth_azure
+    pagination $azure_pagination
+    host "management.azure.com"
+    path join(["/subscriptions/", val(iter_item, "id"), "/resources"])
+    query "api-version","2021-04-01"
+    header "User-Agent", "RS Policies"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "value[*]") do
+      field "subscriptionName", val(iter_item, "name")
+      field "subscriptionId", val(iter_item, "id")
+      field "id", jmes_path(col_item, "id")
+      field "name", jmes_path(col_item, "name")
+      field "location", jmes_path(col_item, "location")
+      field "type", jmes_path(col_item, "type")
+      field "tags", jmes_path(col_item, "tags")
+    end
+  end
+end
+
+datasource "ds_azure_subscriptions_tag_list" do
+  run_script $js_tag_lister, $ds_azure_subscriptions, "Subscription"
+end
+
+datasource "ds_azure_resource_groups_tag_list" do
+  run_script $js_tag_lister, $ds_azure_resource_groups, "Resource Group"
+end
+
+datasource "ds_azure_resources_tag_list" do
+  run_script $js_tag_lister, $ds_azure_resources, "Resource"
+end
+
+datasource "ds_tag_report" do
+  run_script $js_tag_report, $ds_azure_subscriptions_tag_list, $ds_azure_resource_groups_tag_list, $ds_azure_resources_tag_list
+end
+
+###############################################################################
+# Scripts
+###############################################################################
+
+script "js_tag_lister", type: "javascript" do
+  parameters "tagged_list", "tag_type"
+  result "result"
+  code <<-EOS
+  tags = {}
+  result = []
+
+  _.each(tagged_list, function(item) {
+    if (item['tags'] != undefined && item['tags'] != null) {
+      _.each(Object.keys(item['tags']), function(key) {
+        value = item['tags'][key]
+        if (value == "" || value == null || value == undefined) {
+          value = "[Empty Value]"
+        }
+
+        if (tags[key] == undefined || tags[key] == null) {
+          tags[key] = {}
+        }
+
+        if (tags[key][value] == undefined || tags[key][value] == null) {
+          tags[key][value] = 1
+        } else {
+          tags[key][value] += 1
+        }
+      })
+    }
+  })
+
+  _.each(Object.keys(tags), function(key) {
+    _.each(Object.keys(tags[key]), function(value) {
+      result.push({
+        'type': tag_type,
+        'id': key,
+        'value': value,
+        'cardinality': tags[key][value]
+      })
+    })
+  })
+
+  result = _.sortBy(result, 'cardinality').reverse()
+EOS
+end
+
+script "js_tag_report", type: "javascript" do
+  parameters "ds_azure_subscriptions_tag_list", "ds_azure_resource_groups_tag_list", "ds_azure_resources_tag_list"
+  result "result"
+  code <<-EOS
+  result = ds_azure_subscriptions_tag_list.concat(ds_azure_resource_groups_tag_list, ds_azure_resources_tag_list)
+EOS
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "pol_azure_tag_cardinality_report" do
+  validate $ds_tag_report do
+    summary_template "Azure Tag Cardinality Report"
+    check eq(1, 0)
+    escalate $email
+    export do
+      resource_level true
+      field "type" do
+        label "Type"
+      end
+      field "id" do
+        label "Key"
+      end
+      field "value" do
+        label "Value"
+      end
+      field "cardinality" do
+        label "Cardinality"
+      end
+    end
+  end
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
+escalation "email" do
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end

--- a/operational/azure/tag_cardinality/azure_tag_cardinality.pt
+++ b/operational/azure/tag_cardinality/azure_tag_cardinality.pt
@@ -1,7 +1,7 @@
 name "Azure Tag Cardinality Report"
 rs_pt_ver 20180301
 type "policy"
-short_description "Generates a tag cardinality report for Azure Subscriptions, Resource Groups, and Resources. See the [README](https://github.com/flexera-public/policy_templates/tree/master/operational/aws/tag_cardinality) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "Generates a tag cardinality report for Azure Subscriptions, Resource Groups, and Resources. See the [README](https://github.com/flexera-public/policy_templates/tree/master/operational/azure/tag_cardinality) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 severity "low"
 category "Operational"

--- a/operational/azure/tag_cardinality/azure_tag_cardinality.pt
+++ b/operational/azure/tag_cardinality/azure_tag_cardinality.pt
@@ -1,13 +1,16 @@
 name "Azure Tag Cardinality Report"
 rs_pt_ver 20180301
 type "policy"
-short_description "Report on Azure tag cardinality in the account"
+short_description "Generates a tag cardinality report for Azure Subscriptions, Resource Groups, and Resources. See the [README](https://github.com/flexera-public/policy_templates/tree/master/operational/aws/tag_cardinality) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
-category "Onboarding"
 severity "low"
+category "Operational"
 default_frequency "weekly"
 info(
-  version: "2.0"
+  version: "2.0",
+  provider: "Azure",
+  service: "Tags",
+  policy_set: "Tag Cardinality"
 )
 
 ###############################################################################
@@ -210,7 +213,7 @@ policy "pol_azure_tag_cardinality_report" do
   validate $ds_tag_report do
     summary_template "Azure Tag Cardinality Report"
     check eq(1, 0)
-    escalate $email
+    escalate $esc_email
     export do
       resource_level true
       field "type" do
@@ -233,7 +236,7 @@ end
 # Escalations
 ###############################################################################
 
-escalation "email" do
+escalation "esc_email" do
   label "Send Email"
   description "Send incident email"
   email $param_email


### PR DESCRIPTION
Adds policies for AWS and Azure to generate tag cardinality reports. These policies have been tested.

Does not currently include GCP; this is TBD due to difficulties with the GCP API.