### PR TITLE
FOPTS-717 Remove limit for the threshold parameter for Budget Alert Policy

### DIFF
--- a/cost/budget_report_alerts/CHANGELOG.md
+++ b/cost/budget_report_alerts/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v2.1
 
-- Removing the 100% limit for the threshold parameter
+- Removed the 100% limit for the threshold parameter
 
 ## v2.0
 

--- a/cost/budget_report_alerts/CHANGELOG.md
+++ b/cost/budget_report_alerts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1
+
+- Removing the 100% limit for the threshold parameter
+
 ## v2.0
 
 - initial release

--- a/cost/budget_report_alerts/README.md
+++ b/cost/budget_report_alerts/README.md
@@ -28,7 +28,7 @@ This policy has the following input parameters required when launching the polic
 - _Budget Alert Type_ - can be "Actual" or "Forecasted". Actual Spend alerts are based off incurred costs. Forecasted Spend alerts are based off monthly runrates.
 - _Degree of Summarization_ - Determines if budget should be tracked as a whole or per dimension groups, with possible values of Summarized or By dimensions.
 - _Unbudgeted spend_ - parameter that allows including or excluding unbudgeted funds in the calculation
-- _Threshold Percentage_ - Threshold to raise the alert if reach, represented by a number between 0 and 100.
+- _Threshold Percentage_ - Threshold to raise the alert if reached
 - _Email addresses_ - A list of email addresses to notify
 
 ## Cost

--- a/cost/budget_report_alerts/budget_report_alerts.pt
+++ b/cost/budget_report_alerts/budget_report_alerts.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "daily"
 
 info(
-  version: "2.0",
+  version: "2.1",
   provider: "Flexera Optima",
   service: "",
   policy_set: ""
@@ -28,7 +28,6 @@ parameter "param_threshold_percentage" do
   description "Percentage of budget amount to alert on"
   default 90
   min_value 1
-  max_value 100
 end
 
 parameter "param_type" do


### PR DESCRIPTION
### Description

Threshold currently allows up to 100%. This parameter doesn’t accept an input that is above 100% (i.e. max budget). For many customers they are comfortable with a budget over run of up to 105% or 110%. Suggestion is to allow values over 100% to be entered by the user while applying the policy

### Issues Resolved

https://flexera.atlassian.net/browse/FOPTS-717

### Link to Example Applied Policy

https://app.flexera.com/orgs/1105/automation/applied-policies/projects/105882?policyId=644a9a3a7b2db10001f85483

### Contribution Check List

- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
