### PR TITLE
HCLIND-51 Add: Turbonomics Scale Virtual Volumes Recommendations PTs

### DIFF
--- a/cost/turbonomics/scale_virtual_volumes_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/scale_virtual_volumes_recommendations/aws/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v1.0
+
+- Initial Release

--- a/cost/turbonomics/scale_virtual_volumes_recommendations/aws/README.md
+++ b/cost/turbonomics/scale_virtual_volumes_recommendations/aws/README.md
@@ -1,0 +1,25 @@
+# Turbonomics Scale Virtual Volumes Recommendations AWS
+
+## What it does
+
+The Turbonomics Scale Virtual Volumes Recommendations AWS policy uses Turbonomic Actions endpoint (POST xxxx.turbonomic.com/api/v3/markets/Market/actions) and Business Units endpoint (GET xxxx.turbonomic.com/api/v3/businessunits) to provide Scale Virtual Volumes recommendations. From these recommendations we provide monthly savings estimates based on Turbonomic per hour costs.
+
+## Input Parameters
+
+- *Provider* - Cloud provider where we get recommendations, it supports AWS.
+- *Authorization Cookie* - Authorization cookie pulled from manual source.
+  - no_echo: true
+- *Email addresses to notify* - A list of email addresses to notify.
+
+## Supported Clouds
+
+- AWS
+
+## Required Flexera Roles
+
+- policy_manager
+- billing_center_viewer
+
+## Cost
+
+This Policy Template does not incur any cloud costs.

