### PR TITLE
POL-756 Update Forecasting Policies - fix start/end date clash

### DIFF
--- a/cost/forecasting/moving_average/CHANGELOG.md
+++ b/cost/forecasting/moving_average/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1
+
+- Updated `js_generate_past_month_list` logic to fix bug where start date and end date clash when running policy at the end of January
+
 ## v3.0
 
 - Deprecated `auth_rs` authentication (type: `rightscale`) and replaced with `auth_flexera` (type: `oauth2`).  This is a breaking change which requires a Credential for `auth_flexera` [`provider=flexera`] before the policy can be applied.  Please see docs for setting up [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm)

--- a/cost/forecasting/moving_average/moving_average_forecast.pt
+++ b/cost/forecasting/moving_average/moving_average_forecast.pt
@@ -8,15 +8,11 @@ category "Cost"
 tenancy "single"
 default_frequency "daily"
 info(
-  version: "3.0",
+  version: "3.1",
   provider: "Flexera Optima",
   service: "",
   policy_set: "Forecasting"
 )
-
-###############################################################################
-# Permissions
-###############################################################################
 
 ###############################################################################
 # Parameters
@@ -61,6 +57,7 @@ end
 # Authentication
 ###############################################################################
 
+#AUTHENTICATE WITH FLEXERA/OPTIMA
 credentials "auth_flexera" do
   schemes "oauth2"
   label "flexera"
@@ -69,13 +66,10 @@ credentials "auth_flexera" do
 end
 
 ###############################################################################
-# Resources
+# Datasources and Scripts
 ###############################################################################
 
-###############################################################################
-# Datasources
-###############################################################################
-
+#GET CURRENCY REFERENCE
 datasource "ds_currency_reference" do
   request do
     host "raw.githubusercontent.com"
@@ -84,6 +78,7 @@ datasource "ds_currency_reference" do
   end
 end
 
+#GET CURRENCY CODE FOR ORG
 datasource "ds_currency_code" do
   request do
     auth $auth_flexera
@@ -99,6 +94,7 @@ datasource "ds_currency_code" do
   end
 end
 
+#GET ALL BILLING CENTERS FOR ORG
 datasource "ds_billing_centers" do
   request do
     auth $auth_flexera
@@ -121,10 +117,39 @@ datasource "ds_billing_centers" do
   end
 end
 
+#CREATE LIST OF PAST MONTHS
 datasource "ds_past_month_list" do
   run_script $js_generate_past_month_list, $param_lookback_months
 end
 
+script "js_generate_past_month_list", type: "javascript" do
+  parameters "param_lookback_months"
+  result "month_list"
+  code <<-EOS
+  var month_list = [];
+  var previous_month = new Date()
+  previous_month.setMonth( previous_month.getMonth() - 1 )
+
+
+  for (var i = 0; i < param_lookback_months; i++) {
+    var start_date = new Date( previous_month )
+    start_date.setMonth( start_date.getMonth() - i )
+    start_date = start_date.toISOString().split("T")[0]
+    start_month = start_date.split("-")[0] + "-" + start_date.split("-")[1]
+    var end_date = new Date( previous_month )
+    end_date.setMonth( end_date.getMonth() - i + 1 )
+    end_date = end_date.toISOString().split("T")[0]
+    end_month = end_date.split("-")[0] + "-" + end_date.split("-")[1]
+
+    month_list.push({
+      "start_date": start_month,
+      "end_date": end_month
+    })
+  }
+  EOS
+end
+
+#GET COST DATA FOR BILLING CENTERS
 datasource "ds_costs" do
   iterate $ds_past_month_list
   request do
@@ -142,52 +167,6 @@ datasource "ds_costs" do
       field "timestamp", jmes_path(col_item,"timestamp")
     end
   end
