### PR TITLE
POL-765 Vendor Commitment Forecast fix: incident table not populating

### DIFF
--- a/cost/forecasting/commitment_forecast/CHANGELOG.md
+++ b/cost/forecasting/commitment_forecast/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1
+
+- Removed `encodeURI()` function on `spend_data` variable
+
 ## v3.0
 
 - Deprecated `auth_rs` authentication (type: `rightscale`) and replaced with `auth_flexera` (type: `oauth2`).  This is a breaking change which requires a Credential for `auth_flexera` [`provider=flexera`] before the policy can be applied.  Please see docs for setting up [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm)

--- a/cost/forecasting/commitment_forecast/commitment_forecast.pt
+++ b/cost/forecasting/commitment_forecast/commitment_forecast.pt
@@ -8,7 +8,7 @@ category "Cost"
 tenancy "single"
 default_frequency "monthly"
 info(
-  version: "3.0",
+  version: "3.1",
   provider: "Flexera Optima",
   service: "",
   policy_set:"Forecasting",
@@ -352,7 +352,7 @@ script "js_get_chart_data", type: "javascript" do
     chart_y_axis_label: encodeURI("chxl=0:|+1:|+"),
     chart_data_autoscale: encodeURI("chds=a"),
     chart_data_value: encodeURI('chl=' + chart_data_values),
-    report_data: encodeURI(spend_data),
+    report_data: spend_data,
     target_adj: target_name,
     bc_org_name: spend_data[0].name,
     cloud_vendor: spend_data[0].vendor


### PR DESCRIPTION
### Description

Vendor Commitment Forecast policy has incident fields however the fields are not populating.
Linked to this ticket - https://flexera.atlassian.net/browse/SQ-1379

### Issues Resolved

Removal of URI Encoding on Spend Data means that Vendor Commitment Forecast policy incident now populates with data

### Contribution Check List

- [x] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
