### PR TITLE
Azure Rightsize Compute Instances Fix

### DIFF
--- a/cost/azure/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.5
+
+- Fixed issue causing resources to be reported as both underutilized and idle instead of one or the other.
+
 ## v1.4
 
 - Fixed check for underutilized compute instances

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -646,7 +646,7 @@ EOS
     detail_template <<-EOS
 {{ with index data 0 }}{{ .summaryData.idleMessage }}{{ end }}
 EOS
-    check gt(to_n(val(item,"averageCPU")), $param_cpu_idle_avg_percentage)
+    check logic_not(lt(to_n(val(item,"averageCPU")), $param_cpu_idle_avg_percentage))
     escalate $email
     escalate $esc_downsize_instances
     escalate $esc_terminate_instances

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "1.4",
+  version: "1.5",
   provider: "Azure",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -574,7 +574,7 @@ policy "policy_azure_rightsizing_data" do
     detail_template <<-EOS
     {{ with index data 0 }}{{ .summaryData.underutilMessage }}{{ end }}
         EOS
-    check gt(to_n(val(item,"averageCPU")), $param_cpu_underutil_avg_percentage)
+    check logic_and(gt(to_n(val(item,"averageCPU")), $param_cpu_underutil_avg_percentage), le(to_n(val(item,"averageCPU")), $param_cpu_idle_avg_percentage))
     escalate $email
     escalate $esc_downsize_instances
     export do

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -574,7 +574,7 @@ policy "policy_azure_rightsizing_data" do
     detail_template <<-EOS
     {{ with index data 0 }}{{ .summaryData.underutilMessage }}{{ end }}
         EOS
-    check logic_and(gt(to_n(val(item,"averageCPU")), $param_cpu_underutil_avg_percentage), le(to_n(val(item,"averageCPU")), $param_cpu_idle_avg_percentage))
+    check logic_not(logic_and(lt(to_n(val(item,"averageCPU")), $param_cpu_underutil_avg_percentage), ge(to_n(val(item,"averageCPU")), $param_cpu_idle_avg_percentage)))
     escalate $email
     escalate $esc_downsize_instances
     export do


### PR DESCRIPTION
This policy was incorrectly including idle resources in both the idle incident and the underutilized incident.

I have adjusted the check statement for each incident to fix this and ensure that the policy does not have duplicate resources in both incidents, and to ensure it functions identically to what the README says it does.