### PR TITLE
HCLIND-7 Remove already expired instances from the report generated by Azure Expiring Reserved Instances PT

### DIFF
--- a/cost/azure/reserved_instances/expiration/CHANGELOG.md
+++ b/cost/azure/reserved_instances/expiration/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## v2.1
 
-- Previous versions included already expired instances in the report, that was marked as
-a bug and in this release those instances are now filtered.
+- Previous versions included already expired instances in the report, that was marked as a bug and in this release those instances are now filtered.
 
 ## v2.0
 

--- a/cost/azure/reserved_instances/expiration/CHANGELOG.md
+++ b/cost/azure/reserved_instances/expiration/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.1
+
+- Previous versions included already expired instances in the report, that was marked as
+a bug and in this release those instances are now filtered.
+
 ## v2.0
 
 - Deprecated `auth_rs` authentication (type: `rightscale`) and replaced with `auth_flexera` (type: `oauth2`).  This is a breaking change which requires a Credential for `auth_flexera` [`provider=flexera`] before the policy can be applied.  Please see docs for setting up [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm)

--- a/cost/azure/reserved_instances/expiration/CHANGELOG.md
+++ b/cost/azure/reserved_instances/expiration/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v2.1
 
-- Previous versions included already expired instances in the report, that was marked as a bug and in this release those instances are now filtered.
+- Bug fix: Already expired reserved instances are no longer included.
 
 ## v2.0
 

--- a/cost/azure/reserved_instances/expiration/azure_reserved_instance_expiration.pt
+++ b/cost/azure/reserved_instances/expiration/azure_reserved_instance_expiration.pt
@@ -8,7 +8,7 @@ category "Cost"
 tenancy "single"
 default_frequency "daily"
 info(
-  version: "2.0",
+  version: "2.1",
   provider: "Flexera Optima",
   service: "",
   policy_set: ""

--- a/cost/azure/reserved_instances/expiration/azure_reserved_instance_expiration.pt
+++ b/cost/azure/reserved_instances/expiration/azure_reserved_instance_expiration.pt
@@ -95,17 +95,17 @@ script "js_filtered_reservations", type: "javascript" do
   code <<-EOS
     var content=[];
     var now = new Date();
+    var now_ms = now.getTime();
     var one_day=1000*60*60*24;
     var date1_ms = now.getTime();
 
-    for(var i=0; i < reservations.length ; i++){
+    for (var i = 0; i < reservations.length ; i++) {
       reservation = reservations[i]
-      var end_date = (new Date(reservation['expiration_date'])).toISOString().slice(0, 10);
       var date2_ms = (new Date(reservation['expiration_date'])).getTime();
       var difference_ms = date2_ms - date1_ms;
       var daysLeft = Math.round(difference_ms/one_day);
 
-      if(daysLeft <= param_days_expiration) {
+      if (daysLeft <= param_days_expiration && now_ms <= date2_ms) {
         content.push({
           account_name: reservation['account_name'],
           arm_sku_name: reservation['arm_sku_name'],


### PR DESCRIPTION
### Description

Now already expired instances are filtered from the final report.

### Issues Resolved

- [HCLIND-7 issue was addressed:](https://flexera.atlassian.net/browse/HCLIND-7) Expired instances were being included in the report sent to the user, now those instances are being filtered (filter instance from final report if already expired).

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