--- a/cost/turbonomics/scale_virtual_volumes_recommendations/aws/turbonomics_scale_virtual_volumes_recommendations.pt
+++ b/cost/turbonomics/scale_virtual_volumes_recommendations/aws/turbonomics_scale_virtual_volumes_recommendations.pt
@@ -1,0 +1,333 @@
+name "Turbonomics Scale Virtual Volumes Recommendations AWS"
+rs_pt_ver 20180301
+type "policy"
+short_description "Turbonomics policy that gives recommendations to scale Virtual Volumes."
+severity "low"
+category "Cost"
+default_frequency "daily"
+info(
+  version: "1.0",
+  source: "Turbonomic",
+  service: "Usage Discount",
+  provider: "AWS",
+  policy_set: "Rightsize Volumes",
+  recommendation_type: "Usage Reduction"
+)
+
+##################
+# Parameters   #
+##################
+
+parameter "param_turbonomic_endpoint" do
+  type "string"
+  label "Turbonomic endpoint"
+end
+
+parameter "param_provider" do
+  type "string"
+  label "Provider"
+  description "Specifies provider where you want to get recommendations"
+  # Once we can add multiple providers, allow: "All", "AWS", "Azure Subscription", "GCP Project"
+  allowed_values "AWS"
+  # Once we can add multiple providers change this default value
+  default "AWS"
+end
+
+parameter "param_auth_cookie" do
+  type "string"
+  label "Authorization Cookie"
+  no_echo true
+  description "Valid authorization cookie."
+end
+
+parameter "param_email" do
+  type "list"
+  label "Email addresses to notify"
+  description "Email addresses of the recipients you wish to notify when new incidents are created"
+end
+
+###############################################################################
+# Pagination
+###############################################################################
+
+pagination "turbonomics_volumes_pagination_header" do
+  get_page_marker do
+    header "x-next-cursor"
+  end
+  set_page_marker do
+    query "cursor"
+  end
+end
+
+###############################################################################
+# Datasources
+###############################################################################
+
+datasource "ds_get_turbonomics_recommendations" do
+  request do
+    run_script $js_get_turbonomics_recommendations, $param_turbonomic_endpoint, $param_auth_cookie
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "vendorIDValues", jmes_path(col_item, "virtualDisks[0].businessAccount.vendorIds")
+      field "resourceGroup", jmes_path(col_item, "target.aspects.cloudAspect.resourceGroup.displayName")
+      field "resourceID", jmes_path(col_item, "target.vendorIds")
+      field "resourceName", jmes_path(col_item, "target.displayName")
+      field "region", jmes_path(col_item, "currentLocation.displayName")
+      field "currentResourceType", jmes_path(col_item, "currentEntity.displayName")
+      field "newResourceType", jmes_path(col_item, "newEntity.displayName")
+      field "provider", jmes_path(col_item, "target.discoveredBy.type")
+      field "details", jmes_path(col_item, "details")
+      field "tags", jmes_path(col_item, "target.tags")
+      field "createdTime", jmes_path(col_item, "createTime")
+      field "size", jmes_path(col_item, "virtualDisks[0].stats")
+      field "savings", jmes_path(col_item, "stats[0].value")
+      field "savingsCurrency", jmes_path(col_item, "stats[0].units")
+    end
+  end
+end
+
+datasource "ds_get_business_units" do
+  request do
+    run_script $js_get_business_units, $param_turbonomic_endpoint, $param_auth_cookie, $param_provider
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "uuid", jmes_path(col_item, "uuid")
+      field "accountID", jmes_path(col_item, "accountId")
+      field "displayName", jmes_path(col_item, "displayName")
+    end
+  end
+end
+
+datasource "ds_filtered_turbonomics_recommendations" do
+  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_business_units, $param_provider
+end
+
+###############################################################################
+# Scripts
+###############################################################################
+
+script "js_get_turbonomics_recommendations", type: "javascript" do
+  result "request"
+  parameters "turbonomic_endpoint", "auth_cookie"
+  code <<-EOS
+    request = {
+      verb: "POST",
+      host: turbonomic_endpoint,
+      pagination: "turbonomics_volumes_pagination_header",
+      path: "/api/v3/markets/Market/actions"
+      body_fields: {
+        "actionStateList": ["READY", "ACCEPTED", "QUEUED", "IN_PROGRESS"],
+        "actionTypeList":["SCALE"],
+        "relatedEntityTypes":["VirtualVolume"],
+        "environmentType":"CLOUD",
+        "detailLevel":"EXECUTION",
+        "costType":"SAVING"
+      },
+      query_params: {
+        "limit": '100'
+      },
+      headers: {
+        "Content-Type": "application/json"
+        "Cookie": auth_cookie
+      }
+    }
+  EOS
+end
+
+script "js_get_business_units", type: "javascript" do
+  result "request"
+  parameters "turbonomic_endpoint", "auth_cookie", "provider"
+  code <<-EOS
+    query_params = {"type": "DISCOVERED"}
+
+    // Since /api/v3/businessunits only support "AWS", "Azure Subscription" and "GCP Project", in case
+    // user selects "All", we shouldn't add "cloud_type" param in order to get all records.
+    if (provider !== "All") {
+      providers = {
+        "AWS":"AWS",
+        "Azure Subscription":"AZURE",
+        "GCP Project": "GCP",
+      }
+
+      query_params["cloud_type"] = providers[provider]
+    }
+
+    request = {
+      verb: "GET",
+      host: turbonomic_endpoint,
+      path: "/api/v3/businessunits",
+      query_params: query_params,
+      headers: {
+        "Content-Type": "application/json"
+        "Cookie": auth_cookie
+      }
+    }
+  EOS
+end
+
+script "js_filtered_turbonomics_recommendations", type: "javascript" do
+  result "result"
+  parameters "ds_get_turbonomics_recommendations", "ds_get_business_units", "param_provider"
+  code <<-EOS
+    instances = []
+    monthlySavings = 0.0
+    function formatNumber(number, separator) {
+      var numString = number.toString()
+      var values = numString.split(".")
+      var result = ''
+      while (values[0].length > 3) {
+        var chunk = values[0].substr(-3)
+        values[0] = values[0].substr(0, values[0].length - 3)
+        result = separator + chunk + result
+      }
+      if (values[0].length > 0) {
+        result = values[0] + result
+      }
+      if (values[1] == undefined) {
+        return result
+      }
+      return result + "." + values[1]
+    }
+    _.each(ds_get_business_units, function (businessUnit) {
+      _.each(ds_get_turbonomics_recommendations, function (volume, index) {
+        if (volume.businessUUID === businessUnit.uuid) {
+          ds_get_turbonomics_recommendations[index].accountID = businessUnit.accountID
+          ds_get_turbonomics_recommendations[index].accountName = businessUnit.displayName
+        }
+      })
+    })
+    var provider_service = {
+      "AWS": "EBS",
+      "Azure Subscription": "Disk Storage",
+      "GCP Project": "Persistent Disk"
+    }
+    _.each(ds_get_turbonomics_recommendations, function (volume) {
+      if (volume.provider === param_provider || param_provider === "ALL") {
+        if (typeof volume.savingsCurrency != "undefined" && volume.savingsCurrency != null) {
+          if (volume.savingsCurrency.indexOf("$") != -1) {
+            volume.savingsCurrency = "$"
+          }
+        } else {
+          volume.savingsCurrency = "$"
+        }
+        _.each(volume.size, function (stat) {
+          if (stat.name === "StorageAmount") {
+            volume.size = stat.capacity.total + " " + stat.units
+            return
+          }
+        })
+        tags = []
+        if (typeof volume.tags === "undefined" || volume.tags === null) {
+          volume.tags = tags
+        } else {
+          Object.keys(volume['tags']).forEach(function (key) {
+            tags.push(key + '=' + volume['tags'][key][0])
+          });
+        }
+        volume.tags = tags
+        Object.keys(volume.resourceID).forEach(function (key) {
+          volume.resourceID = volume.resourceID[key]
+          return
+        });
+        Object.keys(volume.vendorIDValues).forEach(function (key) {
+          volume.accountID = volume.vendorIDValues[key]
+          volume.accountName = key
+          return
+        });
+        volume.service = provider_service[volume.provider]
+        savingsString = ""
+        if (typeof volume.savings === "undefined" || volume.savings === null || volume.savings === "" || isNaN(volume.savings)) {
+          volume.savings = 0.0
+        }
+        volume.savings = (Math.round(volume.savings * 730 * 1000) / 1000)
+        monthlySavings = monthlySavings + volume.savings
+        instances.push(volume)
+      }
+    })
+    message = ""
+    if (instances.length != 0) {
+      pretty_savings = instances[0].savingsCurrency + ' ' + formatNumber(monthlySavings.toFixed(2), ",")
+      message = "The total estimated monthly savings are " + pretty_savings + '.'
+    }
+    result = {
+      'instances': instances,
+      'message': message
+    }
+  EOS
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "pol_turbonomics_scale_volumes" do
+  validate $ds_filtered_turbonomics_recommendations do
+    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data.instances }} Turbonomic Scalable Virtual Volumes found"
+    detail_template <<-EOS
+      ## Turbonomics Scale Virtual Volumes Recommendations
+      {{data.message}}
+    EOS
+    check eq(size(val(data, "instances")), 0)
+    export "instances" do
+      field "accountID" do
+        label "Account ID"
+      end
+      field "accountName" do
+        label "Account Name"
+      end
+      field "resourceID" do
+        label "Resource ID"
+      end
+      field "resourceName" do
+        label "Resource Name"
+      end
+      field "savingsCurrency" do
+        label "Savings Currency"
+      end
+      field "savings" do
+        label "Savings amount"
+      end
+      field "details" do
+        label "Recommendation Details"
+      end
+      field "resourceType" do
+        label "Current Instance Type and storage tier"
+        path "currentResourceType"
+      end
+      field "newResourceType" do
+        label "Recommended instance type and storage tier"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "tags" do
+        label "Tags"
+      end
+      field "provider" do
+        label "Cloud Provider"
+      end
+      field "createdTime" do
+        label "Created Time"
+      end
+    end
+    escalate $esc_email
+  end
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end

