### PR TITLE
HCLIND-4 Fix: Hardcoded TLD in cloud_cost_anomaly_alerts.pt to US

### DIFF
--- a/cost/cloud_cost_anomaly_alerts/CHANGELOG.md
+++ b/cost/cloud_cost_anomaly_alerts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.3
+
+- changed message from "js_filter_anomalies" script, dynamic TLD (.com or .eu)
+
 ## v2.2
 
 - changed cost metric map key from api call value to more readable value

--- a/cost/cloud_cost_anomaly_alerts/CHANGELOG.md
+++ b/cost/cloud_cost_anomaly_alerts/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v2.3
 
-- changed message from "js_filter_anomalies" script, dynamic TLD (.com or .eu)
+- changed message from "js_filter_anomalies" script, dynamic TLD (.com, .eu or .au)
 
 ## v2.2
 

--- a/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
+++ b/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
@@ -402,10 +402,15 @@ script "js_filter_anomalies", type: "javascript" do
         }
     })
 
+    // Default TLD (app.flexera.com)
     var tld = ".com"
 
     if (rs_governance_host.indexOf(".eu") !== -1 || rs_governance_host.indexOf("-eu") !== -1) {
+      // EU TLD (app.flexera.eu)
       tld = ".eu"
+    } else if (rs_governance_host.indexOf(".au") !== -1 || rs_governance_host.indexOf("-au") !== -1) {
+      // APAC TLD (app.flexera.au)
+      tld = ".au"
     }
 
     message = "https://app.flexera" + tld + "/orgs/" + org_id +"/optima/anomalies?granularity=day&startDate=" + start_at + "&endDate=" + end_at + dimensionAPIString + "&costType=" + cost_metric[param_cost_metric]

--- a/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
+++ b/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
@@ -8,7 +8,7 @@ category "Cost"
 tenancy "single"
 default_frequency "daily"
 info(
-  version: "2.2",
+  version: "2.3",
   provider: "Flexera Optima",
   service: "",
   policy_set:""

--- a/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
+++ b/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
@@ -401,7 +401,15 @@ script "js_filter_anomalies", type: "javascript" do
           })
         }
     })
-    message = "https://app.flexera.com/orgs/" + org_id +"/optima/anomalies?granularity=day&startDate=" + start_at + "&endDate=" + end_at + dimensionAPIString + "&costType=" + cost_metric[param_cost_metric]
+
+    var tld = ".com"
+
+    if (rs_governance_host.indexOf(".eu") !== -1 || rs_governance_host.indexOf("-eu") !== -1) {
+      tld = ".eu"
+    }
+
+    message = "https://app.flexera" + tld + "/orgs/" + org_id +"/optima/anomalies?granularity=day&startDate=" + start_at + "&endDate=" + end_at + dimensionAPIString + "&costType=" + cost_metric[param_cost_metric]
+
     result={
       "anomalies":anomalies,
       "message":message,


### PR DESCRIPTION
### Description

Get dynamic TLD depending of current "rs_governance_host".

### Issues Resolved

Link to the report seems to be hardcoded to US shard.

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
