### PR TITLE
POL-764 limit raise

### DIFF
--- a/cost/aws/elb/clb_unused/CHANGELOG.md
+++ b/cost/aws/elb/clb_unused/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1
+
+- Raised API limit to handle situations where more than 10,000 line items need to be retrieved.
+
 ## v3.0
 
 - Deprecated `auth_rs` authentication (type: `rightscale`) and replaced with `auth_flexera` (type: `oauth2`).  This is a breaking change which requires a Credential for `auth_flexera` [`provider=flexera`] before the policy can be applied.  Please see docs for setting up [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm)

--- a/cost/aws/elb/clb_unused/aws_delete_unused_clb.pt
+++ b/cost/aws/elb/clb_unused/aws_delete_unused_clb.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "3.0",
+  version: "3.1",
   provider: "AWS",
   service: "ELB",
   policy_set: ""
@@ -423,7 +423,7 @@ script "js_get_costs", type:"javascript" do
         "end_at": end_date,
         "metrics": ["cost_nonamortized_unblended_adj"],
         "billing_center_ids": _.compact(_.map(billing_centers, function(value){ return value.id})),
-        "limit": 10000,
+        "limit": 100000,
         "filter": {
           "expressions": [
             {

--- a/cost/aws/gp3_volume_upgrade/CHANGELOG.md
+++ b/cost/aws/gp3_volume_upgrade/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1
+
+- Raised API limit to handle situations where more than 10,000 line items need to be retrieved.
+
 ## v3.0
 
 - Deprecated `auth_rs` authentication (type: `rightscale`) and replaced with `auth_flexera` (type: `oauth2`).  This is a breaking change which requires a Credential for `auth_flexera` [`provider=flexera`] before the policy can be applied.  Please see docs for setting up [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm)

--- a/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume.pt
+++ b/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "3.0",
+  version: "3.1",
   provider: "AWS",
   service: "EBS",
   policy_set: "GP3 Volumes"
@@ -413,7 +413,7 @@ script "js_get_costs", type: "javascript" do
         "end_at": end_date,
         "metrics": ["cost_nonamortized_unblended_adj"],
         "billing_center_ids": _.compact(_.map(billing_centers, function(value){ return value.id})),
-        "limit": 10000,
+        "limit": 100000,
         "filter": {
           "expressions": [
             {

--- a/cost/aws/old_snapshots/CHANGELOG.md
+++ b/cost/aws/old_snapshots/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.2
+
+- Raised API limit to handle situations where more than 10,000 line items need to be retrieved.
+
 ## v4.1
 
 - Added logic required for "Meta Policy" use-cases

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "4.1",
+  version: "4.2",
   provider: "AWS",
   service: "EBS",
   policy_set: "Old Snapshots"
@@ -375,7 +375,7 @@ script "js_get_costs", type: "javascript" do
         "end_at": end_date,
         "metrics": ["cost_nonamortized_unblended_adj"],
         "billing_center_ids": _.compact(_.map(billing_centers, function(value){ return value.id})),
-        "limit": 10000,
+        "limit": 100000,
         "filter": {
           "expressions": [
             {

--- a/cost/aws/unused_rds/CHANGELOG.md
+++ b/cost/aws/unused_rds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.2
+
+- Raised API limit to handle situations where more than 10,000 line items need to be retrieved.
+
 ## v4.1
 
 - Added logic required for "Meta Policy" use-cases

--- a/cost/aws/unused_rds/unused_rds.pt
+++ b/cost/aws/unused_rds/unused_rds.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "4.1",
+  version: "4.2",
   provider: "AWS",
   service: "RDS",
   policy_set: "Unused Database Services"
@@ -436,7 +436,7 @@ script "js_instance_costs", type:"javascript" do
           "end_at": end_date,
           "metrics": ["cost_nonamortized_unblended_adj"],
           "billing_center_ids": _.compact(_.map(billing_centers, function(value){ return value.id})),
-          "limit": 10000,
+          "limit": 100000,
           "filter": {
             "expressions": [
               {

--- a/cost/aws/unused_volumes/CHANGELOG.md
+++ b/cost/aws/unused_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.2
+
+- Raised API limit to handle situations where more than 10,000 line items need to be retrieved.
+
 ## v4.1
 
 - Added logic required for "Meta Policy" use-cases

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "4.1",
+  version: "4.2",
   provider: "AWS",
   service: "EBS",
   policy_set: "Unused Volumes"
@@ -596,7 +596,7 @@ script "js_get_costs", type: "javascript" do
         "end_at": end_date,
         "metrics": ["cost_nonamortized_unblended_adj"],
         "billing_center_ids": _.compact(_.map(billing_centers, function(value){ return value.id})),
-        "limit": 10000,
+        "limit": 100000,
         "filter": {
           "expressions": [
             {

--- a/cost/azure/old_snapshots/CHANGELOG.md
+++ b/cost/azure/old_snapshots/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.3
+
+- Raised API limit to handle situations where more than 10,000 line items need to be retrieved.
+
 ## v4.2
 
 - Replaced the term **whitelist** with **allowed list**.

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "4.2",
+  version: "4.3",
   provider: "Azure",
   service: "Storage",
   policy_set: "Old Snapshots"
@@ -284,7 +284,7 @@ script "js_get_costs", type:"javascript" do
         "end_at": end_date,
         "metrics": ["cost_nonamortized_unblended_adj"],
         "billing_center_ids": _.compact(_.map(billing_centers, function(value){ return value.id})),
-        "limit": 10000,
+        "limit": 100000,
         "filter": {
           "expressions": [
             {

--- a/cost/azure/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.3
+
+- Raised API limit to handle situations where more than 10,000 line items need to be retrieved.
+
 ## v1.2
 
 - Replaced the term **whitelist** with **allowed list**.

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightisizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightisizing.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "1.2",
+  version: "1.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -421,7 +421,7 @@ script "js_get_costs", type: "javascript" do
         "end_at": end_date.toLocaleDateString("en-US").split("-")[0] + "-" + end_date.toLocaleDateString("en-US").split("-")[1],
         "metrics": ["cost_amortized_unblended_adj"],
         "billing_center_ids": _.compact(_.map(billing_centers, function(value){ return value.id})),
-        "limit": 10000,
+        "limit": 100000,
         "filter": {
           "expressions": [
             {

--- a/cost/azure/unattached_volumes/CHANGELOG.md
+++ b/cost/azure/unattached_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.4
+
+- Raised API limit to handle situations where more than 10,000 line items need to be retrieved.
+
 ## v4.3
 
 - Replaced the term **whitelist** with **allowed list**.

--- a/cost/azure/unattached_volumes/azure_delete_unattached_volumes.pt
+++ b/cost/azure/unattached_volumes/azure_delete_unattached_volumes.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "4.3",
+  version: "4.4",
   provider: "Azure",
   service: "Storage",
   policy_set: "Unused Volumes"
@@ -312,7 +312,7 @@ script "js_get_costs", type:"javascript" do
         "end_at": end_date,
         "metrics": ["cost_nonamortized_unblended_adj"],
         "billing_center_ids": _.compact(_.map(billing_centers, function(value){ return value.id})),
-        "limit": 10000,
+        "limit": 100000,
         "filter": {
           "expressions": [
             {

--- a/cost/azure/unused_ip_addresses/CHANGELOG.md
+++ b/cost/azure/unused_ip_addresses/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.4
+
+- Raised API limit to handle situations where more than 10,000 line items need to be retrieved.
+
 ## v4.3
 
 - Replaced the term **whitelist** with **allowed list**.

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.3",
+  version: "4.4",
   provider: "Azure",
   service: "Compute",
   policy_set: "Unused IP Addresses"
@@ -259,7 +259,7 @@ script "js_get_costs", type:"javascript" do
         "end_at": end_date,
         "metrics": ["cost_nonamortized_unblended_adj"],
         "billing_center_ids": _.compact(_.map(billing_centers, function(value){ return value.id })),
-        "limit": 10000,
+        "limit": 100000,
         "filter": {
           "expressions": [
             {

--- a/cost/azure/unused_sql_databases/CHANGELOG.md
+++ b/cost/azure/unused_sql_databases/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.3
+
+- Raised API limit to handle situations where more than 10,000 line items need to be retrieved.
+
 ## v4.2
 
 - Replaced the term **whitelist** with **allowed list**.

--- a/cost/azure/unused_sql_databases/azure_unused_sql_databases.pt
+++ b/cost/azure/unused_sql_databases/azure_unused_sql_databases.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "4.2",
+  version: "4.3",
   provider: "Azure",
   service: "SQL",
   policy_set: "Unused Database Services"
@@ -414,7 +414,7 @@ script "js_get_costs", type:"javascript" do
         "end_at": end_date,
         "metrics": ["cost_nonamortized_unblended_adj"],
         "billing_center_ids": _.compact(_.map(billing_centers, function(value){ return value.id})),
-        "limit": 10000,
+        "limit": 100000,
         "filter": {
           "expressions": [
             {


### PR DESCRIPTION
Raised the limit field from 10000 to 100000 for several policies to ensure that they work correctly when more than 10000 line items are involved. 100000 is the maximum that the API currently supports.