### PR TITLE
FOPTS-228 Added a filter at instances for free SQL Developer & Express versions in Azure VM

### DIFF
--- a/cost/azure/hybrid_use_benefit_sql/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit_sql/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.8
+
+- Added a filter to exclude SQL Server 2017 Developer and Express versions instances that Microsoft provides as free
+
 ## v2.7
 
 - Replaced the term **whitelist** with **allowed list**.

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql.pt
@@ -259,7 +259,6 @@ script "js_filtered_instances", type: "javascript" do
           } else {
               ahub = "No"
             }
-
           result.push({
             subscriptionName: virtualmachine["subscriptionName"],
             id: virtualmachine["id"],

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql.pt
@@ -240,41 +240,38 @@ script "js_filtered_instances", type: "javascript" do
   parameters "sql_virtualmachines", "sql_databases", "sql_managed_instances", "exclusion_tag"
   result "result"
   code <<-EOS
-    var result = [];
+  var result = [];
+  sql_virtualmachines = _.find(sql_virtualmachines, function(vm){ return vm.imageSku != "Developer" && vm.imageSku != "Express" });
 
     //SQL Virtualmachines
-    _.each(sql_virtualmachines, function(virtualmachine, index){
-      if ((virtualmachine.imageSku === "Developer" || virtualmachine.imageSku === "Express") && virtualmachine.imageOffer.split("-")[0] === "SQL2017"){
-          sql_virtualmachines.splice(index,1,virtualmachine)
-        }
-    })
-    _.each(sql_virtualmachines, function(virtualmachine){
-      if (_.has(virtualmachine.tags, exclusion_tag)) {
-      } else {
-          var resourceGroup = virtualmachine.id.split('/')[4];
-          var tags = JSON.stringify(virtualmachine["tags"]);
-          var ahub = "N/A"
-          if (virtualmachine.licenseType === "AHUB") {
-            ahub = "Yes"
-          } else {
-              ahub = "No"
-            }
-          result.push({
-            subscriptionName: virtualmachine["subscriptionName"],
-            id: virtualmachine["id"],
-            vmid: virtualmachine["vmid"],
-            name: virtualmachine["name"],
-            resourceGroup: resourceGroup,
-            location: virtualmachine["location"],
-            ahub: ahub,
-            type: virtualmachine["type"],
-            imageOffer: virtualmachine["imageOffer"],
-            imageSku: virtualmachine["imageSku"]
-            licenseType: virtualmachine["licenseType"],
-            tags: tags
-          })
-        }
-    })
+      _.each(sql_virtualmachines, function(virtualmachine){
+        if (_.has(virtualmachine.tags, exclusion_tag)) {
+        } else {
+            var resourceGroup = virtualmachine.id.split('/')[4];
+            var tags = JSON.stringify(virtualmachine["tags"]);
+            var ahub = "N/A"
+            if (virtualmachine.licenseType === "AHUB") {
+                ahub = "Yes"
+              } else {
+                ahub = "No"
+              }
+
+            result.push({
+              subscriptionName: virtualmachine["subscriptionName"],
+              id: virtualmachine["id"],
+              vmid: virtualmachine["vmid"],
+              name: virtualmachine["name"],
+              resourceGroup: resourceGroup,
+              location: virtualmachine["location"],
+              ahub: ahub,
+              type: virtualmachine["type"],
+              imageOffer: virtualmachine["imageOffer"],
+              imageSku: virtualmachine["imageSku"]
+              licenseType: virtualmachine["licenseType"],
+              tags: tags
+            })
+          }
+      })
 
     //SQL databases
     _.each(sql_databases, function(database){

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql.pt
@@ -241,7 +241,14 @@ script "js_filtered_instances", type: "javascript" do
   result "result"
   code <<-EOS
   var result = [];
+
     //SQL Virtualmachines
+    console.log(sql_virtualmachines.length)
+    _.each(sql_virtualmachines, function(virtualmachine, index){
+      if (virtualmachine.imageSku === 'Developer' && virtualmachine.imageOffer.split("-")[0] === "SQL2017"){
+          sql_virtualmachines.splice(index,1)
+        }
+    })
       _.each(sql_virtualmachines, function(virtualmachine){
         if (_.has(virtualmachine.tags, exclusion_tag)) {
         } else {

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.7",
+  version: "2.8",
   provider: "Azure",
   service: "compute",
   policy_set: ""
@@ -240,43 +240,42 @@ script "js_filtered_instances", type: "javascript" do
   parameters "sql_virtualmachines", "sql_databases", "sql_managed_instances", "exclusion_tag"
   result "result"
   code <<-EOS
-  var result = [];
+    var result = [];
 
     //SQL Virtualmachines
-    console.log(sql_virtualmachines.length)
     _.each(sql_virtualmachines, function(virtualmachine, index){
-      if (virtualmachine.imageSku === 'Developer' && virtualmachine.imageOffer.split("-")[0] === "SQL2017"){
-          sql_virtualmachines.splice(index,1)
+      if ((virtualmachine.imageSku === "Developer" || virtualmachine.imageSku === "Express") && virtualmachine.imageOffer.split("-")[0] === "SQL2017"){
+          sql_virtualmachines.splice(index,1,virtualmachine)
         }
     })
-      _.each(sql_virtualmachines, function(virtualmachine){
-        if (_.has(virtualmachine.tags, exclusion_tag)) {
-        } else {
-            var resourceGroup = virtualmachine.id.split('/')[4];
-            var tags = JSON.stringify(virtualmachine["tags"]);
-            var ahub = "N/A"
-            if (virtualmachine.licenseType === "AHUB") {
-                ahub = "Yes"
-              } else {
-                ahub = "No"
-              }
+    _.each(sql_virtualmachines, function(virtualmachine){
+      if (_.has(virtualmachine.tags, exclusion_tag)) {
+      } else {
+          var resourceGroup = virtualmachine.id.split('/')[4];
+          var tags = JSON.stringify(virtualmachine["tags"]);
+          var ahub = "N/A"
+          if (virtualmachine.licenseType === "AHUB") {
+            ahub = "Yes"
+          } else {
+              ahub = "No"
+            }
 
-            result.push({
-              subscriptionName: virtualmachine["subscriptionName"],
-              id: virtualmachine["id"],
-              vmid: virtualmachine["vmid"],
-              name: virtualmachine["name"],
-              resourceGroup: resourceGroup,
-              location: virtualmachine["location"],
-              ahub: ahub,
-              type: virtualmachine["type"],
-              imageOffer: virtualmachine["imageOffer"],
-              imageSku: virtualmachine["imageSku"]
-              licenseType: virtualmachine["licenseType"],
-              tags: tags
-            })
-          }
-      })
+          result.push({
+            subscriptionName: virtualmachine["subscriptionName"],
+            id: virtualmachine["id"],
+            vmid: virtualmachine["vmid"],
+            name: virtualmachine["name"],
+            resourceGroup: resourceGroup,
+            location: virtualmachine["location"],
+            ahub: ahub,
+            type: virtualmachine["type"],
+            imageOffer: virtualmachine["imageOffer"],
+            imageSku: virtualmachine["imageSku"]
+            licenseType: virtualmachine["licenseType"],
+            tags: tags
+          })
+        }
+    })
 
     //SQL databases
     _.each(sql_databases, function(database){

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql.pt
@@ -241,7 +241,7 @@ script "js_filtered_instances", type: "javascript" do
   result "result"
   code <<-EOS
   var result = [];
-  sql_virtualmachines = _.find(sql_virtualmachines, function(vm){ return vm.imageSku != "Developer" && vm.imageSku != "Express" });
+  sql_virtualmachines = _.filter(sql_virtualmachines, function(vm){ return vm.imageSku != "Developer" && vm.imageSku != "Express" });
 
     //SQL Virtualmachines
       _.each(sql_virtualmachines, function(virtualmachine){

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql.pt
@@ -241,6 +241,7 @@ script "js_filtered_instances", type: "javascript" do
   result "result"
   code <<-EOS
   var result = [];
+  // Filter to exclude SQL Server 2017 Developer and Express versions instances that Microsoft provides as free
   sql_virtualmachines = _.filter(sql_virtualmachines, function(vm){ return vm.imageSku != "Developer" && vm.imageSku != "Express" });
 
     //SQL Virtualmachines


### PR DESCRIPTION
### Description

Added a filter to exclude SQL Developer & Express Server Edition instances that Microsoft Azure Virtual Machines provides as free

### Issues Resolved

Costs were being added for virtual machines that are currently free by the provider, a filter was made on those instances to exclude them from the benefits for the client

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