--- a/cost/turbonomics/scale_virtual_volumes_recommendations/azure/CHANGELOG.md
+++ b/cost/turbonomics/scale_virtual_volumes_recommendations/azure/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v1.0
+
+- Initial Release

--- a/cost/turbonomics/scale_virtual_volumes_recommendations/azure/README.md
+++ b/cost/turbonomics/scale_virtual_volumes_recommendations/azure/README.md
@@ -1,0 +1,25 @@
+# Turbonomics Scale Virtual Volumes Recommendations Azure
+
+## What it does
+
+The Turbonomics Scale Virtual Volumes Recommendations Azure policy uses Turbonomic Actions endpoint (POST xxxx.turbonomic.com/api/v3/markets/Market/actions) and Business Units endpoint (GET xxxx.turbonomic.com/api/v3/businessunits) to provide Scale Virtual Volumes recommendations. From these recommendations we provide monthly savings estimates based on Turbonomic per hour costs.
+
+## Input Parameters
+
+- *Provider* - Cloud provider where we get recommendations, it supports Azure.
+- *Authorization Cookie* - Authorization cookie pulled from manual source.
+  - no_echo: true
+- *Email addresses to notify* - A list of email addresses to notify.
+
+## Supported Clouds
+
+- Azure
+
+## Required Flexera Roles
+
+- policy_manager
+- billing_center_viewer
+
+## Cost
+
+This Policy Template does not incur any cloud costs.

