### PR TITLE
[HCLIND-38] Add source field to the report

### DIFF
--- a/cost/turbonomics/allocate_virtual_machines_recommendations/azure/turbonomics_allocate_virtual_machines.pt
+++ b/cost/turbonomics/allocate_virtual_machines_recommendations/azure/turbonomics_allocate_virtual_machines.pt
@@ -303,6 +303,8 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
 
         vm.savings = (Math.round(vm.savings * 730 * 1000) / 1000)
         monthlySavings = monthlySavings + vm.savings
+
+        vm.source = "Turbonomic"
         instances.push(vm)
       }
     })
@@ -382,6 +384,10 @@ EOS
       field "id" do
         label "Resource ID"
         path "resourceID"
+      end
+      field "source" do
+        label "Source"
+        path "source"
       end
     end
     escalate $esc_email


### PR DESCRIPTION
### Description

Addressing [HCLIND-38](https://flexera.atlassian.net/browse/HCLIND-38):

Ensure that the generated incidents will be converted into spend recommendations, in the policy info block:

- set provider to a corresponding cloud provider
- set recommendation_type to rate reduction
- new field source set to Turbonomic
- set policy set to “Reserved Instances”

### Issues Resolved

It just adds a new field to the report delivered.

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
