### PR TITLE
HCLIND-39 Turbonomics Buy Reserved Instances Recommendations.

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,6 +1,0 @@
-<component name="InspectionProjectProfileManager">
-  <profile version="1.0">
-    <option name="myName" value="Project Default" />
-    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
-  </profile>
-</component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+- Initial Release

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/CHANGELOG.md
@@ -1,3 +1,5 @@
 # Changelog
 
+## v2.0
+
 - Initial Release

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-## v2.0
+## v0.1
 
 - Initial Release

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/README.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/README.md
@@ -2,17 +2,17 @@
 
 ## What it does
 
-The Turbonomics Buy Reserved Instances Recommendations AWS policy utilizes Turbonomics https://turbonomic.com/api/v3/markets/{market_uuid}/actions endpoint to provide AWS purchasable RI recommendations for Reserved Instance coverage. From these recommendations we provide monthly savings estimates based on Turbonomics per hour costs
+The Turbonomics Buy Reserved Instances Recommendations AWS policy utilizes Turbonomics [Credentials]https://turbonomic.com/api/v3/markets/{market_uuid}/actions endpoint to provide AWS purchasable RI recommendations for Reserved Instance coverage. From these recommendations we provide monthly savings estimates based on Turbonomics per hour costs
 
 ## Functional Details
 
 - The policy queries the /api/v3/markets/{market_uuid}/actions endpoint for the turbonomics api and based on action will return action details and savings for on-boarded cloud instances
 - The policy will error after a day, the authorization cookie parameter will need to be refreshed and re-run manually
-- there is a need to run the login credentials against the https://xxxx.turbonomic.com/api/v3/login endpoint to manually recieve cookie authoriztion
+- there is a need to run the login credentials against the [Credentials]https://xxxx.turbonomic.com/api/v3/login endpoint to manually recieve cookie authoriztion
 
 ### Input Parameters
 
-- *Authorization Cookie"* - authorization cookie pulled from turbonomic login endpoint: https://xxxx.turbonomic.com/api/v3/login
+- *Authorization Cookie"* - authorization cookie pulled from turbonomic login endpoint: [Credentials]https://xxxx.turbonomic.com/api/v3/login
 - no_echo: true
 - *Email addresses* - A list of email addresses to notify
 

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/README.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/README.md
@@ -1,18 +1,18 @@
-# Turbonomics Buy Reserved Instances Recommendations AWS
+# Turbonomic Buy Reserved Instances Recommendations AWS
 
 ## What it does
 
-The Turbonomics Buy Reserved Instances Recommendations AWS policy utilizes Turbonomic Actions API endpoint to provide AWS RI purchase recommendations.
+The Turbonomic Buy Reserved Instances Recommendations AWS policy utilizes Turbonomic Actions API endpoint (POST `https://turbonomic.com/api/v3/markets/{market_uuid}/actions`)  to provide AWS RI purchase recommendations.
 
 ## Functional Details
 
-- The policy queries the /api/v3/markets/{market_uuid}/actions endpoint for the turbonomics api and based on action will return action details and savings for on-boarded cloud instances
+- The policy queries the /api/v3/markets/{market_uuid}/actions endpoint for the Turbonomic api and based on action will return action details and savings for on-boarded cloud instances
 - The policy will error after a day, the authorization cookie parameter will need to be refreshed and re-run manually
-- there is a need to run the login credentials against the (`https://xxxx.turbonomic.com/api/v3/login`) endpoint to manually recieve cookie authoriztion
+- there is a need to run the login credentials against the (`https://xxxx.turbonomic.com/api/v3/login`) endpoint to manually receive cookie authorization
 
 ### Input Parameters
 
-- *Authorization Cookie"* - authorization cookie pulled from turbonomic login endpoint: (POST `https://xxxx.turbonomic.com/api/v3/login`)
+- *Authorization Cookie"* - authorization cookie pulled from Turbonomic login endpoint: (POST `https://xxxx.turbonomic.com/api/v3/login`)
 - no_echo: true
 - *Email addresses* - A list of email addresses to notify
 

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/README.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/README.md
@@ -2,7 +2,7 @@
 
 ## What it does
 
-The Turbonomics Buy Reserved Instances Recommendations AWS policy utilizes Turbonomics [Credentials]https://turbonomic.com/api/v3/markets/{market_uuid}/actions endpoint to provide AWS purchasable RI recommendations for Reserved Instance coverage. From these recommendations we provide monthly savings estimates based on Turbonomics per hour costs
+The Turbonomics Buy Reserved Instances Recommendations AWS policy utilizes Turbonomic Actions API endpoint to provide AWS RI purchase recommendations.
 
 ## Functional Details
 

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/README.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/README.md
@@ -1,0 +1,28 @@
+# Turbonomics Buy Reserved Instances Recommendations AWS
+
+## What it does
+
+The Turbonomics Buy Reserved Instances Recommendations AWS policy utilizes Turbonomics https://turbonomic.com/api/v3/markets/{market_uuid}/actions endpoint to provide AWS purchasable RI recommendations for Reserved Instance coverage. From these recommendations we provide monthly savings estimates based on Turbonomics per hour costs
+
+## Functional Details
+
+- The policy queries the /api/v3/markets/{market_uuid}/actions endpoint for the turbonomics api and based on action will return action details and savings for on-boarded cloud instances
+- The policy will error after a day, the authorization cookie parameter will need to be refreshed and re-run manually
+- there is a need to run the login credentials against the https://xxxx.turbonomic.com/api/v3/login endpoint to manually recieve cookie authoriztion
+
+### Input Parameters
+
+- *Authorization Cookie"* - authorization cookie pulled from turbonomic login endpoint: https://xxxx.turbonomic.com/api/v3/login
+- no_echo: true
+- *Email addresses* - A list of email addresses to notify
+
+### Required Flexera Roles
+
+- policy_manager
+- billing_center_viewer
+
+- Turbonomics - administrator
+
+### Cost
+
+This Policy Template does not incur any cloud costs.

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/README.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/README.md
@@ -14,7 +14,8 @@ The Turbonomic Buy Reserved Instances Recommendations AWS policy utilizes Turbon
 
 - *Authorization Cookie"* - authorization cookie pulled from Turbonomic login endpoint: (POST `https://xxxx.turbonomic.com/api/v3/login`)
 - no_echo: true
-- *Email addresses* - A list of email addresses to notify
+- *Email addresses* - A list of email addresses to notify.
+- *Turbonomic Endpoint* -Host of the Turbonomic endpoint.
 
 ### Required Flexera Roles
 

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/README.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/README.md
@@ -8,7 +8,7 @@ The Turbonomic Buy Reserved Instances Recommendations AWS policy utilizes Turbon
 
 - The policy queries the /api/v3/markets/{market_uuid}/actions endpoint for the Turbonomic api and based on action will return action details and savings for on-boarded cloud instances
 - The policy will error after a day, the authorization cookie parameter will need to be refreshed and re-run manually
-- there is a need to run the login credentials against the (`https://xxxx.turbonomic.com/api/v3/login`) endpoint to manually receive cookie authorization
+- There is a need to run the login credentials against the (`https://xxxx.turbonomic.com/api/v3/login`) endpoint to manually receive cookie authorization
 
 ### Input Parameters
 

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/README.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/README.md
@@ -8,11 +8,11 @@ The Turbonomics Buy Reserved Instances Recommendations AWS policy utilizes Turbo
 
 - The policy queries the /api/v3/markets/{market_uuid}/actions endpoint for the turbonomics api and based on action will return action details and savings for on-boarded cloud instances
 - The policy will error after a day, the authorization cookie parameter will need to be refreshed and re-run manually
-- there is a need to run the login credentials against the [Credentials]https://xxxx.turbonomic.com/api/v3/login endpoint to manually recieve cookie authoriztion
+- there is a need to run the login credentials against the (`https://xxxx.turbonomic.com/api/v3/login`) endpoint to manually recieve cookie authoriztion
 
 ### Input Parameters
 
-- *Authorization Cookie"* - authorization cookie pulled from turbonomic login endpoint: [Credentials]https://xxxx.turbonomic.com/api/v3/login
+- *Authorization Cookie"* - authorization cookie pulled from turbonomic login endpoint: (POST `https://xxxx.turbonomic.com/api/v3/login`)
 - no_echo: true
 - *Email addresses* - A list of email addresses to notify
 
@@ -20,8 +20,6 @@ The Turbonomics Buy Reserved Instances Recommendations AWS policy utilizes Turbo
 
 - policy_manager
 - billing_center_viewer