--- a/cost/turbonomics/scale_virtual_volumes_recommendations/azure/turbonomics_scale_virtual_volumes_recommendations.pt
+++ b/cost/turbonomics/scale_virtual_volumes_recommendations/azure/turbonomics_scale_virtual_volumes_recommendations.pt
@@ -1,0 +1,333 @@
+name "Turbonomics Scale Virtual Volumes Recommendations Azure"
+rs_pt_ver 20180301
+type "policy"
+short_description "Turbonomics policy that gives recommendations to scale Virtual Volumes."
+severity "low"
+category "Cost"
+default_frequency "daily"
+info(
+  version: "1.0",
+  source: "Turbonomic",
+  service: "Usage Discount",
+  provider: "Azure",
+  policy_set: "Rightsize Volumes",
+  recommendation_type: "Usage Reduction"
+)
+
+##################
+# Parameters   #
+##################
+
+parameter "param_turbonomic_endpoint" do
+  type "string"
+  label "Turbonomic endpoint"
+end
+
+parameter "param_provider" do
+  type "string"
+  label "Provider"
+  description "Specifies provider where you want to get recommendations"
+  # Once we can add multiple providers, allow: "All", "AWS", "Azure Subscription", "GCP Project"
+  allowed_values "Azure Subscription"
+  # Once we can add multiple providers change this default value
+  default "Azure Subscription"
+end
+
+parameter "param_auth_cookie" do
+  type "string"
+  label "Authorization Cookie"
+  no_echo true
+  description "Valid authorization cookie."
+end
+
+parameter "param_email" do
+  type "list"
+  label "Email addresses to notify"
+  description "Email addresses of the recipients you wish to notify when new incidents are created"
+end
+
+###############################################################################
+# Pagination
+###############################################################################
+
+pagination "turbonomics_volumes_pagination_header" do
+  get_page_marker do
+    header "x-next-cursor"
+  end
+  set_page_marker do
+    query "cursor"
+  end
+end
+
+###############################################################################
+# Datasources
+###############################################################################
+
+datasource "ds_get_turbonomics_recommendations" do
+  request do
+    run_script $js_get_turbonomics_recommendations, $param_turbonomic_endpoint, $param_auth_cookie
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "vendorIDValues", jmes_path(col_item, "virtualDisks[0].businessAccount.vendorIds")
+      field "resourceGroup", jmes_path(col_item, "target.aspects.cloudAspect.resourceGroup.displayName")
+      field "resourceID", jmes_path(col_item, "target.vendorIds")
+      field "resourceName", jmes_path(col_item, "target.displayName")
+      field "region", jmes_path(col_item, "currentLocation.displayName")
+      field "currentResourceType", jmes_path(col_item, "currentEntity.displayName")
+      field "newResourceType", jmes_path(col_item, "newEntity.displayName")
+      field "provider", jmes_path(col_item, "target.discoveredBy.type")
+      field "details", jmes_path(col_item, "details")
+      field "tags", jmes_path(col_item, "target.tags")
+      field "createdTime", jmes_path(col_item, "createTime")
+      field "size", jmes_path(col_item, "virtualDisks[0].stats")
+      field "savings", jmes_path(col_item, "stats[0].value")
+      field "savingsCurrency", jmes_path(col_item, "stats[0].units")
+    end
+  end
+end
+
+datasource "ds_get_business_units" do
+  request do
+    run_script $js_get_business_units, $param_turbonomic_endpoint, $param_auth_cookie, $param_provider
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "uuid", jmes_path(col_item, "uuid")
+      field "accountID", jmes_path(col_item, "accountId")
+      field "displayName", jmes_path(col_item, "displayName")
+    end
+  end
+end
+
+datasource "ds_filtered_turbonomics_recommendations" do
+  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_business_units, $param_provider
+end
+
+###############################################################################
+# Scripts
+###############################################################################
+
+script "js_get_turbonomics_recommendations", type: "javascript" do
+  result "request"
+  parameters "turbonomic_endpoint", "auth_cookie"
+  code <<-EOS
+    request = {
+      verb: "POST",
+      host: turbonomic_endpoint,
+      pagination: "turbonomics_volumes_pagination_header",
+      path: "/api/v3/markets/Market/actions"
+      body_fields: {
+        "actionStateList": ["READY", "ACCEPTED", "QUEUED", "IN_PROGRESS"],
+        "actionTypeList":["SCALE"],
+        "relatedEntityTypes":["VirtualVolume"],
+        "environmentType":"CLOUD",
+        "detailLevel":"EXECUTION",
+        "costType":"SAVING"
+      },
+      query_params: {
+        "limit": '100'
+      },
+      headers: {
+        "Content-Type": "application/json"
+        "Cookie": auth_cookie
+      }
+    }
+  EOS
+end
+
+script "js_get_business_units", type: "javascript" do
+  result "request"
+  parameters "turbonomic_endpoint", "auth_cookie", "provider"
+  code <<-EOS
+    query_params = {"type": "DISCOVERED"}
+
+    // Since /api/v3/businessunits only support "AWS", "Azure Subscription" and "GCP Project", in case
+    // user selects "All", we shouldn't add "cloud_type" param in order to get all records.
+    if (provider !== "All") {
+      providers = {
+        "AWS":"AWS",
+        "Azure Subscription":"AZURE",
+        "GCP Project": "GCP",
+      }
+
+      query_params["cloud_type"] = providers[provider]
+    }
+
+    request = {
+      verb: "GET",
+      host: turbonomic_endpoint,
+      path: "/api/v3/businessunits",
+      query_params: query_params,
+      headers: {
+        "Content-Type": "application/json"
+        "Cookie": auth_cookie
+      }
+    }
+  EOS
+end
+
+script "js_filtered_turbonomics_recommendations", type: "javascript" do
+  result "result"
+  parameters "ds_get_turbonomics_recommendations", "ds_get_business_units", "param_provider"
+  code <<-EOS
+    instances = []
+    monthlySavings = 0.0
+    function formatNumber(number, separator) {
+      var numString = number.toString()
+      var values = numString.split(".")
+      var result = ''
+      while (values[0].length > 3) {
+        var chunk = values[0].substr(-3)
+        values[0] = values[0].substr(0, values[0].length - 3)
+        result = separator + chunk + result
+      }
+      if (values[0].length > 0) {
+        result = values[0] + result
+      }
+      if (values[1] == undefined) {
+        return result
+      }
+      return result + "." + values[1]
+    }
+    _.each(ds_get_business_units, function (businessUnit) {
+      _.each(ds_get_turbonomics_recommendations, function (volume, index) {
+        if (volume.businessUUID === businessUnit.uuid) {
+          ds_get_turbonomics_recommendations[index].accountID = businessUnit.accountID
+          ds_get_turbonomics_recommendations[index].accountName = businessUnit.displayName
+        }
+      })
+    })
+    var provider_service = {
+      "AWS": "EBS",
+      "Azure Subscription": "Disk Storage",
+      "GCP Project": "Persistent Disk"
+    }
+    _.each(ds_get_turbonomics_recommendations, function (volume) {
+      if (volume.provider === param_provider || param_provider === "ALL") {
+        if (typeof volume.savingsCurrency != "undefined" && volume.savingsCurrency != null) {
+          if (volume.savingsCurrency.indexOf("$") != -1) {
+            volume.savingsCurrency = "$"
+          }
+        } else {
+          volume.savingsCurrency = "$"
+        }
+        _.each(volume.size, function (stat) {
+          if (stat.name === "StorageAmount") {
+            volume.size = stat.capacity.total + " " + stat.units
+            return
+          }
+        })
+        tags = []
+        if (typeof volume.tags === "undefined" || volume.tags === null) {
+          volume.tags = tags
+        } else {
+          Object.keys(volume['tags']).forEach(function (key) {
+            tags.push(key + '=' + volume['tags'][key][0])
+          });
+        }
+        volume.tags = tags
+        Object.keys(volume.resourceID).forEach(function (key) {
+          volume.resourceID = volume.resourceID[key]
+          return
+        });
+        Object.keys(volume.vendorIDValues).forEach(function (key) {
+          volume.accountID = volume.vendorIDValues[key]
+          volume.accountName = key
+          return
+        });
+        volume.service = provider_service[volume.provider]
+        savingsString = ""
+        if (typeof volume.savings === "undefined" || volume.savings === null || volume.savings === "" || isNaN(volume.savings)) {
+          volume.savings = 0.0
+        }
+        volume.savings = (Math.round(volume.savings * 730 * 1000) / 1000)
+        monthlySavings = monthlySavings + volume.savings
+        instances.push(volume)
+      }
+    })
+    message = ""
+    if (instances.length != 0) {
+      pretty_savings = instances[0].savingsCurrency + ' ' + formatNumber(monthlySavings.toFixed(2), ",")
+      message = "The total estimated monthly savings are " + pretty_savings + '.'
+    }
+    result = {
+      'instances': instances,
+      'message': message
+    }
+  EOS
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "pol_turbonomics_scale_volumes" do
+  validate $ds_filtered_turbonomics_recommendations do
+    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data.instances }} Turbonomic Scalable Virtual Volumes found"
+    detail_template <<-EOS
+      ## Turbonomics Scale Virtual Volumes Recommendations
+      {{data.message}}
+    EOS
+    check eq(size(val(data, "instances")), 0)
+    export "instances" do
+      field "accountID" do
+        label "Account ID"
+      end
+      field "accountName" do
+        label "Account Name"
+      end
+      field "resourceID" do
+        label "Resource ID"
+      end
+      field "resourceName" do
+        label "Resource Name"
+      end
+      field "savingsCurrency" do
+        label "Savings Currency"
+      end
+      field "savings" do
+        label "Savings amount"
+      end
+      field "details" do
+        label "Recommendation Details"
+      end
+      field "resourceType" do
+        label "Current Instance Type and storage tier"
+        path "currentResourceType"
+      end
+      field "newResourceType" do
+        label "Recommended instance type and storage tier"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "tags" do
+        label "Tags"
+      end
+      field "provider" do
+        label "Cloud Provider"
+      end
+      field "createdTime" do
+        label "Created Time"
+      end
+    end
+    escalate $esc_email
+  end
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end

