### PR TITLE
Size tier list for Azure DBforMySQL flexible servers

### DIFF
--- a/data/azure/mysql_flexible_tier_types.json
+++ b/data/azure/mysql_flexible_tier_types.json
@@ -37,7 +37,7 @@
       "down": "16"
     }
   },
-  "General Purpose": {
+  "GeneralPurpose": {
     "Standard_D2ads_v5": {
       "up": "4",
       "down": null

--- a/data/azure/mysql_flexible_tier_types.json
+++ b/data/azure/mysql_flexible_tier_types.json
@@ -1,0 +1,192 @@
+{
+  "Burstable": {
+    "Standard_B1s": {
+      "up": "1",
+      "down": null
+    },
+    "Standard_B1ms": {
+      "up": "2",
+      "down": "1"
+    },
+    "Standard_B2s": {
+      "up": "2",
+      "down": "1"
+    },
+    "Standard_B2ms": {
+      "up": "4",
+      "down": "2"
+    },
+    "Standard_B4ms": {
+      "up": "8",
+      "down": "2"
+    },
+    "Standard_B8ms": {
+      "up": "12",
+      "down": "4"
+    },
+    "Standard_B12ms": {
+      "up": "16",
+      "down": "8"
+    },
+    "Standard_B16ms": {
+      "up": "20",
+      "down": "12"
+    },
+    "Standard_B20ms": {
+      "up": null,
+      "down": "16"
+    }
+  },
+  "General Purpose": {
+    "Standard_D2ads_v5": {
+      "up": "4",
+      "down": null
+    },
+    "Standard_D2ds_v4": {
+      "up": "4",
+      "down": null
+    },
+    "Standard_D4ads_v5": {
+      "up": "8",
+      "down": "2"
+    },
+    "Standard_D4ds_v4": {
+      "up": "8",
+      "down": "2"
+    },
+    "Standard_D8ads_v5": {
+      "up": "16",
+      "down": "4"
+    },
+    "Standard_D8ds_v4": {
+      "up": "16",
+      "down": "4"
+    },
+    "Standard_D16ads_v5": {
+      "up": "32",
+      "down": "8"
+    },
+    "Standard_D16ds_v4": {
+      "up": "32",
+      "down": "8"
+    },
+    "Standard_D32ads_v5": {
+      "up": "48",
+      "down": "16"
+    },
+    "Standard_D32ds_v4": {
+      "up": "48",
+      "down": "16"
+    },
+    "Standard_D48ads_v5": {
+      "up": "64",
+      "down": "32"
+    },
+    "Standard_D48ds_v4": {
+      "up": "64",
+      "down": "32"
+    },
+    "Standard_D64ads_v5": {
+      "up": null,
+      "down": "48"
+    },
+    "Standard_D64ds_v4": {
+      "up": null,
+      "down": "48"
+    }
+  },
+  "MemoryOptimized": {
+    "Standard_E2ds_v4": {
+      "up": "4",
+      "down": null
+    },
+    "Standard_E2ads_v5": {
+      "up": "4",
+      "down": null
+    },
+    "Standard_E4ds_v4": {
+      "up": "8",
+      "down": "2"
+    },
+    "Standard_E4ads_v5": {
+      "up": "8",
+      "down": "2"
+    },
+    "Standard_E8ds_v4": {
+      "up": "16",
+      "down": "4"
+    },
+    "Standard_E8ads_v5": {
+      "up": "16",
+      "down": "4"
+    },
+    "Standard_E16ds_v4": {
+      "up": "32",
+      "down": "8"
+    },
+    "Standard_E16ads_v5": {
+      "up": "32",
+      "down": "8"
+    },
+    "Standard_E32ds_v4": {
+      "up": "48",
+      "down": "16"
+    },
+    "Standard_E32ads_v5": {
+      "up": "48",
+      "down": "16"
+    },
+    "Standard_E48ds_v4": {
+      "up": "64",
+      "down": "32"
+    },
+    "Standard_E48ads_v5": {
+      "up": "64",
+      "down": "32"
+    },
+    "Standard_E64ds_v4": {
+      "up": "80",
+      "down": "48"
+    },
+    "Standard_E64ads_v5": {
+      "up": "80",
+      "down": "48"
+    },
+    "Standard_E80ids_v4": {
+      "up": null,
+      "down": "64"
+    },
+    "Standard_E2ds_v5": {
+      "up": "4",
+      "down": null
+    },
+    "Standard_E4ds_v5": {
+      "up": "8",
+      "down": "2"
+    },
+    "Standard_E8ds_v5": {
+      "up": "16",
+      "down": "4"
+    },
+    "Standard_E16ds_v5": {
+      "up": "32",
+      "down": "8"
+    },
+    "Standard_E32ds_v5": {
+      "up": "48",
+      "down": "16"
+    },
+    "Standard_E48ds_v5": {
+      "up": "64",
+      "down": "32"
+    },
+    "Standard_E64ds_v5": {
+      "up": "96",
+      "down": "48"
+    },
+    "Standard_E96ds_v5": {
+      "up": null,
+      "down": "64"
+    }
+  }
+}


### PR DESCRIPTION
This is a size tier list for Azure DBforMySQL flexible servers. The data was taken from this website:

https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-service-tiers-storage

I then used ChatGPT to paste the data from the site and have it rearranged in the proper format.

Further research will be needed to figure out how to automate this since "use ChatGPT" isn't really repeatable without manual intervention.

(Note: The already-existing sql_service_tier_types.json can be used for Azure DBforMySQL single servers)