### PR TITLE
HCLIND-4 Fix: Hardcoded TLD in cloud_cost_anomaly_alerts.pt to US

### DIFF
--- a/cost/cloud_cost_anomaly_alerts/CHANGELOG.md
+++ b/cost/cloud_cost_anomaly_alerts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.3
+
+- changed message from "js_filter_anomalies" script, dynamic TLD (.com, .eu or .au)
+
 ## v2.2
 
 - changed cost metric map key from api call value to more readable value

--- a/cost/cloud_cost_anomaly_alerts/CHANGELOG.md
+++ b/cost/cloud_cost_anomaly_alerts/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v2.3
 
-- changed message from "js_filter_anomalies" script, dynamic TLD (.com, .eu or .au)
+- changed URL link to Cost Anomalies report, now it's constructed dynamically based on detected shard
 
 ## v2.2
 

--- a/cost/cloud_cost_anomaly_alerts/README.md
+++ b/cost/cloud_cost_anomaly_alerts/README.md
@@ -2,7 +2,7 @@
 
 ## What it does
 
-The Cloud Cost Anomaly Alerts policy analyzes the spend in an organization over a specified time period and sends email notifications if anomalies were detected, it can be used in ".com", ".eu" and ".au" TLDs. The cost anomalies are identified using Bollinger Bands. The bands are defined as follows:
+The Cloud Cost Anomaly Alerts policy analyzes the spend in an organization over a specified time period and sends email notifications if anomalies were detected. The cost anomalies are identified using Bollinger Bands. The bands are defined as follows:
 The moving average is calculated using a window size specified.
 The upper and lower band are calculated as distance of a given number of standard deviations from the moving average.
 Any point outside of the bands is considered as anomalous. If multiple cost anomalies are detected for the given dimensions, the data point with the greatest deviation is reported as incident. Additionally, a URL link is provided to a graphical report where all detected anomalies are shown.

--- a/cost/cloud_cost_anomaly_alerts/README.md
+++ b/cost/cloud_cost_anomaly_alerts/README.md
@@ -2,7 +2,7 @@
 
 ## What it does
 
-The Cloud Cost Anomaly Alerts policy analyzes the spend in an organization over a specified time period and sends email notifications if anomalies were detected. The cost anomalies are identified using Bollinger Bands. The bands are defined as follows:
+The Cloud Cost Anomaly Alerts policy analyzes the spend in an organization over a specified time period and sends email notifications if anomalies were detected, it can be used in ".com", ".eu" and ".au" TLDs. The cost anomalies are identified using Bollinger Bands. The bands are defined as follows:
 The moving average is calculated using a window size specified.
 The upper and lower band are calculated as distance of a given number of standard deviations from the moving average.
 Any point outside of the bands is considered as anomalous. If multiple cost anomalies are detected for the given dimensions, the data point with the greatest deviation is reported as incident. Additionally, a URL link is provided to a graphical report where all detected anomalies are shown.

--- a/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
+++ b/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
@@ -161,7 +161,7 @@ datasource "ds_get_anomalies" do
 end
 
 datasource "ds_filter_anomalies" do
-  run_script $js_filter_anomalies, $ds_get_anomalies, $param_min_spend, rs_org_id, $param_days, $param_dimensions, $param_cost_metric, $param_anomaly_limit
+  run_script $js_filter_anomalies, $ds_get_anomalies, $param_min_spend, rs_org_id, $param_days, $param_dimensions, $param_cost_metric, $param_anomaly_limit, f1_app_host
 end
 
 ###############################################################################
@@ -298,7 +298,7 @@ script "js_get_anomalies", type: "javascript" do
 end
 
 script "js_filter_anomalies", type: "javascript" do
-  parameters "ds_get_anomalies", "param_min_spend", "org_id", "param_days", "param_dimensions", "param_cost_metric", "param_anomaly_limit"
+  parameters "ds_get_anomalies", "param_min_spend", "org_id", "param_days", "param_dimensions", "param_cost_metric", "param_anomaly_limit", "f1_app_host"
   result "result"
   code <<-EOS
     var start_at = "";
@@ -402,25 +402,7 @@ script "js_filter_anomalies", type: "javascript" do
         }
     })
 
