### PR TITLE
FOPTS-714 Add instance types to EC2 reference file

### DIFF
--- a/data/aws/instance_types.json
+++ b/data/aws/instance_types.json
@@ -586,6 +586,105 @@
     "enhanced_networking": true,
     "vcpu": "72"
   },
+  "c6a.large": {
+    "up": "c6a.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4"
+  },
+  "c6a.xlarge": {
+    "up": "c6a.2xlarge",
+    "down": "c6a.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8"
+  },
+  "c6a.2xlarge": {
+    "up": "c6a.4xlarge",
+    "down": "c6a.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16"
+  },
+  "c6a.4xlarge": {
+    "up": "c6a.8xlarge",
+    "down": "c6a.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32"
+  },
+  "c6a.8xlarge": {
+    "up": "c6a.12xlarge",
+    "down": "c6a.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64"
+  },
+  "c6a.12xlarge": {
+    "up": "c6a.16xlarge",
+    "down": "c6a.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96"
+  },
+  "c6a.16xlarge": {
+    "up": "c6a.24xlarge",
+    "down": "c6a.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128"
+  },
+  "c6a.24xlarge": {
+    "up": "c6a.32xlarge",
+    "down": "c6a.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192"
+  },
+  "c6a.32xlarge": {
+    "up": "c6a.48xlarge",
+    "down": "c6a.24xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256"
+  },
+  "c6a.48xlarge": {
+    "up": null,
+    "down": "c6a.32xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "192",
+    "nfu": "384"
+  },
+  "c6a.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "192",
+    "nfu": "384"
+  },
   "c6g.medium": {
     "up": "c6g.large",
     "down": null,
@@ -817,6 +916,186 @@
     "enhanced_networking": true,
     "vcpu": "64",
     "nfu": "128"
+  },
+  "c6i.large": {
+    "up": "c6i.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4"
+  },
+  "c6i.xlarge": {
+    "up": "c6i.2xlarge",
+    "down": "c6i.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8"
+  },
+  "c6i.2xlarge": {
+    "up": "c6i.4xlarge",
+    "down": "c6i.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16"
+  },
+  "c6i.4xlarge": {
+    "up": "c6i.8xlarge",
+    "down": "c6i.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32"
+  },
+  "c6i.8xlarge": {
+    "up": "c6i.12xlarge",
+    "down": "c6i.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64"
+  },
+  "c6i.12xlarge": {
+    "up": "c6i.16xlarge",
+    "down": "c6i.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96"
+  },
+  "c6i.16xlarge": {
+    "up": "c6i.24xlarge",
+    "down": "c6i.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128"
+  },
+  "c6i.24xlarge": {
+    "up": "c6i.32xlarge",
+    "down": "c6i.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192"
+  },
+  "c6i.32xlarge": {
+    "up": null,
+    "down": "c6i.24xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256"
+  },
+  "c6i.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256"
+  },
+  "c6id.large": {
+    "up": "c6id.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4"
+  },
+  "c6id.xlarge": {
+    "up": "c6id.2xlarge",
+    "down": "c6id.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8"
+  },
+  "c6id.2xlarge": {
+    "up": "c6id.4xlarge",
+    "down": "c6id.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16"
+  },
+  "c6id.4xlarge": {
+    "up": "c6id.8xlarge",
+    "down": "c6id.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32"
+  },
+  "c6id.8xlarge": {
+    "up": "c6id.12xlarge",
+    "down": "c6id.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64"
+  },
+  "c6id.12xlarge": {
+    "up": "c6id.16xlarge",
+    "down": "c6id.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96"
+  },
+  "c6id.16xlarge": {
+    "up": "c6id.24xlarge",
+    "down": "c6id.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128"
+  },
+  "c6id.24xlarge": {
+    "up": "c6id.32xlarge",
+    "down": "c6id.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192"
+  },
+  "c6id.32xlarge": {
+    "up": null,
+    "down": "c6id.24xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256"
+  },
+  "c6id.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256"
   },
   "c7g.medium": {
     "up": "c7g.large",
@@ -2350,6 +2629,105 @@
     "vcpu": "96",
     "nfu": "192"
   },
