### PR TITLE
POL-693 AWS Instance Rightsizing - Merge Idle Instances and Inefficient Instance Utilization

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Reference
 - [AWS Reserved Instance Reservation Coverage](./cost/aws/reserved_instances/coverage/)
 - [AWS Reserved Instances Report by Billing Center](./cost/aws/reserved_instances/report_by_bc)
 - [AWS Reserved Instance Recommendations](./cost/aws/reserved_instances/recommendations)
+- [AWS Rightsize Compute Instances](./cost/aws/rightsize_compute_instances)
 - [AWS Savings Plan Recommendations](./cost/aws/savings_plan/recommendations)
 - [AWS Savings Plan Utilization](./cost/aws/savings_plan/utilization)
 - [AWS Savings Realized from Reservations](./cost/aws/savings_realized)

--- a/cost/aws/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_compute_instances/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v1.0
+
+- Initial release

--- a/cost/aws/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_compute_instances/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-## v1.0
+## v2.0
 
 - Initial release

--- a/cost/aws/rightsize_compute_instances/README.md
+++ b/cost/aws/rightsize_compute_instances/README.md
@@ -15,7 +15,7 @@ This policy checks all the instances in an AWS Account for CPU and Memory usage 
 
 ### Policy savings details
 
-The policy includes the estimated savings. The estimated savings is recognized if the resource is terminated, or downsized. Optima is used to receive the estimated savings which is the cost of the resource for the last full month. The savings is displayed in the Estimated Monthly Savings column. If the resource can not be found in Optima the value is 0.0. The incident message detail includes the sum of each resource Estimated Monthly Savings as Total Estimated Monthly Savings.
+The policy includes the estimated savings. The estimated savings is recognized if the resource is terminated, or downsized. Optima is used to retrieve and calculate the estimated savings which is the cost of the resource for the last full month. The savings is displayed in the Estimated Monthly Savings column. If the resource can not be found in Optima the value is 0.0. The incident message detail includes the sum of each resource *Estimated Monthly Savings* as *Total Estimated Monthly Savings*.
 
 ## Input Parameters
 

--- a/cost/aws/rightsize_compute_instances/README.md
+++ b/cost/aws/rightsize_compute_instances/README.md
@@ -6,12 +6,12 @@ This policy checks all the instances in an AWS Account for CPU and Memory usage 
 
 ## Functional Details
 
-- The policy leverages the AWS API to check all instances and then uses the AWS CloudWatch API to check the instance average CPU and Memory utilization over the past 30 days.
+- The policy leverages the AWS API to retrieve all instances and then uses the AWS CloudWatch API to check the instance average CPU and Memory utilization over the past 30 days.
 - The utilization data is provided for the following statistics: Average, 99th percentile, 95th percentile, 90th percentile.
 - The policy identifies all instances that have CPU utilization and/or Memory utilization below the Idle Instance CPU/Memory Threshold/s defined by the user, to provide a recommendation.
-- (Coming soon) The recommendation provided for Idle Instances is a termination action. These instancse can be terminated in an automated manner or after approval.
+- (Coming soon) The recommendation provided for Idle Instances is a termination action. These instances can be terminated in an automated manner or after approval.
 - The policy identifies all instances that have CPU utilization and/or Memory utilization below the Underutilized Instance CPU/Memory Threshold/s defined by the user, to provide a recommendation.
-- (Coming soon) The recommendation provided for Inefficient/Underutilized Instances is a downsize action. These instancse can be downsized in an automated manner or after approval.
+- (Coming soon) The recommendation provided for Inefficient/Underutilized Instances is a downsize action. These instances can be downsized in an automated manner or after approval.
 
 ### Policy savings details
 

--- a/cost/aws/rightsize_compute_instances/README.md
+++ b/cost/aws/rightsize_compute_instances/README.md
@@ -12,3 +12,30 @@ This policy checks all the instances in an AWS Account for CPU and Memory usage 
 - (Coming soon) The recommendation provided for Idle Instances is a termination action. These instancse can be terminated in an automated manner or after approval.
 - The policy identifies all instances that have CPU utilization and/or Memory utilization below the Underutilized Instance CPU/Memory Threshold/s defined by the user, to provide a recommendation.
 - (Coming soon) The recommendation provided for Inefficient/Underutilized Instances is a downsize action. These instancse can be downsized in an automated manner or after approval.
+
+### Policy savings details
+
+The policy includes the estimated savings. The estimated savings is recognized if the resource is terminated, or downsized. Optima is used to receive the estimated savings which is the cost of the resource for the last full month. The savings is displayed in the Estimated Monthly Savings column. If the resource can not be found in Optima the value is 0.0. The incident message detail includes the sum of each resource Estimated Monthly Savings as Total Estimated Monthly Savings.
+
+## Input Parameters
+
+- *Email addresses to notify* - Email addresses of the recipients you wish to notify when new incidents are created.
+- *Account Number* - The Account number for use with the AWS STS Cross Account Role. Leave blank when using AWS IAM Access key and secret. It only needs to be passed when the desired AWS account is different than the one associated with the Flexera One credential. [more](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1123608)
+- *Allowed Regions* - A list of allowed regions for an AWS account. Please enter the allowed regions code if SCP is enabled, see [Available Regions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) in AWS; otherwise, the policy may fail on regions that are disabled via SCP. Leave blank to consider all the regions.
+- *Idle Instance CPU Threshold (%)* - The CPU threshold at which to consider an instance to be 'idle' and therefore be flagged for termination. Set to -1 to ignore CPU utilization.
+- *Idle Instance Memory Threshold (%)* - The Memory threshold at which to consider an instance to be 'idle' and therefore be flagged for termination. Set to -1 to ignore memory utilization.
+- *Underutilized Instance CPU Threshold (%)* - The CPU threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing. Set to -1 to ignore CPU utilization.
+- *Underutilized Instance Memory Threshold (%)* - The Memory threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing. Set to -1 to ignore memory utilization.
+- *Idle/Utilized for both CPU/Memory or either* - Set whether an instance should be considered idle and/or underutilized only if both CPU and memory are under the thresholds or if either CPU or memory are under. Note: this parameter is only valid when at least one Memory Utilization threshold and one CPU Utilization threshold is NOT set to -1
+- *Exclusion Tag Key* - An Azure-native instance tag key to ignore instances that you don't want to consider for downsizing. Example: exclude_utilization.
+- *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).
+- *Subscription Whitelist* - Whitelisted Subscriptions, if empty, all subscriptions will be checked.
+- *Log to CM Audit Entries* - Boolean for whether or not to log any debugging information from actions to CM Audit Entries, this should be left set to No on Flexera EU.
+
+
+
+- *Idle for both CPU/Memory or either* - Set to Both CPU and Memory to consider an instance idle only if it is below both the CPU and memory utilization parameters. Set to Either CPU or Memory to consider an instance idle if either CPU or memory are below the parameter values. Has no effect if either of the utilization parameters are set to -1.
+- *Threshold Statistic* - Statistic to use for the metric threshold
+- *Exclusion Tag Key:Value* - Cloud native tag to ignore instances. Format: Key:Value
+- *CloudWatch API Wait Time* - The amount of time in seconds to wait between requests to the CloudWatch API to avoid being throttled by AWS. Default is recommended.
+- *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).

--- a/cost/aws/rightsize_compute_instances/README.md
+++ b/cost/aws/rightsize_compute_instances/README.md
@@ -7,8 +7,8 @@ This policy checks all the instances in an AWS Account for CPU and Memory usage 
 ## Functional Details
 
 - The policy leverages the AWS API to check all instances and then uses the AWS CloudWatch API to check the instance average CPU and Memory utilization over the past 30 days.
-- The utilization data is provided for the following statistics: Average, 99th per
-- The policy identifies all instances that have CPU utilization below the Idle Instance CPU Threshold defined by the user, to provide a recommendation.
-- The recommendation provided for Idle Instances is a termination action. These instancse can be terminated in an automated manner or after approval.
-- The policy identifies all instances that have CPU utilization below the Inefficient Instance CPU Threshold defined by the user, to provide a recommendation.
-- The recommendation provided for Inefficient/Underutilized Instances is a downsize action. These instancse can be downsized in an automated manner or after approval.
+- The utilization data is provided for the following statistics: Average, 99th percentile, 95th percentile, 90th percentile.
+- The policy identifies all instances that have CPU utilization and/or Memory utilization below the Idle Instance CPU/Memory Threshold/s defined by the user, to provide a recommendation.
+- (Coming soon) The recommendation provided for Idle Instances is a termination action. These instancse can be terminated in an automated manner or after approval.
+- The policy identifies all instances that have CPU utilization and/or Memory utilization below the Underutilized Instance CPU/Memory Threshold/s defined by the user, to provide a recommendation.
+- (Coming soon) The recommendation provided for Inefficient/Underutilized Instances is a downsize action. These instancse can be downsized in an automated manner or after approval.

