### PR TITLE
POL-823 OCI Bill Ingestion Fixes/Improvements

### DIFF
--- a/cost/oracle/oracle_cbi/CHANGELOG.md
+++ b/cost/oracle/oracle_cbi/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v3.0
+
+- Fixed bug that occasionally caused duplicate or missing cost data
+- Added option to run for previous month along with relevant parameter
+- Added regex to ensure that user-specified billing periods are valid
+- General code cleanup and modernization
+
 ## v2.0
 
 - initial release

--- a/cost/oracle/oracle_cbi/README.md
+++ b/cost/oracle/oracle_cbi/README.md
@@ -10,16 +10,18 @@ This Policy Template is used to automatically take Cost Reports from Oracle Clou
 - The policy then sends those reports, unmodified, into a Flexera CBI endpoint so that they can be ingested and then visible on the platform.
 - The policy does this over the course of multiple runs to avoid hitting memory and other constraints; it is recommended that the default frequency of 15 minutes be used.
 - The policy requires that a valid Oracle CBI endpoint exists, a valid Oracle Cloud credential exists in Flexera One, and that Cost & Usage Reporting is enabled in Oracle Cloud.
+- It is recommended that this policy be applied twice, with Month To Ingest set to Current Month for one instance and with it set to Previous Month for the other. This is to ensure that any changes made to Oracle billing data after the month ends are brought into the Flexera platform.
 
 ## Input Parameters
 
 This policy has the following input parameters required when launching the policy.
 
-- *Billing Period* - The year and month to process bills for in YYYY-MM format. Leave this parameter blank to always do the current month. Example: 2022-09
+- *Month To Ingest* - Whether to process bills for the current month, previous month, or a specific month.
+- *Billing Period* - The year and month to process bills for in YYYY-MM format. Only relevant if Specific Month is selected for the Month To Ingest parameter. Example: 2022-09
 - *Flexera CBI Endpoint* - The name of the Flexera CBI endpoint to use. Example: cbi-oi-oracle-oraclecloud
 - *Oracle Cloud Region* - The region of the Oracle Cloud Object Storage bucket containing the cost and usage reports. Example: us-phoenix-1
 - *Oracle Cloud Cost & Usage Bucket* - OCID of the Oracle Cloud Object Storage bucket containing the Cost and Usage reports.
-- *Block Size* - The number of files to upload with each execution of the policy. Changing from the default value of 20 is not recommended.
+- *Block Size* - The number of files to upload with each execution of the policy. The default value of 20 is recommended.
 - *Commit Delay (Hours)* - The number of hours to wait between committing bill uploads. This is to avoid overloading the CBI system and to ensure bill ingestion occurs at a predictable cadence. The default value of 12 is recommended.
 
 ## Prerequisites

--- a/cost/oracle/oracle_cbi/oracle_cbi.pt
+++ b/cost/oracle/oracle_cbi/oracle_cbi.pt
@@ -207,7 +207,7 @@ script "js_bill_upload", type: "javascript" do
     result = ds_create_bill_upload[0]
   } else {
     result = _.find(ds_existing_bill_uploads, function(upload) {
-      return upload['status'] != 'complete'
+      return upload['status'] == 'in-progress'
     })
   }
 EOS
@@ -243,7 +243,6 @@ script "js_cost_object_list_current_month", type: "javascript" do
   parameters "ds_cost_object_list", "ds_dates"
   result "result"
   code <<-EOS