+  "m6a.large": {
+    "up": "m6a.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4"
+  },
+  "m6a.xlarge": {
+    "up": "m6a.2xlarge",
+    "down": "m6a.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8"
+  },
+  "m6a.2xlarge": {
+    "up": "m6a.4xlarge",
+    "down": "m6a.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16"
+  },
+  "m6a.4xlarge": {
+    "up": "m6a.8xlarge",
+    "down": "m6a.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32"
+  },
+  "m6a.8xlarge": {
+    "up": "m6a.12xlarge",
+    "down": "m6a.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64"
+  },
+  "m6a.12xlarge": {
+    "up": "m6a.16xlarge",
+    "down": "m6a.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96"
+  },
+  "m6a.16xlarge": {
+    "up": "m6a.24xlarge",
+    "down": "m6a.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128"
+  },
+  "m6a.24xlarge": {
+    "up": "m6a.32xlarge",
+    "down": "m6a.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192"
+  },
+  "m6a.32xlarge": {
+    "up": "m6a.48xlarge",
+    "down": "m6a.24xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256"
+  },
+  "m6a.48xlarge": {
+    "up": null,
+    "down": "m6a.32xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "192",
+    "nfu": "384"
+  },
+  "m6a.metal": {
+    "up": null,
+    "down": "m6a.32xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "192",
+    "nfu": "384"
+  },
   "m6g.medium": {
     "up": "m6g.large",
     "down": null,
@@ -2525,6 +2903,186 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64"
+  },
+  "m6i.large": {
+    "up": "m6i.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4"
+  },
+  "m6i.xlarge": {
+    "up": "m6i.2xlarge",
+    "down": "m6i.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8"
+  },
+  "m6i.2xlarge": {
+    "up": "m6i.4xlarge",
+    "down": "m6i.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16"
+  },
+  "m6i.4xlarge": {
+    "up": "m6i.8xlarge",
+    "down": "m6i.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32"
+  },
+  "m6i.8xlarge": {
+    "up": "m6i.12xlarge",
+    "down": "m6i.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64"
+  },
+  "m6i.12xlarge": {
+    "up": "m6i.16xlarge",
+    "down": "m6i.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96"
+  },
+  "m6i.16xlarge": {
+    "up": "m6i.24xlarge",
+    "down": "m6i.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128"
+  },
+  "m6i.24xlarge": {
+    "up": "m6i.32xlarge",
+    "down": "m6i.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192"
+  },
+  "m6i.32xlarge": {
+    "up": null,
+    "down": "m6i.24xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256"
+  },
+  "m6i.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256"
+  },
+  "m6id.large": {
+    "up": "m6id.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4"
+  },
+  "m6id.xlarge": {
+    "up": "m6id.2xlarge",
+    "down": "m6id.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8"
+  },
+  "m6id.2xlarge": {
+    "up": "m6id.4xlarge",
+    "down": "m6id.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16"
+  },
+  "m6id.4xlarge": {
+    "up": "m6id.8xlarge",
+    "down": "m6id.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32"
+  },
+  "m6id.8xlarge": {
+    "up": "m6id.12xlarge",
+    "down": "m6id.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64"
+  },
+  "m6id.12xlarge": {
+    "up": "m6id.16xlarge",
+    "down": "m6id.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96"
+  },
+  "m6id.16xlarge": {
+    "up": "m6id.24xlarge",
+    "down": "m6id.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128"
+  },
+  "m6id.24xlarge": {
+    "up": "m6id.32xlarge",
+    "down": "m6id.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192"
+  },
+  "m6id.32xlarge": {
+    "up": null,
+    "down": "m6id.24xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256"
+  },
+  "m6id.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256"
   },
   "m5a.large": {
     "up": "m5a.xlarge",
@@ -3393,6 +3951,105 @@
     "enhanced_networking": true,
     "vcpu": "96"
   },