--- a/cost/aws/rightsize_compute_instances/README.md
+++ b/cost/aws/rightsize_compute_instances/README.md
@@ -26,16 +26,10 @@ The policy includes the estimated savings. The estimated savings is recognized i
 - *Idle Instance Memory Threshold (%)* - The Memory threshold at which to consider an instance to be 'idle' and therefore be flagged for termination. Set to -1 to ignore memory utilization.
 - *Underutilized Instance CPU Threshold (%)* - The CPU threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing. Set to -1 to ignore CPU utilization.
 - *Underutilized Instance Memory Threshold (%)* - The Memory threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing. Set to -1 to ignore memory utilization.
-- *Idle/Utilized for both CPU/Memory or either* - Set whether an instance should be considered idle and/or underutilized only if both CPU and memory are under the thresholds or if either CPU or memory are under. Note: this parameter is only valid when at least one Memory Utilization threshold and one CPU Utilization threshold is NOT set to -1
-- *Exclusion Tag Key* - An Azure-native instance tag key to ignore instances that you don't want to consider for downsizing. Example: exclude_utilization.
+- *Idle/Utilized for both CPU/Memory or either* - Set whether an instance should be considered idle and/or underutilized only if both CPU and memory are under the thresholds or if either CPU or memory are under. Note: this parameter is only valid when at least one Memory Utilization threshold and one CPU Utilization threshold is NOT set to -1.
+- *Threshold Statistic* - Statistic to use for the metric threshold.
+- *Exclusion Tag Key:Value* - Cloud native tag to ignore instances that you don't want to consider for downsizing or termination. Format: Key:Value
+- *CloudWatch API Wait Time* - The amount of time in seconds to wait between requests to the CloudWatch API to avoid being throttled by AWS. Default is recommended.
 - *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).
 - *Subscription Whitelist* - Whitelisted Subscriptions, if empty, all subscriptions will be checked.
 - *Log to CM Audit Entries* - Boolean for whether or not to log any debugging information from actions to CM Audit Entries, this should be left set to No on Flexera EU.
-
-
-
-- *Idle for both CPU/Memory or either* - Set to Both CPU and Memory to consider an instance idle only if it is below both the CPU and memory utilization parameters. Set to Either CPU or Memory to consider an instance idle if either CPU or memory are below the parameter values. Has no effect if either of the utilization parameters are set to -1.
-- *Threshold Statistic* - Statistic to use for the metric threshold
-- *Exclusion Tag Key:Value* - Cloud native tag to ignore instances. Format: Key:Value
-- *CloudWatch API Wait Time* - The amount of time in seconds to wait between requests to the CloudWatch API to avoid being throttled by AWS. Default is recommended.
-- *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).

--- a/cost/aws/rightsize_compute_instances/README.md
+++ b/cost/aws/rightsize_compute_instances/README.md
@@ -80,6 +80,7 @@ For administrators [creating and managing credentials](https://docs.flexera.com/
       ]
   }
   ```
+
 - [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
   - `billing_center_viewer`
 

--- a/cost/aws/rightsize_compute_instances/README.md
+++ b/cost/aws/rightsize_compute_instances/README.md
@@ -33,3 +33,50 @@ The policy includes the estimated savings. The estimated savings is recognized i
 - *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).
 - *Subscription Whitelist* - Whitelisted Subscriptions, if empty, all subscriptions will be checked.
 - *Log to CM Audit Entries* - Boolean for whether or not to log any debugging information from actions to CM Audit Entries, this should be left set to No on Flexera EU.
+
+Please note that the "Automatic Actions" parameter contains a list of action(s) that can be performed on the resources. When it is selected, the policy will automatically execute the corresponding action on the data that failed the checks, post incident generation. Please leave it blank for *manual* action.
+For example if a user selects the "Terminate Instances" action while applying the policy, all the resources that didn't satisfy the policy condition will be terminated.
+
+## Policy Actions
+
+- Sends an email notification
+- (Coming soon) Terminate virtual machines (if idle) after approval
+- (Coming soon) Downsize virtual machines (if underutilized) after approval
+
+## Prerequisites
+
+This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).
+
+### Credential configuration
+
+For administrators [creating and managing credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) to use with this policy, the following information is needed:
+
+- [**AWS Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1121575) (*provider=aws*) which has the following permissions:
+  - `ec2:DescribeRegions`
+  - `ec2:DescribeInstances`
+  - `ec2:DescribeTags`
+  - `cloudwatch:GetMetricStatistics`
+  - `cloudwatch:GetMetricData`
+  - `cloudwatch:ListMetrics`
+
+  Example IAM Permission Policy:
+
+  ```json
+  {
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "ec2:DescribeRegions",
+                  "ec2:DescribeInstances",
+                  "ec2:DescribeTags",
+                  "cloudwatch:GetMetricStatistics",
+                  "cloudwatch:GetMetricData",
+                  "cloudwatch:ListMetrics"
+              ],
+              "Resource": "*"
+          }
+      ]
+  }
+  ```

--- a/cost/aws/rightsize_compute_instances/README.md
+++ b/cost/aws/rightsize_compute_instances/README.md
@@ -1,0 +1,14 @@
+# AWS Rightsize Compute Instances
+
+## What it does
+
+This policy checks all the instances in an AWS Account for CPU and Memory usage over the last 30 days. If the usage is less than the user provided Idle Instance CPU/Memory percentage threshold then the Virtual Machine is recommended for termination. If the usage is less than the user provided Underutilized Instance CPU/Memory percentage threshold then the Virtual Machine is recommended for downsizing. Both sets of Virtual Machines returned from this policy are emailed to the user.
+
+## Functional Details
+
+- The policy leverages the AWS API to check all instances and then uses the AWS CloudWatch API to check the instance average CPU and Memory utilization over the past 30 days.
+- The utilization data is provided for the following statistics: Average, 99th per
+- The policy identifies all instances that have CPU utilization below the Idle Instance CPU Threshold defined by the user, to provide a recommendation.
+- The recommendation provided for Idle Instances is a termination action. These instancse can be terminated in an automated manner or after approval.
+- The policy identifies all instances that have CPU utilization below the Inefficient Instance CPU Threshold defined by the user, to provide a recommendation.
+- The recommendation provided for Inefficient/Underutilized Instances is a downsize action. These instancse can be downsized in an automated manner or after approval.

--- a/cost/aws/rightsize_compute_instances/README.md
+++ b/cost/aws/rightsize_compute_instances/README.md
@@ -107,7 +107,7 @@ To enable windows support you will need to add the following to your cloudwatch 
 
 ## Supported Clouds
 
-- Azure
+- AWS
 
 ## Cost
 

--- a/cost/aws/rightsize_compute_instances/README.md
+++ b/cost/aws/rightsize_compute_instances/README.md
@@ -80,3 +80,34 @@ For administrators [creating and managing credentials](https://docs.flexera.com/
       ]
   }
   ```