-end
-
-datasource "ds_make_data_package" do
-  run_script $js_make_data_package, $param_cost_metric, $ds_costs
-end
-
-datasource "ds_forecast" do
-  run_script $js_forecast, $ds_make_data_package, $param_average_months
-end
-
-###############################################################################
-# Scripts
-###############################################################################
-script "js_generate_past_month_list", type: "javascript" do
-  parameters "param_lookback_months"
-  result "month_list"
-  code <<-EOS
-  var month_list = [];
-  // format the date for the `daily` API
-  // returns date formatted as string: YYYY-mm-dd
-  function getFormattedDailyDate(date) {
-    var year = date.getFullYear();
-    var month = (1 + date.getMonth()).toString();
-    month = month.length > 1 ? month : '0' + month;
-    return year + '-' + month;
-  }
-
-  function getStartDate( date, month_counter ) {
-    date.setMonth(date.getMonth() - month_counter);
-    return date;
-  }
-
-  function getEndDate( date, month_counter ) {
-    date.setMonth(date.getMonth() - (month_counter - 1));
-    return date;
-  }
-
-  _.each(_.range(1, param_lookback_months + 1), function (month_counter) {
-    var start_date = getFormattedDailyDate(getStartDate(new Date(), month_counter));
-    var end_date = getFormattedDailyDate(getEndDate(new Date(), month_counter));
-    month_list.push({
-      'start_date': start_date,
-      'end_date': end_date,
-    });
-  });
-EOS
 end
 
 script "js_new_costs_request", type: "javascript" do
@@ -233,115 +212,125 @@ script "js_new_costs_request", type: "javascript" do
   EOS
 end
 
+#PACKAGE/SORT COST DATA
+datasource "ds_make_data_package" do
+  run_script $js_make_data_package, $param_cost_metric, $ds_costs
+end
+
 script "js_make_data_package", type: "javascript" do
   parameters "param_cost_metric", "ds_costs"
   result "results"
   code <<-EOS
-  var results = [];
+    var results = [];
 
