### PR TITLE
adjusted jq expression to correctly grab status code not based on pos…

### DIFF
--- a/cost/azure/schedule_instance/CHANGELOG.md
+++ b/cost/azure/schedule_instance/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v2.10
 
-- Changed `'.statuses[1].code/"/"|.[1]'` to `'.statuses[] | select( .code | match("PowerState")) | .code[11:50]'` so that the right item in an array is selected for status
+- Fixed bug related to Instance Status in the resulting incident data
 
 ## v2.9
 

--- a/cost/azure/schedule_instance/CHANGELOG.md
+++ b/cost/azure/schedule_instance/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v3.0
+## v2.10
 
 - Changed `'.statuses[1].code/"/"|.[1]'` to `'.statuses[] | select( .code | match("PowerState")) | .code[11:50]'` so that the right item in an array is selected for status
 

--- a/cost/azure/schedule_instance/CHANGELOG.md
+++ b/cost/azure/schedule_instance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.0
+
+- Changed `'.statuses[1].code/"/"|.[1]'` to `'.statuses[] | select( .code | match("PowerState")) | .code[11:50]'` so that the right item in an array is selected for status
+
 ## v2.9
 
 - Replaced the term **whitelist** with **allowed list**.

--- a/cost/azure/schedule_instance/azure_schedule_instance.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance.pt
@@ -146,7 +146,9 @@ datasource "ds_azure_instances" do
   end
   result do
     encoding "json"
-    field "status", jq(response,'.statuses[] | select( .code | match("PowerState")) | .code[11:50]')
+    # From the statuses[] list select the object with code matching PowerState
+    # With that object, we select the .code string, and use the status after "PowerState/" in the string
+    field "status", jq(response,'.statuses[] | select( .code | match("PowerState")).code | split("\/")[1]')
     field "id", val(iter_item,"id")
     field "rg", val(iter_item,"rg")
     field "name", val(iter_item,"name")

--- a/cost/azure/schedule_instance/azure_schedule_instance.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "3.0",
+  version: "2.10",
   provider: "Azure",
   service: "Compute",
   policy_set:"Schedule Instance"

--- a/cost/azure/schedule_instance/azure_schedule_instance.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.9",
+  version: "3.0",
   provider: "Azure",
   service: "Compute",
   policy_set:"Schedule Instance"

--- a/cost/azure/schedule_instance/azure_schedule_instance.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance.pt
@@ -148,7 +148,7 @@ datasource "ds_azure_instances" do
     encoding "json"
     # From the statuses[] list select the object with code matching PowerState
     # With that object, we select the .code string, and use the status after "PowerState/" in the string
-    field "status", jq(response,'.statuses[] | select( .code | match("PowerState")).code | split("\/")[1]')
+    field "status", jq(response,'.statuses[] | select( .code | match("PowerState")).code | split("/")[1]')
     field "id", val(iter_item,"id")
     field "rg", val(iter_item,"rg")
     field "name", val(iter_item,"name")

--- a/cost/azure/schedule_instance/azure_schedule_instance.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance.pt
@@ -146,7 +146,7 @@ datasource "ds_azure_instances" do
   end
   result do
     encoding "json"
-    field "status", jq(response,'.statuses[1].code/"/"|.[1]')
+    field "status", jq(response,'.statuses[] | select( .code | match("PowerState")) | .code[11:50]')
     field "id", val(iter_item,"id")
     field "rg", val(iter_item,"rg")
     field "name", val(iter_item,"name")


### PR DESCRIPTION


### Description
Adjusted jq expression to correctly grab status code not based on a position within an array but instead matching the text. PowerState code was appearing on some instances not in [1] but in [2]. Seems to be different positions based on the type of deployment. 

### Issues Resolved
incorrectly selecting the wrong status code based on position of element within array.

### Contribution Check List

- [X] All tests pass.
- [X] New functionality has been documented in CHANGELOG.MD