+- [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
+  - `billing_center_viewer`
+
+The [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) page in the docs has detailed instructions for setting up Credentials for the most common providers.
+
+### Memory Support
+
+By default only CPU metrics are available from CloudWatch.  To enable support for memory utilization, you must have the CloudWatch Agent installed on your EC2 instance(s) to collect memory metrics.  Please reference [AWS Docs > Install CloudWatch Agent on EC2 Instance](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/install-CloudWatch-Agent-on-EC2-Instance.html) for more information.
+
+### Windows Support
+
+To enable windows support you will need to add the following to your cloudwatch config.json and restart cloudwatch agent
+
+```json
+"metrics": {
+  "append_dimensions": {
+    "AutoScalingGroupName": "${aws:AutoScalingGroupName}",
+    "ImageId": "${aws:ImageId}",
+    "InstanceId": "${aws:InstanceId}",
+    "InstanceType": "${aws:InstanceType}"
+  }
+}
+```
+
+## Supported Clouds
+
+- Azure
+
+## Cost
+
+This Policy Template does not incur any cloud costs.

--- a/cost/aws/rightsize_compute_instances/aws_compute_rightsizing.pt
+++ b/cost/aws/rightsize_compute_instances/aws_compute_rightsizing.pt
@@ -37,7 +37,7 @@ end
 parameter "param_03_idle_threshold_cpu_value" do
   type "number"
   label "Idle Instance CPU Threshold (%)"
-  description "The threshold at which to consider an instance to be 'idle' and therefore be flagged for termination. Set to -1 to ignore CPU utilization"
+  description "The CPU threshold at which to consider an instance to be 'idle' and therefore be flagged for termination. Set to -1 to ignore CPU utilization"
   default 5
   min_value -1
   max_value 100
@@ -46,7 +46,7 @@ end
 parameter "param_04_idle_threshold_mem_value" do
   type "number"
   label "Idle Instance Memory Threshold (%)"
-  description "The threshold at which to consider an instance to be 'idle' and therefore be flagged for termination. Set to -1 to ignore memory utilization"
+  description "The Memory threshold at which to consider an instance to be 'idle' and therefore be flagged for termination. Set to -1 to ignore memory utilization"
   default 5
   min_value -1
   max_value 100
@@ -57,7 +57,7 @@ end
 parameter "param_05_underutil_threshold_cpu_value" do
   type "number"
   label "Underutilized Instance CPU Threshold (%)" # 'Inefficient' or 'Underutilized' as correct terminology?
-  description "The threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing. Set to -1 to ignore CPU utilization"
+  description "The CPU threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing. Set to -1 to ignore CPU utilization"
   default 40
   min_value -1
   max_value 100
@@ -66,7 +66,7 @@ end
 parameter "param_06_underutil_threshold_mem_value" do
   type "number"
   label "Underutilized Instance Memory Threshold (%)"
-  description "The threshold at which to consider an instance to be 'underutilized' and therefore be flagged for termination. Set to -1 to ignore memory utilization"
+  description "The Memory threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing. Set to -1 to ignore memory utilization"
   default 40
   min_value -1
   max_value 100
@@ -76,8 +76,8 @@ end
 #GLOBAL THRESHOLD PARAMETERS - CHECK MEM AND/OR CPU, SET THRESHOLD STAT
 parameter "param_07_check_both" do
   type "string"
-  label "Idle for both CPU/Memory or either"
-  description "Whether an instance should be considered idle only if both CPU and memory are under the thresholds or if either CPU or memory are under. Note: this parameter is only valid when at least one Memory Utilization threshold and one CPU Utilization threshold is NOT set to -1"
+  label "Idle/Utilized for both CPU/Memory or either"
+  description "Set whether an instance should be considered idle and/or underutilized only if both CPU and memory are under the thresholds or if either CPU or memory are under. Note: this parameter is only valid when at least one Memory Utilization threshold and one CPU Utilization threshold is NOT set to -1"
   default "Either CPU or Memory"
   allowed_values "Both CPU and Memory", "Either CPU or Memory"
 end
@@ -94,7 +94,7 @@ end
 parameter "param_09_exclusion_tag_key" do
   category "User Inputs"
   label "Exclusion Tag Key:Value"
-  description "Cloud native tag to ignore instances. Format: Key:Value"
+  description "Cloud native tag to ignore instances that you don't want to consider for downsizing or termination. Format: Key:Value"
   type "string"
   allowed_pattern /(^$)|([\w]?)+\:([\w]?)+/
   default ""

--- a/cost/aws/rightsize_compute_instances/aws_compute_rightsizing.pt
+++ b/cost/aws/rightsize_compute_instances/aws_compute_rightsizing.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "1.0",
+  version: "2.0",
   provider: "AWS",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",

--- a/cost/aws/rightsize_compute_instances/aws_compute_rightsizing.pt
+++ b/cost/aws/rightsize_compute_instances/aws_compute_rightsizing.pt
@@ -18,7 +18,7 @@ info(
 # Parameters
 ###############################################################################
 
-parameter "param_01_aws_account_number" do
+parameter "param_aws_account_number" do
   type "string"
   label "Account Number"
   description "The account number for AWS STS Cross Account Roles."
@@ -141,7 +141,7 @@ credentials "auth_aws" do
   label "AWS"
   description "Select the AWS Credential from the list"
   tags "provider=aws"
-  aws_account_number $param_01_aws_account_number
+  aws_account_number $param_aws_account_number
 end
 
 #AUTHENTITCATE WITH FLEXERA/OPTIMA
@@ -256,7 +256,7 @@ datasource "ds_regions_list" do
     query "Filter.1.Value.2", "opted-in"
     # Header X-Meta-Flexera has no affect on datasource query, but is required for Meta Policies
     # Forces `ds_is_deleted` datasource to run first during policy execution
-    #header "Meta-Flexera", val($ds_is_deleted, "path")
+    header "Meta-Flexera", val($ds_is_deleted, "path")
   end
   result do
     encoding "xml"
@@ -884,11 +884,11 @@ script "js_get_idle_and_underutil_instances", type:"javascript" do
             idle_total_savings += total_cost
           }
           // If an Underutilized instance
-          if ( instance['cpu' + "_" + param_08_threshold_statistic] < param_05_underutil_threshold_cpu_value 
+          else if ( instance['cpu' + "_" + param_08_threshold_statistic] < param_05_underutil_threshold_cpu_value 
             && instance['mem' + "_" + param_08_threshold_statistic] < param_06_underutil_threshold_mem_value ) {
             instance["savings"] = parseFloat(total_cost).toFixed(3)
             instance["recommendationType"] = "Downsize"
-            idle_total_savings += total_cost
+            underutil_total_savings += total_cost
           }
         }
         // If checking instance is below threshold for both cpu OR memory
@@ -901,11 +901,11 @@ script "js_get_idle_and_underutil_instances", type:"javascript" do
             idle_total_savings += total_cost
           }
           // If an Underutilized instance
-          if ( instance['cpu' + "_" + param_08_threshold_statistic] < param_05_underutil_threshold_cpu_value 
+          else if ( instance['cpu' + "_" + param_08_threshold_statistic] < param_05_underutil_threshold_cpu_value 
             || instance['mem' + "_" + param_08_threshold_statistic] < param_06_underutil_threshold_mem_value ) {
             instance["savings"] = parseFloat(total_cost).toFixed(3)
             instance["recommendationType"] = "Downsize"
-            idle_total_savings += total_cost
+            underutil_total_savings += total_cost
           }
         }
       }
@@ -957,12 +957,12 @@ end
 policy "pol_utilization" do
   validate_each $ds_idle_and_underutil_instances do
     summary_template <<-EOS
-    {{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ with index data 0 }}{{ .summaryData.underutilInstanceCount }}{{ end }} Azure underutilized compute instances found
+    {{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ with index data 0 }}{{ .summaryData.underutilInstanceCount }}{{ end }} AWS underutilized compute instances found
         EOS
     detail_template <<-EOS
     {{ with index data 0 }}{{ .summaryData.underutilMessage }}{{ end }}
         EOS
-    check ne( (val(item, "recommendationType")), "Downsize" )
+    check logic_or($ds_parent_policy_terminated, ne( (val(item, "recommendationType")), "Downsize" ))
     escalate $esc_email
     #escalate $esc_downsize_instances
     export do
@@ -1057,12 +1057,12 @@ policy "pol_utilization" do
   end
   validate_each $ds_idle_and_underutil_instances do
     summary_template <<-EOS
-    {{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ with index data 0 }}{{ .summaryData.idleInstanceCount }}{{end}} Azure idle compute instances found
+    {{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ with index data 0 }}{{ .summaryData.idleInstanceCount }}{{end}} AWS idle compute instances found
     EOS
     detail_template <<-EOS
     {{ with index data 0 }}{{ .summaryData.idleMessage }}{{ end }}
     EOS
-    check ne( (val(item, "recommendationType")), "Terminate" )
+    check logic_or($ds_parent_policy_terminated, ne( (val(item, "recommendationType")), "Terminate" ))
     escalate $esc_email
     #escalate $esc_terminate_instances
     export do
@@ -1165,4 +1165,95 @@ escalation "esc_email" do
   label "Send Email"
   description "Send incident email"
   email $param_email