-    // Default domain name (flexera or flexeratest)
-    var domainName = ".flexera"
-
-    if (rs_governance_host.indexOf(".test.") !== -1) {
-        domainName = ".flexeratest"
-    }
-
-    // Default TLD (app.flexera.com or app.flexeratest.com)
-    var tld = ".com"
-
-    if (rs_governance_host.indexOf(".eu") !== -1 || rs_governance_host.indexOf("-eu") !== -1) {
-      // EU TLD (app.flexera.eu)
-      tld = ".eu"
-    } else if (rs_governance_host.indexOf(".au") !== -1 || rs_governance_host.indexOf("-au") !== -1) {
-      // APAC TLD (app.flexera.au)
-      tld = ".au"
-    }
-
-    message = "https://app" + domainName + tld + "/orgs/" + org_id +"/optima/anomalies?granularity=day&startDate=" + start_at + "&endDate=" + end_at + dimensionAPIString + "&costType=" + cost_metric[param_cost_metric]
+    message = "https://" + f1_app_host + "/orgs/" + org_id +"/optima/anomalies?granularity=day&startDate=" + start_at + "&endDate=" + end_at + dimensionAPIString + "&costType=" + cost_metric[param_cost_metric]
 
     result={
       "anomalies":anomalies,

--- a/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
+++ b/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
@@ -8,7 +8,7 @@ category "Cost"
 tenancy "single"
 default_frequency "daily"
 info(
-  version: "2.2",
+  version: "2.3",
   provider: "Flexera Optima",
   service: "",
   policy_set:""
@@ -401,7 +401,20 @@ script "js_filter_anomalies", type: "javascript" do
           })
         }
     })
-    message = "https://app.flexera.com/orgs/" + org_id +"/optima/anomalies?granularity=day&startDate=" + start_at + "&endDate=" + end_at + dimensionAPIString + "&costType=" + cost_metric[param_cost_metric]
+    
+    // Default TLD (app.flexera.com)
+    var tld = ".com"
+
+    if (rs_governance_host.indexOf(".eu") !== -1 || rs_governance_host.indexOf("-eu") !== -1) {
+      // EU TLD (app.flexera.eu)
+      tld = ".eu"
+    } else if (rs_governance_host.indexOf(".au") !== -1 || rs_governance_host.indexOf("-au") !== -1) {
+      // APAC TLD (app.flexera.au)
+      tld = ".au"
+    }
+
+    message = "https://app.flexera" + tld + "/orgs/" + org_id +"/optima/anomalies?granularity=day&startDate=" + start_at + "&endDate=" + end_at + dimensionAPIString + "&costType=" + cost_metric[param_cost_metric]
+
     result={
       "anomalies":anomalies,
       "message":message,

--- a/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
+++ b/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
@@ -401,7 +401,14 @@ script "js_filter_anomalies", type: "javascript" do
           })
         }
     })
-    
+
+    // Default domain name (flexera or flexeratest)
+    var domainName = ".flexera"
+
+    if (rs_governance_host.indexOf(".test.") !== -1) {
+        domainName = ".flexeratest"
+    }
+
     // Default TLD (app.flexera.com or app.flexeratest.com)
     var tld = ".com"
 
@@ -413,7 +420,7 @@ script "js_filter_anomalies", type: "javascript" do
       tld = ".au"
     }
 
-    message = "https://app.flexera" + tld + "/orgs/" + org_id +"/optima/anomalies?granularity=day&startDate=" + start_at + "&endDate=" + end_at + dimensionAPIString + "&costType=" + cost_metric[param_cost_metric]
+    message = "https://app" + domainName + tld + "/orgs/" + org_id +"/optima/anomalies?granularity=day&startDate=" + start_at + "&endDate=" + end_at + dimensionAPIString + "&costType=" + cost_metric[param_cost_metric]
 
     result={
       "anomalies":anomalies,

--- a/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
+++ b/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
@@ -402,7 +402,7 @@ script "js_filter_anomalies", type: "javascript" do
         }
     })
     
-    // Default TLD (app.flexera.com)
+    // Default TLD (app.flexera.com or app.flexeratest.com)
     var tld = ".com"
 
     if (rs_governance_host.indexOf(".eu") !== -1 || rs_governance_host.indexOf("-eu") !== -1) {


### PR DESCRIPTION
### Description

Get dynamic TLD depending of current "rs_governance_host".

### Issues Resolved

Link to the report seems to be hardcoded to US shard.

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
