### PR TITLE
HCLIND-62 Fix: Prevent publish Turbonomic Rightsize Databases/Virtual Volumes policies

### DIFF
--- a/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
+++ b/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
@@ -11,7 +11,8 @@ info(
   service: "Usage Discount",
   provider: "AWS",
   policy_set: "Rightsize Database Instances",
-  recommendation_type: "Usage Reduction"
+  recommendation_type: "Usage Reduction",
+  publish: "false"
 )
 
 ##################

--- a/cost/turbonomics/rightsize_databases_recommendations/azure/turbonomics_rightsize_databases_recommendations.pt
+++ b/cost/turbonomics/rightsize_databases_recommendations/azure/turbonomics_rightsize_databases_recommendations.pt
@@ -11,7 +11,8 @@ info(
   service: "Usage Discount",
   provider: "Azure",
   policy_set: "Rightsize Database Instances",
-  recommendation_type: "Usage Reduction"
+  recommendation_type: "Usage Reduction",
+  publish: "false"
 )
 
 ##################

--- a/cost/turbonomics/rightsize_databases_recommendations/gcp/turbonomics_rightsize_databases_recommendations.pt
+++ b/cost/turbonomics/rightsize_databases_recommendations/gcp/turbonomics_rightsize_databases_recommendations.pt
@@ -11,7 +11,8 @@ info(
   service: "Usage Discount",
   provider: "GCP",
   policy_set: "Rightsize Database Instances",
-  recommendation_type: "Usage Reduction"
+  recommendation_type: "Usage Reduction",
+  publish: "false"
 )
 
 ##################

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/aws/turbonomics_rightsize_virtual_volumes_recommendations.pt
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/aws/turbonomics_rightsize_virtual_volumes_recommendations.pt
@@ -11,7 +11,8 @@ info(
   service: "Usage Discount",
   provider: "AWS",
   policy_set: "Rightsize Volumes",
-  recommendation_type: "Usage Reduction"
+  recommendation_type: "Usage Reduction",
+  publish: "false"
 )
 
 ##################

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/azure/turbonomics_rightsize_virtual_volumes_recommendations.pt
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/azure/turbonomics_rightsize_virtual_volumes_recommendations.pt
@@ -11,7 +11,8 @@ info(
   service: "Usage Discount",
   provider: "Azure",
   policy_set: "Rightsize Volumes",
-  recommendation_type: "Usage Reduction"
+  recommendation_type: "Usage Reduction",
+  publish: "false"
 )
 
 ##################

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/gcp/turbonomics_rightsize_virtual_volumes_recommendations.pt
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/gcp/turbonomics_rightsize_virtual_volumes_recommendations.pt
@@ -11,7 +11,8 @@ info(
   service: "Usage Discount",
   provider: "GCP",
   policy_set: "Rightsize Volumes",
-  recommendation_type: "Usage Reduction"
+  recommendation_type: "Usage Reduction",
+  publish: "false"
 )
 
 ##################


### PR DESCRIPTION
### Description

Currently this two policies are published on Automation Catalog:

_cost/turbonomics/rightsize_databases_recommendations/*/turbonomics_rightsize_databases_recommendations.pt_

_cost/turbonomics/rightsize_virtual_volumes_recommendations/*/turbonomics_rightsize_virtual_volumes_recommendations.pt_

This isn't the expected behavior, so we added `publish: false` on info block to prevent it.

### Issues Resolved

Undesired policies published on Automation Catalog.

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
