### PR TITLE
HCLIND-5 - Budget Alerts Policy Redux

### DIFF
--- a/cost/budget_alerts/CHANGELOG.md
+++ b/cost/budget_alerts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1
+
+- Deprecating this policy as it's replaced by [the new version](../budget_report_alerts)
+
 ## v2.0
 
 - Deprecated `auth_rs` authentication (type: `rightscale`) and replaced with `auth_flexera` (type: `oauth2`).  This is a breaking change which requires a Credential for `auth_flexera` [`provider=flexera`] before the policy can be applied.  Please see docs for setting up [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm)

--- a/cost/budget_alerts/README.md
+++ b/cost/budget_alerts/README.md
@@ -1,5 +1,7 @@
 # Budget Alerts Policy
 
+**NOTE:** This policy is be deprecated and replaced by this [new version](../budget_report_alerts)
+
 ## What it does
 
 This Policy uses Optima to determine if a Billing Center or the entire Organization has exceeded its monthly cost budget. The policy should be run daily and will take into account data from 3 days ago to ensure there is a complete set.

--- a/cost/budget_alerts/budget_alert.pt
+++ b/cost/budget_alerts/budget_alert.pt
@@ -8,7 +8,7 @@ category "Cost"
 tenancy "single"
 default_frequency "daily"
 info(
-  version: "2.0",
+  version: "2.1",
   provider: "Flexera Optima",
   service: "",
   policy_set: ""

--- a/cost/budget_report_alerts/CHANGELOG.md
+++ b/cost/budget_report_alerts/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v1.0
+
+- initial release

--- a/cost/budget_report_alerts/README.md
+++ b/cost/budget_report_alerts/README.md
@@ -1,0 +1,42 @@
+# Budget Alerts Policy
+
+## What it does
+
+This policy uses the Optima Budgets API to determine if the selected budget expense is exceeded. The policy can also be run for all exists budgets. The policy should be run daily to calculate projected expenses and how much they exceed the current monthly budget.
+
+## Prerequisites
+
+This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).
+
+- [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*)
+
+The [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) page in the docs has detailed instructions for setting up Credentials for the most common providers.
+
+## Functional Details
+
+- This policy supports a single target (ie. 1 specific Budget or the entire Organization). In order to apply a budget alert for multiple targets, you will need to apply this policy multiple times.
+- Actual expense budget alerts will trigger an incident if the target has exceeded the budget for any month of the period from Start to present.
+- Forecasted Spend budget alerts will raise an incident when the target's run-rate is on track to exceed the budget for the month
+- Data can be grouped by Dimensions. The API supports two grouping fields: "vendor" and "service"
+- Granularity of the sample can be specified: "Monthly" or "Summarized". In the second case, forecasted data is not calculated.
+
+### Input Parameters
+
+This policy has the following input parameters required when launching the policy.
+
+- *Budget Name or ID* - if the scope is "Budget", supply the name or Id of the target Budget. When left blank the policy reports on all the Budgets in the CMP Organization.
+- *Threshold Percentage* - Percentage of budget amount to alert on
+- *Granularity* - can be "Monthly" or "Summarized"
+- *Start date (yyyy-mm)* - set the year and month of the beginning of sampling. If the budget start date is closer, it will be used.
+- *Dimensions* - List of dimension groups for the policy. Can be "vendor" or "service"
+- *Email addresses* - A list of email addresses to notify
+
+## Supported Clouds
+
+- AWS
+- Azure
+- Google
+
+## Cost
+
+This Policy Template does not incur any cloud costs.