--- a/cost/turbonomics/scale_virtual_volumes_recommendations/gcp/CHANGELOG.md
+++ b/cost/turbonomics/scale_virtual_volumes_recommendations/gcp/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v1.0
+
+- Initial Release

--- a/cost/turbonomics/scale_virtual_volumes_recommendations/gcp/README.md
+++ b/cost/turbonomics/scale_virtual_volumes_recommendations/gcp/README.md
@@ -1,0 +1,25 @@
+# Turbonomics Scale Virtual Volumes Recommendations Azure
+
+## What it does
+
+The Turbonomics Scale Virtual Volumes Recommendations Azure policy uses Turbonomic Actions endpoint (POST xxxx.turbonomic.com/api/v3/markets/Market/actions) and Business Units endpoint (GET xxxx.turbonomic.com/api/v3/businessunits) to provide Scale Virtual Volumes recommendations. From these recommendations we provide monthly savings estimates based on Turbonomic per hour costs.
+
+## Input Parameters
+
+- *Provider* - Cloud provider where we get recommendations, it supports Azure.
+- *Authorization Cookie* - Authorization cookie pulled from manual source.
+  - no_echo: true
+- *Email addresses to notify* - A list of email addresses to notify.
+
+## Supported Clouds
+
+- Azure
+
+## Required Flexera Roles
+
+- policy_manager
+- billing_center_viewer
+
+## Cost
+
+This Policy Template does not incur any cloud costs.