+end
+
+###############################################################################
+# Meta Policy [alpha]
+# Not intended to be modified or used by policy developers
+###############################################################################
+
+# If the meta_parent_policy_id is not set it will evaluate to an empty string and we will look for the policy itself,
+# if it is set we will look for the parent policy.
+datasource "ds_get_policy" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    ignore_status [404]
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", switch(ne(meta_parent_policy_id,""), meta_parent_policy_id, policy_id) ])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+  end
+end
+
+
+datasource "ds_parent_policy_terminated" do
+  run_script $js_decide_if_self_terminate, $ds_get_policy, policy_id, meta_parent_policy_id
+end
+
+# If the policy was applied by a meta_parent_policy we confirm it exists if it doesn't we confirm we are deleting
+# This information is used in two places:
+# - determining whether or not we make a delete call
+# - determining if we should create an incident (we don't want to create an incident on the run where we terminate)
+script "js_decide_if_self_terminate", type: "javascript" do
+  parameters "found", "self_policy_id", "meta_parent_policy_id"
+  result "result"
+  code <<-EOS
+  var result
+  if (meta_parent_policy_id != "" && found.id == undefined) {
+    result = true
+  } else {
+    result = false
+  }
+  EOS
+end
+
+# Two potentials ways to set this up:
+# - this way and make a unneeded 'get' request when not deleting
+# - make the delete request an interate and have it iterate over an empty array when not deleting and an array with one item when deleting
+script "js_make_terminate_request", type: "javascript" do
+  parameters "should_delete", "policy_id", "rs_project_id", "rs_governance_host"
+  result "request"
+  code <<-EOS
+
+  var request = {
+    auth:  'auth_flexera',
+    host: rs_governance_host,
+    path: "/api/governance/projects/" + rs_project_id + "/applied_policies/" + policy_id,
+    headers: {
+      "API-Version": "1.0",
+      "Content-Type":"application/json"
+    },
+  }
+
+  if (should_delete) {
+    request.verb = 'DELETE'
+  }
+  EOS
+end
+
+datasource "ds_terminate_self" do
+  request do
+    run_script $js_make_terminate_request, $ds_parent_policy_terminated, policy_id, rs_project_id, rs_governance_host
+  end
+end
+
+datasource "ds_is_deleted" do
+  run_script $js_check_deleted, $ds_terminate_self
+end
+
+# This is just a way to have the check delete request connect to the farthest leaf from policy.
+# We want the delete check to the first thing the policy does to avoid the policy erroring before it can decide whether or not it needs to self terminate
+# Example a customer deletes a credential and then terminates the parent policy. We still want the children to self terminate
+# The only way I could see this not happening is if the user who applied the parent_meta_policy was offboarded or lost policy access, the policies who are impersonating the user
+# would not have access to self-terminate
+# It may be useful for the backend to enable a mass terminate at some point for all meta_child_policies associated with an id.
+script "js_check_deleted", type: "javascript" do
+  parameters "response"
+  result "result"
+  code <<-EOS
+  result = {"path":"/"}
+  EOS
 end

--- a/cost/aws/rightsize_compute_instances/aws_compute_rightsizing.pt
+++ b/cost/aws/rightsize_compute_instances/aws_compute_rightsizing.pt
@@ -144,7 +144,7 @@ credentials "auth_aws" do
   aws_account_number $param_aws_account_number
 end
 
-#AUTHENTITCATE WITH FLEXERA/OPTIMA
+#AUTHENTICATE WITH FLEXERA/OPTIMA
 credentials "auth_flexera" do
   schemes "oauth2"
   label "flexera"