-  result = []
   period = new Date(ds_dates['period'])
 
   result = _.filter(ds_cost_object_list, function(object) {

--- a/cost/oracle/oracle_cbi/oracle_cbi.pt
+++ b/cost/oracle/oracle_cbi/oracle_cbi.pt
@@ -142,6 +142,9 @@ datasource "ds_existing_bill_uploads" do
   end
 end
 
+# Branching logic:
+# This datasource contains an empty array if a bill upload is already in progress.
+# Otherwise, it contains a single item for the next datasource to iterate over.
 datasource "ds_bill_upload_check" do
   run_script $js_bill_upload_check, $ds_existing_bill_uploads
 end
@@ -150,22 +153,19 @@ script "js_bill_upload_check", type: "javascript" do
   parameters "ds_existing_bill_uploads"
   result "result"
   code <<-EOS
-  incomplete_upload_found = false
+  result = [1]
+  statuses = _.pluck(ds_existing_bill_uploads, 'status')
 
-  _.each(ds_existing_bill_uploads, function(upload) {
-    if (upload['status'] == 'in-progress') {
-      incomplete_upload_found = true
-    }
-  })
-
-  if (incomplete_upload_found) {
+  if (_.contains(statuses, 'in-progress')) {
     result = []
-  } else {
-    result = [1]
   }
 EOS
 end
 
+# Branching logic:
+# If the above datasource did not find an existing bill upload, then we iterate
+# across its single item to create a new bill upload and store information about it.
+# Otherwise, it iterates over an empty list and produces an empty list as a result.
 datasource "ds_create_bill_upload" do
   iterate $ds_bill_upload_check
   request do
@@ -190,6 +190,11 @@ datasource "ds_create_bill_upload" do
   end
 end
 
+# Branching logic:
+# This datasource looks at both the list of existing bill uploads and the above
+# datasource for creating a new bill upload and contains either the data for the
+# new bill upload, or if one was not created, the data for the existing
+# in progress bill upload.
 datasource "ds_bill_upload" do
   run_script $js_bill_upload, $ds_existing_bill_uploads, $ds_create_bill_upload
 end
@@ -198,15 +203,11 @@ script "js_bill_upload", type: "javascript" do
   parameters "ds_existing_bill_uploads", "ds_create_bill_upload"
   result "result"
   code <<-EOS
-  result = null
-
   if (ds_create_bill_upload.length != 0) {
     result = ds_create_bill_upload[0]
   } else {
-    _.each(ds_existing_bill_uploads, function(upload) {
-      if (upload['status'] != 'complete') {
-        result = upload
-      }
+    result = _.find(ds_existing_bill_uploads, function(upload) {
+      return upload['status'] != 'complete'
     })
   }
 EOS
@@ -243,14 +244,11 @@ script "js_cost_object_list_current_month", type: "javascript" do
   result "result"
   code <<-EOS
   result = []
+  period = new Date(ds_dates['period'])
 
-  _.each(ds_cost_object_list, function(object) {
-    object_month = object['timeCreated'].split('T')[0]
-    object_month = object_month.split('-')[0] + '-' + object_month.split('-')[1]
-
-    if (object_month == ds_dates['period']) {
-      result.push(object)
-    }
+  result = _.filter(ds_cost_object_list, function(object) {
+    object_date = new Date(object['timeCreated'])
+    return period.getMonth() == object_date.getMonth() && period.getYear() == object_date.getYear()
   })
 EOS
 end
@@ -272,12 +270,8 @@ script "js_cost_object_list_filtered", type: "javascript" do
   }
 
   if (bill_upload_length < ds_cost_object_list_current_month.length) {
-    start_block = bill_upload_length
     end_block = bill_upload_length + param_block_size
-
-    result = _.sortBy(ds_cost_object_list_current_month, "timeCreated").slice(start_block, end_block)
-  } else {
-    result = []
+    result = _.sortBy(ds_cost_object_list_current_month, "timeCreated").slice(bill_upload_length, end_block)
   }
 EOS
 end
@@ -327,14 +321,15 @@ script "js_upload_file", type: "javascript" do
     verb: "POST",
     host: rs_optima_host,
     path: ["/optima/orgs/", rs_org_id, "/billUploads/", ds_bill_upload['id'], '/files/', now, '_', Math.random().toString().split('.')[1], '_', ds_dates['period'], '.csv.gz'].join(''),
-    headers: {
-      "User-Agent": "RS Policies",
-    },
+    headers: { "User-Agent": "RS Policies" },
     body: oracle_cost_file
   }
 EOS
 end
 
+# Branching logic:
+# This datasource contains an empty list if we still have files to upload.
+# Otherwise, it contains the details of the bill upload so we can commit it.
 datasource "ds_commit_assess" do
   run_script $js_commit_assess, $ds_upload_file, $ds_cost_object_list_current_month, $ds_dates, $ds_bill_upload, $param_commit_delay
 end
@@ -343,6 +338,8 @@ script "js_commit_assess", type: "javascript" do
   parameters "ds_upload_file", "ds_cost_object_list_current_month", "ds_dates", "ds_bill_upload", "param_commit_delay"
   result "result"
   code <<-EOS
+  result = []
+
   if (ds_bill_upload['files'] != null && ds_bill_upload['files'] != undefined) {
     bill_upload_length = ds_bill_upload['files'].length
   } else {
@@ -359,12 +356,13 @@ script "js_commit_assess", type: "javascript" do
 
   if (bill_upload_length == ds_cost_object_list_current_month.length && time_difference >= param_commit_delay) {
     result = [ds_bill_upload]
-  } else {
-    result = []
   }
 EOS
 end
 
+# Branching logic:
+# If the above datasource returned an empty list, it means we still have files to upload
+# and this datasource won't do anything. Otherwise, we'll commit the bill upload.
 datasource "ds_commit_bill_upload" do
   iterate $ds_commit_assess
   request do
@@ -399,7 +397,7 @@ script "js_commit_bill_upload", type: "javascript" do
     headers: {
       "User-Agent": "RS Policies",
     },
-    body_fields: {"operation":"commit"}
+    body_fields: { "operation": "commit" }
   }
 EOS
 end

--- a/cost/oracle/oracle_cbi/oracle_cbi.pt
+++ b/cost/oracle/oracle_cbi/oracle_cbi.pt
@@ -261,11 +261,10 @@ script "js_cost_object_list_filtered", type: "javascript" do
   result "result"
   code <<-EOS
   result = []
+  bill_upload_length = 0
 
   if (ds_bill_upload['files'] != null && ds_bill_upload['files'] != undefined) {
     bill_upload_length = ds_bill_upload['files'].length
-  } else {
-    bill_upload_length = 0
   }
 
   if (bill_upload_length < ds_cost_object_list_current_month.length) {

--- a/cost/oracle/oracle_cbi/oracle_cbi.pt
+++ b/cost/oracle/oracle_cbi/oracle_cbi.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "15 minutes"
 info(
-  version: "2.0",
+  version: "3.0",
   provider: "Oracle",
   service: "Common Bill Ingestion",
   policy_set: "Common Bill Ingestion"
@@ -16,11 +16,20 @@ info(
 # Parameters
 ###############################################################################
 
-parameter "param_period" do
+parameter "param_billing_period" do
+  type "string"
+  label "Month To Ingest"
+  description "Month to process bills for."
+  default "Current Month"
+  allowed_values "Current Month", "Previous Month", "Specific Month"
+end
+
+parameter "param_specific_period" do
   type "string"
   label "Billing Period"
-  description "Month to process bills for in YYYY-MM format. Leave blank to do current month."
-  default ""
+  description "Billing period to process bills for in YYYY-MM format. Only relevant if Specific Month is selected for Month To Ingest."
+  default "2020-01"
+  allowed_pattern /^(19|20)\d\d-(0[1-9]|1[0-2])$/
 end
 
 parameter "param_cbi_endpoint" do
@@ -91,11 +100,33 @@ pagination "pagination_oracle" do
 end
 
 ###############################################################################
-# Datasources
+# Datasources & Scripts
 ###############################################################################
 
 datasource "ds_dates" do
-  run_script $js_dates, $param_period
+  run_script $js_dates, $param_billing_period, $param_specific_period
+end
+
+script "js_dates", type: "javascript" do
+  parameters "param_billing_period", "param_specific_period"
+  result "result"
+  code <<-EOS
+  result = { period: param_specific_period }
+
+  if (param_billing_period != 'Specific Month') {
+    date = new Date()
+    date.setDate(date.getDate() - 1)
+
+    if (param_billing_period == 'Previous Month') {
+      date.setMonth(date.getMonth() - 1)
+    }
+
+    year = date.toISOString().split('-')[0]
+    month = date.toISOString().split('-')[1]
+
+    result = { period: year + '-' + month }
+  }
+EOS
 end
 
 datasource "ds_existing_bill_uploads" do
@@ -113,6 +144,26 @@ end
 
 datasource "ds_bill_upload_check" do
   run_script $js_bill_upload_check, $ds_existing_bill_uploads
+end
+
+script "js_bill_upload_check", type: "javascript" do
+  parameters "ds_existing_bill_uploads"
+  result "result"
+  code <<-EOS
+  incomplete_upload_found = false
+
+  _.each(ds_existing_bill_uploads, function(upload) {
+    if (upload['status'] == 'in-progress') {
+      incomplete_upload_found = true
+    }
+  })
+
+  if (incomplete_upload_found) {
+    result = []
+  } else {
+    result = [1]
+  }
+EOS
 end
 
 datasource "ds_create_bill_upload" do
@@ -143,6 +194,24 @@ datasource "ds_bill_upload" do
   run_script $js_bill_upload, $ds_existing_bill_uploads, $ds_create_bill_upload
 end
 
+script "js_bill_upload", type: "javascript" do
+  parameters "ds_existing_bill_uploads", "ds_create_bill_upload"
+  result "result"
+  code <<-EOS
+  result = null
+
+  if (ds_create_bill_upload.length != 0) {
+    result = ds_create_bill_upload[0]
+  } else {
+    _.each(ds_existing_bill_uploads, function(upload) {
+      if (upload['status'] != 'complete') {
+        result = upload
+      }
+    })
+  }
+EOS
+end
+
 datasource "ds_cost_object_list" do
   request do
     auth $auth_oracle
@@ -169,8 +238,48 @@ datasource "ds_cost_object_list_current_month" do
   run_script $js_cost_object_list_current_month, $ds_cost_object_list, $ds_dates
 end
 
+script "js_cost_object_list_current_month", type: "javascript" do
+  parameters "ds_cost_object_list", "ds_dates"
+  result "result"
+  code <<-EOS
+  result = []
+
+  _.each(ds_cost_object_list, function(object) {
+    object_month = object['timeCreated'].split('T')[0]
+    object_month = object_month.split('-')[0] + '-' + object_month.split('-')[1]
+
+    if (object_month == ds_dates['period']) {
+      result.push(object)
+    }
+  })
+EOS
+end
+
 datasource "ds_cost_object_list_filtered" do
   run_script $js_cost_object_list_filtered, $ds_cost_object_list_current_month, $ds_bill_upload, $param_block_size
+end
+
+script "js_cost_object_list_filtered", type: "javascript" do
+  parameters "ds_cost_object_list_current_month", "ds_bill_upload", "param_block_size"
+  result "result"
+  code <<-EOS
+  result = []
+
+  if (ds_bill_upload['files'] != null && ds_bill_upload['files'] != undefined) {
+    bill_upload_length = ds_bill_upload['files'].length
+  } else {
+    bill_upload_length = 0
+  }
+
+  if (bill_upload_length < ds_cost_object_list_current_month.length) {
+    start_block = bill_upload_length
+    end_block = bill_upload_length + param_block_size
+
+    result = _.sortBy(ds_cost_object_list_current_month, "timeCreated").slice(start_block, end_block)
+  } else {
+    result = []
+  }
+EOS
 end
 
 datasource "ds_cost_objects" do
@@ -190,7 +299,7 @@ end
 datasource "ds_upload_file" do
   iterate $ds_cost_objects
   request do
-    run_script $js_cbi_upload_file, iter_item, rs_org_id, rs_optima_host, $ds_bill_upload, $ds_dates
+    run_script $js_upload_file, iter_item, rs_org_id, rs_optima_host, $ds_bill_upload, $ds_dates
   end
   result do
     encoding "json"
@@ -204,136 +313,8 @@ datasource "ds_upload_file" do
   end
 end
 
-datasource "ds_commit_assess" do
-  run_script $js_commit_assess, $ds_upload_file, $ds_cost_object_list_current_month, $ds_dates, $ds_bill_upload, $param_commit_delay
-end
-
-datasource "ds_commit_bill_upload" do
-  iterate $ds_commit_assess
-  request do
-    run_script $js_cbi_commit, rs_org_id, rs_optima_host, val(iter_item, 'id')
-  end
-  result do
-    encoding "json"
-    field "id", jmes_path(response, "id")
-    field "billConnectId", jmes_path(response, "billConnectId")
-    field "billingPeriod", jmes_path(response, "billingPeriod")
-    field "createdAt", jmes_path(response, "createdAt")
-    field "files", jmes_path(response, "files")
-    field "status", jmes_path(response, "status")
-    field "updatedAt", jmes_path(response, "updatedAt")
-  end
-end
-
-datasource "ds_status" do
-  run_script $js_status, $ds_create_bill_upload, $ds_commit_bill_upload, $ds_bill_upload, $ds_cost_object_list_current_month, $ds_cost_object_list_filtered, $ds_dates, $param_commit_delay
-end
-
-###############################################################################
-# Scripts
-###############################################################################
-
-script "js_dates", type: "javascript" do
-  parameters "param_period"
-  result "result"
-  code <<-EOS
-  result = {
-    period: param_period
-  }
-
-  if (param_period == '') {
-    day = new Date()
-    day.setDate(day.getDate() - 1)
-    day = day.toISOString().split('T')[0]
-    month = day.split('-')[0] + '-' + day.split('-')[1]
-
-    result = {
-      period: month
-    }
-  }
-EOS
-end
-
-script "js_bill_upload_check", type: "javascript" do
-  parameters "ds_existing_bill_uploads"
-  result "result"
-  code <<-EOS
-  incomplete_upload_found = false
-
-  _.each(ds_existing_bill_uploads, function(upload) {
-    if (upload['status'] == 'in-progress') {
-      incomplete_upload_found = true
-    }
-  })
-
-  if (incomplete_upload_found) {
-    result = []
-  } else {
-    result = [1]
-  }
-EOS
-end
-
-script "js_bill_upload", type: "javascript" do
-  parameters "ds_existing_bill_uploads", "ds_create_bill_upload"
-  result "result"
-  code <<-EOS
-  result = null
-
-  if (ds_create_bill_upload.length != 0) {
-    result = ds_create_bill_upload[0]
-  } else {
-    _.each(ds_existing_bill_uploads, function(upload) {
-      if (upload['status'] != 'complete') {
-        result = upload
-      }
-    })
-  }
-EOS
-end
-
-script "js_cost_object_list_current_month", type: "javascript" do
-  parameters "ds_cost_object_list", "ds_dates"
-  result "result"
-  code <<-EOS
-  result = []
-
-  _.each(ds_cost_object_list, function(object) {
-    object_month = object['timeModified'].split('T')[0]
-    object_month = object_month.split('-')[0] + '-' + object_month.split('-')[1]
-
-    if (object_month == ds_dates['period']) {
-      result.push(object)
-    }
-  })
-EOS
-end
-
-script "js_cost_object_list_filtered", type: "javascript" do
-  parameters "ds_cost_object_list_current_month", "ds_bill_upload", "param_block_size"
-  result "result"
-  code <<-EOS
-  result = []
-
-  if (ds_bill_upload['files'] != null && ds_bill_upload['files'] != undefined) {
-    bill_upload_length = ds_bill_upload['files'].length
-  } else {
-    bill_upload_length = 0
-  }
-
-  if (bill_upload_length < ds_cost_object_list_current_month.length) {
-    start_block = bill_upload_length
-    end_block = bill_upload_length + param_block_size
-
-    result = _.sortBy(ds_cost_object_list_current_month, "timeModified").slice(start_block, end_block)
-  } else {
-    result = []
-  }
-EOS
-end
-
-script "js_cbi_upload_file", type: "javascript" do
-  parameters "oracle_cost_file", "org_id", "optima_host", "ds_bill_upload", "ds_dates"
+script "js_upload_file", type: "javascript" do
+  parameters "oracle_cost_file", "rs_org_id", "rs_optima_host", "ds_bill_upload", "ds_dates"
   result "request"
   code <<-EOS
   // Slow down rate of requests to prevent throttling
@@ -344,14 +325,18 @@ script "js_cbi_upload_file", type: "javascript" do
   var request = {
     auth: "auth_flexera",
     verb: "POST",
-    host: optima_host,
-    path: ["/optima/orgs/", org_id, "/billUploads/", ds_bill_upload['id'], '/files/', now, '_', Math.random().toString().split('.')[1], '_', ds_dates['period'], '.csv.gz'].join(''),
+    host: rs_optima_host,
+    path: ["/optima/orgs/", rs_org_id, "/billUploads/", ds_bill_upload['id'], '/files/', now, '_', Math.random().toString().split('.')[1], '_', ds_dates['period'], '.csv.gz'].join(''),
     headers: {
       "User-Agent": "RS Policies",
     },
     body: oracle_cost_file
   }
 EOS
+end
+
+datasource "ds_commit_assess" do
+  run_script $js_commit_assess, $ds_upload_file, $ds_cost_object_list_current_month, $ds_dates, $ds_bill_upload, $param_commit_delay
 end
 
 script "js_commit_assess", type: "javascript" do
@@ -380,8 +365,25 @@ script "js_commit_assess", type: "javascript" do
 EOS
 end
 
-script "js_cbi_commit", type: "javascript" do
-  parameters "org_id", "optima_host", "bill_upload_id"
+datasource "ds_commit_bill_upload" do
+  iterate $ds_commit_assess
+  request do
+    run_script $js_commit_bill_upload, rs_org_id, rs_optima_host, val(iter_item, 'id')
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+    field "billConnectId", jmes_path(response, "billConnectId")
+    field "billingPeriod", jmes_path(response, "billingPeriod")
+    field "createdAt", jmes_path(response, "createdAt")
+    field "files", jmes_path(response, "files")
+    field "status", jmes_path(response, "status")
+    field "updatedAt", jmes_path(response, "updatedAt")
+  end
+end
+
+script "js_commit_bill_upload", type: "javascript" do
+  parameters "rs_org_id", "rs_optima_host", "bill_upload_id"
   result "request"
   code <<-EOS
   // Slow down rate of requests to prevent throttling
@@ -392,14 +394,18 @@ script "js_cbi_commit", type: "javascript" do
   var request = {
     auth: "auth_flexera",
     verb: "POST",
-    host: optima_host,
-    path: ['/optima/orgs/', org_id, '/billUploads/', bill_upload_id, '/operations'].join(''),
+    host: rs_optima_host,
+    path: ['/optima/orgs/', rs_org_id, '/billUploads/', bill_upload_id, '/operations'].join(''),
     headers: {
       "User-Agent": "RS Policies",
     },
     body_fields: {"operation":"commit"}
   }
 EOS
+end
+
+datasource "ds_status" do
+  run_script $js_status, $ds_create_bill_upload, $ds_commit_bill_upload, $ds_bill_upload, $ds_cost_object_list_current_month, $ds_cost_object_list_filtered, $ds_dates, $param_commit_delay
 end
 
 script "js_status", type: "javascript" do


### PR DESCRIPTION
### Description

This is a minor overhaul of this policy to fix bugs, improve usability, and ensure the policy follows best practices.

### Issues Resolved

- Fixed bug that occasionally caused duplicate or missing cost data. This was caused by relying on timeModified instead of timeCreated when determining which objects to send into CBI.

- Added option to run for previous month along with relevant parameter. The README was also updated to recommend that users apply the policy twice, once for the current month and once for the previous month, to ensure that any changes made to the bill after the month ends (a common thing for cloud providers) are incorporated into the platform.

- Added regex to ensure that user-specified billing periods are valid. Self-explanatory why this would be a good thing.

- General code cleanup and modernization. In particular, some code was refactored to make more effective use of underscore.js, datasources were paired with their respective scripts instead of having a distinct section in the policy for each, and comments were added to explain the branching logic of the policy.

### Link to Example Applied Policy

We do not have a shared test environment where I can link to an applied policy, but I can confirm that I have tested this new policy with a customer (Banco de Chile) and it works as expected.

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
