### PR TITLE
Add List of Values to Tag Cardinality Policies

### DIFF
--- a/operational/aws/tag_cardinality/CHANGELOG.md
+++ b/operational/aws/tag_cardinality/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.3
+
+- A list of the unique tag values is now included as a column in the incident
+
 ## v2.2
 
 - fixed issue with inconsistent cardinality results

--- a/operational/aws/tag_cardinality/README.md
+++ b/operational/aws/tag_cardinality/README.md
@@ -2,7 +2,7 @@
 
 ## What it does
 
-This Policy Template is used to generate a tag cardinality (how many unique values each tag key has) report for AWS. The report includes cardinality for all tag values for both AWS Accounts and Resources.
+This Policy Template is used to generate a tag cardinality (how many unique values each tag key has) report for AWS, along with a list of those unique values for each tag key. The report includes cardinality for all tag values for both AWS Accounts and Resources.
 
 > *NOTE: This Policy Template must be appled to the **AWS Organization Master Payer** account.*
 

--- a/operational/aws/tag_cardinality/aws_tag_cardinality.pt
+++ b/operational/aws/tag_cardinality/aws_tag_cardinality.pt
@@ -208,7 +208,7 @@ script "js_tag_lister", type: "javascript" do
       'type': tag_type,
       'key': key,
       'cardinality': _.uniq(tags[key]).length,
-      'value_list': _.uniq(tags[key]).join(',')
+      'value_list': _.uniq(tags[key]).join(', ')
     })
   })
 

--- a/operational/aws/tag_cardinality/aws_tag_cardinality.pt
+++ b/operational/aws/tag_cardinality/aws_tag_cardinality.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "2.2",
+  version: "2.3",
   provider: "AWS",
   service: "Tags",
   policy_set: "Tag Cardinality"
@@ -207,7 +207,8 @@ script "js_tag_lister", type: "javascript" do
     result.push({
       'type': tag_type,
       'key': key,
-      'cardinality': _.uniq(tags[key]).length
+      'cardinality': _.uniq(tags[key]).length,
+      'value_list': _.uniq(tags[key]).join(',')
     })
   })
 
@@ -242,6 +243,9 @@ policy "pol_aws_tag_cardinality_report" do
       end
       field "cardinality" do
         label "Cardinality"
+      end
+      field "value_list" do
+        label "Unique Values"
       end
     end
   end

--- a/operational/azure/tag_cardinality/CHANGELOG.md
+++ b/operational/azure/tag_cardinality/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.3
+
+- A list of the unique tag values is now included as a column in the incident
+
 ## v2.2
 
 - policy now reports cardinality proper instead of tag values directly

--- a/operational/azure/tag_cardinality/README.md
+++ b/operational/azure/tag_cardinality/README.md
@@ -2,7 +2,7 @@
 
 ## What it does
 
-This Policy Template is used to generate a tag cardinality (how many unique values each tag key has) report for Azure. The report includes cardinality for all tag values for Azure Subscriptions, Resource Groups, and Resources.
+This Policy Template is used to generate a tag cardinality (how many unique values each tag key has) report for Azure, along with a list of those unique values for each tag key. The report includes cardinality for all tag values for Azure Subscriptions, Resource Groups, and Resources.
 
 ## Functional Details
 

--- a/operational/azure/tag_cardinality/azure_tag_cardinality.pt
+++ b/operational/azure/tag_cardinality/azure_tag_cardinality.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "2.2",
+  version: "2.3",
   provider: "Azure",
   service: "Tags",
   policy_set: "Tag Cardinality"
@@ -185,7 +185,8 @@ script "js_tag_lister", type: "javascript" do
     result.push({
       'type': tag_type,
       'key': key,
-      'cardinality': _.uniq(tags[key]).length
+      'cardinality': _.uniq(tags[key]).length,
+      'value_list': _.uniq(tags[key]).join(',')
     })
   })
 
@@ -220,6 +221,9 @@ policy "pol_azure_tag_cardinality_report" do
       end
       field "cardinality" do
         label "Cardinality"
+      end
+      field "value_list" do
+        label "Unique Values"
       end
     end
   end

--- a/operational/azure/tag_cardinality/azure_tag_cardinality.pt
+++ b/operational/azure/tag_cardinality/azure_tag_cardinality.pt
@@ -186,7 +186,7 @@ script "js_tag_lister", type: "javascript" do
       'type': tag_type,
       'key': key,
       'cardinality': _.uniq(tags[key]).length,
-      'value_list': _.uniq(tags[key]).join(',')
+      'value_list': _.uniq(tags[key]).join(', ')
     })
   })
 


### PR DESCRIPTION
### Description

This adds an additional column to the incident output to show a list of unique tag values in addition to the cardinality.

### Issues Resolved

This is a feature enhancement to accommodate some asks from the sales team.

### Link to Example Applied Policy

Applied Policy: https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=644175f8ff3f0400013d9362

Incident: https://app.flexera.com/orgs/6/automation/incidents/projects/7954?incidentId=6441784fe31cbc0001f8be32

(AWS changes are identical so they should also work)

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