-  var cost_metric = {
-    "Unamortized Unblended": "cost_nonamortized_unblended_adj",
-    "Amortized Unblended": "cost_amortized_unblended_adj",
-    "Unamortized Blended": "cost_nonamortized_blended_adj",
-    "Amortized Blended": "cost_amortized_blended_adj"
-  }
-
-  var mapped_costs = _.groupBy(ds_costs, function (value) {
-    return value.start_date;
-  });
-  var unsorted_results = _.map(mapped_costs, function (group) {
-    var counter = 0;
-    for (var i = 0; i < group.length; i++) {
-      var item = group[i];
-      if (item[cost_metric[param_cost_metric]] == 0) {
-        counter = counter + 1;
-      } else {
-        break;
-      }
+    var cost_metric = {
+      "Unamortized Unblended": "cost_nonamortized_unblended_adj",
+      "Amortized Unblended": "cost_amortized_unblended_adj",
+      "Unamortized Blended": "cost_nonamortized_blended_adj",
+      "Amortized Blended": "cost_amortized_blended_adj"
     }
 
-    var arr_new_sum = _.pluck(group, cost_metric[param_cost_metric]);
-
-    var summed = _.reduce(arr_new_sum, function (memo, num) { return memo + num; }, 0);
-    return {
-      start_date: group[0].start_date,
-      cost: summed,
-    };
-  });
-
-  var costs = [];
-  _.each(unsorted_results, function (item) {
-    costs.push({
-      start_date: item.start_date,
-      cost: item.cost,
+    var mapped_costs = _.groupBy(ds_costs, function (value) {
+      return value.start_date;
     });
-  });
+    var unsorted_results = _.map(mapped_costs, function (group) {
+      var counter = 0;
+      for (var i = 0; i < group.length; i++) {
+        var item = group[i];
+        if (item[cost_metric[param_cost_metric]] == 0) {
+          counter = counter + 1;
+        } else {
+          break;
+        }
+      }
 
-  var sorted_costs = _.sortBy(costs, function (o) { var dt = new Date(o.start_date); return -dt; });
-  console.log(sorted_costs);
-  results.push({
-    costs: sorted_costs,
-  });
-EOS
+      var arr_new_sum = _.pluck(group, cost_metric[param_cost_metric]);
+
+      var summed = _.reduce(arr_new_sum, function (memo, num) { return memo + num; }, 0);
+      return {
+        start_date: group[0].start_date,
+        cost: summed,
+      };
+    });
+
+    var costs = [];
+    _.each(unsorted_results, function (item) {
+      costs.push({
+        start_date: item.start_date,
+        cost: item.cost,
+      });
+    });
+
+    var sorted_costs = _.sortBy(costs, function (o) { var dt = new Date(o.start_date); return -dt; });
+    console.log(sorted_costs);
+    results.push({
+      costs: sorted_costs,
+    });
+  EOS
+end
+
+#CALUCLATE FORECAST DATA AND CREATE CHART
+datasource "ds_forecast" do
+  run_script $js_forecast, $ds_make_data_package, $param_average_months
 end
 
 script "js_forecast", type: "javascript" do
   parameters "ds_make_data_package", "param_average_months"
   result "report"
   code <<-EOS
-  var forecasted_costs = [];
+    var forecasted_costs = [];
 
-  // https://blog.oliverjumpertz.dev/the-moving-average-simple-and-exponential-theory-math-and-implementation-in-javascript
-  function simpleMovingAverage(prices, window) {
-    if (!prices || prices.length < window) {
-      return [];
+    // https://blog.oliverjumpertz.dev/the-moving-average-simple-and-exponential-theory-math-and-implementation-in-javascript
+    function simpleMovingAverage(prices, window) {
+      if (!prices || prices.length < window) {
+        return [];
+      }
+
+      var index = window - 1;
+      var length = prices.length + 1;
+
+      var simpleMovingAverages = [];
+      var counter = 0;
+      while (++index < length) {
+        var windowSlice = prices.slice(index - window, index);
+        var sum = _.reduce(windowSlice, function (prev, curr) {return  prev + curr; });
+        simpleMovingAverages.push( sum / window );
+        counter = counter + 1;
+      }
+
+      return simpleMovingAverages;
     }
 
-    var index = window - 1;
-    var length = prices.length + 1;
 
-    var simpleMovingAverages = [];
-    var counter = 0;
-    while (++index < length) {
-      var windowSlice = prices.slice(index - window, index);
-      var sum = _.reduce(windowSlice, function (prev, curr) {return  prev + curr; });
-      simpleMovingAverages.push( sum / window );
-      counter = counter + 1;
-    }
+    var costs = ds_make_data_package[0].costs;
+    console.log(costs);
 
-    return simpleMovingAverages;
-  }
+    var arr_costs = _.pluck(costs, 'cost');
 
+    forecasted_costs.push({ name: param_average_months + ' month average', average: simpleMovingAverage(arr_costs, param_average_months).reverse() });
+    size_difference = arr_costs.length - forecasted_costs[0]['average'].length
+    _.each(_.range(1, size_difference), function(item) {
+      forecasted_costs[0]['average'].push(forecasted_costs[0]['average'][forecasted_costs[0]['average'].length - 1])
+    })
+    var XAxisArray = _.range(1, arr_costs.length).reverse();
+    var chartData = 'chd=a:' + forecasted_costs[0]['average'].join(',') + '|' + arr_costs.reverse().join(',');
+    var chartXAxis = 'chxl=0:|' + XAxisArray.join('|');
+    forecasted_costs[0]['average'] = forecasted_costs[0]['average'].reverse()
+    var report = {
+      chartType: encodeURI('cht=lc'),
+      chartSize: encodeURI('chs=999x500'),
+      chartTitle: encodeURI('chtt=Moving Average'),
+      chartLabel: encodeURI('chdl=Moving Average|Actual Spend&chdlp=t'),
+      chartAxis: encodeURI('chxt=x,y'),
+      chartXAxis: encodeURI(chartXAxis),
+      chartAxisFormat: encodeURI('chxs=1N*cUSD0sz*'),
+      chartData: encodeURI(chartData),
+      chartColors: encodeURI('chco=3072F3,ff0000,00aaaa'),
+      chartExtension: encodeURI('chof=.png'),
+      reportData: forecasted_costs,
+    };
 
-  var costs = ds_make_data_package[0].costs;
-  console.log(costs);
-
-  var arr_costs = _.pluck(costs, 'cost');
-
-  forecasted_costs.push({ name: param_average_months + ' month average', average: simpleMovingAverage(arr_costs, param_average_months).reverse() });
-  size_difference = arr_costs.length - forecasted_costs[0]['average'].length
-  _.each(_.range(1, size_difference), function(item) {
-    forecasted_costs[0]['average'].push(forecasted_costs[0]['average'][forecasted_costs[0]['average'].length - 1])
-  })
-  var XAxisArray = _.range(1, arr_costs.length).reverse();
-  var chartData = 'chd=a:' + forecasted_costs[0]['average'].join(',') + '|' + arr_costs.reverse().join(',');
-  var chartXAxis = 'chxl=0:|' + XAxisArray.join('|');
-  forecasted_costs[0]['average'] = forecasted_costs[0]['average'].reverse()
-  var report = {
-    chartType: encodeURI('cht=lc'),
-    chartSize: encodeURI('chs=999x500'),
-    chartTitle: encodeURI('chtt=Moving Average'),
-    chartLabel: encodeURI('chdl=Moving Average|Actual Spend&chdlp=t'),
-    chartAxis: encodeURI('chxt=x,y'),
-    chartXAxis: encodeURI(chartXAxis),
-    chartAxisFormat: encodeURI('chxs=1N*cUSD0sz*'),
-    chartData: encodeURI(chartData),
-    chartColors: encodeURI('chco=3072F3,ff0000,00aaaa'),
-    chartExtension: encodeURI('chof=.png'),
-    reportData: forecasted_costs,
-  };
-
-EOS
+  EOS
 end
 
 ###############################################################################

--- a/cost/forecasting/straight_line_forecast/linear_regression/CHANGELOG.md
+++ b/cost/forecasting/straight_line_forecast/linear_regression/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1
+
+- Updated `js_generate_past_month_list` logic to fix bug where start date and end date clash when running policy at the end of January
+
 ## v3.0
 
 - Deprecated `auth_rs` authentication (type: `rightscale`) and replaced with `auth_flexera` (type: `oauth2`).  This is a breaking change which requires a Credential for `auth_flexera` [`provider=flexera`] before the policy can be applied.  Please see docs for setting up [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm)

--- a/cost/forecasting/straight_line_forecast/linear_regression/straight_line_forecast_linear_regression.pt
+++ b/cost/forecasting/straight_line_forecast/linear_regression/straight_line_forecast_linear_regression.pt
@@ -8,15 +8,11 @@ category "Cost"
 tenancy "single"
 default_frequency "monthly"
 info(
-  version: "3.0",
+  version: "3.1",
   provider: "Flexera Optima",
   service: "",
   policy_set: "Forecasting"
 )
-
-###############################################################################
-# Permissions
-###############################################################################
 
 ###############################################################################
 # Parameters
@@ -138,33 +134,25 @@ script "js_generate_past_month_list", type: "javascript" do
   result "month_list"
   code <<-EOS
   var month_list = [];
-  // format the date for the `daily` API
-  // returns date formatted as string: YYYY-mm-dd
-  function getFormattedDailyDate(date) {
-    var year = date.getFullYear();
-    var month = (1 + date.getMonth()).toString();
-    month = month.length > 1 ? month : '0' + month;
-    return year + '-' + month;
-  }
+  var previous_month = new Date()
+  previous_month.setMonth( previous_month.getMonth() - 1 )
 
-  function getStartDate( date, month_counter ) {
-    date.setMonth(date.getMonth() - month_counter);
-    return date;
-  }
 
-  function getEndDate( date, month_counter ) {
-    date.setMonth(date.getMonth() - (month_counter - 1));
-    return date;
-  }
+  for (var i = 0; i < param_lookback_months; i++) {
+    var start_date = new Date( previous_month )
+    start_date.setMonth( start_date.getMonth() - i )
+    start_date = start_date.toISOString().split("T")[0]
+    start_month = start_date.split("-")[0] + "-" + start_date.split("-")[1]
+    var end_date = new Date( previous_month )
+    end_date.setMonth( end_date.getMonth() - i + 1 )
+    end_date = end_date.toISOString().split("T")[0]
+    end_month = end_date.split("-")[0] + "-" + end_date.split("-")[1]
 
-  _.each(_.range(1, param_lookback_months + 1), function (month_counter) {
-    var start_date = getFormattedDailyDate(getStartDate(new Date(), month_counter));
-    var end_date = getFormattedDailyDate(getEndDate(new Date(), month_counter));
     month_list.push({
-      'start_date': start_date,
-      'end_date': end_date,
-    });
-  });
+      "start_date": start_month,
+      "end_date": end_month
+    })
+  }
   EOS
 end
 

--- a/cost/forecasting/straight_line_forecast/simple/CHANGELOG.md
+++ b/cost/forecasting/straight_line_forecast/simple/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1
+
+- Updated `js_generate_past_month_list` logic to fix bug where start date and end date clash when running policy at the end of January
+
 ## v3.0
 
 - Deprecated `auth_rs` authentication (type: `rightscale`) and replaced with `auth_flexera` (type: `oauth2`).  This is a breaking change which requires a Credential for `auth_flexera` [`provider=flexera`] before the policy can be applied.  Please see docs for setting up [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm)

--- a/cost/forecasting/straight_line_forecast/simple/straight_line_forecast_simple.pt
+++ b/cost/forecasting/straight_line_forecast/simple/straight_line_forecast_simple.pt
@@ -8,15 +8,11 @@ category "Cost"
 tenancy "single"
 default_frequency "monthly"
 info(
-  version: "3.0",
+  version: "3.1",
   provider: "Flexera Optima",
   service: "",
   policy_set: "Forecasting"
 )
-
-###############################################################################
-# Permissions
-###############################################################################
 
 ###############################################################################
 # Parameters
@@ -138,33 +134,25 @@ script "js_generate_past_month_list", type: "javascript" do
   result "month_list"
   code <<-EOS
   var month_list = [];
-  // format the date for the `daily` API
-  // returns date formatted as string: YYYY-mm-dd
-  function getFormattedDailyDate(date) {
-    var year = date.getFullYear();
-    var month = (1 + date.getMonth()).toString();
-    month = month.length > 1 ? month : '0' + month;
-    return year + '-' + month;
-  }
+  var previous_month = new Date()
+  previous_month.setMonth( previous_month.getMonth() - 1 )
 
-  function getStartDate( date, month_counter ) {
-    date.setMonth(date.getMonth() - month_counter);
-    return date;
-  }
 
-  function getEndDate( date, month_counter ) {
-    date.setMonth(date.getMonth() - (month_counter - 1));
-    return date;
-  }
+  for (var i = 0; i < param_lookback_months; i++) {
+    var start_date = new Date( previous_month )
+    start_date.setMonth( start_date.getMonth() - i )
+    start_date = start_date.toISOString().split("T")[0]
+    start_month = start_date.split("-")[0] + "-" + start_date.split("-")[1]
+    var end_date = new Date( previous_month )
+    end_date.setMonth( end_date.getMonth() - i + 1 )
+    end_date = end_date.toISOString().split("T")[0]
+    end_month = end_date.split("-")[0] + "-" + end_date.split("-")[1]
 
-  _.each(_.range(1, param_lookback_months + 1), function (month_counter) {
-    var start_date = getFormattedDailyDate(getStartDate(new Date(), month_counter));
-    var end_date = getFormattedDailyDate(getEndDate(new Date(), month_counter));
     month_list.push({
-      'start_date': start_date,
-      'end_date': end_date,
-    });
-  });
+      "start_date": start_month,
+      "end_date": end_month
+    })
+  }
   EOS
 end
 

