### PR TITLE
Fill in the policySet field to populate the new total potential savin…

### DIFF
--- a/cost/aws/reserved_instances/recommendations/CHANGELOG.md
+++ b/cost/aws/reserved_instances/recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.14
+
+- Added policySet as Reserved Instance to populate the Total Potential Savings
+
 ## v2.13
 
 - Replaced references `github.com/rightscale/policy_templates` and `github.com/flexera/policy_templates` with `github.com/flexera-public/policy_templates`

--- a/cost/aws/reserved_instances/recommendations/aws_reserved_instance_recommendations.pt
+++ b/cost/aws/reserved_instances/recommendations/aws_reserved_instance_recommendations.pt
@@ -7,10 +7,10 @@ severity "medium"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.13",
+  version: "2.14",
   provider: "AWS",
   service: "EC2",
-  policy_set: ""
+  policy_set: "Reserved Instance"
 )
 
 ###############################################################################

--- a/cost/aws/savings_plan/recommendations/CHANGELOG.md
+++ b/cost/aws/savings_plan/recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.14
+
+- Added policySet as Savings Plan to populate the Total Potential Savings
+
 ## v2.13
 
 - Added accountName call and field

--- a/cost/aws/savings_plan/recommendations/aws_savings_plan_recommendations.pt
+++ b/cost/aws/savings_plan/recommendations/aws_savings_plan_recommendations.pt
@@ -7,10 +7,10 @@ severity "medium"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.13",
+  version: "2.14",
   provider: "AWS",
   service: "",
-  policy_set: ""
+  policy_set: "Savings Plan"
 )
 
 ##############################################################################


### PR DESCRIPTION


### Description

Add the Policy Set for Reserved Instance and Savings Plans to populate new charts for the Total Potential Savigns

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