-
-- Turbonomics - administrator
 
 ### Cost
 

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
@@ -19,9 +19,9 @@ info(
 # Parameters #
 ##################
 
-parameter "param_turbonomic_endpoint" do
+parameter "param_turbonomic_host" do
   type "string"
-  label "Turbonomic Endpoint"
+  label "Turbonomic Host"
 end
 
 parameter "auth_cookie" do
@@ -57,7 +57,7 @@ end
 #get turbonomic recommendation data
 datasource "ds_get_turbonomics_recommendations" do
   request do
-    run_script $js_get_turbonomics_recommendations, $param_turbonomic_endpoint,$auth_cookie
+    run_script $js_get_turbonomics_recommendations, $param_turbonomic_host,$auth_cookie
   end
   result do
     encoding "json"
@@ -87,7 +87,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, $param_turbonomic_endpoint,$auth_cookie
+    run_script $js_get_business_units, $param_turbonomic_host,$auth_cookie
   end
   result do
     encoding "json"
@@ -110,13 +110,13 @@ end
 ##script using a manually acquired turbonomic cookie and pulls hard coded purchasable ri data
 script "js_get_turbonomics_recommendations", type: "javascript" do
   result "request"
-  parameters "param_turbonomic_endpoint","auth_cookie"
+  parameters "param_turbonomic_host","auth_cookie"
   code <<-EOS
   //replace cookie every day this is run
   var request = {
       verb: "POST",
       pagination: "turbonomics_buy_ris_pagination_header",
-      host: param_turbonomic_endpoint,
+      host: param_turbonomic_host,
       path: "/api/v3/markets/Market/actions",
       body_fields: {
           "actionStateList": ["READY", "ACCEPTED", "QUEUED", "IN_PROGRESS"],
@@ -140,12 +140,12 @@ end
 ## verified that discovered is the only one we need
 script "js_get_business_units", type: "javascript" do
   result "request"
-  parameters "param_turbonomic_endpoint","auth_cookie"
+  parameters "param_turbonomic_host","auth_cookie"
   code <<-EOS
   //replace cookie every day this is run
   var request = {
       verb: "GET",
-      host: param_turbonomic_endpoint,
+      host: param_turbonomic_host,
       path: "/api/v3/businessunits",
       query_params: {
           "cloud_type": "AWS",

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
@@ -1,0 +1,307 @@
+name "Turbonomics Buy Reserved Instances Recommendations AWS"
+rs_pt_ver 20180301
+type "policy"
+short_description "Turbonomics policy for recommending purchasable reserved instances [README](https://github.com/flexera-public/policy_templates/tree/master/cost/turbonomics/buy_reserved_instances_recommendations/aws) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+severity "low"
+category "Cost"
+default_frequency "daily"
+info(
+  version: "2.0",
+  provider: "AWS",
+  source: "Turbonomics",
+  service: "RIs",
+  policy_set: "Buy RIs",
+  recommendation_type: "Rate Reduction",
+  publish: "false"
+)
+
+##################
+# Parameters #
+##################
+parameter "param_turbonomic_endpoint" do
+  type "string"
+  label "Turbonomic Endpoint"
+  default "sales1.demo.turbonomic.com"
+end
+
+parameter "auth_cookie" do
+  type "string"
+  label "Authorization Cookie"
+  no_echo true
+  description "authorization cookie pulled from manual source"
+end
+
+parameter "param_email" do
+  type "list"
+  label "Email addresses to notify"
+  description "Email addresses of the recipients you wish to notify when new incidents are created"
+end
+
+###############################################################################
+# Pagination
+###############################################################################
+
+pagination "turbonomics_buy_ris_pagination_header" do
+  get_page_marker do
+    header "x-next-cursor"
+  end
+  set_page_marker do
+    query "cursor"
+  end
+end
+
+###############################################################################
+# Datasources
+###############################################################################
+
+#get turbonomic recommendation data
+datasource "ds_get_turbonomics_recommendations" do
+  request do
+    run_script $js_get_turbonomics_recommendations, $param_turbonomic_endpoint,$auth_cookie
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "businessUUID", jmes_path(col_item, "reservedInstance.accountId")
+      field "termValue", jmes_path(col_item, "reservedInstance.term.value")
+      field "termUnits", jmes_path(col_item, "reservedInstance.term.units")
+      field "paymentOptions", jmes_path(col_item, "reservedInstance.payment")
+      field "tenancy", jmes_path(col_item, "reservedInstance.tenancy")
+      field "region", jmes_path(col_item, "currentLocation.displayName")
+      field "resourceType", jmes_path(col_item, "newEntity.displayName")
+      field "riType", jmes_path(col_item, "reservedInstance.type")
+      field "provider", jmes_path(col_item, "target.discoveredBy.type")
+      field "numberOfInstances", jmes_path(col_item, "reservedInstance.instanceCount")
+      field "details", jmes_path(col_item, "details")
+      field "platform", jmes_path(col_item, "reservedInstance.platform")
+      field "upfrontCost", jmes_path(col_item, "reservedInstance.upFrontCost")
+      field "recurringCost", jmes_path(col_item, "reservedInstance.actualHourlyCost")
+      field "effectiveCost", jmes_path(col_item, "reservedInstance.effectiveHourlyCost")
+      field "sizeFlexible", jmes_path(col_item, "reservedInstance.sizeFlexible")
+      field "savings", jmes_path(col_item, "stats[0].value")
+      field "savingsCurrency", jmes_path(col_item, "stats[0].units")
+    end
+  end
+end
+
+##this will potentially be a lot of calls. how to make this more performant
+datasource "ds_get_business_units" do
+  request do
+    run_script $js_get_business_units, $param_turbonomic_endpoint,$auth_cookie
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "uuid", jmes_path(col_item, "uuid")
+      field "accountID", jmes_path(col_item, "accountId")
+      field "displayName", jmes_path(col_item, "displayName")
+    end
+  end
+end
+
+datasource "ds_filtered_turbonomics_recommendations" do
+  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_business_units
+end
+
+###############################################################################
+# Scripts
+###############################################################################
+
+##script using a manually acquired turbonomic cookie and pulls hard coded purchasable ri data
+script "js_get_turbonomics_recommendations", type: "javascript" do
+  result "request"
+  parameters "param_turbonomic_endpoint","auth_cookie"
+  code <<-EOS
+  //replace cookie every day this is run
+    var request = {
+      verb: "POST",
+      pagination: "turbonomics_buy_ris_pagination_header",
+      host: param_turbonomic_endpoint,
+      path: "/api/v3/markets/Market/actions",
+      body_fields: {
+        "actionStateList": ["READY", "ACCEPTED", "QUEUED", "IN_PROGRESS"],
+        "relatedEntityTypes":["Region"],
+        "actionTypeList":["BUY_RI"],
+        "environmentType":"CLOUD",
+        "detailLevel":"EXECUTION",
+        "costType":"SAVING"
+      },
+      query_params: {
+        "limit": '1000'
+      },
+      headers: {
+        "Content-Type": "application/json"
+        "Cookie": auth_cookie
+      }
+    }
+EOS
+end
+
+## verified that discovered is the only one we need
+script "js_get_business_units", type: "javascript" do
+  result "request"
+  parameters "param_turbonomic_endpoint","auth_cookie"
+  code <<-EOS
+  //replace cookie every day this is run
+    var request = {
+      verb: "GET",
+      host: param_turbonomic_endpoint,
+      path: "/api/v3/businessunits",
+      query_params: {
+        "cloud_type": "AWS",
+        "type":"DISCOVERED"
+      },
+      headers: {
+        "Content-Type": "application/json"
+        "Cookie": auth_cookie
+      }
+    }
+EOS
+end
+
+script "js_filtered_turbonomics_recommendations", type: "javascript" do
+  result "result"
+  parameters "ds_get_turbonomics_recommendations", "ds_get_business_units"
+  code <<-EOS
+    instances = []
+    monthlySavings = 0.0
+    function formatNumber(number, separator){
+    var numString =number.toString()
+    var values=numString.split(".")
+    var result = ''
+    while (values[0].length > 3){
+      var chunk = values[0].substr(-3)
+      values[0] = values[0].substr(0, values[0].length - 3)
+      result = separator + chunk + result
+    }
+    if (values[0].length > 0){
+      result = values[0] + result
+    }
+    if(values[1]==undefined){
+      return result
+    }
+    return result+"."+values[1]
+    }
+
+    _.each(ds_get_business_units, function(businessUnit) {
+      _.each(ds_get_turbonomics_recommendations, function(ri, index){
+        if (ri.businessUUID === businessUnit.uuid) {
+          if (ri.provider === "AWS") {
+            if (typeof ri.savingsCurrency != "undefined" && ri.savingsCurrency != null) {
+              if (ri.savingsCurrency.indexOf("$") != -1) {
+                ri.savingsCurrency = "$"
+              }
+            } else {
+              ri.savingsCurrency = "$"
+            }
+            ri.term = ri.termValue + " " + ri.termUnits
+            ri.service = "EC2"
+            if (typeof ri.savings === "undefined" || ri.savings === null || ri.savings === "" || isNaN(ri.savings)) {
+              ri.savings = 0.0
+            }
+            if (typeof ri.effectiveCost === "undefined" || ri.effectiveCost === null || ri.effectiveCost === "" || isNaN(ri.effectiveCost)) {
+              ri.effectiveCost = 0.0
+            }
+            ri.accountID=businessUnit.accountID
+            ri.accountName=businessUnit.accountName
+            ri.savings = (Math.round(ri.savings * 730 * 1000) / 1000)
+            ri.effectiveCost = (Math.round(ri.effectiveCost * 730 * 1000) / 1000)
+            ri.recurringCost = (Math.round(ri.recurringCost * 730 * 1000) / 1000)
+            monthlySavings = monthlySavings + ri.savings
+            instances.push(ri)
+        }
+      }
+      })
+    })
+
+    message = ""
+    if (instances.length != 0) {
+      pretty_savings = instances[0].savingsCurrency + ' ' + formatNumber(monthlySavings.toFixed(2), ",")
+      message = "The total estimated monthly savings are " + pretty_savings + '.'
+    }
+
+    result = {
+      'instances': instances,
+      'message': message
+    }
+EOS
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "pol_turbonomics_buy_ri" do
+  validate $ds_filtered_turbonomics_recommendations do
+    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data.instances }} Turbonomic Purchase Reserved Instance Recommendations found"
+    detail_template <<-EOS
+{{data.message}}
+EOS
+    check eq(size(val(data, "instances")), 0)
+    export "instances" do
+      field "accountID" do
+        label "Account ID"
+      end
+      field "accountName" do
+        label "Account Name"
+      end
+      field "savingsCurrency" do
+        label "Savings Currency"
+      end
+      field "savings" do
+        label "Savings"
+      end
+      field "details" do
+        label "Recommendation Details"
+      end
+      field "numberOfInstances" do
+        label "Number of Reserved Instances"
+      end
+      field "resourceType" do
+        label "Resource Type"
+      end
+      field "riType" do
+        label "Reserved Instance Type"
+      end
+      field "term" do
+        label "Term"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "platform" do
+        label "Platform"
+      end
+      field "tenancy" do
+        label "Tenancy"
+      end
+      field "upfrontCost" do
+        label "Up Front Cost"
+      end
+      field "recurringCost" do
+        label "Recurring Cost"
+      end
+      field "effectiveCost" do
+        label "Effective Cost"
+      end
+      field "sizeFlexible" do
+        label "Size Flexible"
+      end
+    end
+    escalate $esc_email
+  end
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
@@ -213,10 +213,10 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
 
                     ri.accountID = businessUnit.accountID
                     ri.accountName = businessUnit.displayName
-                    ri.upfrontCost= ri.numberOfInstances* ri.upfrontCost
-                    ri.savings = (Math.round(ri.savings * 730 * 1000) / 1000)
-                    ri.effectiveCost = (Math.round(ri.effectiveCost * 730 * ri.termValue * 12 * ri.numberOfInstances * 1000) / 1000)
-                    ri.recurringCost = (Math.round(ri.recurringCost * 730 * ri.numberOfInstances * 1000) / 1000)
+                    ri.upfrontCost= Number(ri.numberOfInstances * ri.upfrontCost).toFixed(2)
+                    ri.savings = Math.round(ri.savings * 730*100)/100
+                    ri.effectiveCost = Number(ri.effectiveCost * 730 * ri.termValue * 12 * ri.numberOfInstances).toFixed(2)
+                    ri.recurringCost = Number(ri.recurringCost * 730 * ri.numberOfInstances).toFixed(2)
                     monthlySavings = monthlySavings + ri.savings
                     instances.push(ri)
                 }

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
@@ -280,7 +280,7 @@ EOS
         label "Tenancy"
       end
       field "upfrontCost" do
-        label "Up Front Cost"
+        label "Upfront Cost"
       end
       field "recurringCost" do
         label "Recurring Cost"

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
@@ -8,9 +8,9 @@ default_frequency "daily"
 info(
   version: "2.0",
   provider: "AWS",
-  source: "Turbonomics",
-  service: "RIs",
-  policy_set: "Buy RIs",
+  source: "Turbonomic",
+  service: "Usage Discount",
+  policy_set: "Reserved Instance",
   recommendation_type: "Rate Reduction",
   publish: "false"
 )

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
@@ -18,6 +18,7 @@ info(
 ##################
 # Parameters #
 ##################
+
 parameter "param_turbonomic_endpoint" do
   type "string"
   label "Turbonomic Endpoint"

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.0",
+  version: "0.1",
   provider: "AWS",
   source: "Turbonomic",
   service: "Usage Discount",

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
@@ -184,6 +184,13 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
         return result + "." + values[1]
     }
 
+    function empty(value) {
+      if (typeof value === "undefined" || value === null || value === "" || isNaN(value)) {
+        return value = 0.0
+      }
+      return value
+    }
+
     _.each(ds_get_business_units, function(businessUnit) {
         _.each(ds_get_turbonomic_recommendations, function(ri, index) {
             if (ri.businessUUID === businessUnit.uuid) {
@@ -197,17 +204,19 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
                     }
                     ri.term = ri.termValue + " " + ri.termUnits
                     ri.service = "EC2"
-                    if (typeof ri.savings === "undefined" || ri.savings === null || ri.savings === "" || isNaN(ri.savings)) {
-                        ri.savings = 0.0
-                    }
-                    if (typeof ri.effectiveCost === "undefined" || ri.effectiveCost === null || ri.effectiveCost === "" || isNaN(ri.effectiveCost)) {
-                        ri.effectiveCost = 0.0
-                    }
+
+                    ri.savings=empty(ri.savings)
+                    ri.effectiveCost=empty(ri.effectiveCost)
+                    ri.recurringCost=empty(ri.recurringCost)
+                    ri.upfrontCost=empty(ri.upfrontCost)
+                    ri.numberOfInstances=empty(ri.numberOfInstances)
+
                     ri.accountID = businessUnit.accountID
                     ri.accountName = businessUnit.displayName
+                    ri.upfrontCost= ri.numberOfInstances* ri.upfrontCost
                     ri.savings = (Math.round(ri.savings * 730 * 1000) / 1000)
-                    ri.effectiveCost = (Math.round(ri.effectiveCost * 730 * 1000) / 1000)
-                    ri.recurringCost = (Math.round(ri.recurringCost * 730 * 1000) / 1000)
+                    ri.effectiveCost = (Math.round(ri.effectiveCost * 730 * ri.termValue * 12 * ri.numberOfInstances * 1000) / 1000)
+                    ri.recurringCost = (Math.round(ri.recurringCost * 730 * ri.numberOfInstances * 1000) / 1000)
                     monthlySavings = monthlySavings + ri.savings
                     instances.push(ri)
                 }

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
@@ -22,14 +22,13 @@ info(
 parameter "param_turbonomic_endpoint" do
   type "string"
   label "Turbonomic Endpoint"
-  default "sales1.demo.turbonomic.com"
 end
 
 parameter "auth_cookie" do
   type "string"
   label "Authorization Cookie"
   no_echo true
-  description "authorization cookie pulled from manual source"
+  description "valid authorization cookie"
 end
 
 parameter "param_email" do

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
@@ -1,7 +1,7 @@
-name "Turbonomics Buy Reserved Instances Recommendations AWS"
+name "Turbonomic Buy Reserved Instances Recommendations AWS"
 rs_pt_ver 20180301
 type "policy"
-short_description "Turbonomics policy for recommending purchasable reserved instances [README](https://github.com/flexera-public/policy_templates/tree/master/cost/turbonomics/buy_reserved_instances_recommendations/aws) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "Turbonomic policy for recommending purchasable reserved instances [README](https://github.com/flexera-public/policy_templates/tree/master/cost/turbonomics/buy_reserved_instances_recommendations/aws) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 severity "low"
 category "Cost"
 default_frequency "daily"
@@ -41,7 +41,7 @@ end
 # Pagination
 ###############################################################################
 
-pagination "turbonomics_buy_ris_pagination_header" do
+pagination "turbonomic_buy_ris_pagination_header" do
   get_page_marker do
     header "x-next-cursor"
   end
@@ -55,9 +55,9 @@ end
 ###############################################################################
 
 #get turbonomic recommendation data
-datasource "ds_get_turbonomics_recommendations" do
+datasource "ds_get_turbonomic_recommendations" do
   request do
-    run_script $js_get_turbonomics_recommendations, $param_turbonomic_host,$auth_cookie
+    run_script $js_get_turbonomic_recommendations, $param_turbonomic_host,$auth_cookie
   end
   result do
     encoding "json"
@@ -99,8 +99,8 @@ datasource "ds_get_business_units" do
   end
 end
 
-datasource "ds_filtered_turbonomics_recommendations" do
-  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_business_units
+datasource "ds_filtered_turbonomic_recommendations" do
+  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units
 end
 
 ###############################################################################
@@ -108,14 +108,14 @@ end
 ###############################################################################
 
 ##script using a manually acquired turbonomic cookie and pulls hard coded purchasable ri data
-script "js_get_turbonomics_recommendations", type: "javascript" do
+script "js_get_turbonomic_recommendations", type: "javascript" do
   result "request"
   parameters "param_turbonomic_host","auth_cookie"
   code <<-EOS
   //replace cookie every day this is run
   var request = {
       verb: "POST",
-      pagination: "turbonomics_buy_ris_pagination_header",
+      pagination: "turbonomic_buy_ris_pagination_header",
       host: param_turbonomic_host,
       path: "/api/v3/markets/Market/actions",
       body_fields: {
@@ -159,9 +159,9 @@ script "js_get_business_units", type: "javascript" do
 EOS
 end
 
-script "js_filtered_turbonomics_recommendations", type: "javascript" do
+script "js_filtered_turbonomic_recommendations", type: "javascript" do
   result "result"
-  parameters "ds_get_turbonomics_recommendations", "ds_get_business_units"
+  parameters "ds_get_turbonomic_recommendations", "ds_get_business_units"
   code <<-EOS
     instances = []
     monthlySavings = 0.0
@@ -185,7 +185,7 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
     }
 
     _.each(ds_get_business_units, function(businessUnit) {
-        _.each(ds_get_turbonomics_recommendations, function(ri, index) {
+        _.each(ds_get_turbonomic_recommendations, function(ri, index) {
             if (ri.businessUUID === businessUnit.uuid) {
                 if (ri.provider === "AWS") {
                     if (typeof ri.savingsCurrency != "undefined" && ri.savingsCurrency != null) {
@@ -232,8 +232,8 @@ end
 # Policy
 ###############################################################################
 
-policy "pol_turbonomics_buy_ri" do
-  validate $ds_filtered_turbonomics_recommendations do
+policy "pol_turbonomic_buy_ri" do
+  validate $ds_filtered_turbonomic_recommendations do
     summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data.instances }} Turbonomic Purchase Reserved Instance Recommendations found"
     detail_template <<-EOS
 {{data.message}}

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
@@ -114,27 +114,27 @@ script "js_get_turbonomics_recommendations", type: "javascript" do
   parameters "param_turbonomic_endpoint","auth_cookie"
   code <<-EOS
   //replace cookie every day this is run
-    var request = {
+  var request = {
       verb: "POST",
       pagination: "turbonomics_buy_ris_pagination_header",
       host: param_turbonomic_endpoint,
       path: "/api/v3/markets/Market/actions",
       body_fields: {
-        "actionStateList": ["READY", "ACCEPTED", "QUEUED", "IN_PROGRESS"],
-        "relatedEntityTypes":["Region"],
-        "actionTypeList":["BUY_RI"],
-        "environmentType":"CLOUD",
-        "detailLevel":"EXECUTION",
-        "costType":"SAVING"
+          "actionStateList": ["READY", "ACCEPTED", "QUEUED", "IN_PROGRESS"],
+          "relatedEntityTypes": ["Region"],
+          "actionTypeList": ["BUY_RI"],
+          "environmentType": "CLOUD",
+          "detailLevel": "EXECUTION",
+          "costType": "SAVING"
       },
       query_params: {
-        "limit": '1000'
+          "limit": '1000'
       },
       headers: {
-        "Content-Type": "application/json"
-        "Cookie": auth_cookie
+          "Content-Type": "application/json"
+          "Cookie": auth_cookie
       }
-    }
+  }
 EOS
 end
 
@@ -144,19 +144,19 @@ script "js_get_business_units", type: "javascript" do
   parameters "param_turbonomic_endpoint","auth_cookie"
   code <<-EOS
   //replace cookie every day this is run
-    var request = {
+  var request = {
       verb: "GET",
       host: param_turbonomic_endpoint,
       path: "/api/v3/businessunits",
       query_params: {
-        "cloud_type": "AWS",
-        "type":"DISCOVERED"
+          "cloud_type": "AWS",
+          "type": "DISCOVERED"
       },
       headers: {
-        "Content-Type": "application/json"
-        "Cookie": auth_cookie
+          "Content-Type": "application/json"
+          "Cookie": auth_cookie
       }
-    }
+  }
 EOS
 end
 
@@ -166,64 +166,65 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
   code <<-EOS
     instances = []
     monthlySavings = 0.0
-    function formatNumber(number, separator){
-    var numString =number.toString()
-    var values=numString.split(".")
-    var result = ''
-    while (values[0].length > 3){
-      var chunk = values[0].substr(-3)
-      values[0] = values[0].substr(0, values[0].length - 3)
-      result = separator + chunk + result
-    }
-    if (values[0].length > 0){
-      result = values[0] + result
-    }
-    if(values[1]==undefined){
-      return result
-    }
-    return result+"."+values[1]
+
+    function formatNumber(number, separator) {
+        var numString = number.toString()
+        var values = numString.split(".")
+        var result = ''
+        while (values[0].length > 3) {
+            var chunk = values[0].substr(-3)
+            values[0] = values[0].substr(0, values[0].length - 3)
+            result = separator + chunk + result
+        }
+        if (values[0].length > 0) {
+            result = values[0] + result
+        }
+        if (values[1] == undefined) {
+            return result
+        }
+        return result + "." + values[1]
     }
 
     _.each(ds_get_business_units, function(businessUnit) {
-      _.each(ds_get_turbonomics_recommendations, function(ri, index){
-        if (ri.businessUUID === businessUnit.uuid) {
-          if (ri.provider === "AWS") {
-            if (typeof ri.savingsCurrency != "undefined" && ri.savingsCurrency != null) {
-              if (ri.savingsCurrency.indexOf("$") != -1) {
-                ri.savingsCurrency = "$"
-              }
-            } else {
-              ri.savingsCurrency = "$"
+        _.each(ds_get_turbonomics_recommendations, function(ri, index) {
+            if (ri.businessUUID === businessUnit.uuid) {
+                if (ri.provider === "AWS") {
+                    if (typeof ri.savingsCurrency != "undefined" && ri.savingsCurrency != null) {
+                        if (ri.savingsCurrency.indexOf("$") != -1) {
+                            ri.savingsCurrency = "$"
+                        }
+                    } else {
+                        ri.savingsCurrency = "$"
+                    }
+                    ri.term = ri.termValue + " " + ri.termUnits
+                    ri.service = "EC2"
+                    if (typeof ri.savings === "undefined" || ri.savings === null || ri.savings === "" || isNaN(ri.savings)) {
+                        ri.savings = 0.0
+                    }
+                    if (typeof ri.effectiveCost === "undefined" || ri.effectiveCost === null || ri.effectiveCost === "" || isNaN(ri.effectiveCost)) {
+                        ri.effectiveCost = 0.0
+                    }
+                    ri.accountID = businessUnit.accountID
+                    ri.accountName = businessUnit.displayName
+                    ri.savings = (Math.round(ri.savings * 730 * 1000) / 1000)
+                    ri.effectiveCost = (Math.round(ri.effectiveCost * 730 * 1000) / 1000)
+                    ri.recurringCost = (Math.round(ri.recurringCost * 730 * 1000) / 1000)
+                    monthlySavings = monthlySavings + ri.savings
+                    instances.push(ri)
+                }
             }
-            ri.term = ri.termValue + " " + ri.termUnits
-            ri.service = "EC2"
-            if (typeof ri.savings === "undefined" || ri.savings === null || ri.savings === "" || isNaN(ri.savings)) {
-              ri.savings = 0.0
-            }
-            if (typeof ri.effectiveCost === "undefined" || ri.effectiveCost === null || ri.effectiveCost === "" || isNaN(ri.effectiveCost)) {
-              ri.effectiveCost = 0.0
-            }
-            ri.accountID=businessUnit.accountID
-            ri.accountName=businessUnit.accountName
-            ri.savings = (Math.round(ri.savings * 730 * 1000) / 1000)
-            ri.effectiveCost = (Math.round(ri.effectiveCost * 730 * 1000) / 1000)
-            ri.recurringCost = (Math.round(ri.recurringCost * 730 * 1000) / 1000)
-            monthlySavings = monthlySavings + ri.savings
-            instances.push(ri)
-        }
-      }
-      })
+        })
     })
 
     message = ""
     if (instances.length != 0) {
-      pretty_savings = instances[0].savingsCurrency + ' ' + formatNumber(monthlySavings.toFixed(2), ",")
-      message = "The total estimated monthly savings are " + pretty_savings + '.'
+        pretty_savings = instances[0].savingsCurrency + ' ' + formatNumber(monthlySavings.toFixed(2), ",")
+        message = "The total estimated monthly savings are " + pretty_savings + '.'
     }
 
     result = {
-      'instances': instances,
-      'message': message
+        'instances': instances,
+        'message': message
     }
 EOS
 end

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/CHANGELOG.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+- Initial Release

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/CHANGELOG.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/CHANGELOG.md
@@ -1,3 +1,5 @@
 # Changelog
 
+## v2.0
+
 - Initial Release

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/CHANGELOG.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-## v2.0
+## v0.1
 
 - Initial Release

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/README.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/README.md
@@ -2,17 +2,17 @@
 
 ## What it does
 
-The Turbonomics Buy Reserved Instances Recommendations Azure policy utilizes Turbonomics https://turbonomic.com/api/v3/markets/{market_uuid}/actions endpoint to provide Azure purchasable RI recommendations for Reserved Instance coverage. From these recommendations we provide monthly savings estimates based on Turbonomics per hour costs
+The Turbonomics Buy Reserved Instances Recommendations Azure policy utilizes Turbonomics [Credentials]https://turbonomic.com/api/v3/markets/{market_uuid}/actions endpoint to provide Azure purchasable RI recommendations for Reserved Instance coverage. From these recommendations we provide monthly savings estimates based on Turbonomics per hour costs
 
 ## Functional Details
 
 - The policy queries the /api/v3/markets/{market_uuid}/actions endpoint for the turbonomics api and based on action will return action details and savings for on-boarded cloud instances
 - The policy will error after a day, the authorization cookie parameter will need to be refreshed and re-run manually
-- there is a need to run the login credentials against the https://xxxx.turbonomic.com/api/v3/login endpoint to manually recieve cookie authoriztion
+- there is a need to run the login credentials against the [Credentials]https://xxxx.turbonomic.com/api/v3/login endpoint to manually recieve cookie authoriztion
 
 ### Input Parameters
 
-- *Authorization Cookie"* - authorization cookie pulled from turbonomic login endpoint: https://xxxx.turbonomic.com/api/v3/login
+- *Authorization Cookie"* - authorization cookie pulled from turbonomic login endpoint: [Credentials]https://xxxx.turbonomic.com/api/v3/login
 - no_echo: true
 - *Email addresses* - A list of email addresses to notify
 

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/README.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/README.md
@@ -14,7 +14,8 @@ The Turbonomic Buy Reserved Instances Recommendations AWS policy utilizes Turbon
 
 - *Authorization Cookie"* - authorization cookie pulled from Turbonomic login endpoint: (POST `https://xxxx.turbonomic.com/api/v3/login`)
 - no_echo: true
-- *Email addresses* - A list of email addresses to notify
+- *Email addresses* - A list of email addresses to notify.
+- *Turbonomic Endpoint* -Host of the Turbonomic endpoint.
 
 ### Required Flexera Roles
 

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/README.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/README.md
@@ -1,0 +1,28 @@
+# Turbonomics Buy Reserved Instances Recommendations Azure
+
+## What it does
+
+The Turbonomics Buy Reserved Instances Recommendations Azure policy utilizes Turbonomics https://turbonomic.com/api/v3/markets/{market_uuid}/actions endpoint to provide Azure purchasable RI recommendations for Reserved Instance coverage. From these recommendations we provide monthly savings estimates based on Turbonomics per hour costs
+
+## Functional Details
+
+- The policy queries the /api/v3/markets/{market_uuid}/actions endpoint for the turbonomics api and based on action will return action details and savings for on-boarded cloud instances
+- The policy will error after a day, the authorization cookie parameter will need to be refreshed and re-run manually
+- there is a need to run the login credentials against the https://xxxx.turbonomic.com/api/v3/login endpoint to manually recieve cookie authoriztion
+
+### Input Parameters
+
+- *Authorization Cookie"* - authorization cookie pulled from turbonomic login endpoint: https://xxxx.turbonomic.com/api/v3/login
+- no_echo: true
+- *Email addresses* - A list of email addresses to notify
+
+### Required Flexera Roles
+
+- policy_manager
+- billing_center_viewer
+
+- Turbonomics - administrator
+
+### Cost
+
+This Policy Template does not incur any cloud costs.

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/README.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/README.md
@@ -8,7 +8,7 @@ The Turbonomic Buy Reserved Instances Recommendations AWS policy utilizes Turbon
 
 - The policy queries the /api/v3/markets/{market_uuid}/actions endpoint for the Turbonomic api and based on action will return action details and savings for on-boarded cloud instances
 - The policy will error after a day, the authorization cookie parameter will need to be refreshed and re-run manually
-- there is a need to run the login credentials against the (`https://xxxx.turbonomic.com/api/v3/login`) endpoint to manually receive cookie authorization
+- There is a need to run the login credentials against the (`https://xxxx.turbonomic.com/api/v3/login`) endpoint to manually receive cookie authorization
 
 ### Input Parameters
 

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/README.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/README.md
@@ -8,11 +8,11 @@ The Turbonomics Buy Reserved Instances Recommendations AWS policy utilizes Turbo
 
 - The policy queries the /api/v3/markets/{market_uuid}/actions endpoint for the turbonomics api and based on action will return action details and savings for on-boarded cloud instances
 - The policy will error after a day, the authorization cookie parameter will need to be refreshed and re-run manually
-- there is a need to run the login credentials against the [Credentials]https://xxxx.turbonomic.com/api/v3/login endpoint to manually recieve cookie authoriztion
+- there is a need to run the login credentials against the (`https://xxxx.turbonomic.com/api/v3/login`) endpoint to manually recieve cookie authoriztion
 
 ### Input Parameters
 
-- *Authorization Cookie"* - authorization cookie pulled from turbonomic login endpoint: [Credentials]https://xxxx.turbonomic.com/api/v3/login
+- *Authorization Cookie"* - authorization cookie pulled from turbonomic login endpoint: (POST `https://xxxx.turbonomic.com/api/v3/login`)
 - no_echo: true
 - *Email addresses* - A list of email addresses to notify
 
@@ -20,8 +20,6 @@ The Turbonomics Buy Reserved Instances Recommendations AWS policy utilizes Turbo
 
 - policy_manager
 - billing_center_viewer
-
-- Turbonomics - administrator
 
 ### Cost
 

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/README.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/README.md
@@ -1,18 +1,18 @@
-# Turbonomics Buy Reserved Instances Recommendations Azure
+# Turbonomic Buy Reserved Instances Recommendations Azure
 
 ## What it does
 
-The Turbonomics Buy Reserved Instances Recommendations AWS policy utilizes Turbonomic Actions API endpoint to provide AWS RI purchase recommendations.
+The Turbonomic Buy Reserved Instances Recommendations AWS policy utilizes Turbonomic Actions API endpoint (POST `https://turbonomic.com/api/v3/markets/{market_uuid}/actions`) to provide AWS RI purchase recommendations.
 
 ## Functional Details
 
-- The policy queries the /api/v3/markets/{market_uuid}/actions endpoint for the turbonomics api and based on action will return action details and savings for on-boarded cloud instances
+- The policy queries the /api/v3/markets/{market_uuid}/actions endpoint for the Turbonomic api and based on action will return action details and savings for on-boarded cloud instances
 - The policy will error after a day, the authorization cookie parameter will need to be refreshed and re-run manually
-- there is a need to run the login credentials against the (`https://xxxx.turbonomic.com/api/v3/login`) endpoint to manually recieve cookie authoriztion
+- there is a need to run the login credentials against the (`https://xxxx.turbonomic.com/api/v3/login`) endpoint to manually receive cookie authorization
 
 ### Input Parameters
 
-- *Authorization Cookie"* - authorization cookie pulled from turbonomic login endpoint: (POST `https://xxxx.turbonomic.com/api/v3/login`)
+- *Authorization Cookie"* - authorization cookie pulled from Turbonomic login endpoint: (POST `https://xxxx.turbonomic.com/api/v3/login`)
 - no_echo: true
 - *Email addresses* - A list of email addresses to notify
 

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/README.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/README.md
@@ -2,7 +2,7 @@
 
 ## What it does
 
-The Turbonomics Buy Reserved Instances Recommendations Azure policy utilizes Turbonomics [Credentials]https://turbonomic.com/api/v3/markets/{market_uuid}/actions endpoint to provide Azure purchasable RI recommendations for Reserved Instance coverage. From these recommendations we provide monthly savings estimates based on Turbonomics per hour costs
+The Turbonomics Buy Reserved Instances Recommendations AWS policy utilizes Turbonomic Actions API endpoint to provide AWS RI purchase recommendations.
 
 ## Functional Details
 

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
@@ -16,7 +16,7 @@ info(
 )
 
 ##################
-# Parameters   #
+# Parameters #
 ##################
 
 parameter "param_turbonomic_endpoint" do
@@ -58,7 +58,7 @@ end
 #get turbonomic recommendation data
 datasource "ds_get_turbonomics_recommendations" do
   request do
-    run_script $js_get_turbonomics_recommendations, $param_turbonomic_endpoint $auth_cookie
+    run_script $js_get_turbonomics_recommendations, $param_turbonomic_endpoint, $auth_cookie
   end
   result do
     encoding "json"
@@ -85,7 +85,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, $auth_cookie
+    run_script $js_get_business_units, $param_turbonomic_endpoint, $auth_cookie
   end
   result do
     encoding "json"
@@ -111,27 +111,27 @@ script "js_get_turbonomics_recommendations", type: "javascript" do
   parameters "param_turbonomic_endpoint","auth_cookie"
   code <<-EOS
   //replace cookie every day this is run
-    var request = {
+  var request = {
       verb: "POST",
       pagination: "turbonomics_buy_ris_pagination_header",
       host: param_turbonomic_endpoint,
       path: "/api/v3/markets/Market/actions",
       body_fields: {
-        "actionStateList": ["READY", "ACCEPTED", "QUEUED", "IN_PROGRESS"],
-        "relatedEntityTypes":["Region"],
-        "actionTypeList":["BUY_RI"],
-        "environmentType":"CLOUD",
-        "detailLevel":"EXECUTION",
-        "costType":"SAVING"
+          "actionStateList": ["READY", "ACCEPTED", "QUEUED", "IN_PROGRESS"],
+          "relatedEntityTypes": ["Region"],
+          "actionTypeList": ["BUY_RI"],
+          "environmentType": "CLOUD",
+          "detailLevel": "EXECUTION",
+          "costType": "SAVING"
       },
       query_params: {
-        "limit": '1000'
+          "limit": '1000'
       },
       headers: {
-        "Content-Type": "application/json"
-        "Cookie": auth_cookie
+          "Content-Type": "application/json"
+          "Cookie": auth_cookie
       }
-    }
+  }
 EOS
 end
 
@@ -141,19 +141,19 @@ script "js_get_business_units", type: "javascript" do
   parameters "param_turbonomic_endpoint","auth_cookie"
   code <<-EOS
   //replace cookie every day this is run
-    var request = {
+  var request = {
       verb: "GET",
       host: param_turbonomic_endpoint,
       path: "/api/v3/businessunits",
       query_params: {
-        "cloud_type": "AZURE",
-        "type":"DISCOVERED"
+          "cloud_type": "AZURE",
+          "type": "DISCOVERED"
       },
       headers: {
-        "Content-Type": "application/json"
-        "Cookie": auth_cookie
+          "Content-Type": "application/json"
+          "Cookie": auth_cookie
       }
-    }
+  }
 EOS
 end
 
@@ -163,64 +163,65 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
   code <<-EOS
     instances = []
     monthlySavings = 0.0
-    function formatNumber(number, separator){
-    var numString =number.toString()
-    var values=numString.split(".")
-    var result = ''
-    while (values[0].length > 3){
-      var chunk = values[0].substr(-3)
-      values[0] = values[0].substr(0, values[0].length - 3)
-      result = separator + chunk + result
-    }
-    if (values[0].length > 0){
-      result = values[0] + result
-    }
-    if(values[1]==undefined){
-      return result
-    }
-    return result+"."+values[1]
+
+    function formatNumber(number, separator) {
+        var numString = number.toString()
+        var values = numString.split(".")
+        var result = ''
+        while (values[0].length > 3) {
+            var chunk = values[0].substr(-3)
+            values[0] = values[0].substr(0, values[0].length - 3)
+            result = separator + chunk + result
+        }
+        if (values[0].length > 0) {
+            result = values[0] + result
+        }
+        if (values[1] == undefined) {
+            return result
+        }
+        return result + "." + values[1]
     }
 
     _.each(ds_get_business_units, function(businessUnit) {
-      _.each(ds_get_turbonomics_recommendations, function(ri, index){
-        if (ri.businessUUID === businessUnit.uuid) {
-          if (ri.provider === "Azure Subscription") {
-            if (typeof ri.savingsCurrency != "undefined" && ri.savingsCurrency != null) {
-              if (ri.savingsCurrency.indexOf("$") != -1) {
-                ri.savingsCurrency = "$"
-              }
-            } else {
-              ri.savingsCurrency = "$"
+        _.each(ds_get_turbonomics_recommendations, function(ri, index) {
+            if (ri.businessUUID === businessUnit.uuid) {
+                if (ri.provider === "Azure Subscription") {
+                    if (typeof ri.savingsCurrency != "undefined" && ri.savingsCurrency != null) {
+                        if (ri.savingsCurrency.indexOf("$") != -1) {
+                            ri.savingsCurrency = "$"
+                        }
+                    } else {
+                        ri.savingsCurrency = "$"
+                    }
+                    ri.term = ri.termValue + " " + ri.termUnits
+                    ri.service = "Microsoft.Compute"
+                    if (typeof ri.savings === "undefined" || ri.savings === null || ri.savings === "" || isNaN(ri.savings)) {
+                        ri.savings = 0.0
+                    }
+                    if (typeof ri.effectiveCost === "undefined" || ri.effectiveCost === null || ri.effectiveCost === "" || isNaN(ri.effectiveCost)) {
+                        ri.effectiveCost = 0.0
+                    }
+                    ri.accountID = businessUnit.accountID
+                    ri.accountName = businessUnit.displayName
+                    ri.savings = (Math.round(ri.savings * 730 * 1000) / 1000)
+                    ri.effectiveCost = (Math.round(ri.effectiveCost * 730 * 1000) / 1000)
+                    ri.recurringCost = (Math.round(ri.recurringCost * 730 * 1000) / 1000)
+                    monthlySavings = monthlySavings + ri.savings
+                    instances.push(ri)
+                }
             }
-            ri.term = ri.termValue + " " + ri.termUnits
-            ri.service = "Microsoft.Compute"
-            if (typeof ri.savings === "undefined" || ri.savings === null || ri.savings === "" || isNaN(ri.savings)) {
-              ri.savings = 0.0
-            }
-            if (typeof ri.effectiveCost === "undefined" || ri.effectiveCost === null || ri.effectiveCost === "" || isNaN(ri.effectiveCost)) {
-              ri.effectiveCost = 0.0
-            }
-            ri.accountID=businessUnit.accountID
-            ri.accountName=businessUnit.accountName
-            ri.savings = (Math.round(ri.savings * 730 * 1000) / 1000)
-            ri.effectiveCost = (Math.round(ri.effectiveCost * 730 * 1000) / 1000)
-            ri.recurringCost = (Math.round(ri.recurringCost * 730 * 1000) / 1000)
-            monthlySavings = monthlySavings + ri.savings
-            instances.push(ri)
-          }
-        }
-      })
+        })
     })
 
     message = ""
     if (instances.length != 0) {
-      pretty_savings = instances[0].savingsCurrency + ' ' + formatNumber(monthlySavings.toFixed(2), ",")
-      message = "The total estimated monthly savings are " + pretty_savings + '.'
+        pretty_savings = instances[0].savingsCurrency + ' ' + formatNumber(monthlySavings.toFixed(2), ",")
+        message = "The total estimated monthly savings are " + pretty_savings + '.'
     }
 
     result = {
-      'instances': instances,
-      'message': message
+        'instances': instances,
+        'message': message
     }
 EOS
 end

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
@@ -1,7 +1,7 @@
-name "Turbonomics Buy Reserved Instances Recommendations Azure"
+name "Turbonomic Buy Reserved Instances Recommendations Azure"
 rs_pt_ver 20180301
 type "policy"
-short_description "Turbonomics policy for recommending purchaseable reserved instances [README](https://github.com/flexera-public/policy_templates/tree/master/cost/turbonomics/buy_reserved_instances_recommendations/azure) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "Turbonomic policy for recommending purchaseable reserved instances [README](https://github.com/flexera-public/policy_templates/tree/master/cost/turbonomics/buy_reserved_instances_recommendations/azure) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 severity "low"
 category "Cost"
 default_frequency "daily"
@@ -41,7 +41,7 @@ end
 # Pagination
 ###############################################################################
 
-pagination "turbonomics_buy_ris_pagination_header" do
+pagination "turbonomic_buy_ris_pagination_header" do
   get_page_marker do
     header "x-next-cursor"
   end
@@ -55,9 +55,9 @@ end
 ###############################################################################
 
 #get turbonomic recommendation data
-datasource "ds_get_turbonomics_recommendations" do
+datasource "ds_get_turbonomic_recommendations" do
   request do
-    run_script $js_get_turbonomics_recommendations, $param_turbonomic_host, $auth_cookie
+    run_script $js_get_turbonomic_recommendations, $param_turbonomic_host, $auth_cookie
   end
   result do
     encoding "json"
@@ -96,8 +96,8 @@ datasource "ds_get_business_units" do
   end
 end
 
-datasource "ds_filtered_turbonomics_recommendations" do
-  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_business_units
+datasource "ds_filtered_turbonomic_recommendations" do
+  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units
 end
 
 ###############################################################################
@@ -105,14 +105,14 @@ end
 ###############################################################################
 
 ##script using a manually acquired turbonomic cookie and pulls hard coded purchasable ri data
-script "js_get_turbonomics_recommendations", type: "javascript" do
+script "js_get_turbonomic_recommendations", type: "javascript" do
   result "request"
   parameters "param_turbonomic_host","auth_cookie"
   code <<-EOS
   //replace cookie every day this is run
   var request = {
       verb: "POST",
-      pagination: "turbonomics_buy_ris_pagination_header",
+      pagination: "turbonomic_buy_ris_pagination_header",
       host: param_turbonomic_host,
       path: "/api/v3/markets/Market/actions",
       body_fields: {
@@ -156,9 +156,9 @@ script "js_get_business_units", type: "javascript" do
 EOS
 end
 
-script "js_filtered_turbonomics_recommendations", type: "javascript" do
+script "js_filtered_turbonomic_recommendations", type: "javascript" do
   result "result"
-  parameters "ds_get_turbonomics_recommendations", "ds_get_business_units"
+  parameters "ds_get_turbonomic_recommendations", "ds_get_business_units"
   code <<-EOS
     instances = []
     monthlySavings = 0.0
@@ -182,7 +182,7 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
     }
 
     _.each(ds_get_business_units, function(businessUnit) {
-        _.each(ds_get_turbonomics_recommendations, function(ri, index) {
+        _.each(ds_get_turbonomic_recommendations, function(ri, index) {
             if (ri.businessUUID === businessUnit.uuid) {
                 if (ri.provider === "Azure Subscription") {
                     if (typeof ri.savingsCurrency != "undefined" && ri.savingsCurrency != null) {
@@ -229,11 +229,11 @@ end
 # Policy
 ###############################################################################
 
-policy "pol_turbonomics_buy_ri" do
-  validate $ds_filtered_turbonomics_recommendations do
+policy "pol_turbonomic_buy_ri" do
+  validate $ds_filtered_turbonomic_recommendations do
     summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data.instances }} Turbonomic Purchase Reserved Instance Recommendations found"
     detail_template <<-EOS
-## Turbonomics Buy RI
+## Turbonomic Buy RI
 {{data.message}}
 EOS
     check eq(size(val(data, "instances")), 0)

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
@@ -181,6 +181,13 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
         return result + "." + values[1]
     }
 
+    function empty(value) {
+        if (typeof value === "undefined" || value === null || value === "" || isNaN(value)) {
+          return value = 0.0
+        }
+        return value
+      }
+
     _.each(ds_get_business_units, function(businessUnit) {
         _.each(ds_get_turbonomic_recommendations, function(ri, index) {
             if (ri.businessUUID === businessUnit.uuid) {
@@ -194,17 +201,20 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
                     }
                     ri.term = ri.termValue + " " + ri.termUnits
                     ri.service = "Microsoft.Compute"
-                    if (typeof ri.savings === "undefined" || ri.savings === null || ri.savings === "" || isNaN(ri.savings)) {
-                        ri.savings = 0.0
-                    }
-                    if (typeof ri.effectiveCost === "undefined" || ri.effectiveCost === null || ri.effectiveCost === "" || isNaN(ri.effectiveCost)) {
-                        ri.effectiveCost = 0.0
-                    }
+
+                    ri.savings=empty(ri.savings)
+                    ri.effectiveCost=empty(ri.effectiveCost)
+                    ri.recurringCost=empty(ri.recurringCost)
+                    ri.upfrontCost=empty(ri.upfrontCost)
+                    ri.numberOfInstances=empty(ri.numberOfInstances)
+
                     ri.accountID = businessUnit.accountID
                     ri.accountName = businessUnit.displayName
                     ri.savings = (Math.round(ri.savings * 730 * 1000) / 1000)
-                    ri.effectiveCost = (Math.round(ri.effectiveCost * 730 * 1000) / 1000)
-                    ri.recurringCost = (Math.round(ri.recurringCost * 730 * 1000) / 1000)
+                    ri.upfrontCost= ri.numberOfInstances* ri.upfrontCost
+
+                    ri.effectiveCost = (Math.round(ri.effectiveCost * 730 * ri.termValue * 12 * ri.numberOfInstances * 1000) / 1000)
+                    ri.recurringCost = (Math.round(ri.recurringCost * 730 * ri.numberOfInstances * 1000) / 1000)
                     monthlySavings = monthlySavings + ri.savings
                     instances.push(ri)
                 }

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
@@ -269,7 +269,7 @@ EOS
         label "Service"
       end
       field "upfrontCost" do
-        label "Up Front Cost"
+        label "Upfront Cost"
       end
       field "recurringCost" do
         label "Recurring Cost"

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
@@ -8,9 +8,9 @@ default_frequency "daily"
 info(
   version: "2.0",
   provider: "Azure",
-  source: "Turbonomics",
-  service: "RIs",
-  policy_set: "Buy RIs",
+  source: "Turbonomic",
+  service: "Usage Discount",
+  policy_set: "Reserved Instance",
   recommendation_type: "Rate Reduction",
   publish: "false"
 )

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.0",
+  version: "0.1",
   provider: "Azure",
   source: "Turbonomic",
   service: "Usage Discount",

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
@@ -19,9 +19,9 @@ info(
 # Parameters #
 ##################
 
-parameter "param_turbonomic_endpoint" do
+parameter "param_turbonomic_host" do
   type "string"
-  label "Turbonomic Endpoint"
+  label "Turbonomic Host"
 end
 
 parameter "auth_cookie" do
@@ -57,7 +57,7 @@ end
 #get turbonomic recommendation data
 datasource "ds_get_turbonomics_recommendations" do
   request do
-    run_script $js_get_turbonomics_recommendations, $param_turbonomic_endpoint, $auth_cookie
+    run_script $js_get_turbonomics_recommendations, $param_turbonomic_host, $auth_cookie
   end
   result do
     encoding "json"
@@ -84,7 +84,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, $param_turbonomic_endpoint, $auth_cookie
+    run_script $js_get_business_units, $param_turbonomic_host, $auth_cookie
   end
   result do
     encoding "json"
@@ -107,13 +107,13 @@ end
 ##script using a manually acquired turbonomic cookie and pulls hard coded purchasable ri data
 script "js_get_turbonomics_recommendations", type: "javascript" do
   result "request"
-  parameters "param_turbonomic_endpoint","auth_cookie"
+  parameters "param_turbonomic_host","auth_cookie"
   code <<-EOS
   //replace cookie every day this is run
   var request = {
       verb: "POST",
       pagination: "turbonomics_buy_ris_pagination_header",
-      host: param_turbonomic_endpoint,
+      host: param_turbonomic_host,
       path: "/api/v3/markets/Market/actions",
       body_fields: {
           "actionStateList": ["READY", "ACCEPTED", "QUEUED", "IN_PROGRESS"],
@@ -137,12 +137,12 @@ end
 ## verified that discovered is the only one we need
 script "js_get_business_units", type: "javascript" do
   result "request"
-  parameters "param_turbonomic_endpoint","auth_cookie"
+  parameters "param_turbonomic_host","auth_cookie"
   code <<-EOS
   //replace cookie every day this is run
   var request = {
       verb: "GET",
-      host: param_turbonomic_endpoint,
+      host: param_turbonomic_host,
       path: "/api/v3/businessunits",
       query_params: {
           "cloud_type": "AZURE",

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
@@ -18,6 +18,7 @@ info(
 ##################
 # Parameters   #
 ##################
+
 parameter "param_turbonomic_endpoint" do
   type "string"
   label "Turbonomic Endpoint"
@@ -36,10 +37,6 @@ parameter "param_email" do
   label "Email addresses to notify"
   description "Email addresses of the recipients you wish to notify when new incidents are created"
 end
-
-###############################################################################
-# Authentication
-###############################################################################
 
 ###############################################################################
 # Pagination
@@ -298,7 +295,3 @@ escalation "esc_email" do
   description "Send incident email"
   email $param_email
 end
-
-###############################################################################
-# Cloud Workflow
-###############################################################################

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
@@ -210,11 +210,10 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
 
                     ri.accountID = businessUnit.accountID
                     ri.accountName = businessUnit.displayName
-                    ri.savings = (Math.round(ri.savings * 730 * 1000) / 1000)
-                    ri.upfrontCost= ri.numberOfInstances* ri.upfrontCost
-
-                    ri.effectiveCost = (Math.round(ri.effectiveCost * 730 * ri.termValue * 12 * ri.numberOfInstances * 1000) / 1000)
-                    ri.recurringCost = (Math.round(ri.recurringCost * 730 * ri.numberOfInstances * 1000) / 1000)
+                    ri.upfrontCost= Number(ri.numberOfInstances * ri.upfrontCost).toFixed(2)
+                    ri.savings = Math.round(ri.savings * 730*100)/100
+                    ri.effectiveCost = Number(ri.effectiveCost * 730 * ri.termValue * 12 * ri.numberOfInstances).toFixed(2)
+                    ri.recurringCost = Number(ri.recurringCost * 730 * ri.numberOfInstances).toFixed(2)
                     monthlySavings = monthlySavings + ri.savings
                     instances.push(ri)
                 }

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
@@ -22,14 +22,13 @@ info(
 parameter "param_turbonomic_endpoint" do
   type "string"
   label "Turbonomic Endpoint"
-  default "sales1.demo.turbonomic.com"
 end
 
 parameter "auth_cookie" do
   type "string"
   label "Authorization Cookie"
   no_echo true
-  description "authorization cookie pulled from manual source"
+  description "valid authorization cookie"
 end
 
 parameter "param_email" do

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
@@ -1,0 +1,304 @@
+name "Turbonomics Buy Reserved Instances Recommendations Azure"
+rs_pt_ver 20180301
+type "policy"
+short_description "Turbonomics policy for recommending purchaseable reserved instances [README](https://github.com/flexera-public/policy_templates/tree/master/cost/turbonomics/buy_reserved_instances_recommendations/azure) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+severity "low"
+category "Cost"
+default_frequency "daily"
+info(
+  version: "2.0",
+  provider: "Azure",
+  source: "Turbonomics",
+  service: "RIs",
+  policy_set: "Buy RIs",
+  recommendation_type: "Rate Reduction",
+  publish: "false"
+)
+
+##################
+# Parameters   #
+##################
+parameter "param_turbonomic_endpoint" do
+  type "string"
+  label "Turbonomic Endpoint"
+  default "sales1.demo.turbonomic.com"
+end
+
+parameter "auth_cookie" do
+  type "string"
+  label "Authorization Cookie"
+  no_echo true
+  description "authorization cookie pulled from manual source"
+end
+
+parameter "param_email" do
+  type "list"
+  label "Email addresses to notify"
+  description "Email addresses of the recipients you wish to notify when new incidents are created"
+end
+
+###############################################################################
+# Authentication
+###############################################################################
+
+###############################################################################
+# Pagination
+###############################################################################
+
+pagination "turbonomics_buy_ris_pagination_header" do
+  get_page_marker do
+    header "x-next-cursor"
+  end
+  set_page_marker do
+    query "cursor"
+  end
+end
+
+###############################################################################
+# Datasources
+###############################################################################
+
+#get turbonomic recommendation data
+datasource "ds_get_turbonomics_recommendations" do
+  request do
+    run_script $js_get_turbonomics_recommendations, $param_turbonomic_endpoint $auth_cookie
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "businessUUID", jmes_path(col_item, "reservedInstance.accountId")
+      field "termValue", jmes_path(col_item, "reservedInstance.term.value")
+      field "termUnits", jmes_path(col_item, "reservedInstance.term.units")
+      field "paymentOptions", jmes_path(col_item, "reservedInstance.payment")
+      field "region", jmes_path(col_item, "currentLocation.displayName")
+      field "resourceType", jmes_path(col_item, "newEntity.displayName")
+      field "provider", jmes_path(col_item, "target.discoveredBy.type")
+      field "numberOfInstances", jmes_path(col_item, "reservedInstance.instanceCount")
+      field "details", jmes_path(col_item, "details")
+      field "upfrontCost", jmes_path(col_item, "reservedInstance.upFrontCost")
+      field "recurringCost", jmes_path(col_item, "reservedInstance.actualHourlyCost")
+      field "effectiveCost", jmes_path(col_item, "reservedInstance.effectiveHourlyCost")
+      field "sizeFlexible", jmes_path(col_item, "reservedInstance.sizeFlexible")
+      field "savings", jmes_path(col_item, "stats[0].value")
+      field "savingsCurrency", jmes_path(col_item, "stats[0].units")
+    end
+  end
+end
+
+##this will potentially be a lot of calls. how to make this more performant
+datasource "ds_get_business_units" do
+  request do
+    run_script $js_get_business_units, $auth_cookie
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "uuid", jmes_path(col_item, "uuid")
+      field "accountID", jmes_path(col_item, "accountId")
+      field "displayName", jmes_path(col_item, "displayName")
+    end
+  end
+end
+
+datasource "ds_filtered_turbonomics_recommendations" do
+  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_business_units
+end
+
+###############################################################################
+# Scripts
+###############################################################################
+
+##script using a manually acquired turbonomic cookie and pulls hard coded purchasable ri data
+script "js_get_turbonomics_recommendations", type: "javascript" do
+  result "request"
+  parameters "param_turbonomic_endpoint","auth_cookie"
+  code <<-EOS
+  //replace cookie every day this is run
+    var request = {
+      verb: "POST",
+      pagination: "turbonomics_buy_ris_pagination_header",
+      host: param_turbonomic_endpoint,
+      path: "/api/v3/markets/Market/actions",
+      body_fields: {
+        "actionStateList": ["READY", "ACCEPTED", "QUEUED", "IN_PROGRESS"],
+        "relatedEntityTypes":["Region"],
+        "actionTypeList":["BUY_RI"],
+        "environmentType":"CLOUD",
+        "detailLevel":"EXECUTION",
+        "costType":"SAVING"
+      },
+      query_params: {
+        "limit": '1000'
+      },
+      headers: {
+        "Content-Type": "application/json"
+        "Cookie": auth_cookie
+      }
+    }
+EOS
+end
+
+## verified that discovered is the only one we need
+script "js_get_business_units", type: "javascript" do
+  result "request"
+  parameters "param_turbonomic_endpoint","auth_cookie"
+  code <<-EOS
+  //replace cookie every day this is run
+    var request = {
+      verb: "GET",
+      host: param_turbonomic_endpoint,
+      path: "/api/v3/businessunits",
+      query_params: {
+        "cloud_type": "AZURE",
+        "type":"DISCOVERED"
+      },
+      headers: {
+        "Content-Type": "application/json"
+        "Cookie": auth_cookie
+      }
+    }
+EOS
+end
+
+script "js_filtered_turbonomics_recommendations", type: "javascript" do
+  result "result"
+  parameters "ds_get_turbonomics_recommendations", "ds_get_business_units"
+  code <<-EOS
+    instances = []
+    monthlySavings = 0.0
+    function formatNumber(number, separator){
+    var numString =number.toString()
+    var values=numString.split(".")
+    var result = ''
+    while (values[0].length > 3){
+      var chunk = values[0].substr(-3)
+      values[0] = values[0].substr(0, values[0].length - 3)
+      result = separator + chunk + result
+    }
+    if (values[0].length > 0){
+      result = values[0] + result
+    }
+    if(values[1]==undefined){
+      return result
+    }
+    return result+"."+values[1]
+    }
+
+    _.each(ds_get_business_units, function(businessUnit) {
+      _.each(ds_get_turbonomics_recommendations, function(ri, index){
+        if (ri.businessUUID === businessUnit.uuid) {
+          if (ri.provider === "Azure Subscription") {
+            if (typeof ri.savingsCurrency != "undefined" && ri.savingsCurrency != null) {
+              if (ri.savingsCurrency.indexOf("$") != -1) {
+                ri.savingsCurrency = "$"
+              }
+            } else {
+              ri.savingsCurrency = "$"
+            }
+            ri.term = ri.termValue + " " + ri.termUnits
+            ri.service = "Microsoft.Compute"
+            if (typeof ri.savings === "undefined" || ri.savings === null || ri.savings === "" || isNaN(ri.savings)) {
+              ri.savings = 0.0
+            }
+            if (typeof ri.effectiveCost === "undefined" || ri.effectiveCost === null || ri.effectiveCost === "" || isNaN(ri.effectiveCost)) {
+              ri.effectiveCost = 0.0
+            }
+            ri.accountID=businessUnit.accountID
+            ri.accountName=businessUnit.accountName
+            ri.savings = (Math.round(ri.savings * 730 * 1000) / 1000)
+            ri.effectiveCost = (Math.round(ri.effectiveCost * 730 * 1000) / 1000)
+            ri.recurringCost = (Math.round(ri.recurringCost * 730 * 1000) / 1000)
+            monthlySavings = monthlySavings + ri.savings
+            instances.push(ri)
+          }
+        }
+      })
+    })
+
+    message = ""
+    if (instances.length != 0) {
+      pretty_savings = instances[0].savingsCurrency + ' ' + formatNumber(monthlySavings.toFixed(2), ",")
+      message = "The total estimated monthly savings are " + pretty_savings + '.'
+    }
+
+    result = {
+      'instances': instances,
+      'message': message
+    }
+EOS
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "pol_turbonomics_buy_ri" do
+  validate $ds_filtered_turbonomics_recommendations do
+    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data.instances }} Turbonomic Purchase Reserved Instance Recommendations found"
+    detail_template <<-EOS
+## Turbonomics Buy RI
+{{data.message}}
+EOS
+    check eq(size(val(data, "instances")), 0)
+    export "instances" do
+      field "accountID" do
+        label "Account ID"
+      end
+      field "accountName" do
+        label "Account Name"
+      end
+      field "savingsCurrency" do
+        label "Savings Currency"
+      end
+      field "savings" do
+        label "Savings"
+      end
+      field "details" do
+        label "Recommendation Details"
+      end
+      field "numberOfInstances" do
+        label "Number of Reserved Instances"
+      end
+      field "resourceType" do
+        label "Resource Type"
+      end
+      field "term" do
+        label "Term"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "upfrontCost" do
+        label "Up Front Cost"
+      end
+      field "recurringCost" do
+        label "Recurring Cost"
+      end
+      field "effectiveCost" do
+        label "Effective Cost"
+      end
+      field "sizeFlexible" do
+        label "Size Flexible"
+      end
+    end
+    escalate $esc_email
+  end
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
+
+###############################################################################
+# Cloud Workflow
+###############################################################################


### PR DESCRIPTION
### Description

Allows to review in Flexera CCO the cost savings due to Buy RI recommendations, so I can slice and dice them by billing centers.

### Issues Resolved

Create a new automation policy to retrieve Buy RI recommendations for cloud environments via Turbonomic APIs.

### Relevant Links

Aws : https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/107982?policyId=6411b4829f94b400016e18d9

Azure : https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/107982?policyId=6411b5199f94b400016e18da

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