--- a/operational/aws/total_instance_hours_forecast/CHANGELOG.md
+++ b/operational/aws/total_instance_hours_forecast/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1
+
+- Updated `js_generate_past_month_list` logic to fix bug where start date and end date clash when running policy at the end of January
+
 ## v3.0
 
 - Deprecated `auth_rs` authentication (type: `rightscale`) and replaced with `auth_flexera` (type: `oauth2`).  This is a breaking change which requires a Credential for `auth_flexera` [`provider=flexera`] before the policy can be applied.  Please see docs for setting up [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm)

--- a/operational/aws/total_instance_hours_forecast/aws_total_instance_hrs_forecast.pt
+++ b/operational/aws/total_instance_hours_forecast/aws_total_instance_hrs_forecast.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "3.0",
+  version: "3.1",
   provider: "Flexera Optima",
   service: "",
   policy_set: ""
@@ -105,33 +105,25 @@ script "js_generate_past_month_list", type: "javascript" do
   result "month_list"
   code <<-EOS
   var month_list = [];
-  // format the date for the `daily` API
-  // returns date formatted as string: YYYY-mm-dd
-  function getFormattedDailyDate(date) {
-    var year = date.getFullYear();
-    var month = (1 + date.getMonth()).toString();
-    month = month.length > 1 ? month : '0' + month;
-    return year + '-' + month;
-  }
+  var previous_month = new Date()
+  previous_month.setMonth( previous_month.getMonth() - 1 )
 