--- a/cost/budget_report_alerts/budget_report_alerts.pt
+++ b/cost/budget_report_alerts/budget_report_alerts.pt
@@ -1,0 +1,392 @@
+name "Budget Alerts"
+rs_pt_ver 20180301
+type "policy"
+short_description "Create a Monthly Budget Alert for a selected Budget or for the entire Organization. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/budget_report_alerts/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+severity "medium"
+category "Cost"
+tenancy "single"
+default_frequency "daily"
+
+info(
+  version: "1.0",
+  provider: "Flexera Optima",
+  service: "",
+  policy_set: ""
+)
+
+parameter "param_budget_name_id" do
+  label "Budget Name or ID"
+  description "Provide the name or id of a Budget if the report scope is 'Budget'. Leave it blank for 'Organization' scope"
+  type "string"
+end
+
+parameter "param_granularity" do
+  label "Granularity"
+  type "string"
+  default "Monthly"
+  allowed_values "Monthly", "Summarized"
+  description "Report granularity"
+end
+
+parameter "param_start_date" do
+  label "Start date (yyyy-mm). Leave it blank to check only the last month"
+  description "Provide the year and month to start tracking"
+  type "string"
+end
+
+parameter "param_threshold_percentage" do
+  label "Threshold Percentage"
+  type "number"
+  description "Percentage of budget amount to alert on"
+  default 90
+end
+
+parameter "param_dimensions" do
+  type "list"
+  label "Dimensions"
+  allowed_values "vendor", "service"
+  description "List of dimension groups for the policy"
+end
+
+parameter "param_email" do
+  label "Email addresses"
+  type "list"
+  description "A list of email addresses to notify"
+end
+
+credentials "auth_flexera" do
+  schemes "oauth2"
+  label "flexera"
+  description "Select Flexera One OAuth2 credentials"
+  tags "provider=flexera"
+end
+
+
+
+datasource "ds_currency_reference" do
+  request do
+    host "raw.githubusercontent.com"
+    path "/rightscale/policy_templates/master/cost/scheduled_reports/currency_reference.json"
+    header "User-Agent", "RS Policies"
+  end
+end
+
+datasource "ds_currency_code" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/bill-analysis/orgs/",rs_org_id,"/settings/currency_code"])
+    header "Api-Version", "0.1"
+    header "User-Agent", "RS Policies"
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response,"id")
+    field "value", jmes_path(response,"value")
+  end
+end
+
+datasource "ds_budgets" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/bill-analysis/v0/orgs/",rs_org_id,"/budgets"])
+    header "Api-Version", "1.0"
+    header "User-Agent", "RS Policies"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response,"[*]") do
+      field "id", jmes_path(col_item,"id")
+      field "name", jmes_path(col_item,"name")
+      field "metric", jmes_path(col_item,"metric")
+      field "dimensions", jmes_path(col_item,"dimensions")
+      field "budgetYearMonths", jmes_path(col_item,"budgetYearMonths")
+    end
+  end
+end
+
+datasource "ds_filtered_budgets" do
+  run_script $js_filter_budgets, $ds_budgets, $param_budget_name_id
+end
+
+#
+script "js_filter_budgets", type: "javascript" do
+  parameters "budgets", "budget_name_id"
+  result "results"
+  code <<-EOS
+  var currDate = new Date();
+  var results =
+    _.filter(budgets, function(b){
+      b.start_date = Date.now();
+      b.end_date = 0;
+      var has_curr_month = _.some(b.budgetYearMonths, function (yearMonth) {
+        var curr = currDate.getFullYear() + '-' + (currDate.getMonth()+1);
+        b.start_date = Math.min(b.start_date, Date.parse(yearMonth))
+        b.end_date = Math.max(b.end_date, Date.parse(yearMonth))
+        return yearMonth == curr
+      })
+      return (!budget_name_id || b.name == budget_name_id || b.id == budget_name_id) && has_curr_month;
+    });
+EOS
+end
+
+datasource "ds_reports" do
+  iterate $ds_filtered_budgets
+  request do
+    run_script $report_request, rs_optima_host, rs_org_id, $param_start_date, $param_granularity, $param_dimensions, iter_item
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response,"[*]") do
+      field "name", val(iter_item, "name")
+      field "metric", val(iter_item, "metric")
+      field "timestamp", jmes_path(col_item,"timestamp")
+      field "dimensions", jmes_path(col_item,"dimensions")
+      field "budgetAmount", jmes_path(col_item,"metrics.budgetAmount")
+      field "spendAmount", jmes_path(col_item,"metrics.spendAmount")
+    end
+  end
+end
+
+script "report_request", type: "javascript" do
+  parameters "rs_optima_host", "org","start_date","granularity", "dimensions", "budget"
+  result "request"
+  code <<-EOS
+  var current = new Date();
+  if (!start_date) {
+    start_date = current.getFullYear() + '-' + ('0' + (current.getMonth()+1)).slice(-2);
+  } else {
+    var start = new Date(Math.max(Date.parse(start_date), budget.start_date))
+    start_date = start.getFullYear() + '-' + ('0' + (start.getMonth()+1)).slice(-2);
+  }
+  current.setMonth(current.getMonth()+1);
+  var end_date = current.getFullYear() + '-' + ('0' + (current.getMonth()+1)).slice(-2);
+
+  var request = {
+    auth: "auth_flexera",
+    host: rs_optima_host,
+    verb: "POST",
+    path: "/bill-analysis/v0/orgs/" + org + "/budgets/" + budget.id + "/report",
+    body_fields: {
+      "dimensions": dimensions,
+      "endAt": end_date,
+      "startAt": start_date,
+      "includeUnbudgeted": false,
+      "summarized": granularity == 'Summarized',
+    },
+    headers: {
+      "User-Agent": "RS Policies",
+      "Api-Version": "1.0"
+    }
+  }
+  EOS
+end
+
+
+datasource "ds_aggregated" do
+  run_script $js_aggregated, $ds_reports, $ds_currency_code, $ds_currency_reference, $param_threshold_percentage
+end
+
+
+script "js_aggregated", type: "javascript" do
+  parameters "reports", "currency_code", "currency_reference", "threshold_percent"
+  result "results"
+  code <<-EOS
+  var results = {
+    exceeded: [],
+    forecasted: [],
+  }
+  var currency = currency_code.value || '';
+  var ref = currency ? currency_reference[currency] : undefined;
+  if (ref) {
+    currency = ref.symbol || "";
+  }
+
+  function forecasted(curr) {
+    var now = new Date();
+    var day = now.getUTCDate();
+    var days = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate()
+    return curr / day * days
+  }
+
+  _.each(reports, function (item) {
+    if (item.budgetAmount && item.spendAmount) {
+      item.forecasted = "";
+      item.forecastedAmount = item.spendAmount;
+      var date = new Date(item.timestamp);
+      item.date = date.toLocaleDateString();
+      var now = new Date();
+      if (date.getFullYear() == now.getFullYear() && date.getMonth() == now.getMonth()) {
+        item.forecastedAmount = Math.round(forecasted(item.spendAmount) * 100) / 100;
+        item.forecasted = item.forecastedAmount;
+      }
+
+      item.budgetAmount = Math.round(item.budgetAmount * 100) / 100;
+      item.spendAmount = Math.round(item.spendAmount * 100) / 100;
+      item.overBudgetAmount = Math.max(0, Math.round((item.spendAmount - item.budgetAmount) * 100) / 100);
+      item.spentPercent = Math.round(item.spendAmount / item.budgetAmount * 100)
+      item.overBudgetAmountForec = Math.max(0, Math.round((item.forecastedAmount - item.budgetAmount) * 100) / 100);
+      item.spentPercentForec = Math.round(item.forecastedAmount / item.budgetAmount * 100)
+
+      // values for export
+      item.budget = item.budgetAmount;
+      item.spend = item.spendAmount;
+      item.overBudget = item.overBudgetAmount;
+      item.overBudgetForec = item.overBudgetAmountForec;
+      item.vendor = item.dimensions && item.dimensions.vendor || "All";
+      item.service = item.dimensions && item.dimensions.service || "All";
+      item.metric = (item.metric || '').replace("cost_", "").replace("_adj", "").replace("_", " ")
+
+
+      if (item.budget > 0) {
+        item.budget = currency + item.budget;
+      }
+      if (item.spend > 0) {
+        item.spend = currency + item.spend;
+      }
+      if (item.overBudget > 0) {
+        item.overBudget = currency + item.overBudget;
+      }
+      if (item.forecasted) {
+        item.forecasted = currency + item.forecasted;
+      }
+
+      var budget_percent = item.spentPercent
+      item.spentPercent += "%"
+      item.spentPercentForec += "%"
+
+      if (item.spendAmount > item.budgetAmount) {
+        item.details = "Budget exceeded"
+        results.exceeded.push(item);
+      } else if (threshold_percent < budget_percent) {
+        item.details = "Threshold exceeded"
+        results.exceeded.push(item);
+      } else if (item.forecastedAmount > item.budgetAmount) {
+        item.details = "Forecasted Budget exceeded"
+        results.forecasted.push(item);
+      }
+    }
+  });
+EOS
+end
+
+datasource "ds_only_forecasted" do
+  run_script $js_only_forecasted, $ds_aggregated
+end
+
+script "js_only_forecasted", type: "javascript" do
+  parameters "arg"
+  result "results"
+  code <<-EOS
+    results = arg.forecasted
+  EOS
+end
+
+datasource "ds_only_exceeded" do
+  run_script $js_only_exceeded, $ds_aggregated
+end
+
+script "js_only_exceeded", type: "javascript" do
+  parameters "arg"
+  result "results"
+  code <<-EOS
+    results = arg.exceeded
+  EOS
+end
+
+escalation "esc_budget_alert" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
+
+policy "budget_alert" do
+  validate $ds_only_exceeded do
+    summary_template "{{ parameters.param_granularity }} Budget Exceeded {{parameters.param_threshold_percentage}} Percent Threshold"
+    hash_exclude "budgetAmount", "overBudgetAmount", "spendAmount"
+    escalate $esc_budget_alert
+    check eq(size(data),0)
+    export do
+      field "name" do
+        label "Budget Name"
+      end
+      field "date" do
+        label "Date"
+      end
+      field "vendor" do
+        label "Vendor"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "budget" do
+        label "Budget"
+      end
+      field "spend" do
+        label "Spend"
+      end
+      field "overBudget" do
+        label "Over Budget Amount"
+      end
+      field "spentPercent" do
+        label "Spent Percent"
+      end
+      field "details" do
+        label "Details"
+      end
+      field "metric" do
+        label "Metric"
+      end
+    end
+  end
+
+  validate $ds_only_forecasted do
+    summary_template "{{ parameters.param_granularity }} Budget Projected (prorated) Spent Exceeded"
+    hash_exclude "budgetAmount", "overBudgetAmount", "spendAmount"
+    escalate $esc_budget_alert
+    check eq(size(data),0)
+    export do
+      field "name" do
+        label "Budget Name"
+      end
+      field "date" do
+        label "Date"
+      end
+      field "vendor" do
+        label "Vendor"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "budget" do
+        label "Budget"
+      end
+      field "spend" do
+        label "Spend"
+      end
+      field "overBudget" do
+        label "Over Budget Amount"
+      end
+      field "spentPercent" do
+        label "Spent Percent"
+      end
+      field "forecasted" do
+        label "Projected (prorated) spend"
+      end
+      field "overBudgetForec" do
+        label "Over Budget Projected Amount"
+      end
+      field "spentPercentForec" do
+        label "Projected Spent Percent"
+      end
+      field "details" do
+        label "Details"
+      end
+      field "metric" do
+        label "Metric"
+      end
+    end
+  end
+end