+  "r6a.large": {
+    "up": "r6a.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4"
+  },
+  "r6a.xlarge": {
+    "up": "r6a.2xlarge",
+    "down": "r6a.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8"
+  },
+  "r6a.2xlarge": {
+    "up": "r6a.4xlarge",
+    "down": "r6a.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16"
+  },
+  "r6a.4xlarge": {
+    "up": "r6a.8xlarge",
+    "down": "r6a.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32"
+  },
+  "r6a.8xlarge": {
+    "up": "r6a.12xlarge",
+    "down": "r6a.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64"
+  },
+  "r6a.12xlarge": {
+    "up": "r6a.16xlarge",
+    "down": "r6a.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96"
+  },
+  "r6a.16xlarge": {
+    "up": "r6a.24xlarge",
+    "down": "r6a.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128"
+  },
+  "r6a.24xlarge": {
+    "up": "r6a.32xlarge",
+    "down": "r6a.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192"
+  },
+  "r6a.32xlarge": {
+    "up": "r6a.48xlarge",
+    "down": "r6a.24xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256"
+  },
+  "r6a.48xlarge": {
+    "up": null,
+    "down": "r6a.32xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "192",
+    "nfu": "384"
+  },
+  "r6a.metal": {
+    "up": null,
+    "down": "r6a.32xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "192",
+    "nfu": "384"
+  },
   "r6g.medium": {
     "up": "r6g.large",
     "down": null,
@@ -3553,6 +4210,186 @@
     "enhanced_networking": true,
     "vcpu": "64"
   },
+  "r6i.large": {
+    "up": "r6i.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4"
+  },
+  "r6i.xlarge": {
+    "up": "r6i.2xlarge",
+    "down": "r6i.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8"
+  },
+  "r6i.2xlarge": {
+    "up": "r6i.4xlarge",
+    "down": "r6i.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16"
+  },
+  "r6i.4xlarge": {
+    "up": "r6i.8xlarge",
+    "down": "r6i.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32"
+  },
+  "r6i.8xlarge": {
+    "up": "r6i.12xlarge",
+    "down": "r6i.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64"
+  },
+  "r6i.12xlarge": {
+    "up": "r6i.16xlarge",
+    "down": "r6i.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96"
+  },
+  "r6i.16xlarge": {
+    "up": "r6i.24xlarge",
+    "down": "r6i.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128"
+  },
+  "r6i.24xlarge": {
+    "up": "r6i.32xlarge",
+    "down": "r6i.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192"
+  },
+  "r6i.32xlarge": {
+    "up": null,
+    "down": "r6i.24xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256"
+  },
+  "r6i.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256"
+  },
+  "r6id.large": {
+    "up": "r6id.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4"
+  },
+  "r6id.xlarge": {
+    "up": "r6id.2xlarge",
+    "down": "r6id.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8"
+  },
+  "r6id.2xlarge": {
+    "up": "r6id.4xlarge",
+    "down": "r6id.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16"
+  },
+  "r6id.4xlarge": {
+    "up": "r6id.8xlarge",
+    "down": "r6id.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32"
+  },
+  "r6id.8xlarge": {
+    "up": "r6id.12xlarge",
+    "down": "r6id.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64"
+  },
+  "r6id.12xlarge": {
+    "up": "r6id.16xlarge",
+    "down": "r6id.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96"
+  },
+  "r6id.16xlarge": {
+    "up": "r6id.24xlarge",
+    "down": "r6id.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128"
+  },
+  "r6id.24xlarge": {
+    "up": "r6id.32xlarge",
+    "down": "r6id.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192"
+  },
+  "r6id.32xlarge": {
+    "up": null,
+    "down": "r6id.24xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256"
+  },
+  "r6id.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256"
+  },
   "x1.16xlarge": {
     "up": "x1.32xlarge",
     "down": null,
@@ -3705,6 +4542,96 @@
     "enhanced_networking": true,
     "vcpu": "64",
     "nfu": "1024"
+  },
+  "x2idn.16xlarge": {
+    "up": "x2idn.24xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128"
+  },
+  "x2idn.24xlarge": {
+    "up": "x2idn.32xlarge",
+    "down": "x2idn.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192"
+  },
+  "x2idn.32xlarge": {
+    "up": null,
+    "down": "x2idn.24xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256"
+  },
+  "x2idn.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256"
+  },
+  "x2iezn.2xlarge": {
+    "up": "x2iezn.4xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16"
+  },
+  "x2iezn.4xlarge": {
+    "up": "x2iezn.6xlarge",
+    "down": "x2iezn.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32"
+  },
+  "x2iezn.6xlarge": {
+    "up": "x2iezn.8xlarge",
+    "down": "x2iezn.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "24",
+    "nfu": "46"
+  },
+  "x2iezn.8xlarge": {
+    "up": "x2iezn.12xlarge",
+    "down": "x2iezn.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64"
+  },
+  "x2iezn.12xlarge": {
+    "up": null,
+    "down": "x2iezn.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96"
+  },
+  "x2iezn.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96"
   },
   "z1d.large": {
     "up": "z1d.xlarge",
@@ -4299,6 +5226,42 @@
     "down": "db.t3.xlarge",
     "nfu": "16"
   },
