### PR TITLE
SQ-1555 Fixed the comparisons made to match the instance cost with the utilization

### DIFF
--- a/cost/azure/unused_sql_databases/CHANGELOG.md
+++ b/cost/azure/unused_sql_databases/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.4
+
+- Fixed the comparison made to match the instance's costs with the instance's usage; this caused some instances not to show savings, although they were added to the incident.
+
 ## v4.3
 
 - Raised API limit to handle situations where more than 10,000 line items need to be retrieved.

--- a/cost/azure/unused_sql_databases/azure_unused_sql_databases.pt
+++ b/cost/azure/unused_sql_databases/azure_unused_sql_databases.pt
@@ -7,11 +7,11 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "4.3",
+  version: "4.4",
   provider: "Azure",
   service: "SQL",
   policy_set: "Unused Database Services"
-  )
+)
 
 ###############################################################################
 # Parameters
@@ -469,10 +469,10 @@ script "js_instance_cost_mapping", type:"javascript" do
       // Put costs into a map by resource ID and only include them for resource IDs we actually need
       var costs_by_resource_id = {};
       _.each(instance_list, function(instance) {
-        costs_by_resource_id[instance.resourceID] = [];
+        costs_by_resource_id[instance.resourceID.toLowerCase()] = [];
       });
       _.each(instance_costs, function(cost) {
-        var costs = costs_by_resource_id[cost.resource_id];
+        var costs = costs_by_resource_id[cost.resource_id.toLowerCase()];
         if (costs != null) {
           costs.push(cost);
         }
@@ -496,7 +496,7 @@ script "js_instance_cost_mapping", type:"javascript" do
       }
       var total_savings=0;
       _.each(instance_list, function(instance){
-        var cost_objects = costs_by_resource_id[instance.resourceID];
+        var cost_objects = costs_by_resource_id[instance.resourceID.toLowerCase()];
         if (_.size(cost_objects) > 0){
           count++;
           var sum = _.reduce(_.compact(_.map(cost_objects, function(value){return value.cost_nonamortized_unblended_adj})), function(memo, num){ return memo + num; }, 0);


### PR DESCRIPTION
Fixed the comparison made to match the instance's costs with the instance's usage; this caused some instances not to show savings, although they were added to the incident.

### Description

Fixed the comparison made to match the instance's costs with the instance's usage; this caused some instances not to show savings, although they were added to the incident.

### Issues Resolved

Previously, policy was not showing the correct savings since it was not matching the instance utilization with the instance costs.

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD

All the screenshots and demonstrations are included in: https://flexera.atlassian.net/browse/SQ-1555