-  function getStartDate( date, month_counter ) {
-    date.setMonth(date.getMonth() - month_counter);
-    return date;
-  }
 
-  function getEndDate( date, month_counter ) {
-    date.setMonth(date.getMonth() - (month_counter - 1));
-    return date;
-  }
+  for (var i = 0; i < param_lookback_months; i++) {
+    var start_date = new Date( previous_month )
+    start_date.setMonth( start_date.getMonth() - i )
+    start_date = start_date.toISOString().split("T")[0]
+    start_month = start_date.split("-")[0] + "-" + start_date.split("-")[1]
+    var end_date = new Date( previous_month )
+    end_date.setMonth( end_date.getMonth() - i + 1 )
+    end_date = end_date.toISOString().split("T")[0]
+    end_month = end_date.split("-")[0] + "-" + end_date.split("-")[1]
 
-  _.each(_.range(1, param_lookback_months + 1), function (month_counter) {
-    var start_date = getFormattedDailyDate(getStartDate(new Date(), month_counter));
-    var end_date = getFormattedDailyDate(getEndDate(new Date(), month_counter));
     month_list.push({
-      'start_date': start_date,
-      'end_date': end_date,
-    });
-  });
+      "start_date": start_month,
+      "end_date": end_month
+    })
+  }
   EOS
 end
 

