### PR TITLE
Fix for AWS Tag Cardinality

### DIFF
--- a/operational/aws/tag_cardinality/CHANGELOG.md
+++ b/operational/aws/tag_cardinality/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2
+
+- fixed issue with inconsistent cardinality results
+
 ## v2.1
 
 - policy now reports cardinality proper instead of tag values directly

--- a/operational/aws/tag_cardinality/aws_tag_cardinality.pt
+++ b/operational/aws/tag_cardinality/aws_tag_cardinality.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "2.1",
+  version: "2.2",
   provider: "AWS",
   service: "Tags",
   policy_set: "Tag Cardinality"
@@ -149,11 +149,11 @@ datasource "ds_aws_resources_sorted" do
 end
 
 datasource "ds_aws_accounts_tag_list" do
-  run_script $js_tag_lister, $ds_aws_accounts, "Account"
+  run_script $js_tag_lister, $ds_aws_accounts_sorted, "Account"
 end
 
 datasource "ds_aws_resources_tag_list" do
-  run_script $js_tag_lister, $ds_aws_resources, "Resource"
+  run_script $js_tag_lister, $ds_aws_resources_sorted, "Resource"
 end
 
 datasource "ds_tag_report" do


### PR DESCRIPTION
Fixes an issue causing the AWS Tag Cardinality to sometimes not work correctly.

For more information on why this error, which should have caused it to NEVER work correctly, only causes it to randomly sometimes not work correctly, hit me up because it is very strange.