### PR TITLE
Feat/adding param statistics idle compute

### DIFF
--- a/cost/aws/idle_compute_instances/CHANGELOG.md
+++ b/cost/aws/idle_compute_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.2
+
+- Added the following options to `param_threshold_statistic`, `"p95", "p90"`
+
 ## v4.1
 
 - Added `param_threshold_statistic` which can be used to select the statistic used in determining an instance idle

--- a/cost/aws/idle_compute_instances/CHANGELOG.md
+++ b/cost/aws/idle_compute_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.2
 
-- Added the following options to `param_threshold_statistic`, `"p95", "p90"`
+- Added the following options to `param_threshold_statistic`: `p95` `p90`
 
 ## v4.1
 

--- a/cost/aws/idle_compute_instances/idle_compute_instances.pt
+++ b/cost/aws/idle_compute_instances/idle_compute_instances.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "4.1",
+  version: "4.2",
   provider: "AWS",
   service: "EC2",
   policy_set: "Idle Compute Instances"
@@ -64,7 +64,7 @@ parameter "param_threshold_statistic" do
   label "Threshold Statistic"
   description "Statistic to use for the metric threshold"
   default "Average"
-  allowed_values "Average", "p99"
+  allowed_values "Average", "p99", "p95", "p90"
 end
 
 parameter "param_allowed_regions" do
@@ -451,7 +451,7 @@ script "js_instances_queries", type: "javascript" do
       queries[instance['region']] = []
     }
     //We want to collect each of these list of statistics we care about
-    stats = ["Average", "Minimum", "Maximum", "p99"]
+    stats = ["Average", "Minimum", "Maximum", "p99", "p95", "p90"]
     // Only query for CPU usage if we're actually checking it
     if (param_avg_cpu != -1) {
       _.each(stats, function(stat) {
@@ -654,7 +654,7 @@ script "js_merged_metrics", type: "javascript" do
   code <<-EOS
   result = []
   //We want to collect each of these list of statistics we care about
-  stats = ["Average", "Minimum", "Maximum", "p99"]
+  stats = ["Average", "Minimum", "Maximum", "p99", "p95", "p90"]
 
   _.each(ds_instances, function(instance) {
     region = instance['region']
@@ -867,6 +867,12 @@ EOS
       field "cpu_p99" do
         label "CPU p99"
       end
+      field "cpu_p95" do
+        label "CPU p95"
+      end
+      field "cpu_p90" do
+        label "CPU p90"
+      end
       field "mem_maximum" do
         label "Memory Maximum %"
       end
@@ -878,6 +884,12 @@ EOS
       end
       field "mem_p99" do
         label "Memory p99"
+      end
+      field "mem_p95" do
+        label "Memory p95"
+      end
+      field "mem_p90" do
+        label "Memory p90"
       end
       field "tags" do
         label "Tags"


### PR DESCRIPTION
### Description

- Added the following options to `param_threshold_statistic`, `"p95", "p90"`

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
