### PR TITLE
Fix: CF Template and README to add `cloudwatch:GetMetricData`

### DIFF
--- a/.github/workflows/cfn-test.yaml
+++ b/.github/workflows/cfn-test.yaml
@@ -21,7 +21,13 @@ jobs:
         template_files:
           - ./cost/aws/FlexeraReadOnlyPolicy.template
           - ./tools/cloudformation-template/FlexeraAutomationPolicies.template
-          - ./tools/cloudformation-template/releases/*.template
+          
+          # TODO: Fix wildcard/dynamic release list
+          # - ./tools/cloudformation-template/releases/*.template
+          
+          # Staticly define release templates for now
+          - ./tools/cloudformation-template/releases/FlexeraAutomationPolicies_v0.1.0.template
+          - ./tools/cloudformation-template/releases/FlexeraAutomationPolicies_v0.1.1.template
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/cfn-test.yaml
+++ b/.github/workflows/cfn-test.yaml
@@ -17,11 +17,17 @@ jobs:
       # Prevents needing to re-run tests to find errors in other template files
       fail-fast: false
       matrix:
-        # matrix.template_dirs is a list of dirs containing CloudFormation template files to test
-        template_dirs:
-          - ./cost/aws/
-          - ./tools/cloudformation-template/
-          - ./tools/cloudformation-template/releases/
+        # matrix.template_files is a list of template files to test
+        template_files:
+          - ./cost/aws/FlexeraReadOnlyPolicy.template
+          - ./tools/cloudformation-template/FlexeraAutomationPolicies.template
+          
+          # TODO: Fix wildcard/dynamic release list
+          # - ./tools/cloudformation-template/releases/*.template
+          
+          # Staticly define release templates for now
+          - ./tools/cloudformation-template/releases/FlexeraAutomationPolicies_v0.1.0.template
+          - ./tools/cloudformation-template/releases/FlexeraAutomationPolicies_v0.1.1.template
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -33,11 +39,11 @@ jobs:
         id: cfn-lint
         run: |
           cfn-lint -t ${{ matrix.template_files }}
-          
+
       - name: Run Checkov action
         id: checkov
-        uses: bridgecrewio/checkov-action@v12
+        uses: bridgecrewio/checkov-action@master
         with:
-          directory: ${{ matrix.template_dirs }}
+          file: ${{ matrix.template_files }}
           quiet: true # optional: display only failed checks
           framework: cloudformation # optional: run only on a specific infrastructure

--- a/.github/workflows/cfn-test.yaml
+++ b/.github/workflows/cfn-test.yaml
@@ -17,17 +17,11 @@ jobs:
       # Prevents needing to re-run tests to find errors in other template files
       fail-fast: false
       matrix:
-        # matrix.template_files is a list of template files to test
-        template_files:
-          - ./cost/aws/FlexeraReadOnlyPolicy.template
-          - ./tools/cloudformation-template/FlexeraAutomationPolicies.template
-          
-          # TODO: Fix wildcard/dynamic release list
-          # - ./tools/cloudformation-template/releases/*.template
-          
-          # Staticly define release templates for now
-          - ./tools/cloudformation-template/releases/FlexeraAutomationPolicies_v0.1.0.template
-          - ./tools/cloudformation-template/releases/FlexeraAutomationPolicies_v0.1.1.template
+        # matrix.template_dirs is a list of dirs containing CloudFormation template files to test
+        template_dirs:
+          - ./cost/aws/
+          - ./tools/cloudformation-template/
+          - ./tools/cloudformation-template/releases/
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -39,11 +33,11 @@ jobs:
         id: cfn-lint
         run: |
           cfn-lint -t ${{ matrix.template_files }}
-
+          
       - name: Run Checkov action
         id: checkov
-        uses: bridgecrewio/checkov-action@master
+        uses: bridgecrewio/checkov-action@v12
         with:
-          file: ${{ matrix.template_files }}
+          directory: ${{ matrix.template_dirs }}
           quiet: true # optional: display only failed checks
           framework: cloudformation # optional: run only on a specific infrastructure

--- a/cost/aws/idle_compute_instances/README.md
+++ b/cost/aws/idle_compute_instances/README.md
@@ -11,6 +11,7 @@ This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Auto
   - `ec2:DescribeInstances`
   - `ec2:DescribeTags`
   - `cloudwatch:GetMetricStatistics`
+  - `cloudwatch:GetMetricData`
   - `cloudwatch:ListMetrics`
 
   Example IAM Permission Policy:
@@ -26,6 +27,7 @@ This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Auto
                   "ec2:DescribeInstances",
                   "ec2:DescribeTags",
                   "cloudwatch:GetMetricStatistics",
+                  "cloudwatch:GetMetricData",
                   "cloudwatch:ListMetrics"
               ],
               "Resource": "*"

--- a/cost/aws/unused_rds/README.md
+++ b/cost/aws/unused_rds/README.md
@@ -11,6 +11,7 @@ This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Auto
 - [**AWS Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1121575) (*provider=aws*) which has the following permissions:
   - `ec2:DescribeRegions`
   - `cloudwatch:GetMetricStatistics`
+  - `cloudwatch:GetMetricData`
   - `cloudwatch:ListMetrics`
 
   Example IAM Permission Policy:
@@ -24,6 +25,7 @@ This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Auto
               "Action": [
                   "ec2:DescribeRegions",
                   "cloudwatch:GetMetricStatistics",
+                  "cloudwatch:GetMetricData",
                   "cloudwatch:ListMetrics",
               ],
               "Resource": "*"

--- a/tools/cloudformation-template/FlexeraAutomationPolicies.template
+++ b/tools/cloudformation-template/FlexeraAutomationPolicies.template
@@ -209,6 +209,7 @@ Mappings:
         - "ec2:DescribeInstances"
         - "ec2:DescribeTags"
         - "cloudwatch:GetMetricStatistics"
+        - "cloudwatch:GetMetricData"
         - "cloudwatch:ListMetrics"
       action: []
 

--- a/tools/cloudformation-template/FlexeraAutomationPolicies.template
+++ b/tools/cloudformation-template/FlexeraAutomationPolicies.template
@@ -177,6 +177,7 @@ Mappings:
         - "ec2:DescribeVolumes"
         - "ec2:DescribeSnapshots"
         - "cloudwatch:GetMetricStatistics"
+        - "cloudwatch:GetMetricData"
       action:
         - "ec2:CreateTags"
         - "ec2:CreateSnapshot"
@@ -185,6 +186,7 @@ Mappings:
       read:
         - "ec2:DescribeRegions"
         - "cloudwatch:GetMetricStatistics"
+        - "cloudwatch:GetMetricData"
         - "cloudwatch:ListMetrics"
       action: []
     AWSUnusedIPAddresses:

--- a/tools/cloudformation-template/README.md
+++ b/tools/cloudformation-template/README.md
@@ -37,9 +37,9 @@ As you follow the official docs, you can use the recommended configurations belo
 
    <https://flexera-cloudformation-public.s3.us-east-2.amazonaws.com/FlexeraAutomationPolicies_latest.template>
 
-   > It's recommended to use an official release for Production use-cases (i.e. *vX.Y.Z*).  All official releases can be found under [releases/](./releases/) folder and are published to  `https://flexera-cloudformation-public.s3.us-east-2.amazonaws.com/`.  
+   > It's recommended to use an official release for Production use-cases (i.e. *vX.Y.Z*).  All official releases can be found under [releases/](./releases/) folder and are published to  `https://flexera-cloudformation-public.s3.us-east-2.amazonaws.com/FlexeraAutomationPolicies_vX.Y.Z.template`. An example of an release template S3 URL:
    > 
-   > <small>An example of an release template S3 URL: **https://flexera-cloudformation-public.s3.us-east-2.amazonaws.com/FlexeraAutomationPolicies_v0.1.1.template**</small>
+   > **https://flexera-cloudformation-public.s3.us-east-2.amazonaws.com/FlexeraAutomationPolicies_v0.1.1.template**
 
  - On the **Specify StackSet details** page, provide a name for the stack set, specify *Flexera Organization ID* and any other parameters, and then choose **Next**.
 

--- a/tools/cloudformation-template/README.md
+++ b/tools/cloudformation-template/README.md
@@ -35,11 +35,11 @@ As you follow the official docs, you can use the recommended configurations belo
 
  - Under **Specify template**, provide the template S3 URL:
 
-   <https://flexera-cloudformation-public.s3.us-east-2.amazonaws.com/FlexeraAutomationPolicies_v0.1.0.template>
+   <https://flexera-cloudformation-public.s3.us-east-2.amazonaws.com/FlexeraAutomationPolicies_latest.template>
 
-   It's recommended to use an official release for Production use-cases (i.e. *vX.Y.Z*) but we also provide *[FlexeraAutomationPolicies_latest.template](https://flexera-cloudformation-public.s3.us-east-2.amazonaws.com/FlexeraAutomationPolicies_latest.template)* which will always have the most recent changes.
-
-   All official releases can be found under [releases/](./releases/) folder and are published to  `https://flexera-cloudformation-public.s3.us-east-2.amazonaws.com/`
+   > It's recommended to use an official release for Production use-cases (i.e. *vX.Y.Z*).  All official releases can be found under [releases/](./releases/) folder and are published to  `https://flexera-cloudformation-public.s3.us-east-2.amazonaws.com/`.  
+   > 
+   > <small>An example of an release template S3 URL: **https://flexera-cloudformation-public.s3.us-east-2.amazonaws.com/FlexeraAutomationPolicies_v0.1.1.template**</small>
 
  - On the **Specify StackSet details** page, provide a name for the stack set, specify *Flexera Organization ID* and any other parameters, and then choose **Next**.
 

--- a/tools/cloudformation-template/README.md
+++ b/tools/cloudformation-template/README.md
@@ -38,7 +38,7 @@ As you follow the official docs, you can use the recommended configurations belo
    <https://flexera-cloudformation-public.s3.us-east-2.amazonaws.com/FlexeraAutomationPolicies_latest.template>
 
    > It's recommended to use an official release for Production use-cases (i.e. *vX.Y.Z*).  All official releases can be found under [releases/](./releases/) folder and are published to  `https://flexera-cloudformation-public.s3.us-east-2.amazonaws.com/FlexeraAutomationPolicies_vX.Y.Z.template`. An example of an release template S3 URL:
-   > 
+   >
    > **https://flexera-cloudformation-public.s3.us-east-2.amazonaws.com/FlexeraAutomationPolicies_v0.1.1.template**
 
  - On the **Specify StackSet details** page, provide a name for the stack set, specify *Flexera Organization ID* and any other parameters, and then choose **Next**.

--- a/tools/cloudformation-template/releases/FlexeraAutomationPolicies_v0.1.1.template
+++ b/tools/cloudformation-template/releases/FlexeraAutomationPolicies_v0.1.1.template
@@ -1,0 +1,409 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: "CloudFormation Stack with IAM Role and IAM Permission Policy used by Flexera Automation. Official Docs: https://docs.flexera.com/"
+
+Metadata:
+  # AWS::CloudFormation::Interface is a metadata key that defines how parameters are grouped and sorted in the AWS CloudFormation console.
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html
+  AWS::CloudFormation::Interface:
+    # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudformation-interface-parametergroup.html
+    ParameterGroups:
+      # ParameterGroup with paramFlexeraOrgId should be first.
+      # paramFlexeraOrgId only param that is actually required (if Org is on app.flexera.com)
+      - Label: 
+          default: "Parameters related to your Organization on the Flexera Platform"
+        Parameters:
+          - paramFlexeraOrgId
+          - paramFlexeraZone
+      - Label:
+          default: "Parameters related to the IAM Role that is created"
+        Parameters:
+          - paramRoleName
+          - paramRolePath
+      - Label:
+          default: "Parameters related to Policy Template permissions on the IAM Role that is created"
+        Parameters:
+          - paramPermsAWSUnusedVolumes
+          - paramPermsAWSUnusedRDS
+          - paramPermsAWSUnusedIPAddresses
+          - paramPermsAWSOldSnapshots
+          - paramPermsAWSIdleComputeInstances
+    # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudformation-interface-parameterlabel.html
+    ParameterLabels:
+      paramRoleName:
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudformation-interface-label.html
+        # The default label that the CloudFormation console uses to name a parameter group or parameter.
+        default: "IAM Role Name"
+      paramRolePath:
+        default: "IAM Role Path"
+      paramFlexeraOrgId:
+        default: "Flexera Organization ID"
+      paramFlexeraZone:
+        default: "Flexera Zone"
+      paramPermsAWSUnusedVolumes:
+        default: "Permissions for Policy Template: AWS Unused Volumes"
+      paramPermsAWSUnusedRDS:
+        default: "Permissions for Policy Template: AWS Unused RDS"
+      paramPermsAWSUnusedIPAddresses:
+        default: "Permissions for Policy Template: AWS Unused IP Addresses"
+      paramPermsAWSOldSnapshots:
+        default: "Permissions for Policy Template: AWS Old Snapshots"
+      paramPermsAWSIdleComputeInstances:
+        default: "Permissions for Policy Template: AWS Idle Compute Instances"
+
+Parameters:
+  # ParameterGroup: Parameters related to your Organization on the Flexera Platform
+  paramFlexeraOrgId:
+    Description: >-
+      The Organization ID in Flexera which trust will be granted to use the IAM Role that will be created
+    Type: String
+    AllowedPattern: "[0-9]+"
+    MinLength: 1
+    ConstraintDescription: Organization ID must be provided and match regex [0-9]+
+  paramFlexeraZone:
+    Description: >-
+      The Flexera Zone which trust will be granted to.  The Organization ID should be located in this Flexera Zone.
+    Type: String
+    Default: app.flexera.com
+    AllowedValues:
+      - app.flexera.com
+      - app.flexera.eu
+      - app.flexeratest.com
+
+  # ParameterGroup: Parameters for the IAM Role that is created
+  paramRoleName:
+    Description: Name of the the IAM Role that will be created. If you plan to create more than one IAM Role (i.e. one for each Policy Template, or to trust multiple Orgs) you will need to modify this to prevent naming conflict.
+    Type: String
+    Default: FlexeraAutomationAccessRole
+    # IAM Role Name Max Length is 64chars
+    MaxLength: 64
+  paramRolePath:
+    Description: Path for the IAM Role that will be created. Generally does not need to be modified.
+    Type: String
+    Default: /
+
+  # ParameterGroup: Parameters to define Policy Template permissions on the IAM Role that is created
+  paramPermsAWSUnusedVolumes:
+    Description: 'What permissions should policies using "AWS Unused Volumes" Policy Template be granted on the IAM Role that will be created?'
+    Type: String
+    Default: Read Only
+    AllowedValues:
+      - No Access
+      - Read Only
+      - Read and Take Action
+  paramPermsAWSUnusedRDS:
+    Description: 'What permissions should policies using "AWS Unused RDS" Policy Template be granted on the IAM Role that will be created?'
+    Type: String
+    Default: Read Only
+    AllowedValues:
+      - No Access
+      - Read Only
+  paramPermsAWSUnusedIPAddresses:
+    Description: 'What permissions should policies using "AWS Unused IP Addresses" Policy Template be granted on the IAM Role that will be created?'
+    Type: String
+    Default: Read Only
+    AllowedValues:
+      - No Access
+      - Read Only
+      - Read and Take Action
+  paramPermsAWSOldSnapshots:
+    Description: 'What permissions should policies using "AWS Old Snapshots" Policy Template be granted on the IAM Role that will be created?'
+    Type: String
+    Default: Read Only
+    AllowedValues:
+      - No Access
+      - Read Only
+      - Read and Take Action
+  paramPermsAWSIdleComputeInstances:
+    Description: 'What permissions should policies using "AWS Idle Compute Instances" Policy Template be granted on the IAM Role that will be created?'
+    Type: String
+    Default: Read Only
+    AllowedValues:
+      - No Access
+      - Read Only
+
+Conditions:
+  CreatePolicyAWSUnusedVolumesRead: !Not
+    - !Equals
+      - !Ref paramPermsAWSUnusedVolumes
+      - No Access
+  CreatePolicyAWSUnusedVolumesAction: !Equals
+    - !Ref paramPermsAWSUnusedVolumes
+    - Read and Take Action
+  CreatePolicyAWSUnusedRDSRead: !Not
+    - !Equals
+      - !Ref paramPermsAWSUnusedRDS
+      - No Access
+  # Policy has no actions currently, commenting out to prevent cfn-lint W8001 Error Condition not used
+  # CreatePolicyAWSUnusedRDSAction: !Equals
+  #   - !Ref paramPermsAWSUnusedRDS
+  #   - Read and Take Action
+  CreatePolicyAWSUnusedIPAddressesRead: !Not
+    - !Equals
+      - !Ref paramPermsAWSUnusedIPAddresses
+      - No Access
+  CreatePolicyAWSUnusedIPAddressesAction: !Equals
+    - !Ref paramPermsAWSUnusedIPAddresses
+    - Read and Take Action
+  CreatePolicyAWSOldSnapshotsRead: !Not
+    - !Equals
+      - !Ref paramPermsAWSOldSnapshots
+      - No Access
+  CreatePolicyAWSOldSnapshotsAction: !Equals
+    - !Ref paramPermsAWSOldSnapshots
+    - Read and Take Action
+  CreatePolicyAWSIdleComputeInstancesRead: !Not
+    - !Equals
+      - !Ref paramPermsAWSIdleComputeInstances
+      - No Access
+  # Policy has no actions currently, commenting out to prevent cfn-lint W8001 Error Condition not used
+  # CreatePolicyAWSIdleComputeInstancesAction: !Equals
+  #   - !Ref paramPermsAWSIdleComputeInstances
+  #   - Read and Take Action
+
+Mappings:
+  TrustedRoleMap:
+    app.flexera.com:
+      roleArn: "arn:aws:iam::451234325714:role/production_customer_access"
+    app.flexera.eu:
+      roleArn: "arn:aws:iam::451234325714:role/production_eu_customer_access"
+    app.flexeratest.com:
+      roleArn: "arn:aws:iam::274571843445:role/staging_customer_access"
+  PermissionMap:
+    # Begin IAM Permissions Map
+    # Expect 2 lists for each Policy Template (read and action)
+    AWSUnusedVolumes:
+      read:
+        - "ec2:DescribeRegions"
+        - "ec2:DescribeVolumes"
+        - "ec2:DescribeSnapshots"
+        - "cloudwatch:GetMetricStatistics"
+        - "cloudwatch:GetMetricData"
+      action:
+        - "ec2:CreateTags"
+        - "ec2:CreateSnapshot"
+        - "ec2:DeleteVolume"
+    AWSUnusedRDS:
+      read:
+        - "ec2:DescribeRegions"
+        - "cloudwatch:GetMetricStatistics"
+        - "cloudwatch:GetMetricData"
+        - "cloudwatch:ListMetrics"
+      action: []
+    AWSUnusedIPAddresses:
+      read:
+        - "ec2:DescribeRegions"
+        - "ec2:DescribeAddresses"
+        - "pricing:GetProducts"
+      action:
+        - "ec2:ReleaseAddress"
+    AWSOldSnapshots:
+      read:
+        - "ec2:DescribeRegions"
+        - "ec2:DescribeImages"
+        - "ec2:DescribeSnapshots"
+        - "sts:GetCallerIdentity"
+      action:
+        - "ec2:DeregisterImage"
+        - "ec2:DeleteSnapshot"
+    AWSIdleComputeInstances:
+      read:
+        - "ec2:DescribeRegions"
+        - "ec2:DescribeInstances"
+        - "ec2:DescribeTags"
+        - "cloudwatch:GetMetricStatistics"
+        - "cloudwatch:GetMetricData"
+        - "cloudwatch:ListMetrics"
+      action: []
+
+Resources:
+  # IAM Role Resource
+  iamRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: !Ref paramRoleName
+      Description: !Join
+        - " "
+        - - "Allows access from Flexera Platform. This IAM Role and the attached permission policies were created and are managed by CloudFormation Stack:"
+          - !Ref AWS::StackId
+      Path: !Ref paramRolePath
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !FindInMap
+                - TrustedRoleMap
+                - !Ref paramFlexeraZone
+                - roleArn
+            Action: "sts:AssumeRole"
+            Condition:
+              StringEquals:
+                "sts:ExternalId": !Ref paramFlexeraOrgId
+  # Begin IAM Permission Policy Resources
+  # 1 or 2 Permission Policies per Policy Template (read and action)
+  # Policy create/attachment is conditional based on parameter input for each policy
+  ## AWS Unused Volumes Permission Policies
+  iamPolicyAWSUnusedVolumesRead:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSUnusedVolumesRead
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSUnusedVolumesReadPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSUnusedVolumes
+              - read
+            Resource: "*"
+  iamPolicyAWSUnusedVolumesAction:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSUnusedVolumesAction
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSUnusedVolumesActionPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSUnusedVolumes
+              - action
+            Resource: "*"
+  ## AWS Unused RDS Permission Policies
+  iamPolicyAWSUnusedRDSRead:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSUnusedRDSRead
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSUnusedRDSReadPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSUnusedRDS
+              - read
+            Resource: "*"
+  iamPolicyAWSUnusedIPAddresses:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSUnusedIPAddressesRead
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSUnusedIPAddressesReadPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSUnusedIPAddresses
+              - read
+            Resource: "*"
+  ## AWS Unused IP Addresses Permission Policies
+  iamPolicyAWSUnusedIPAddressesAction:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSUnusedIPAddressesAction
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSUnusedIPAddressesActionPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSUnusedIPAddresses
+              - action
+            Resource: "*"
+  ## AWS Old Snapshots Permission Policies
+  iamPolicyAWSOldSnapshots:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSOldSnapshotsRead
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSOldSnapshotsReadPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSOldSnapshots
+              - read
+            Resource: "*"
+  iamPolicyAWSOldSnapshotsAction:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSOldSnapshotsAction
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSOldSnapshotsActionPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSOldSnapshots
+              - action
+            Resource: "*"
+  ## AWS Idle Compute Instances Permission Policies
+  iamPolicyAWSIdleComputeInstances:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSIdleComputeInstancesRead
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSIdleComputeInstancesReadPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSIdleComputeInstances
+              - read
+            Resource: "*"
+  # End IAM Permission Policy Resources
+
+Outputs:
+  iamRoleArn:
+    Description: The ARN of the IAM Role that was created
+    Value: !GetAtt
+      - iamRole
+      - Arn


### PR DESCRIPTION
### Description

Policies were refactored to use GetMetricData but the README was not updated at that time.  This fixes that issue.

The CF Template that is used to create Roles for IAM had it's permissions updated as well to include GetMetricData.

### Contribution Check List

- [X] All tests pass.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