--- a/operational/aws/total_instance_vcpus_forecast/CHANGELOG.md
+++ b/operational/aws/total_instance_vcpus_forecast/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1
+
+- Updated `js_generate_past_month_list` logic to fix bug where start date and end date clash when running policy at the end of January
+
 ## v3.0
 
 - Deprecated `auth_rs` authentication (type: `rightscale`) and replaced with `auth_flexera` (type: `oauth2`).  This is a breaking change which requires a Credential for `auth_flexera` [`provider=flexera`] before the policy can be applied.  Please see docs for setting up [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm)

--- a/operational/aws/total_instance_vcpus_forecast/aws_total_instance_vcpus_forecast.pt
+++ b/operational/aws/total_instance_vcpus_forecast/aws_total_instance_vcpus_forecast.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "3.0",
+  version: "3.1",
   provider: "Flexera Optima",
   service: "",
   policy_set: ""
@@ -105,33 +105,25 @@ script "js_generate_past_month_list", type: "javascript" do
   result "month_list"
   code <<-EOS
   var month_list = [];
-  // format the date for the `daily` API
-  // returns date formatted as string: YYYY-mm-dd
-  function getFormattedDailyDate(date) {
-    var year = date.getFullYear();
-    var month = (1 + date.getMonth()).toString();
-    month = month.length > 1 ? month : '0' + month;
-    return year + '-' + month;
-  }
+  var previous_month = new Date()
+  previous_month.setMonth( previous_month.getMonth() - 1 )
 
-  function getStartDate( date, month_counter ) {
-    date.setMonth(date.getMonth() - month_counter);
-    return date;
-  }
 
-  function getEndDate( date, month_counter ) {
-    date.setMonth(date.getMonth() - (month_counter - 1));
-    return date;
-  }
+  for (var i = 0; i < param_lookback_months; i++) {
+    var start_date = new Date( previous_month )
+    start_date.setMonth( start_date.getMonth() - i )
+    start_date = start_date.toISOString().split("T")[0]
+    start_month = start_date.split("-")[0] + "-" + start_date.split("-")[1]
+    var end_date = new Date( previous_month )
+    end_date.setMonth( end_date.getMonth() - i + 1 )
+    end_date = end_date.toISOString().split("T")[0]
+    end_month = end_date.split("-")[0] + "-" + end_date.split("-")[1]
 
-  _.each(_.range(1, param_lookback_months + 1), function (month_counter) {
-    var start_date = getFormattedDailyDate(getStartDate(new Date(), month_counter));
-    var end_date = getFormattedDailyDate(getEndDate(new Date(), month_counter));
     month_list.push({
-      'start_date': start_date,
-      'end_date': end_date,
-    });
-  });
+      "start_date": start_month,
+      "end_date": end_month
+    })
+  }
   EOS
 end
 


### PR DESCRIPTION
This is to fix a bug in the forecasting policies where the Start Date and End Date used to call the Aggregated Costs API clash. See details of the identified error below:

The logic in the “js_generate_past_month_list” script must be rewritten to prevent this problem from happening

Link to Jira ticket - https://flexera.atlassian.net/browse/POL-756 

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
