### PR TITLE
Fixed the minimum and maximum values of the incident report

### DIFF
--- a/cost/google/idle_vm_recommendations/CHANGELOG.md
+++ b/cost/google/idle_vm_recommendations/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.6
+
+- Fixed the values shown at `cpuMaximum` and `cpuMinimum`:
+
+At version 2.5 we changed the way we calculated the CPU utilization, we retrieved the average of utilization of each day and then we selected the maximum average as the maximum and the minimum average as the minimum, now we show the actual maximum and minimum of the CPU utilization thanks to a change in our GCP MQL query.
+
 ## v2.5
 
 - Modified to make this policy run faster by using aggregated GCP API endpoints.

--- a/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
+++ b/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.5",
+  version: "2.6",
   provider:"Google",
   service: "Compute",
   policy_set: "Idle Compute Instances"
@@ -138,32 +138,30 @@ datasource "ds_recommendations" do
   end
 end
 
-datasource "ds_compute_utilization" do
+datasource "ds_calculated_utilization" do
   iterate $ds_google_project
   request do
     auth $auth_google
     verb "POST"
     host "monitoring.googleapis.com"
     path join(["/v3/projects/", val(iter_item,"accountID"), "/timeSeries:query"])
-    body_field "query", "fetch gce_instance | metric 'compute.googleapis.com/instance/cpu/utilization' | within 14d | align | every 1d | group_by [instance_name, instance_id, zone], mean(value)"
+    body_field "query", "fetch gce_instance | metric compute.googleapis.com/instance/cpu/utilization | within 14d | { group_by sliding(14d), .mean ; group_by sliding(14d), .max  ; group_by sliding(14d), . min } | join"
     ignore_status [403, 404]
   end
   result do
     encoding "json"
     collect jmes_path(response, "timeSeriesData[*]") do
-      field "resourceName", jmes_path(col_item, "labelValues[0].stringValue")
-      field "resourceID", jmes_path(col_item, "labelValues[1].stringValue")
-      field "zone", jmes_path(col_item, "labelValues[2].stringValue")
-      field "accountID", val(iter_item,"accountID")
-      field "cpuPoints", jmes_path(col_item, "pointData[*].values[0].doubleValue")
-      field "accountName", val(iter_item,"accountName")
-      field "projectNumber", val(iter_item,"projectNumber")
+      field "resourceName", jmes_path(col_item, "labelValues[3].stringValue")
+      field "resourceID", jmes_path(col_item, "labelValues[2].stringValue")
+      field "zone", jmes_path(col_item, "labelValues[1].stringValue")
+      field "accountID", val(iter_item, "accountID")
+      field "accountName", val(iter_item, "accountName")
+      field "projectNumber", val(iter_item, "projectNumber")
+      field "cpuAverage", prod(jmes_path(col_item, "pointData[0].values[0].doubleValue"), 100)
+      field "cpuMaximum", prod(jmes_path(col_item, "pointData[0].values[1].doubleValue"), 100)
+      field "cpuMinimum", prod(jmes_path(col_item, "pointData[0].values[2].doubleValue"), 100)
     end
   end
-end
-
-datasource "ds_calculated_utilization" do
-  run_script $js_calculated_utilization, $ds_compute_utilization
 end
 
 datasource "ds_grouped_account_ids" do
@@ -280,52 +278,6 @@ script "js_recommender_call", type: "javascript" do
     query_strings: { alt: "json" }
   }
 EOF
-end
-
-script "js_calculated_utilization", type: "javascript" do
-  result "results"
-  parameters "ds_compute_utilization"
-  code <<-EOS
-  results = []
-  for (i = 0; i < ds_compute_utilization.length; i++) {
-    var resourceID = ds_compute_utilization[i].resourceID
-    if (resourceID === null || resourceID === undefined) {
-      // No instance id, continue
-    } else {
-      var points = ds_compute_utilization[i].cpuPoints
-      if (points === null || points === undefined) {
-        var cpuMaximum = "101"
-        var cpuAverage = "101"
-        var cpuMinimum = "101"
-      } else {
-        points = _.map(points, function(point) {
-          return point * 100
-        })
-        var cpuMaximum = parseFloat(points.reduce(function(x, y) {
-          return Math.max(x, y)
-        })).toFixed(2)
-        var cpu_sum = _.reduce(points, function(memo, num) {
-          return memo + num;
-        }, 0);
-        var cpuAverage = parseFloat(cpu_sum / points.length).toFixed(2)
-        var cpuMinimum = parseFloat(points.reduce(function(x, y) {
-          return Math.min(x, y)
-        })).toFixed(2)
-      }
-      results.push({
-        zone: ds_compute_utilization[i].zone,
-        accountID: ds_compute_utilization[i].accountID,
-        accountName: ds_compute_utilization[i].accountName,
-        projectNumber: ds_compute_utilization[i].projectNumber
-        resourceID: resourceID,
-        resourceName: ds_compute_utilization[i].resourceName
-        cpuAverage: cpuAverage,
-        cpuMaximum: cpuMaximum,
-        cpuMinimum: cpuMinimum
-      })
-    }
-  }
-EOS
 end
 
 script "js_collected_vms", type: "javascript" do


### PR DESCRIPTION
### Description

- Fixed the values shown at `cpuMaximum` and `cpuMinimum`:

At version 2.5 we changed the way we calculated the CPU utilization, we retrieved the average of utilization of each day and then we selected the maximum average as the maximum and the minimum average as the minimum, now we show the actual maximum and minimum of the CPU utilization thanks to a change in our GCP MQL query.

### Issues Resolved

- Fixed the values shown at `cpuMaximum` and `cpuMinimum`:

### Link to Example Applied Policy

https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/107982?policyId=6448959f4a6748000178a563

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
