### PR TITLE
Add Child Policy Code to AWS Object Storage Optimization Policy

### DIFF
--- a/cost/aws/object_storage_optimization/CHANGELOG.md
+++ b/cost/aws/object_storage_optimization/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v2.10
+## v3.0
 
 - Added logic required for "Meta Policy" use-cases
 

--- a/cost/aws/object_storage_optimization/CHANGELOG.md
+++ b/cost/aws/object_storage_optimization/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v3.0
+## v2.10
 
 - Added logic required for "Meta Policy" use-cases
 

--- a/cost/aws/object_storage_optimization/CHANGELOG.md
+++ b/cost/aws/object_storage_optimization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.0
+
+- Added logic required for "Meta Policy" use-cases
+
 ## v2.9
 
 - Modified `sys_log` definition to disable `rs_cm.audit_entry.create` outside Flexera NAM

--- a/cost/aws/object_storage_optimization/README.md
+++ b/cost/aws/object_storage_optimization/README.md
@@ -25,7 +25,44 @@ For example if a user selects the "Update S3 Object Class" action while applying
 
 ## Prerequisites
 
-This policy uses [credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for connecting to the cloud -- in order to apply this policy you must have a credential registered in the system that is compatible with this policy. If there are no credentials listed when you apply the policy, please contact your cloud admin and ask them to register a credential that is compatible with this policy. The information below should be consulted when creating the credential.
+This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).
+
+- [**AWS Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1121575) (*provider=aws*) which has the following permissions:
+  - `s3:ListAllMyBuckets`
+  - `s3:GetBucketLocation`
+  - `s3:ListBucket`
+  - `s3:GetObject`
+  - `s3:GetObjectTagging`
+  - `s3:PutObject`
+  - `s3:DeleteObject`
+
+  Example IAM Permission Policy:
+
+  ```json
+  {
+    "Version": "2006-03-01",
+    "Statement":[
+      {
+        "Effect":"Allow",
+        "Action":[
+          "s3:ListAllMyBuckets",
+          "s3:GetBucketLocation",
+          "s3:ListBucket",
+          "s3:GetObject",
+          "s3:GetObjectTagging",
+          "s3:PutObject",
+          "s3:DeleteObject"
+        ],
+        "Resource":"*"
+      }
+    ]
+  }
+  ```
+
+- [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
+  - `billing_center_viewer`
+
+The [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) page in the docs has detailed instructions for setting up Credentials for the most common providers.
 
 ### Credential configuration
 

--- a/cost/aws/object_storage_optimization/README.md
+++ b/cost/aws/object_storage_optimization/README.md
@@ -64,37 +64,6 @@ This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Auto
 
 The [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) page in the docs has detailed instructions for setting up Credentials for the most common providers.
 
-### Credential configuration
-
-For administrators [creating and managing credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) to use with this policy, the following information is needed:
-
-Provider tag value to match this policy: `aws`
-
-Required permissions in the provider:
-
-```json
-{
-  "Version": "2006-03-01",
-  "Statement":[
-    {
-      "Effect":"Allow",
-      "Action":[
-        "s3:ListAllMyBuckets",
-        "s3:GetBucketLocation",
-        "s3:ListBucket",
-        "s3:GetObject",
-        "s3:GetObjectTagging",
-        "s3:PutObject",
-        "s3:DeleteObject"
-      ],
-      "Resource":"*"
-    }
-  ]
-}
-```
-
-Note: To get the list and modify S3-objects present in the S3 bucket, user must have READ and Write access to the bucket.
-
 ## Supported Clouds
 
 - AWS

--- a/cost/aws/object_storage_optimization/README.md
+++ b/cost/aws/object_storage_optimization/README.md
@@ -59,7 +59,7 @@ This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Auto
   }
   ```
 
-- [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
+- [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1141082) (*provider=flexera*) which has the following roles:
   - `billing_center_viewer`
 
 The [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) page in the docs has detailed instructions for setting up Credentials for the most common providers.

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.10",
+  version: "3.0",
   provider: "AWS",
   service: "S3",
   policy_set: "Object Store Optimization"

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "3.0",
+  version: "2.10",
   provider: "AWS",
   service: "S3",
   policy_set: "Object Store Optimization"

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
@@ -93,6 +93,25 @@ end
 # Datasources
 ###############################################################################
 
+#https://docs.aws.amazon.com/AmazonS3/latest/API/RESTServiceGET.html
+datasource "ds_aws_buckets" do
+  request do
+    auth $auth_aws
+    host "s3.amazonaws.com"
+    path "/"
+    # Header X-Meta-Flexera has no affect on datasource query, but is required for Meta Policies
+    # Forces `ds_is_deleted` datasource to run first during policy execution
+    header "Meta-Flexera", val($ds_is_deleted, "path")
+  end
+  result do
+    encoding "xml"
+    collect xpath(response, "//ListAllMyBucketsResult/Buckets/Bucket", "array") do
+      field "bucket_name", xpath(col_item,"Name")
+      field "bucket_creation_date", xpath(col_item, "CreationDate")
+    end
+  end
+end
+
 datasource "ds_get_caller_identity" do
   request do
     auth $auth_aws
@@ -107,22 +126,6 @@ datasource "ds_get_caller_identity" do
     encoding "xml"
     collect xpath(response, "//GetCallerIdentityResponse/GetCallerIdentityResult") do
       field "account",xpath(col_item, "Account")
-    end
-  end
-end
-
-#https://docs.aws.amazon.com/AmazonS3/latest/API/RESTServiceGET.html
-datasource "ds_aws_buckets" do
-  request do
-    auth $auth_aws
-    host "s3.amazonaws.com"
-    path "/"
-  end
-  result do
-    encoding "xml"
-    collect xpath(response, "//ListAllMyBucketsResult/Buckets/Bucket", "array") do
-      field "bucket_name", xpath(col_item,"Name")
-      field "bucket_creation_date", xpath(col_item, "CreationDate")
     end
   end
 end
@@ -332,7 +335,7 @@ policy "policy_s3_object_list" do
     escalate $esc_report_s3_Objects_list
     escalate $esc_modify_s3_object_storage_class_approval
     escalate $esc_delete_s3_objects_approval
-    check eq(size(data),0)
+    check logic_or($ds_parent_policy_terminated, eq(size(data), 0))
     export do
       resource_level true
       field "accountId" do

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.9",
+  version: "3.0",
   provider: "AWS",
   service: "S3",
   policy_set: "Object Store Optimization"
@@ -488,4 +488,96 @@ define url_encode($string) return $encoded_string do
   $encoded_string = gsub($encoded_string, "@", "%40")
   $encoded_string = gsub($encoded_string, "[", "%5B")
   $encoded_string = gsub($encoded_string, "]", "%5D")
+end
+
+
+###############################################################################
+# Meta Policy [alpha]
+# Not intended to be modified or used by policy developers
+###############################################################################
+
+# If the meta_parent_policy_id is not set it will evaluate to an empty string and we will look for the policy itself,
+# if it is set we will look for the parent policy.
+datasource "ds_get_policy" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    ignore_status [404]
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", switch(ne(meta_parent_policy_id,""), meta_parent_policy_id, policy_id) ])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+  end
+end
+
+
+datasource "ds_parent_policy_terminated" do
+  run_script $js_decide_if_self_terminate, $ds_get_policy, policy_id, meta_parent_policy_id
+end
+
+# If the policy was applied by a meta_parent_policy we confirm it exists if it doesn't we confirm we are deleting
+# This information is used in two places:
+# - determining whether or not we make a delete call
+# - determining if we should create an incident (we don't want to create an incident on the run where we terminate)
+script "js_decide_if_self_terminate", type: "javascript" do
+  parameters "found", "self_policy_id", "meta_parent_policy_id"
+  result "result"
+  code <<-EOS
+  var result
+  if (meta_parent_policy_id != "" && found.id == undefined) {
+    result = true
+  } else {
+    result = false
+  }
+  EOS
+end
+
+# Two potentials ways to set this up:
+# - this way and make a unneeded 'get' request when not deleting
+# - make the delete request an interate and have it iterate over an empty array when not deleting and an array with one item when deleting
+script "js_make_terminate_request", type: "javascript" do
+  parameters "should_delete", "policy_id", "rs_project_id", "rs_governance_host"
+  result "request"
+  code <<-EOS
+
+  var request = {
+    auth:  'auth_flexera',
+    host: rs_governance_host,
+    path: "/api/governance/projects/" + rs_project_id + "/applied_policies/" + policy_id,
+    headers: {
+      "API-Version": "1.0",
+      "Content-Type":"application/json"
+    },
+  }
+
+  if (should_delete) {
+    request.verb = 'DELETE'
+  }
+  EOS
+end
+
+datasource "ds_terminate_self" do
+  request do
+    run_script $js_make_terminate_request, $ds_parent_policy_terminated, policy_id, rs_project_id, rs_governance_host
+  end
+end
+
+datasource "ds_is_deleted" do
+  run_script $js_check_deleted, $ds_terminate_self
+end
+
+# This is just a way to have the check delete request connect to the farthest leaf from policy.
+# We want the delete check to the first thing the policy does to avoid the policy erroring before it can decide whether or not it needs to self terminate
+# Example a customer deletes a credential and then terminates the parent policy. We still want the children to self terminate
+# The only way I could see this not happening is if the user who applied the parent_meta_policy was offboarded or lost policy access, the policies who are impersonating the user
+# would not have access to self-terminate
+# It may be useful for the backend to enable a mass terminate at some point for all meta_child_policies associated with an id.
+script "js_check_deleted", type: "javascript" do
+  parameters "response"
+  result "result"
+  code <<-EOS
+  result = {"path":"/"}
+  EOS
 end

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
@@ -69,6 +69,13 @@ credentials "auth_aws" do
   aws_account_number $param_aws_account_number
 end
 
+credentials "auth_flexera" do
+  schemes "oauth2"
+  label "flexera"
+  description "Select Flexera One OAuth2 credentials"
+  tags "provider=flexera"
+end
+
 ###############################################################################
 # Pagination
 ###############################################################################


### PR DESCRIPTION
This just adds the additional code needed for this policy to work as a child policy.

Functionality as a regular policy is unchanged apart from the addition of a Flexera credential, since this is needed for the child policy functionality but was not present in the original policy.

The version is also bumped from 2.9 to 3.0, so even if the above is considered a "breaking change" (I imagine most customers have a Flexera credential at this point), the major version number also changed.