### PR TITLE
HCLIND-47 Fix: ITAM policies are hardcoded for NAM

### DIFF
--- a/compliance/fnms/fnms_licenses_expiring/CHANGELOG.md
+++ b/compliance/fnms/fnms_licenses_expiring/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2
+
+- Replaced hardcoded `host` in `ds_licenses` using `f1_app_host` as base
+
 ## v2.1
 
 - Replaced references `github.com/rightscale/policy_templates` and `github.com/flexera/policy_templates` with `github.com/flexera-public/policy_templates`

--- a/compliance/fnms/fnms_licenses_expiring/expiring_licenses.pt
+++ b/compliance/fnms/fnms_licenses_expiring/expiring_licenses.pt
@@ -7,7 +7,7 @@ severity "medium"
 category "Compliance"
 default_frequency "weekly"
 info(
-  version: "2.1",
+  version: "2.2",
   provider: "Flexera ITAM",
   service: "",
   policy_set: "ITAM"
@@ -45,7 +45,7 @@ end
 datasource "ds_licenses" do
   request do
     auth $auth_flexeraone
-    host "api.flexera.com"
+    host join(["api.", get(1, split(f1_app_host, "app."))])
     path join(["/fnms/v1/orgs/", rs_org_id, "/license-attributes"])
     header "Api-Version", "0.1"
     header "User-Agent", "RS Policies"

--- a/compliance/fnms/ignored_recent_inventory_dates/CHANGELOG.md
+++ b/compliance/fnms/ignored_recent_inventory_dates/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2
+
+- Replaced hardcoded `host` in `ds_inventories` using `f1_app_host` as base
+
 ## v2.1
 
 - Replaced references `github.com/rightscale/policy_templates` and `github.com/flexera/policy_templates` with `github.com/flexera-public/policy_templates`

--- a/compliance/fnms/ignored_recent_inventory_dates/ignored_recent_inventory_dates.pt
+++ b/compliance/fnms/ignored_recent_inventory_dates/ignored_recent_inventory_dates.pt
@@ -8,7 +8,7 @@ category "Compliance"
 default_frequency "weekly"
 
 info(
-  version: "2.1",
+  version: "2.2",
   provider: "Flexera ITAM",
   service: "",
   policy_set: "ITAM"
@@ -46,7 +46,7 @@ end
 datasource "ds_inventories" do
   request do
     auth $auth_flexeraone
-    host "api.flexera.com"
+    host join(["api.", get(1, split(f1_app_host, "app."))])
     path join(["/fnms/v1/orgs/", rs_org_id, "/inventories"])
     header "Api-Version", "0.1"
     header "User-Agent", "RS Policies"

--- a/compliance/fnms/missing_active_machines/CHANGELOG.md
+++ b/compliance/fnms/missing_active_machines/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2
+
+- Replaced hardcoded `host` in `ds_inventories` using `f1_app_host` as base
+
 ## v2.1
 
 - Replaced references `github.com/rightscale/policy_templates` and `github.com/flexera/policy_templates` with `github.com/flexera-public/policy_templates`

--- a/compliance/fnms/missing_active_machines/CHANGELOG.md
+++ b/compliance/fnms/missing_active_machines/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v2.2
 
-- Replaced hardcoded `host` in `ds_inventories` using `f1_app_host` as base 
+- Replaced hardcoded `host` in `ds_inventories` using `f1_app_host` as base
 
 ## v2.1
 

--- a/compliance/fnms/missing_active_machines/CHANGELOG.md
+++ b/compliance/fnms/missing_active_machines/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v2.2
 
-- Replaced hardcoded `host` in `ds_inventories` using `f1_app_host` as base
+- Replaced hardcoded `host` in `ds_inventories` using `f1_app_host` as base 
 
 ## v2.1
 

--- a/compliance/fnms/missing_active_machines/missing_active_machines.pt
+++ b/compliance/fnms/missing_active_machines/missing_active_machines.pt
@@ -8,7 +8,7 @@ category "Compliance"
 default_frequency "weekly"
 
 info(
-  version: "2.1",
+  version: "2.2",
   provider: "Flexera ITAM",
   service: "",
   policy_set: "ITAM"

--- a/compliance/fnms/missing_active_machines/missing_active_machines.pt
+++ b/compliance/fnms/missing_active_machines/missing_active_machines.pt
@@ -46,7 +46,7 @@ end
 datasource "ds_inventories" do
   request do
     auth $auth_flexeraone
-    host "api.flexera.com"
+    host join(["api.", get(1, split(f1_app_host, "app."))])
     path join(["/fnms/v1/orgs/", rs_org_id, "/inventories"])
     header "Api-Version", "0.1"
     header "User-Agent", "RS Policies"

--- a/compliance/fnms/overused_licenses/CHANGELOG.md
+++ b/compliance/fnms/overused_licenses/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2
+
+- Replaced hardcoded `host` in `ds_license_attributes` and `ds_license_entitlements` using `f1_app_host` as base
+
 ## v2.1
 
 - Replaced references `github.com/rightscale/policy_templates` and `github.com/flexera/policy_templates` with `github.com/flexera-public/policy_templates`

--- a/compliance/fnms/overused_licenses/overused_licenses.pt
+++ b/compliance/fnms/overused_licenses/overused_licenses.pt
@@ -7,7 +7,7 @@ severity "medium"
 category "Compliance"
 default_frequency "daily"
 info(
-  version: "2.1",
+  version: "2.2",
   provider: "Flexera FNMS",
   service: "",
   policy_set: ""
@@ -49,7 +49,7 @@ datasource "ds_license_attributes" do
   request do
     auth $auth_flexeraone
     verb "GET"
-    host "api.flexera.com"
+    host join(["api.", get(1, split(f1_app_host, "app."))])
     path join(["/fnms/v1/orgs/", rs_org_id, "/license-attributes"])
     query "offset", ""
     query "limit", ""
@@ -60,7 +60,7 @@ datasource "ds_license_entitlements" do
   request do
     auth $auth_flexeraone
     verb "GET"
-    host "api.flexera.com"
+    host join(["api.", get(1, split(f1_app_host, "app."))])
     path join(["/fnms/v1/orgs/", rs_org_id, "/license-entitlements"])
     query "offset", ""
     query "limit", ""

--- a/compliance/fnms/vms_missing_hostid/CHANGELOG.md
+++ b/compliance/fnms/vms_missing_hostid/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2
+
+- Replaced hardcoded `host` in `ds_inventories` using `f1_app_host` as base
+
 ## v2.1
 
 - Replaced references `github.com/rightscale/policy_templates` and `github.com/flexera/policy_templates` with `github.com/flexera-public/policy_templates`

--- a/compliance/fnms/vms_missing_hostid/vms_missing_hostid.pt
+++ b/compliance/fnms/vms_missing_hostid/vms_missing_hostid.pt
@@ -7,7 +7,7 @@ severity "medium"
 category "Compliance"
 default_frequency "daily"
 info(
-  version: "2.1",
+  version: "2.2",
   provider: "Flexera ITAM",
   service: "",
   policy_set: "ITAM"
@@ -54,7 +54,7 @@ end
 datasource "ds_inventories" do
   request do
     auth $auth_flexeraone
-    host "api.flexera.com"
+    host join(["api.", get(1, split(f1_app_host, "app."))])
     path join(["/fnms/v1/orgs/", rs_org_id, "/inventories"])
     header "Api-Version", "0.1"
     header "User-Agent", "RS Policies"


### PR DESCRIPTION
### Description

Replaced hardcoded host in all ds using f1_app_host as base.

### Issues Resolved

ITAM policies are hardcoded for NAM, more info: [Here](https://flexera.atlassian.net/browse/HCLIND-47).

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