+  "db.t4g.micro": {
+    "vcpu": "2",
+    "up": "db.t4g.small",
+    "down": null,
+    "nfu": "0.5"
+  },
+  "db.t4g.small": {
+    "vcpu": "2",
+    "up": "db.t4g.medium",
+    "down": "db.t4g.micro",
+    "nfu": "1"
+  },
+  "db.t4g.medium": {
+    "vcpu": "2",
+    "up": "db.t4g.large",
+    "down": "db.t4g.small",
+    "nfu": "2"
+  },
+  "db.t4g.large": {
+    "vcpu": "2",
+    "up": "db.t4g.xlarge",
+    "down": "db.t4g.medium",
+    "nfu": "4"
+  },
+  "db.t4g.xlarge": {
+    "vcpu": "4",
+    "up": "db.t4g.2xlarge",
+    "down": "db.t4g.large",
+    "nfu": "8"
+  },
+  "db.t4g.2xlarge": {
+    "vcpu": "8",
+    "up": null,
+    "down": "db.t4g.xlarge",
+    "nfu": "16"
+  },
   "db.m4.large": {
     "vcpu": "2",
     "up": "db.m4.xlarge",
@@ -4374,7 +5337,7 @@
   "db.m5.24xlarge": {
     "vcpu": "96",
     "up": null,
-    "down": "db.m5.12xlarge",
+    "down": "db.m5.16xlarge",
     "nfu": "192"
   },
   "db.m6g.large": {
@@ -4418,6 +5381,60 @@
     "up": null,
     "down": "db.m6g.12xlarge",
     "nfu": "128"
+  },
+  "db.m6i.large": {
+    "vcpu": "2",
+    "up": "db.m6i.xlarge",
+    "down": null,
+    "nfu": "4"
+  },
+  "db.m6i.xlarge": {
+    "vcpu": "4",
+    "up": "db.m6i.2xlarge",
+    "down": "db.m6i.large",
+    "nfu": "8"
+  },
+  "db.m6i.2xlarge": {
+    "vcpu": "8",
+    "up": "db.m6i.4xlarge",
+    "down": "db.m6i.xlarge",
+    "nfu": "16"
+  },
+  "db.m6i.4xlarge": {
+    "vcpu": "16",
+    "up": "db.m6i.8xlarge",
+    "down": "db.m6i.2xlarge",
+    "nfu": "32"
+  },
+  "db.m6i.8xlarge": {
+    "vcpu": "32",
+    "up": "db.m6i.12xlarge",
+    "down": "db.m6i.4xlarge",
+    "nfu": "64"
+  },
+  "db.m6i.12xlarge": {
+    "vcpu": "48",
+    "up": "db.m6i.16xlarge",
+    "down": "db.m6i.8xlarge",
+    "nfu": "96"
+  },
+  "db.m6i.16xlarge": {
+    "vcpu": "64",
+    "up": "db.m6i.24xlarge",
+    "down": "db.m6i.12xlarge",
+    "nfu": "128"
+  },
+  "db.m6i.24xlarge": {
+    "vcpu": "96",
+    "up": "db.m6i.32xlarge",
+    "down": "db.m6i.16xlarge",
+    "nfu": "192"
+  },
+  "db.m6i.32xlarge": {
+    "vcpu": "128",
+    "up": null,
+    "down": "db.m6i.24xlarge",
+    "nfu": "256"
   },
   "db.r6g.large": {
     "vcpu": "2",


### PR DESCRIPTION
### Description

Support for M6a was called out by generali as being missing from our rightsizing recommendations.  See attached list of all instance types in use by Generali, we ideally need to be able to provide alternatives for all of these instance types.

Details of instance types are here: https://aws.amazon.com/ec2/instance-types/

### Issues Resolved

https://flexera.atlassian.net/browse/FOPTS-714

