### PR TITLE
For for Graph when using "Week"

### DIFF
--- a/cost/scheduled_reports/CHANGELOG.md
+++ b/cost/scheduled_reports/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1
+
+- Fixed issue with incorrectly-rendered graph when selecting "Week" for the Billing Term parameter
+
 ## v2.0
 
 - Deprecated `auth_rs` authentication (type: `rightscale`) and replaced with `auth_flexera` (type: `oauth2`).  This is a breaking change which requires a Credential for `auth_flexera` [`provider=flexera`] before the policy can be applied.  Please see docs for setting up [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm)

--- a/cost/scheduled_reports/scheduled_report.pt
+++ b/cost/scheduled_reports/scheduled_report.pt
@@ -20,7 +20,7 @@ category "Cost"
 default_frequency "monthly"
 tenancy "single"
 info(
-  version: "2.0",
+  version: "2.1",
   provider: "Flexera Optima",
   service: "",
   policy_set: ""
@@ -1017,7 +1017,7 @@ script "js_generate_report", type: "javascript" do
   } else if (param_billing_term === "Week") {
     _.each(categories, function (category) {
       var seriesData = [];
-      _.each(stringWeek, function (week) {
+      _.each(stringWeeks, function (week) {
         var tempTotal = _.where(collated_data, { stringWeek: week, category: category });
         if (tempTotal.length === 0) {
           seriesData.push("_")


### PR DESCRIPTION
Fixed issue with incorrectly-rendered graph when selecting "Week" for the Billing Term parameter