### PR TITLE
POL-713-changing-powerOff-deallocate

### DIFF
--- a/cost/azure/schedule_instance/CHANGELOG.md
+++ b/cost/azure/schedule_instance/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.7
+
+- Modified cloud workflow Azure API to change `powerOff` to `deallocate` to release resources and start savings
+- Mofified Azure API version to most updated `2022-08-01`
+
 ## v2.6
 
 - Modified `sys_log` definition to disable `rs_cm.audit_entry.create` outside Flexera NAM

--- a/cost/azure/schedule_instance/README.md
+++ b/cost/azure/schedule_instance/README.md
@@ -65,7 +65,7 @@ Required permissions in the provider:
 - Microsoft.Compute/virtualMachines/write
 - Microsoft.Compute/virtualMachines/delete
 - Microsoft.Compute/virtualMachines/start/action
-- Microsoft.Compute/virtualMachines/powerOff/action
+- Microsoft.Compute/virtualMachines/deallocate/action
 
 ## Supported Clouds
 

--- a/cost/azure/schedule_instance/azure_schedule_instance.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.6",
+  version: "2.7",
   provider: "Azure",
   service: "Compute",
   policy_set:"Schedule Instance"

--- a/cost/azure/schedule_instance/azure_schedule_instance.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance.pt
@@ -433,9 +433,9 @@ define schedule_instance($data, $$rs_optima_host) return $all_responses do
             verb: "post",
             host: "management.azure.com",
             https: true,
-            href: join([$item['id'],"/powerOff"]),
+            href: join([$item['id'],"/deallocate"]),
             query_strings: {
-              "api-version": "2019-12-01"
+              "api-version": "2022-08-01"
             },
             headers: {
               "cache-control": "no-cache",


### PR DESCRIPTION
### Description

- Modified cloud workflow Azure API to change `powerOff` to `deallocate` to release resources and start savings
- Mofified Azure API version to most updated `2022-08-01`

### Issues Resolved

Scheduled instances was using /powerOff api command but this did not allow for savings for shut off. 

### Contribution Check List

- [X] All tests pass.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
