### PR TITLE
fix tested

### DIFF
--- a/cost/azure/idle_compute_instances/CHANGELOG.md
+++ b/cost/azure/idle_compute_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.1
+
+- Fixed bug when filtering by tag key when Azure API does not return tag data for an instance
+
 ## v4.0
 
 - Deprecated `auth_rs` authentication (type: `rightscale`) and replaced with `auth_flexera` (type: `oauth2`).  This is a breaking change which requires a Credential for `auth_flexera` [`provider=flexera`] before the policy can be applied.  Please see docs for setting up [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm)

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "4.0",
+  version: "4.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Idle Compute Instances"
@@ -345,24 +345,25 @@ end
 
 script "js_filter_instances", type: "javascript" do
   parameters "ds_azure_virtualmachines", "param_exclusion_tag_key"
-  result "results"
+  result "result"
   code <<-EOF
-  var results = _.filter(ds_azure_virtualmachines, function(instance){
-    var tags = []
-    if (_.has(instance.tags, param_exclusion_tag_key)) {
-    } else if (typeof instance.tags === "undefined" || instance.tags === null){
-      instance.tags = tags
-    }else{
-      Object.keys(instance.tags).forEach(function(key) {
-        tags.push(key+'='+instance.tags[key])
-      });
-      instance.tags = tags
-      resourceTypeSplit = instance['resourceType'].split("/")
-      service = resourceTypeSplit[0]
-      instance['service'] = service
-      return instance
-    }
-  })
+  if (param_exclusion_tag_key == "" || param_exclusion_tag_key == null || param_exclusion_tag_key == undefined) {
+    result = ds_azure_virtualmachines
+  } else {
+    result = []
+
+    _.each(ds_azure_virtualmachines, function(vm) {
+      if (vm['tags'] != null && vm['tags'] != undefined) {
+        tag_keys = Object.keys(vm['tags'])
+      } else {
+        tag_keys = []
+      }
+
+      if (_.contains(tag_keys, param_exclusion_tag_key) == false) {
+        result.push(vm)
+      }
+    })
+  }
 EOF
 end
 


### PR DESCRIPTION
I discovered an issue where the tag key filtering was not working correctly. It seems like there are edge cases where, depending on the credential permissions and level of access, the Azure API returns values for the "tags" field that the original policy did not handle correctly, resulting in all VMs being filtered, and thus no results being generated, even if the tag filter parameter was left blank.

I reworked the relevant script block so that it no longer has this issue, and I've tested it in our testing environment to ensure that the policy works as expected both when filtering by tag key and when leaving the field blank.