--- a/cost/aws/rightsize_compute_instances/aws_compute_rightsizing.pt
+++ b/cost/aws/rightsize_compute_instances/aws_compute_rightsizing.pt
@@ -1,0 +1,1168 @@
+name "AWS Rightsize Compute Instances"
+rs_pt_ver 20180301
+type "policy"
+short_description "Check for instances that have inefficient utilization for the last 30 days and rightsizes or terminates them after approval. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/rightsize_compute_instances/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+long_description ""
+severity "low"
+category "Cost"
+default_frequency "weekly"
+info(
+  version: "1.0",
+  provider: "AWS",
+  service: "Compute",
+  policy_set: "Rightsize Compute Instances",
+  recommendation_type: "Usage Reduction"
+)
+
+###############################################################################
+# Parameters
+###############################################################################
+
+parameter "param_01_aws_account_number" do
+  type "string"
+  label "Account Number"
+  description "The account number for AWS STS Cross Account Roles."
+  default ""
+end
+
+parameter "param_02_allowed_regions" do
+  type "list"
+  label "Allowed Regions"
+  allowed_pattern /^([a-zA-Z-_]+-[a-zA-Z0-9-_]+-[0-9-_]+,*|)+$/
+  description "A list of allowed regions. See the README for more details"
+  default []
+end
+
+#IDLE INSTANCE THRESHOLD PARAMETERS##########
+parameter "param_03_idle_threshold_cpu_value" do
+  type "number"
+  label "Idle Instance CPU Threshold (%)"
+  description "The threshold at which to consider an instance to be 'idle' and therefore be flagged for termination. Set to -1 to ignore CPU utilization"
+  default 5
+  min_value -1
+  max_value 100
+end
+
+parameter "param_04_idle_threshold_mem_value" do
+  type "number"
+  label "Idle Instance Memory Threshold (%)"
+  description "The threshold at which to consider an instance to be 'idle' and therefore be flagged for termination. Set to -1 to ignore memory utilization"
+  default 5
+  min_value -1
+  max_value 100
+end
+#############################################
+
+#UNDERUTILIZED INSTANCE THRESHOLD PARAMETERS#
+parameter "param_05_underutil_threshold_cpu_value" do
+  type "number"
+  label "Underutilized Instance CPU Threshold (%)" # 'Inefficient' or 'Underutilized' as correct terminology?
+  description "The threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing. Set to -1 to ignore CPU utilization"
+  default 40
+  min_value -1
+  max_value 100
+end
+
+parameter "param_06_underutil_threshold_mem_value" do
+  type "number"
+  label "Underutilized Instance Memory Threshold (%)"
+  description "The threshold at which to consider an instance to be 'underutilized' and therefore be flagged for termination. Set to -1 to ignore memory utilization"
+  default 40
+  min_value -1
+  max_value 100
+end
+#############################################
+
+#GLOBAL THRESHOLD PARAMETERS - CHECK MEM AND/OR CPU, SET THRESHOLD STAT
+parameter "param_07_check_both" do
+  type "string"
+  label "Idle for both CPU/Memory or either"
+  description "Whether an instance should be considered idle only if both CPU and memory are under the thresholds or if either CPU or memory are under. Note: this parameter is only valid when at least one Memory Utilization threshold and one CPU Utilization threshold is NOT set to -1"
+  default "Either CPU or Memory"
+  allowed_values "Both CPU and Memory", "Either CPU or Memory"
+end
+
+parameter "param_08_threshold_statistic" do
+  type "string"
+  label "Threshold Statistic"
+  description "Statistic to use for the metric threshold"
+  default "Average"
+  allowed_values "Average", "p99", "p95", "p90"
+end
+#############################################
+
+parameter "param_09_exclusion_tag_key" do
+  category "User Inputs"
+  label "Exclusion Tag Key:Value"
+  description "Cloud native tag to ignore instances. Format: Key:Value"
+  type "string"
+  allowed_pattern /(^$)|([\w]?)+\:([\w]?)+/
+  default ""
+end
+
+parameter "param_10_api_wait" do
+  type "number"
+  label "CloudWatch API Wait Time"
+  description "Amount of time to wait between CloudWatch API requests to avoid throttling (seconds)"
+  default 5
+  min_value 1
+  max_value 60
+end
+
+parameter "param_11_automatic_action" do
+  type "list"
+  label "Automatic Actions"
+  description "When this value is set, this policy will automatically take the selected action(s)"
+  allowed_values ["Terminate Instances"]
+  default []
+end
+
+parameter "param_12_log_to_cm_audit_entries" do
+  type "string"
+  label "Log to CM Audit Entries"
+  description "Boolean for whether or not to log any debugging information from actions to CM Audit Entries, this should be left set to No on Flexera EU"
+  default "No"
+  allowed_values "Yes", "No"
+end
+
+parameter "param_email" do
+  type "list"
+  label "Email addresses to notify"
+  description "Email addresses of the recipients you wish to notify when new incidents are created"
+end
+
+###############################################################################
+# Authentication
+###############################################################################
+
+#AUTHENTICATE WITH AWS
+credentials "auth_aws" do
+  schemes "aws","aws_sts"
+  label "AWS"
+  description "Select the AWS Credential from the list"
+  tags "provider=aws"
+  aws_account_number $param_01_aws_account_number
+end
+
+#AUTHENTITCATE WITH FLEXERA/OPTIMA
+credentials "auth_flexera" do
+  schemes "oauth2"
+  label "flexera"
+  description "Select Flexera One OAuth2 credentials"
+  tags "provider=flexera"
+end
+
+###############################################################################
+# Datasources & Scripts
+###############################################################################
+
+#GET CURRENCY REFERENCE AND CURRENCY CODE FOR ORG
+datasource "ds_currency_reference" do
+  request do
+    host "raw.githubusercontent.com"
+    path "/rightscale/policy_templates/master/cost/scheduled_reports/currency_reference.json"
+    header "User-Agent", "RS Policies"
+  end
+end
+
+datasource "ds_currency_code" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/bill-analysis/orgs/",rs_org_id,"/settings/currency_code"])
+    header "Api-Version", "0.1"
+    header "User-Agent", "RS Policies"
+    ignore_status [403]
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response,"id")
+    field "value", jmes_path(response,"value")
+  end
+end
+
+#CREATE SIMPLE OBJECT CONTAINING CURRENCY CODE AND NUMBER SEPARATOR
+datasource "ds_currency" do
+  run_script $js_create_currency, $ds_currency_reference, $ds_currency_code
+end
+
+script "js_create_currency", type:"javascript" do
+  parameters "ds_currency_reference", "ds_currency_code"
+  result "result"
+  code <<-EOS
+    var symbol = ""
+    var separator = ""
+    if( ds_currency_code['value'] !== undefined ) {
+      if (ds_currency_reference[ds_currency_code['value']] !== undefined ) {
+        symbol = ds_currency_reference[ds_currency_code['value']]['symbol']
+        if( ds_currency_reference[ds_currency_code['value']]['t_separator'] !== undefined ) {
+          separator = ds_currency_reference[ds_currency_code['value']]['t_separator']
+        }
+      }
+    } else {
+      symbol = "$"
+      separator = ","
+    }
+    result = {
+      'symbol': symbol,
+      'separator': separator
+    }
+  EOS
+end
+
+#GET AWS ACCOUNT NUMBER TO FILTER REQUESTS TO JUST THE ACCOUNT BEING CHECKED
+datasource "ds_get_caller_identity" do
+  request do
+    auth $auth_aws
+    verb "GET"
+    host "sts.amazonaws.com"
+    path "/"
+    header "User-Agent", "RS Policies"
+    query "Action", "GetCallerIdentity"
+    query "Version", "2011-06-15"
+  end
+  result do
+    encoding "xml"
+    collect xpath(response, "//GetCallerIdentityResponse/GetCallerIdentityResult") do
+      field "account", xpath(col_item, "Account")
+    end
+  end
+end
+
+datasource "ds_aws_account" do
+  run_script $js_get_aws_account, $ds_get_caller_identity
+end
+
+script "js_get_aws_account", type:"javascript" do
+  parameters "ds_get_caller_identity"
+  result "result"
+  code <<-EOS
+    result = ds_get_caller_identity[0]['account']
+  EOS
+end
+
+# GET LIST OF OPTED-IN OR OPTED-IN-NOT-REQUIRED REGIONS
+datasource "ds_regions_list" do
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+  request do
+    auth $auth_aws
+    verb "GET"
+    host "ec2.amazonaws.com"
+    path "/"
+    query "Action", "DescribeRegions"
+    query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
+    # Header X-Meta-Flexera has no affect on datasource query, but is required for Meta Policies
+    # Forces `ds_is_deleted` datasource to run first during policy execution
+    #header "Meta-Flexera", val($ds_is_deleted, "path")
+  end
+  result do
+    encoding "xml"
+    collect xpath(response, "//DescribeRegionsResponse/regionInfo/item", "array") do
+      field "region", xpath(col_item, "regionName")
+    end
+  end
+end
+
+#FILTER REGIONS LIST ON 'ALLOWED REGIONS' PARAMETER
+datasource "ds_regions" do
+  run_script $js_get_regions, $param_02_allowed_regions, $ds_regions_list
+end
+
+script "js_get_regions", type:"javascript" do
+  parameters "user_entered_regions", "all_regions"
+  result "regions"
+  code <<-EOS
+    if (_.isEmpty(user_entered_regions)) {
+      regions = all_regions
+    } else {
+      //Filter unique regions
+      var uniqueRegions = _.uniq(user_entered_regions)
+      var all_regions_list = []
+      all_regions.forEach(function(all_region){
+        all_regions_list.push(all_region.region)
+      })
+      //Filter valid regions
+      var valid_regions = []
+      _.map(uniqueRegions, function(uniqueRegion){
+        if(all_regions_list.indexOf(uniqueRegion) > -1){
+          valid_regions.push({"region": uniqueRegion})
+        }
+      })
+      //Throw an error if no valid regions found
+      if (_.isEmpty(valid_regions)) {
+        regions = all_regions
+      }else{
+        regions = valid_regions
+      }
+    }
+  EOS
+end
+
+#GET LIST OF INSTANCES FROM AWS
+datasource "ds_instances_set" do
+  iterate $ds_regions
+  request do
+    auth $auth_aws
+    host join(['ec2.', val(iter_item, 'region'), '.amazonaws.com'])
+    path '/'
+    header 'User-Agent', 'RS Policies'
+    header 'Content-Type', 'text/xml'
+    query 'Action', 'DescribeInstances'
+    query 'Version', '2016-11-15'
+    query 'Filter.1.Name', 'instance-state-name'
+    query 'Filter.1.Value.1', 'running'
+  end
+  result do
+    encoding "xml"
+    collect xpath(response, "//DescribeInstancesResponse/reservationSet/item", "array") do
+      field "instances_set" do
+        collect xpath(col_item,"instancesSet/item","array") do
+          field "region",val(iter_item, "region")
+          field "instanceId", xpath(col_item,"instanceId")
+          field "imageId", xpath(col_item,"imageId")
+          field "resourceType", xpath(col_item, "instanceType")
+          field "platform", xpath(col_item, "platformDetails")
+          field "privateDnsName", xpath(col_item, "privateDnsName")
+          field "launchTime", xpath(col_item, "launchTime")
+          field "tags" do
+            collect xpath(col_item,"tagSet/item","array") do
+              field "key", xpath(col_item, "key")
+              field "value", xpath(col_item, "value")
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+#FILTER INSTANCES BY 'TAG KEY EXCLUSION' PARAMETER
+datasource "ds_instances" do
+  run_script $js_filter_instances, $ds_instances_set, $param_09_exclusion_tag_key
+end
+
+script "js_filter_instances", type: "javascript" do
+  result "result"
+  parameters "ds_instance_set", "param_09_exclusion_tag_key"
+  code <<-EOS
+    var tag_key = param_09_exclusion_tag_key.split(':')[0]
+    var tag_value = param_09_exclusion_tag_key.split(':')[1]
+    var result = []
+    _.each(ds_instance_set, function(ds_item) {
+      _.each(ds_item['instances_set'], function(instance) {
+        var tags = instance.tags
+        if (!(_.contains(_.pluck(tags,'key'), tag_key) && _.contains(_.pluck(tags,'value'), tag_value))) {
+          result.push(instance)
+        }
+      })
+    })
+  EOS
+end
+
+#BUILD CLOUDWATCH QUERIES FOR LIST OF FILTERED INSTANCES
+datasource "ds_instances_queries" do
+  run_script $js_build_instances_queries, $ds_instances, $param_03_idle_threshold_cpu_value, $param_04_idle_threshold_mem_value, $param_05_underutil_threshold_cpu_value, $param_06_underutil_threshold_mem_value
+end
+
+script "js_build_instances_queries", type: "javascript" do
+  result "queries"
+  parameters "ds_instances", "param_03_idle_threshold_cpu_value", "param_04_idle_threshold_mem_value", "param_05_underutil_threshold_cpu_value", "param_06_underutil_threshold_mem_value"
+  code <<-EOS
+
+    // Set CPU threshold for CloudWatch call (if Underutilized threshold is ignored, then check for Idle threshold)
+    var param_avg_cpu = -1
+    if (param_05_underutil_threshold_cpu_value != -1) {
+      param_avg_cpu = param_05_underutil_threshold_cpu_value
+    } else {
+      if (param_03_idle_threshold_cpu_value != -1){
+        param_avg_cpu = param_03_idle_threshold_cpu_value
+      }
+    }
+
+    // Set Memory threshold for CloudWatch call (if Underutilized threshold is ignored, then check for Idle threshold)
+    var param_avg_mem = -1
+    if (param_06_underutil_threshold_mem_value != -1) {
+      param_avg_mem = param_06_underutil_threshold_mem_value
+    } else {
+      if (param_04_idle_threshold_mem_value != -1){
+        param_avg_mem = param_04_idle_threshold_mem_value
+      }
+    }
+
+    //console.log("CPU threshold for CloudWatch: ", param_avg_cpu)
+    //console.log("Mem threshold for CloudWatch: ", param_avg_mem)
+  
+    // Create the various queries we're going to send to CloudWatch for each instance
+    queries = {}
+    _.each(ds_instances, function(instance) {
+      // Make sure the queries object has an array for the region to push items to
+      if (queries[instance['region']] == undefined || queries[instance['region']] == null) {
+        queries[instance['region']] = []
+      }
+      //We want to collect each of these list of statistics we care about
+      stats = ["Average", "Minimum", "Maximum", "p99", "p95", "p90"]
+      // Only query for CPU usage if we're actually checking it
+      if (param_avg_cpu != -1) {
+        _.each(stats, function(stat) {
+          query = {
+            "Id": instance['instanceId'].replace('-', '_') + "_cpu" + stat,
+            "MetricStat": {
+              "Metric": {
+                "Namespace": "AWS/EC2",
+                "MetricName": "CPUUtilization",
+                "Dimensions": [
+                  { "Name": "InstanceId", "Value": instance['instanceId'] }
+                ]
+              },
+              "Period": 2592000,
+              "Stat": stat
+            },
+            "ReturnData": true
+          }
+          queries[instance['region']].push(query)
+        })
+      }
+      // Only query for MEM usage if we're actually checking it
+      if (param_avg_mem != -1) {
+        if (instance['platform'] == "Windows") {
+          // If platform is Windows, we need to use the Windows custom metric
+          mem_metricname = "Memory % Committed Bytes In Use"
+          dimensions = [
+            { "Name": "ImageId", "Value": instance['imageId'] },
+            { "Name": "InstanceId", "Value": instance['instanceId'] },
+            { "Name": "InstanceType", "Value": instance['resourceType'] },
+            { "Name": "objectname", "Value": "Memory" }
+          ]
+        } else {
+          // Else assume Platform is Linux, and use the Linux custom metric
+          mem_metricname = "mem_used_percent"
+          dimensions = [
+            { "Name": "ImageId", "Value": instance['imageId'] },
+            { "Name": "InstanceId", "Value": instance['instanceId'] },
+            { "Name": "InstanceType", "Value": instance['resourceType'] }
+          ]
+        }
+        _.each(stats, function(stat) {
+          query = {
+            "Id": instance['instanceId'].replace('-', '_') + "_mem" + stat,
+            "MetricStat": {
+              "Metric": {
+                "Namespace": "CWAgent",
+                "MetricName": mem_metricname,
+                "Dimensions": dimensions
+              },
+              "Period": 2592000,
+              "Stat": stat
+            },
+            "ReturnData": true
+          }
+          queries[instance['region']].push(query)
+        })
+      }
+    })
+  EOS
+end
+
+#COMBINE THE ABOVE QUERIES INTO DISCRETE REQUESTS OF 500 OR FEWER QUERIES TO SEND INTO CLOUDWATCH API
+datasource "ds_instances_requests" do
+  run_script $js_get_instances_requests, $ds_instances_queries
+end
+
+script "js_get_instances_requests", type: "javascript" do
+  result "result"
+  parameters "queries"
+  code <<-EOS
+    // Organize the queries into discrete requests to send in.
+    // Queries are first sorted by region and then split into 500 item blocks.
+    result = []
+    end_date = parseInt(new Date().getTime() / 1000)
+    start_date = parseInt(new Date(new Date().setDate(new Date().getDate() - 30)).getTime() / 1000)
+    query_block_size = 500
+    _.each(Object.keys(queries), function(region) {
+      for (i = 0; i < queries[region].length; i += query_block_size) {
+        chunk = queries[region].slice(i, i + query_block_size)
+        result.push({
+          'body': { "StartTime": start_date, "EndTime": end_date, "MetricDataQueries": chunk },
+          'region': region
+        })
+      }
+    })
+  EOS
+end
+
+#GET CPU AND MEMORY UTILIZATION DATA FROM CLOUDWATCH USING BUILT INSTANCE QUERIES
+datasource "ds_cloudwatch_data" do
+  iterate $ds_instances_requests
+  request do
+    run_script $js_get_cloudwatch_data, val(iter_item, "region"), val(iter_item, "body"), $param_10_api_wait
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "MetricDataResults[*]") do
+      field "region", val(iter_item, "region")
+      field "id", jmes_path(col_item, "Id")
+      field "label", jmes_path(col_item, "Label")
+      field "values", jmes_path(col_item, "Values")
+    end
+  end
+end
+
+script "js_get_cloudwatch_data", type: "javascript" do
+  result "results"
+  parameters "region", "body", "api_wait"
+  code <<-EOS
+    // Slow down rate of requests to prevent throttling
+    var now = new Date().getTime()
+    while(new Date().getTime() < now + (api_wait * 1000)) { /* Do nothing */ }
+    results = {
+      "auth": "auth_aws",
+      "host": 'monitoring.' + region + '.amazonaws.com',
+      "verb": "POST",
+      "path": "/",
+      "headers": {
+        "User-Agent": "RS Policies",
+        "Content-Type": "application/json",
+        "x-amz-target": "GraniteServiceVersion20100801.GetMetricData",
+        "Accept": "application/json",
+        "Content-Encoding": "amz-1.0"
+      }
+      "query_params": {
+        'Action': 'GetMetricData',
+        'Version': '2010-08-01'
+      },
+      body: JSON.stringify(body)
+    }
+  EOS
+end
+
+#PARSE CLOUDWATCH DATA INTO JAVASCRIPT OBJECT
+datasource "ds_cloudwatch_data_sorted" do
+  run_script $js_sort_cloudwatch_data, $ds_cloudwatch_data
+end
+
+script "js_sort_cloudwatch_data", type: "javascript" do
+  result "result"
+  parameters "ds_cloudwatch_data"
+  code <<-EOS
+    // Sort the CloudWatch data into an object with keys for regions and instance names.
+    // This eliminates the need to "double loop" later on to match it with our instances list.
+    result = {}
+    _.each(ds_cloudwatch_data, function(item) {
+      region = item.region
+      instance_name = item.id.split('_')[0] + '-' + item.id.split('_')[1]
+      metric = item.id.split('_')[2]
+      value = item.values[0]
+      if (result[region] == undefined) {
+        result[region] = {}
+      }
+      if (result[region][instance_name] == undefined) {
+        result[region][instance_name] = {}
+      }
+      result[region][instance_name][metric] = value
+    })
+  EOS
+end
+
+#GET BILLING CENTERS FOR ORG (REQUIRED FOR GETTING ESTIMATED SAVINGS)
+datasource "ds_billing_centers" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/analytics/orgs/",rs_org_id,"/billing_centers"])
+    header "Api-Version", "1.0"
+    header "User-Agent", "RS Policies"
+    query "view", "allocation_table"
+    ignore_status [403]
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response,"[*]") do
+      field "href", jmes_path(col_item,"href")
+      field "id", jmes_path(col_item,"id")
+      field "name", jmes_path(col_item,"name")
+      field "parent_id", jmes_path(col_item,"parent_id")
+    end
+  end
+end
+
+#FILTER BILLING CENTERS FOR TOP LEVEL BCS
+datasource "ds_top_level_billing_centers" do
+  run_script $js_top_level_bc, $ds_billing_centers
+end
+
+script "js_top_level_bc", type: "javascript" do
+  parameters "billing_centers"
+  result "filtered_billing_centers"
+  code <<-EOS
+    var filtered_billing_centers =
+      _.reject(billing_centers, function(bc){ return bc.parent_id != null && bc.parent_id != undefined });
+  EOS
+end
+
+#GET INSTANCE COSTS FOR EACH BILLING CENTER
+datasource "ds_instance_costs" do
+  request do
+    run_script $js_get_instance_costs, $ds_aws_account, $ds_top_level_billing_centers, rs_org_id, rs_optima_host
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response,"rows[*]") do
+      field "resourceId", jmes_path(col_item, "dimensions.resource_id")
+      field "resourceType", jmes_path(col_item, "dimensions.resource_type")
+      field "vendorAccountName", jmes_path(col_item, "dimensions.vendor_account_name")
+      field "adjustmentName", jmes_path(col_item, "dimensions.adjustment_name")
+      field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
+    end
+  end
+end
+
+script "js_get_instance_costs", type: "javascript" do
+  parameters "aws_account_id", "billing_centers", "org_id", "optima_host"
+  result "request"
+  code <<-EOS
+    //Get Start and End dates
+    start_date = new Date(), end_date = new Date()
+    start_date.setMonth(start_date.getMonth() - 1)
+    end_date.setMonth(end_date.getMonth() - 0)
+    //some questions around best start/finish date - one day does not seem like long enough, and one month prior seems too far in past
+
+    var request = {
+      auth: "auth_flexera",
+      host: optima_host,
+      verb: "POST",
+      path: "/bill-analysis/orgs/" + org_id + "/costs/select",
+      body_fields: {
+        "dimensions": ["resource_id", "vendor_account_name", "resource_type", "adjustment_name"],
+        "granularity": "month",
+        "start_at": start_date.toLocaleDateString("en-US").split("-")[0] + "-" + start_date.toLocaleDateString("en-US").split("-")[1],
+        "end_at": end_date.toLocaleDateString("en-US").split("-")[0] + "-" + end_date.toLocaleDateString("en-US").split("-")[1],
+        "metrics": ["cost_amortized_unblended_adj"],
+        "billing_center_ids": _.compact(_.map(billing_centers, function(value){ return value.id})),
+        "limit": 100000,
+        "filter": {
+          "expressions": [
+            {
+              "dimension": "service",
+              "type": "equal",
+              "value": "AmazonEC2"
+            },
+            {
+              "dimension": "resource_type",
+              "type": "equal",
+              "value": "Compute Instance"
+            },
+            {
+              "dimension": "vendor_account",
+              "type": "equal",
+              "value": aws_account_id
+            },
+            {
+              "type": "not",
+              "expression": {
+                "dimension": "adjustment_name",
+                "type": "substring",
+                "substring": "Shared"
+              }
+            }
+          ],
+          "type": "and"
+        }
+      },
+      headers: {
+        "User-Agent": "RS Policies",
+        "Api-Version": "1.0"
+      },
+      ignore_status: [400]
+    }
+  EOS
+end
+
+#GET AWS INSTANCE SIZE MAP
+datasource "ds_aws_instance_size_map" do
+  request do
+    verb "GET"
+    host "raw.githubusercontent.com"
+    path "/flexera-public/policy_templates/master/data/aws/instance_types.json"
+    header "User-Agent", "RS Policies"
+  end
+end
+
+#COMBINE INSTANCE UTILIZATION DATA FROM CLOUDWATCH WITH INSTANCE LIST FROM AWS
+datasource "ds_merged_metrics" do
+  run_script $js_combine_metrics, $ds_cloudwatch_data_sorted, $ds_instances, $ds_aws_account, $ds_currency
+end
+
+script "js_combine_metrics", type: "javascript" do
+  result "result"
+  parameters "cloudwatch_data", "ds_instances", "aws_account_id", "currency"
+  code <<-EOS
+    result = []
+    //We want to collect each of these list of statistics we care about
+    stats = ["Average", "Minimum", "Maximum", "p99", "p95", "p90"]
+
+    _.each(ds_instances, function(instance) {
+      region = instance.region
+      id = instance.instanceId
+      // Only proceed if the CloudWatch data actually has the region and instance id.
+      // Otherwise, we have no usage data on the instance and thus dont include it in the results.
+      if (cloudwatch_data[region] != undefined) {
+        if (cloudwatch_data[region][id] != undefined) {
+          r = {
+            "region": instance.region,
+            "id": instance.instanceId,
+            "resourceID": instance.instanceId,
+            "platform": instance.platform,
+            "service": "EC2",
+            "privateDnsName": instance.privateDnsName,
+            "launchTime": instance.launchTime,
+            "hostname": instance.privateDnsName.split('.')[0],
+            "tags": instance.tags,
+            "resourceType": instance.resourceType,
+            "savings": null,
+            "accountID": aws_account_id,
+            "accountName": "",
+            "savingsCurrency": currency.symbol
+          }
+
+          // Grab usage data for the instance if it is present
+          _.each(stats, function(stat) {
+            _.each(["cpu", "mem"], function(metric) {
+              statname = metric + stat
+              //legacyStatName is the name of the attribute that was used in all versions up to version 4.X
+              //We use this instead of statname to keep backwards compatability for the exported data
+              legacyStatName = metric + "_" + stat.toLowerCase()
+              r[legacyStatName] = null
+              if (cloudwatch_data[region][id][statname] != undefined && cloudwatch_data[region][id][statname] != null) {
+                r[legacyStatName] = cloudwatch_data[region][id][statname]
+              }
+            })
+          })
+          // Send the instance information with the CloudWatch data into the final result.
+          // Also adds in the account ID and currency symbol since itll be needed for the incident.
+          result.push(r)
+        }
+      }
+    })
+  EOS
+end
+
+#COMBINE INSTANCE DATA WITH INSTANCE COST DATA FROM FLEXERA OPTIMA
+datasource "ds_idle_and_underutil_instances" do
+  run_script $js_get_idle_and_underutil_instances, $ds_merged_metrics, $ds_instance_costs, $ds_aws_instance_size_map,
+  $param_03_idle_threshold_cpu_value, $param_04_idle_threshold_mem_value, $param_05_underutil_threshold_cpu_value, $param_06_underutil_threshold_mem_value, 
+  $ds_currency, $param_07_check_both, $param_08_threshold_statistic
+end
+
+script "js_get_idle_and_underutil_instances", type:"javascript" do
+  parameters "ds_merged_metrics", "ds_instance_costs", "ds_aws_instance_size_map", "param_03_idle_threshold_cpu_value", "param_04_idle_threshold_mem_value", "param_05_underutil_threshold_cpu_value", "param_06_underutil_threshold_mem_value", "currency", "param_07_check_both", "param_08_threshold_statistic"
+  result "result"
+  code <<-EOS
+  var result = []
+
+  // Used for formatting numbers to look pretty
+  function formatNumber(number, separator){
+    var numString = number.toString()
+    var values = numString.split(".")
+    var result = ''
+    while (values[0].length > 3) {
+      var chunk = values[0].substr(-3)
+      values[0] = values[0].substr(0, values[0].length - 3)
+      result = separator + chunk + result
+    }
+    if (values[0].length > 0) {
+      result = values[0] + result
+    }
+    if (values[1] == undefined) {
+      return result
+    }
+    return result + "." + values[1]
+  }
+
+  // Get Account Name - Does not work where account name does not exist?
+  var accountName = ""
+  if (_.size(ds_instance_costs) > 0) {
+    accountName = ds_instance_costs[0].vendorAccountName
+  }
+
+  var idle_instances = []
+  var total_savings = 0.00
+  var cost_data_found = false
+  
+  // The key name is lowercase, param value needs to be lowercase. We use this to keep backwards compatibility for the exported data.
+  param_08_threshold_statistic = param_08_threshold_statistic.toLowerCase()
+  
+  // Set CPU threshold (if Underutilized threshold is ignored, then check for Idle threshold)
+  var param_avg_cpu = -1
+  if (param_05_underutil_threshold_cpu_value != -1) {
+    param_avg_cpu = param_05_underutil_threshold_cpu_value
+  } else {
+    if (param_03_idle_threshold_cpu_value != -1) {
+      param_avg_cpu = param_03_idle_threshold_cpu_value
+    }
+  }
+
+  // Set Memory threshold (if Underutilized threshold is ignored, then check for Idle threshold)
+  var param_avg_mem = -1
+  if (param_06_underutil_threshold_mem_value != -1) {
+    param_avg_mem = param_06_underutil_threshold_mem_value
+  } else {
+    if (param_04_idle_threshold_mem_value != -1){
+      param_avg_mem = param_04_idle_threshold_mem_value
+    }
+  }
+
+  //ADD COSTS TO INSTANCE UTILIZATION DATA
+  var underutil_total_savings = 0, idle_total_savings = 0
+
+  // Only bother doing anything if we're checking at least one metric
+  if (param_avg_cpu != -1 || param_avg_mem != -1) {
+    // Group cost data by resourceId - easier to cycle through cost data in the next step
+    _.each(ds_instance_costs, function(cost_data){ cost_data["resourceId"] = cost_data.resourceId.toLowerCase() })
+    var grouped_cost_data = _.groupBy(ds_instance_costs, function(cost_data){ return cost_data.resourceId })
+
+    // Loop through metrics data, appending cost data
+    _.each(ds_merged_metrics, function(instance) {
+      var util_resource_id = instance.id.toLowerCase()
+      var total_cost = 0
+      _.each(grouped_cost_data[util_resource_id], function(cost_data){
+        if ( isNaN(cost_data.cost) ){
+          total_cost += 0
+        } else {
+          if ( cost_data.cost == 0 ){
+            total_cost += 0
+          } else {
+            total_cost += cost_data.cost
+          }
+          cost_data_found = true
+        }
+      })
+      //var include_instance = false
+      
+      //CONDITIONS - checking if instance is idle or underutilized based on user params
+      // If checking ONLY cpu utilization -
+      if (param_avg_mem == -1) {
+        // If an Idle instance
+        if ( instance['cpu' + "_" + param_08_threshold_statistic] < param_03_idle_threshold_cpu_value ) {
+          instance["savings"] = parseFloat(total_cost).toFixed(3)
+          instance["recommendationType"] = "Terminate"
+          idle_total_savings += total_cost
+        } 
+        // If an Underutilized instance
+        else if ( instance['cpu' + "_" + param_08_threshold_statistic] < param_05_underutil_threshold_cpu_value ) {
+          instance["savings"] = parseFloat(total_cost / 2).toFixed(3)
+          instance["recommendationType"] = "Downsize"
+          underutil_total_savings += total_cost
+        }
+      } 
+      // If checking ONLY memory utilization -
+      if (param_avg_cpu == -1) {
+        // If an Idle instance
+        if ( instance['mem' + "_" + param_08_threshold_statistic] < param_04_idle_threshold_mem_value ) {
+          instance["savings"] = parseFloat(total_cost).toFixed(3)
+          instance["recommendationType"] = "Terminate"
+          idle_total_savings += total_cost
+        }
+        // If an Underutilized instance
+        else if ( instance['mem' + "_" + param_08_threshold_statistic] < param_06_underutil_threshold_mem_value ) {
+          instance["savings"] = parseFloat(total_cost / 2).toFixed(3)
+          instance["recommendationType"] = "Downsize"
+          underutil_total_savings += total_cost
+        }
+      }
+      // If checking both cpu AND memory utilization
+      if ( param_avg_cpu != -1 && param_avg_mem != -1 ) {
+        // If checking instance is below threshold for both cpu AND memory 
+        if ( param_07_check_both == "Both CPU and Memory" ) {
+          // If an Idle instance
+          if ( instance['cpu' + "_" + param_08_threshold_statistic] < param_03_idle_threshold_cpu_value 
+            && instance['mem' + "_" + param_08_threshold_statistic] < param_04_idle_threshold_mem_value ) {
+            instance["savings"] = parseFloat(total_cost).toFixed(3)
+            instance["recommendationType"] = "Terminate"
+            idle_total_savings += total_cost
+          }
+          // If an Underutilized instance
+          if ( instance['cpu' + "_" + param_08_threshold_statistic] < param_05_underutil_threshold_cpu_value 
+            && instance['mem' + "_" + param_08_threshold_statistic] < param_06_underutil_threshold_mem_value ) {
+            instance["savings"] = parseFloat(total_cost).toFixed(3)
+            instance["recommendationType"] = "Downsize"
+            idle_total_savings += total_cost
+          }
+        }
+        // If checking instance is below threshold for both cpu OR memory
+        else {
+          // If an Idle instance
+          if ( instance['cpu' + "_" + param_08_threshold_statistic] < param_03_idle_threshold_cpu_value 
+            || instance['mem' + "_" + param_08_threshold_statistic] < param_04_idle_threshold_mem_value ) {
+            instance["savings"] = parseFloat(total_cost).toFixed(3)
+            instance["recommendationType"] = "Terminate"
+            idle_total_savings += total_cost
+          }
+          // If an Underutilized instance
+          if ( instance['cpu' + "_" + param_08_threshold_statistic] < param_05_underutil_threshold_cpu_value 
+            || instance['mem' + "_" + param_08_threshold_statistic] < param_06_underutil_threshold_mem_value ) {
+            instance["savings"] = parseFloat(total_cost).toFixed(3)
+            instance["recommendationType"] = "Downsize"
+            idle_total_savings += total_cost
+          }
+        }
+      }
+      instance["accountName"] = accountName
+      instance["savingsCurrency"] = currency.symbol
+
+      //Get Instance Size of Downsized instance
+      var vm_size_down = ""
+      if (instance.recommendationType == "Downsize") {
+        if ( ds_aws_instance_size_map[instance.resourceType] ) {
+          vm_size_down = ds_aws_instance_size_map[instance.resourceType].down
+          if ( vm_size_down == null ) { vm_size_down = "N/A" }
+        } 
+      } else {
+        vm_size_down = "Terminate Instance"
+      }
+      instance["recommendedVmSize"] = vm_size_down
+      
+    })
+    
+    //Sort By Region and then by Account Name
+    result = _.sortBy(ds_merged_metrics, "region")
+    result = _.sortBy(result, "accountName")
+  }
+
+  underutil_total_savings = currency.symbol + ' ' + formatNumber((Math.round(underutil_total_savings * 100) / 100), currency.separator)
+  idle_total_savings = currency.symbol + ' ' + formatNumber((Math.round(idle_total_savings * 100) / 100), currency.separator)
+
+  summary_data = {
+    "underutilMessage": "The total estimated monthly savings is " + underutil_total_savings,
+    "idleMessage": "The total estimated monthly savings is " + idle_total_savings,
+    "underutilInstanceCount": _.size( _.filter(result, function(res){ 
+      return res.recommendationType == "Downsize" }) ),
+    "idleInstanceCount": _.size( _.filter(result, function(res){
+      return res.recommendationType == "Terminate" }) )
+  }
+
+  _.each(result, function(res){
+    res["summaryData"] = summary_data
+  })
+
+  EOS
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "pol_utilization" do
+  validate_each $ds_idle_and_underutil_instances do
+    summary_template <<-EOS
+    {{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ with index data 0 }}{{ .summaryData.underutilInstanceCount }}{{ end }} Azure underutilized compute instances found
+        EOS
+    detail_template <<-EOS
+    {{ with index data 0 }}{{ .summaryData.underutilMessage }}{{ end }}
+        EOS
+    check ne( (val(item, "recommendationType")), "Downsize" )
+    escalate $esc_email
+    #escalate $esc_downsize_instances
+    export do
+      resource_level true
+      field "accountID" do
+        label "Account ID"
+      end
+      field "accountName" do
+        label "Account Name"
+      end
+      field "resourceID" do
+        label "Resource ID"
+      end
+      field "resourceType" do
+        # label "Resource Type"
+        label "Instance Size"
+      end
+      # field "vmSize" do
+      #   label "Instance Size"
+      # end
+      field "recommendedVmSize" do
+        label "Recommended Instance Size"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "platform" do
+        label "Platform"
+      end
+      field "hostname" do
+        label "Hostname"
+      end
+      field "savings" do
+        label "Estimated Monthly Savings"
+      end
+      field "savingsCurrency" do
+        label "Savings Currency"
+      end
+      field "privateDnsName" do
+        label "Private DNS Name"
+      end
+      field "launchTime" do
+        label "Launch Time"
+      end
+      field "cpu_maximum" do
+        label "CPU Maximum %"
+      end
+      field "cpu_minimum" do
+        label "CPU Minimum %"
+      end
+      field "cpu_average" do
+        label "CPU Average %"
+      end
+      field "cpu_p99" do
+        label "CPU p99"
+      end
+      field "cpu_p95" do
+        label "CPU p95"
+      end
+      field "cpu_p90" do
+        label "CPU p90"
+      end
+      field "mem_maximum" do
+        label "Memory Maximum %"
+      end
+      field "mem_minimum" do
+        label "Memory Minimum %"
+      end
+      field "mem_average" do
+        label "Memory Average %"
+      end
+      field "mem_p99" do
+        label "Memory p99"
+      end
+      field "mem_p95" do
+        label "Memory p95"
+      end
+      field "mem_p90" do
+        label "Memory p90"
+      end
+      field "tags" do
+        label "Tags"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "id" do
+        label "ID"
+        path "resourceID"
+      end
+    end
+  end
+  validate_each $ds_idle_and_underutil_instances do
+    summary_template <<-EOS
+    {{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ with index data 0 }}{{ .summaryData.idleInstanceCount }}{{end}} Azure idle compute instances found
+    EOS
+    detail_template <<-EOS
+    {{ with index data 0 }}{{ .summaryData.idleMessage }}{{ end }}
+    EOS
+    check ne( (val(item, "recommendationType")), "Terminate" )
+    escalate $esc_email
+    #escalate $esc_terminate_instances
+    export do
+      resource_level true
+      field "accountID" do
+        label "Account ID"
+      end
+      field "accountName" do
+        label "Account Name"
+      end
+      field "resourceID" do
+        label "Resource ID"
+      end
+      field "resourceType" do
+        label "Resource Type"
+      end
+      field "vmSize" do
+        label "Instance Size"
+      end
+      field "recommendedVmSize" do
+        label "Recommended Instance Size"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "platform" do
+        label "Platform"
+      end
+      field "hostname" do
+        label "Hostname"
+      end
+      field "savings" do
+        label "Estimated Monthly Savings"
+      end
+      field "savingsCurrency" do
+        label "Savings Currency"
+      end
+      field "privateDnsName" do
+        label "Private DNS Name"
+      end
+      field "launchTime" do
+        label "Launch Time"
+      end
+      field "cpu_maximum" do
+        label "CPU Maximum %"
+      end
+      field "cpu_minimum" do
+        label "CPU Minimum %"
+      end
+      field "cpu_average" do
+        label "CPU Average %"
+      end
+      field "cpu_p99" do
+        label "CPU p99"
+      end
+      field "cpu_p95" do
+        label "CPU p95"
+      end
+      field "cpu_p90" do
+        label "CPU p90"
+      end
+      field "mem_maximum" do
+        label "Memory Maximum %"
+      end
+      field "mem_minimum" do
+        label "Memory Minimum %"
+      end
+      field "mem_average" do
+        label "Memory Average %"
+      end
+      field "mem_p99" do
+        label "Memory p99"
+      end
+      field "mem_p95" do
+        label "Memory p95"
+      end
+      field "mem_p90" do
+        label "Memory p90"
+      end
+      field "tags" do
+        label "Tags"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "id" do
+        label "ID"
+        path "resourceID"
+      end
+    end
+  end
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end


### PR DESCRIPTION
### Description

As part of this PR - produce one policy for rightsizing that includes a threshold for idle (default <5%) and underutilized (default <40%) - options for both CPU and RAM stats (if available from log sources).  Cost savings for idle as per current policy.  Cost savings for rightsizing = 50% of idle calculation (i.e. assumption next instance size down = 50% cheaper).  Bring in instance size recommendations from current Inefficient Utilization policies.

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