--- a/cost/budget_report_alerts/budget_report_alerts.pt
+++ b/cost/budget_report_alerts/budget_report_alerts.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "daily"
 
 info(
-  version: "1.0",
+  version: "2.0",
   provider: "Flexera Optima",
   service: "",
   policy_set: ""
@@ -20,20 +20,6 @@ parameter "param_budget_name_id" do
   type "string"
 end
 
-parameter "param_granularity" do
-  label "Granularity"
-  type "string"
-  default "Monthly"
-  allowed_values "Monthly", "Summarized"
-  description "Report granularity"
-end
-
-parameter "param_start_date" do
-  label "Start date (yyyy-mm). Leave it blank to check only the last month"
-  description "Provide the year and month to start tracking"
-  type "string"
-end
-
 parameter "param_threshold_percentage" do
   label "Threshold Percentage"
   type "number"
@@ -41,11 +27,20 @@ parameter "param_threshold_percentage" do
   default 90
 end
 
-parameter "param_dimensions" do
-  type "list"
-  label "Dimensions"
-  allowed_values "vendor", "service"
-  description "List of dimension groups for the policy"
+parameter "param_type" do
+  label "Budget Alert Type"
+  type "string"
+  allowed_values "Actual Spend","Forecasted Spend"
+  description "Actual Spend alerts are based off incurred costs. Forecasted Spend alerts are based off monthly runrates."
+  default "Actual Spend"
+end
+
+parameter "param_use_groups" do
+  type "string"
+  label "Data grouping"
+  allowed_values "Summarized","By dimensions"
+  default "Summarized"
+  description "Use this parameter to specify how to group the data"
 end
 
 parameter "param_email" do
@@ -110,7 +105,6 @@ datasource "ds_filtered_budgets" do
   run_script $js_filter_budgets, $ds_budgets, $param_budget_name_id
 end
 
-#
 script "js_filter_budgets", type: "javascript" do
   parameters "budgets", "budget_name_id"
   result "results"
@@ -120,11 +114,14 @@ script "js_filter_budgets", type: "javascript" do
     _.filter(budgets, function(b){
       b.start_date = Date.now();
       b.end_date = 0;
-      var has_curr_month = _.some(b.budgetYearMonths, function (yearMonth) {
+      var has_curr_month = false;
+      _.each(b.budgetYearMonths, function (yearMonth) {
         var curr = currDate.getFullYear() + '-' + (currDate.getMonth()+1);
         b.start_date = Math.min(b.start_date, Date.parse(yearMonth))
         b.end_date = Math.max(b.end_date, Date.parse(yearMonth))
-        return yearMonth == curr
+        if (yearMonth == curr) {
+          has_curr_month = true;
+        }
       })
       return (!budget_name_id || b.name == budget_name_id || b.id == budget_name_id) && has_curr_month;
     });
@@ -134,7 +131,7 @@ end
 datasource "ds_reports" do
   iterate $ds_filtered_budgets
   request do
-    run_script $report_request, rs_optima_host, rs_org_id, $param_start_date, $param_granularity, $param_dimensions, iter_item
+    run_script $report_request, rs_optima_host, rs_org_id, $param_use_groups, iter_item
   end
   result do
     encoding "json"
@@ -150,16 +147,11 @@ datasource "ds_reports" do
 end
 
 script "report_request", type: "javascript" do
-  parameters "rs_optima_host", "org","start_date","granularity", "dimensions", "budget"
+  parameters "rs_optima_host", "org", "use_groups", "budget"
   result "request"
   code <<-EOS
   var current = new Date();
-  if (!start_date) {
-    start_date = current.getFullYear() + '-' + ('0' + (current.getMonth()+1)).slice(-2);
-  } else {
-    var start = new Date(Math.max(Date.parse(start_date), budget.start_date))
-    start_date = start.getFullYear() + '-' + ('0' + (start.getMonth()+1)).slice(-2);
-  }
+  var start_date = current.getFullYear() + '-' + ('0' + (current.getMonth()+1)).slice(-2);
   current.setMonth(current.getMonth()+1);
   var end_date = current.getFullYear() + '-' + ('0' + (current.getMonth()+1)).slice(-2);
 
@@ -169,11 +161,10 @@ script "report_request", type: "javascript" do
     verb: "POST",
     path: "/bill-analysis/v0/orgs/" + org + "/budgets/" + budget.id + "/report",
     body_fields: {
-      "dimensions": dimensions,
+      "dimensions": use_groups == "Summarized" ? [] : budget.dimensions,
       "endAt": end_date,
       "startAt": start_date,
       "includeUnbudgeted": false,
-      "summarized": granularity == 'Summarized',
     },
     headers: {
       "User-Agent": "RS Policies",
@@ -185,12 +176,12 @@ end
 
 
 datasource "ds_aggregated" do
-  run_script $js_aggregated, $ds_reports, $ds_currency_code, $ds_currency_reference, $param_threshold_percentage
+  run_script $js_aggregated, $ds_reports, $ds_currency_code, $ds_currency_reference, $param_threshold_percentage, $param_type
 end
 
 
 script "js_aggregated", type: "javascript" do
-  parameters "reports", "currency_code", "currency_reference", "threshold_percent"
+  parameters "reports", "currency_code", "currency_reference", "threshold_percent", "param_type"
   result "results"
   code <<-EOS
   var results = {
@@ -234,8 +225,10 @@ script "js_aggregated", type: "javascript" do
       item.spend = item.spendAmount;
       item.overBudget = item.overBudgetAmount;
       item.overBudgetForec = item.overBudgetAmountForec;
-      item.vendor = item.dimensions && item.dimensions.vendor || "All";
-      item.service = item.dimensions && item.dimensions.service || "All";
+      item.group = "";
+      if (item.dimensions) {
+        item.group = _.values(item.dimensions).join("|");
+      }
       item.metric = (item.metric || '').replace("cost_", "").replace("_adj", "").replace("_", " ")
 
 
@@ -253,18 +246,26 @@ script "js_aggregated", type: "javascript" do
       }
 
       var budget_percent = item.spentPercent
+      var budget_percent_forec = item.spentPercentForec
       item.spentPercent += "%"
       item.spentPercentForec += "%"
 
-      if (item.spendAmount > item.budgetAmount) {
-        item.details = "Budget exceeded"
-        results.exceeded.push(item);
-      } else if (threshold_percent < budget_percent) {
-        item.details = "Threshold exceeded"
-        results.exceeded.push(item);
-      } else if (item.forecastedAmount > item.budgetAmount) {
-        item.details = "Forecasted Budget exceeded"
-        results.forecasted.push(item);
+      if (param_type == "Actual Spend") {
+        if (item.spendAmount > item.budgetAmount) {
+          item.details = "Budget exceeded"
+          results.exceeded.push(item);
+        } else if (threshold_percent < budget_percent) {
+          item.details = "Threshold exceeded"
+          results.exceeded.push(item);
+        }
+      } else {
+        if (item.forecastedAmount > item.budgetAmount) {
+          item.details = "Forecasted Budget exceeded"
+          results.forecasted.push(item);
+        } else if (threshold_percent < budget_percent_forec) {
+          item.details = "Threshold exceeded"
+          results.exceeded.push(item);
+        }
       }
     }
   });
@@ -315,11 +316,8 @@ policy "budget_alert" do
       field "date" do
         label "Date"
       end
-      field "vendor" do
-        label "Vendor"
-      end
-      field "service" do
-        label "Service"
+      field "group" do
+        label "Group"
       end
       field "budget" do
         label "Budget"
@@ -354,11 +352,8 @@ policy "budget_alert" do
       field "date" do
         label "Date"
       end
-      field "vendor" do
-        label "Vendor"
-      end
-      field "service" do
-        label "Service"
+      field "group" do
+        label "Group"
       end
       field "budget" do
         label "Budget"

--- a/cost/budget_report_alerts/budget_report_alerts.pt
+++ b/cost/budget_report_alerts/budget_report_alerts.pt
@@ -56,8 +56,6 @@ credentials "auth_flexera" do
   tags "provider=flexera"
 end
 
-
-
 datasource "ds_currency_reference" do
   request do
     host "raw.githubusercontent.com"
@@ -116,7 +114,7 @@ script "js_filter_budgets", type: "javascript" do
       b.end_date = 0;
       var has_curr_month = false;
       _.each(b.budgetYearMonths, function (yearMonth) {
-        var curr = currDate.getFullYear() + '-' + (currDate.getMonth()+1);
+        var curr = currDate.getFullYear() + '-' + ('0' + (currDate.getMonth()+1)).slice(-2);
         b.start_date = Math.min(b.start_date, Date.parse(yearMonth))
         b.end_date = Math.max(b.end_date, Date.parse(yearMonth))
         if (yearMonth == curr) {
@@ -241,6 +239,9 @@ script "js_aggregated", type: "javascript" do
       if (item.overBudget > 0) {
         item.overBudget = currency + item.overBudget;
       }
+      if (item.overBudgetForec > 0) {
+        item.overBudgetForec = currency + item.overBudgetForec;
+      }
       if (item.forecasted) {
         item.forecasted = currency + item.forecasted;
       }
@@ -305,7 +306,7 @@ end
 
 policy "budget_alert" do
   validate $ds_only_exceeded do
-    summary_template "{{ parameters.param_granularity }} Budget Exceeded {{parameters.param_threshold_percentage}} Percent Threshold"
+    summary_template "{{parameters.param_threshold_percentage}}% Budget Threshold Is Exceeded ({{ parameters.param_type }})"
     hash_exclude "budgetAmount", "overBudgetAmount", "spendAmount"
     escalate $esc_budget_alert
     check eq(size(data),0)
@@ -341,7 +342,7 @@ policy "budget_alert" do
   end
 
   validate $ds_only_forecasted do
-    summary_template "{{ parameters.param_granularity }} Budget Projected (prorated) Spent Exceeded"
+    summary_template "{{parameters.param_threshold_percentage}}% Budget Threshold Is Exceeded ({{ parameters.param_type }})"
     hash_exclude "budgetAmount", "overBudgetAmount", "spendAmount"
     escalate $esc_budget_alert
     check eq(size(data),0)


### PR DESCRIPTION
### Description

Create a new budget alerts policy to use the new budget API

### Issues Resolved

- Created a new policy based on the new Budgets API that implements alerts if expenses exceeded budget for any month of the period from inception to the present (or the entire period).
- Alerts about exceeding projected or actual costs.
- Data can be grouped by dimensions. The API supports two dimensions fields: "provider" and "service".
- Sampling granularity can be specified: "monthly" or "summarized".

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