--- a/cost/turbonomics/scale_virtual_volumes_recommendations/gcp/turbonomics_scale_virtual_volumes_recommendations.pt
+++ b/cost/turbonomics/scale_virtual_volumes_recommendations/gcp/turbonomics_scale_virtual_volumes_recommendations.pt
@@ -1,0 +1,333 @@
+name "Turbonomics Scale Virtual Volumes Recommendations GCP"
+rs_pt_ver 20180301
+type "policy"
+short_description "Turbonomics policy that gives recommendations to scale Virtual Volumes."
+severity "low"
+category "Cost"
+default_frequency "daily"
+info(
+  version: "1.0",
+  source: "Turbonomic",
+  service: "Usage Discount",
+  provider: "GCP",
+  policy_set: "Rightsize Volumes",
+  recommendation_type: "Usage Reduction"
+)
+
+##################
+# Parameters   #
+##################
+
+parameter "param_turbonomic_endpoint" do
+  type "string"
+  label "Turbonomic endpoint"
+end
+
+parameter "param_provider" do
+  type "string"
+  label "Provider"
+  description "Specifies provider where you want to get recommendations"
+  # Once we can add multiple providers, allow: "All", "AWS", "Azure Subscription", "GCP Project"
+  allowed_values "GCP Project"
+  # Once we can add multiple providers change this default value
+  default "GCP Project"
+end
+
+parameter "param_auth_cookie" do
+  type "string"
+  label "Authorization Cookie"
+  no_echo true
+  description "Valid authorization cookie."
+end
+
+parameter "param_email" do
+  type "list"
+  label "Email addresses to notify"
+  description "Email addresses of the recipients you wish to notify when new incidents are created"
+end
+
+###############################################################################
+# Pagination
+###############################################################################
+
+pagination "turbonomics_volumes_pagination_header" do
+  get_page_marker do
+    header "x-next-cursor"
+  end
+  set_page_marker do
+    query "cursor"
+  end
+end
+
+###############################################################################
+# Datasources
+###############################################################################
+
+datasource "ds_get_turbonomics_recommendations" do
+  request do
+    run_script $js_get_turbonomics_recommendations, $param_turbonomic_endpoint, $param_auth_cookie
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "vendorIDValues", jmes_path(col_item, "virtualDisks[0].businessAccount.vendorIds")
+      field "resourceGroup", jmes_path(col_item, "target.aspects.cloudAspect.resourceGroup.displayName")
+      field "resourceID", jmes_path(col_item, "target.vendorIds")
+      field "resourceName", jmes_path(col_item, "target.displayName")
+      field "region", jmes_path(col_item, "currentLocation.displayName")
+      field "currentResourceType", jmes_path(col_item, "currentEntity.displayName")
+      field "newResourceType", jmes_path(col_item, "newEntity.displayName")
+      field "provider", jmes_path(col_item, "target.discoveredBy.type")
+      field "details", jmes_path(col_item, "details")
+      field "tags", jmes_path(col_item, "target.tags")
+      field "createdTime", jmes_path(col_item, "createTime")
+      field "size", jmes_path(col_item, "virtualDisks[0].stats")
+      field "savings", jmes_path(col_item, "stats[0].value")
+      field "savingsCurrency", jmes_path(col_item, "stats[0].units")
+    end
+  end
+end
+
+datasource "ds_get_business_units" do
+  request do
+    run_script $js_get_business_units, $param_turbonomic_endpoint, $param_auth_cookie, $param_provider
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "uuid", jmes_path(col_item, "uuid")
+      field "accountID", jmes_path(col_item, "accountId")
+      field "displayName", jmes_path(col_item, "displayName")
+    end
+  end
+end
+
+datasource "ds_filtered_turbonomics_recommendations" do
+  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_business_units, $param_provider
+end
+
+###############################################################################
+# Scripts
+###############################################################################
+
+script "js_get_turbonomics_recommendations", type: "javascript" do
+  result "request"
+  parameters "turbonomic_endpoint", "auth_cookie"
+  code <<-EOS
+    request = {
+      verb: "POST",
+      host: turbonomic_endpoint,
+      pagination: "turbonomics_volumes_pagination_header",
+      path: "/api/v3/markets/Market/actions"
+      body_fields: {
+        "actionStateList": ["READY", "ACCEPTED", "QUEUED", "IN_PROGRESS"],
+        "actionTypeList":["SCALE"],
+        "relatedEntityTypes":["VirtualVolume"],
+        "environmentType":"CLOUD",
+        "detailLevel":"EXECUTION",
+        "costType":"SAVING"
+      },
+      query_params: {
+        "limit": '100'
+      },
+      headers: {
+        "Content-Type": "application/json"
+        "Cookie": auth_cookie
+      }
+    }
+  EOS
+end
+
+script "js_get_business_units", type: "javascript" do
+  result "request"
+  parameters "turbonomic_endpoint", "auth_cookie", "provider"
+  code <<-EOS
+    query_params = {"type": "DISCOVERED"}
+
+    // Since /api/v3/businessunits only support "AWS", "Azure Subscription" and "GCP Project", in case
+    // user selects "All", we shouldn't add "cloud_type" param in order to get all records.
+    if (provider !== "All") {
+      providers = {
+        "AWS":"AWS",
+        "Azure Subscription":"AZURE",
+        "GCP Project": "GCP",
+      }
+
+      query_params["cloud_type"] = providers[provider]
+    }
+
+    request = {
+      verb: "GET",
+      host: turbonomic_endpoint,
+      path: "/api/v3/businessunits",
+      query_params: query_params,
+      headers: {
+        "Content-Type": "application/json"
+        "Cookie": auth_cookie
+      }
+    }
+  EOS
+end
+
+script "js_filtered_turbonomics_recommendations", type: "javascript" do
+  result "result"
+  parameters "ds_get_turbonomics_recommendations", "ds_get_business_units", "param_provider"
+  code <<-EOS
+    instances = []
+    monthlySavings = 0.0
+    function formatNumber(number, separator) {
+      var numString = number.toString()
+      var values = numString.split(".")
+      var result = ''
+      while (values[0].length > 3) {
+        var chunk = values[0].substr(-3)
+        values[0] = values[0].substr(0, values[0].length - 3)
+        result = separator + chunk + result
+      }
+      if (values[0].length > 0) {
+        result = values[0] + result
+      }
+      if (values[1] == undefined) {
+        return result
+      }
+      return result + "." + values[1]
+    }
+    _.each(ds_get_business_units, function (businessUnit) {
+      _.each(ds_get_turbonomics_recommendations, function (volume, index) {
+        if (volume.businessUUID === businessUnit.uuid) {
+          ds_get_turbonomics_recommendations[index].accountID = businessUnit.accountID
+          ds_get_turbonomics_recommendations[index].accountName = businessUnit.displayName
+        }
+      })
+    })
+    var provider_service = {
+      "AWS": "EBS",
+      "Azure Subscription": "Disk Storage",
+      "GCP Project": "Persistent Disk"
+    }
+    _.each(ds_get_turbonomics_recommendations, function (volume) {
+      if (volume.provider === param_provider || param_provider === "ALL") {
+        if (typeof volume.savingsCurrency != "undefined" && volume.savingsCurrency != null) {
+          if (volume.savingsCurrency.indexOf("$") != -1) {
+            volume.savingsCurrency = "$"
+          }
+        } else {
+          volume.savingsCurrency = "$"
+        }
+        _.each(volume.size, function (stat) {
+          if (stat.name === "StorageAmount") {
+            volume.size = stat.capacity.total + " " + stat.units
+            return
+          }
+        })
+        tags = []
+        if (typeof volume.tags === "undefined" || volume.tags === null) {
+          volume.tags = tags
+        } else {
+          Object.keys(volume['tags']).forEach(function (key) {
+            tags.push(key + '=' + volume['tags'][key][0])
+          });
+        }
+        volume.tags = tags
+        Object.keys(volume.resourceID).forEach(function (key) {
+          volume.resourceID = volume.resourceID[key]
+          return
+        });
+        Object.keys(volume.vendorIDValues).forEach(function (key) {
+          volume.accountID = volume.vendorIDValues[key]
+          volume.accountName = key
+          return
+        });
+        volume.service = provider_service[volume.provider]
+        savingsString = ""
+        if (typeof volume.savings === "undefined" || volume.savings === null || volume.savings === "" || isNaN(volume.savings)) {
+          volume.savings = 0.0
+        }
+        volume.savings = (Math.round(volume.savings * 730 * 1000) / 1000)
+        monthlySavings = monthlySavings + volume.savings
+        instances.push(volume)
+      }
+    })
+    message = ""
+    if (instances.length != 0) {
+      pretty_savings = instances[0].savingsCurrency + ' ' + formatNumber(monthlySavings.toFixed(2), ",")
+      message = "The total estimated monthly savings are " + pretty_savings + '.'
+    }
+    result = {
+      'instances': instances,
+      'message': message
+    }
+  EOS
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "pol_turbonomics_scale_volumes" do
+  validate $ds_filtered_turbonomics_recommendations do
+    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data.instances }} Turbonomic Scalable Virtual Volumes found"
+    detail_template <<-EOS
+      ## Turbonomics Scale Virtual Volumes Recommendations
+      {{data.message}}
+    EOS
+    check eq(size(val(data, "instances")), 0)
+    export "instances" do
+      field "accountID" do
+        label "Account ID"
+      end
+      field "accountName" do
+        label "Account Name"
+      end
+      field "resourceID" do
+        label "Resource ID"
+      end
+      field "resourceName" do
+        label "Resource Name"
+      end
+      field "savingsCurrency" do
+        label "Savings Currency"
+      end
+      field "savings" do
+        label "Savings amount"
+      end
+      field "details" do
+        label "Recommendation Details"
+      end
+      field "resourceType" do
+        label "Current Instance Type and storage tier"
+        path "currentResourceType"
+      end
+      field "newResourceType" do
+        label "Recommended instance type and storage tier"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "tags" do
+        label "Tags"
+      end
+      field "provider" do
+        label "Cloud Provider"
+      end
+      field "createdTime" do
+        label "Created Time"
+      end
+    end
+    escalate $esc_email
+  end
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end


### PR DESCRIPTION
### Description

"Turbonomics Scale Virtual Volumes Recommendations AWS", "Turbonomics Scale Virtual Volumes Recommendations Azure" and "Turbonomics Scale Virtual Volumes Recommendations GCP" Policy Templates, get recommendations to scale Virtual Volumes entity types using Turbonomics APIs. Each one works with a specific cloud provider (AWS, Azure and GCloud).

### Issues Resolved

From [ticket](https://flexera.atlassian.net/browse/HCLIND-51): _As a Turbonomic user , I would like to be able to review in Flexera CCO the cost savings due to Scale Volume recommendations, so I can slice and dice them by billing centers._

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
