### PR TITLE
FOPTS-805 Fix the method used to match recommendation and resource data at GCP Recommender policies

### DIFF
--- a/cost/google/cloud_sql_idle_instance_recommendations/CHANGELOG.md
+++ b/cost/google/cloud_sql_idle_instance_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.7
+
+- Fix: Duplicated entries from incident report were removed.
+
 ## v2.6
 
 - Modified filters, previously applied in code, now those are applied in request

--- a/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations.pt
+++ b/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations.pt
@@ -376,9 +376,14 @@ script "js_sql_instances_cost_mapping", type:"javascript" do
               recommendation.costNanos = 0
             }
 
-            if (recommendation.costUnits < 0) {
+            if (!(recommendation.costUnits == null || recommendation.costUnits == undefined)) {
+              if (recommendation.costUnits != 0) {
                 recommendation.costUnits = recommendation.costUnits * -1
+              }
+            } else {
+              recommendation.costUnits = 0
             }
+
             var cost_nano = recommendation.costNanos * Math.pow(10, -9)
             var combine = Number(recommendation.costUnits) + Number(parseFloat(cost_nano))
             var monthsDuration = parseFloat(recommendation.duration.replace("s", "")) / 2628288
@@ -386,6 +391,7 @@ script "js_sql_instances_cost_mapping", type:"javascript" do
             total = total + monthlySavings
             database['savings'] = (Math.round(monthlySavings * 1000) / 1000)
             database['savingsCurrency'] = cur
+            database['description'] = recommendation['description']
             database['priority'] = recommendation['priority']
             database['primaryImpact'] = recommendation['primaryImpact']
             database['recommenderSubtype'] = recommendation['recommenderSubtype']
@@ -460,6 +466,9 @@ policy "policy_recommendations" do
       end
       field "tags" do
         label "Tags"
+      end
+      field "description" do
+        label "Description"
       end
       field "service" do
         label "Service"

--- a/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations.pt
+++ b/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations.pt
@@ -361,13 +361,13 @@ script "js_sql_instances_cost_mapping", type:"javascript" do
             count++
             if (recommendation['currency'] !== undefined) {
                 if (ds_currency_reference[recommendation['currency']] !== undefined) {
-                    var cur = ds_currency_reference[recommendation['currency']]['symbol']
+                    cur = ds_currency_reference[recommendation['currency']]['symbol']
                 } else {
-                    var cur = "$"
+                    cur = "$"
                 }
                 database['savingsCurrency'] = cur
             } else {
-                var cur = "$"
+                cur = "$"
                 var separator = ","
             }
             if (recommendation.costNanos < 0) {
@@ -450,6 +450,10 @@ policy "policy_recommendations" do
       end
       field "region" do
         label "Region"
+      end
+      field "primaryImpactCategory" do
+        label "Recommendation Primary Impact Category"
+        path "primaryImpact.category"
       end
       field "tags" do
         label "Tags"

--- a/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations.pt
+++ b/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations.pt
@@ -376,8 +376,8 @@ script "js_sql_instances_cost_mapping", type:"javascript" do
             if (recommendation.costUnits < 0) {
                 recommendation.costUnits = recommendation.costUnits * -1
             }
-            var strNano = "." + recommendation.costNanos
-            var combine = recommendation.costUnits + parseFloat(strNano)
+            var cost_nano = recommendation.costNanos * Math.pow(10, -9)
+            var combine = Number(recommendation.costUnits) + Number(parseFloat(cost_nano))
             var monthsDuration = parseFloat(recommendation.duration.replace("s", "")) / 2628288
             var monthlySavings = combine / monthsDuration
             total = total + monthlySavings

--- a/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations.pt
+++ b/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations.pt
@@ -68,7 +68,7 @@ pagination "google_pagination" do
 end
 
 ###############################################################################
-# Datasources
+# Datasources & Scripts
 ###############################################################################
 
 datasource "ds_currency_reference" do
@@ -104,79 +104,6 @@ datasource "ds_projects" do
   run_script $js_projects, $ds_all_projects, $param_project_ids
 end
 
-# Gets all SQL instances of Google projects from "ds_projects".
-datasource "ds_all_sql_instances" do
-  iterate $ds_projects
-  request do
-    run_script $js_sql_instances_call, val(iter_item, "accountID"), val(iter_item, "sleep"), $param_exclude_tags
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response,"items[*]") do
-      field "accountID", val(iter_item, "accountID")
-      field "accountName", val(iter_item, "accountName")
-      field "projectNumber", val(iter_item, "projectNumber")
-      field "resourceID", jmes_path(col_item, "name")
-      field "state", jmes_path(col_item,"state")
-      field "selfLink", jmes_path(col_item, "selfLink")
-      field "tier", jmes_path(col_item, "settings.tier")
-      field "region", jmes_path(col_item, "region")
-      field "tags", jmes_path(col_item,"settings.userLabels")
-      field "resourceType", val(col_item, "instanceType")
-      field "resourceName", jmes_path(col_item, "name")
-      field "resourceType", jmes_path(col_item, "instanceType")
-      field "status", jmes_path(col_item, "state")
-    end
-  end
-end
-
-# Removes instances that aren't in "param_regions" (In case it isn't empty).
-datasource "ds_sql_instances" do
-  run_script $js_sql_instances, $ds_all_sql_instances, $param_regions
-end
-
-# Array of objects with Account ID and region each one to make a call to Recommender API.
-datasource "ds_recommenders" do
-  run_script $js_recommenders, $ds_sql_instances
-end
-
-# SQL idle instances recommendations got from Recommender API.
-datasource "ds_recommendations" do
-  iterate $ds_recommenders
-  request do
-    run_script $js_recommender_call, val(iter_item,"accountID"), val(iter_item, "region"), val(iter_item, "sleep")
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "recommendations[*]") do
-      field "accountID", val(iter_item, "accountID")
-      field "projectNumber", val(iter_item, "projectNumber")
-      field "region", val(iter_item, "region")
-      field "id", jmes_path(col_item, "name")
-      field "description", jmes_path(col_item, "description")
-      field "resourceLink", jmes_path(col_item, "content.overview.resource")
-      field "resourceName", jmes_path(col_item, "content.overview.resourceName")
-      field "primaryImpact", jmes_path(col_item, "primaryImpact")
-      field "costUnits", jmes_path(col_item, "primaryImpact.costProjection.cost.units")
-      field "costNanos", jmes_path(col_item, "primaryImpact.costProjection.cost.nanos")
-      field "duration", jmes_path(col_item, "primaryImpact.costProjection.duration")
-      field "currency", jmes_path(col_item, "primaryImpact.costProjection.cost.currencyCode")
-      field "priority", jmes_path(col_item, "priority")
-      field "recommenderSubtype", jmes_path(col_item, "recommenderSubtype")
-      field "state", jmes_path(col_item, "stateInfo.state")
-    end
-  end
-end
-
-# Total estimated monthly savings based on SQL instances/recommendations.
-datasource "ds_sql_cost_mapping" do
-  run_script $js_sql_instances_cost_mapping, $ds_sql_instances, $ds_recommendations, $ds_currency_reference
-end
-
-###############################################################################
-# Scripts
-###############################################################################
-
 script "js_projects", type: "javascript" do
   parameters "ds_all_projects", "param_project_ids"
   result "projects"
@@ -204,6 +131,32 @@ script "js_projects", type: "javascript" do
         }
     })
   EOF
+end
+
+# Gets all SQL instances of Google projects from "ds_projects".
+datasource "ds_all_sql_instances" do
+  iterate $ds_projects
+  request do
+    run_script $js_sql_instances_call, val(iter_item, "accountID"), val(iter_item, "sleep"), $param_exclude_tags
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response,"items[*]") do
+      field "accountID", val(iter_item, "accountID")
+      field "accountName", val(iter_item, "accountName")
+      field "projectNumber", val(iter_item, "projectNumber")
+      field "resourceID", jmes_path(col_item, "name")
+      field "state", jmes_path(col_item,"state")
+      field "selfLink", jmes_path(col_item, "selfLink")
+      field "tier", jmes_path(col_item, "settings.tier")
+      field "region", jmes_path(col_item, "region")
+      field "tags", jmes_path(col_item,"settings.userLabels")
+      field "resourceType", val(col_item, "instanceType")
+      field "resourceName", jmes_path(col_item, "name")
+      field "resourceType", jmes_path(col_item, "instanceType")
+      field "status", jmes_path(col_item, "state")
+    end
+  end
 end
 
 script "js_sql_instances_call", type: "javascript" do
@@ -248,6 +201,11 @@ script "js_sql_instances_call", type: "javascript" do
   EOS
 end
 
+# Removes instances that aren't in "param_regions" (In case it isn't empty).
+datasource "ds_sql_instances" do
+  run_script $js_sql_instances, $ds_all_sql_instances, $param_regions
+end
+
 script "js_sql_instances", type: "javascript" do
   parameters "ds_all_sql_instances", "param_regions"
   result "sql_instances"
@@ -264,6 +222,11 @@ script "js_sql_instances", type: "javascript" do
         })
     }
   EOF
+end
+
+# Array of objects with Account ID and region each one to make a call to Recommender API.
+datasource "ds_recommenders" do
+  run_script $js_recommenders, $ds_sql_instances
 end
 
 script "js_recommenders", type: "javascript" do
@@ -295,6 +258,34 @@ script "js_recommenders", type: "javascript" do
   EOF
 end
 
+# SQL idle instances recommendations got from Recommender API.
+datasource "ds_recommendations" do
+  iterate $ds_recommenders
+  request do
+    run_script $js_recommender_call, val(iter_item,"accountID"), val(iter_item, "region"), val(iter_item, "sleep")
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "recommendations[*]") do
+      field "accountID", val(iter_item, "accountID")
+      field "projectNumber", val(iter_item, "projectNumber")
+      field "region", val(iter_item, "region")
+      field "id", jmes_path(col_item, "name")
+      field "description", jmes_path(col_item, "description")
+      field "resourceLink", jmes_path(col_item, "content.overview.resource")
+      field "resourceName", jmes_path(col_item, "content.overview.resourceName")
+      field "primaryImpact", jmes_path(col_item, "primaryImpact")
+      field "costUnits", jmes_path(col_item, "primaryImpact.costProjection.cost.units")
+      field "costNanos", jmes_path(col_item, "primaryImpact.costProjection.cost.nanos")
+      field "duration", jmes_path(col_item, "primaryImpact.costProjection.duration")
+      field "currency", jmes_path(col_item, "primaryImpact.costProjection.cost.currencyCode")
+      field "priority", jmes_path(col_item, "priority")
+      field "recommenderSubtype", jmes_path(col_item, "recommenderSubtype")
+      field "state", jmes_path(col_item, "stateInfo.state")
+    end
+  end
+end
+
 script "js_recommender_call", type: "javascript" do
   parameters "accountID", "region", "sleep"
   result "request"
@@ -314,6 +305,11 @@ script "js_recommender_call", type: "javascript" do
       query_strings: { alt: "json" }
     }
   EOF
+end
+
+# Total estimated monthly savings based on SQL instances/recommendations.
+datasource "ds_sql_cost_mapping" do
+  run_script $js_sql_instances_cost_mapping, $ds_sql_instances, $ds_recommendations, $ds_currency_reference
 end
 
 script "js_sql_instances_cost_mapping", type:"javascript" do
@@ -370,9 +366,16 @@ script "js_sql_instances_cost_mapping", type:"javascript" do
                 cur = "$"
                 var separator = ","
             }
-            if (recommendation.costNanos < 0) {
+
+            //Convert Costs from Negative to Positive and add Units and Nanos
+            if (!(recommendation.costNanos == null || recommendation.costNanos == undefined)) {
+              if (recommendation.costNanos != 0) {
                 recommendation.costNanos = recommendation.costNanos * -1
+              }
+            } else {
+              recommendation.costNanos = 0
             }
+
             if (recommendation.costUnits < 0) {
                 recommendation.costUnits = recommendation.costUnits * -1
             }

--- a/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations.pt
+++ b/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.6",
+  version: "2.7",
   provider:"Google",
   service: "SQL",
   policy_set: "Unused Database Service"
@@ -154,6 +154,7 @@ datasource "ds_recommendations" do
       field "region", val(iter_item, "region")
       field "id", jmes_path(col_item, "name")
       field "description", jmes_path(col_item, "description")
+      field "resourceLink", jmes_path(col_item, "content.overview.resource")
       field "resourceName", jmes_path(col_item, "content.overview.resourceName")
       field "primaryImpact", jmes_path(col_item, "primaryImpact")
       field "costUnits", jmes_path(col_item, "primaryImpact.costProjection.cost.units")
@@ -341,52 +342,62 @@ script "js_sql_instances_cost_mapping", type:"javascript" do
         }
         return result + "." + values[1];
     }
+
     var total = 0
     var cur = ""
-    _.each(databases, function (database) {
-        _.each(recommendations, function (recommendation) {
-            if (database.resourceName == recommendation.resourceName) {
-                count++
-                if (recommendation['currency'] !== undefined) {
-                    if (ds_currency_reference[recommendation['currency']] !== undefined) {
-                        var cur = ds_currency_reference[recommendation['currency']]['symbol']
-                    } else {
-                        var cur = "$"
-                    }
-                    database['savingsCurrency'] = cur
+
+    _.each(databases, function(database) {
+        var resource_link = database.selfLink.replace("https://www.googleapis.com/compute/v1/", "")
+        database["resourceLink"] = resource_link
+    })
+
+    _.each(recommendations, function (recommendation) {
+        count ++
+        var rec_resource_link = recommendation.resourceLink.replace("//compute.googleapis.com/", "")
+        var database = _.find(databases, function(db) {
+            return db.resourceLink == rec_resource_link
+        })
+        if (!(database == undefined || database == null)) {
+            count++
+            if (recommendation['currency'] !== undefined) {
+                if (ds_currency_reference[recommendation['currency']] !== undefined) {
+                    var cur = ds_currency_reference[recommendation['currency']]['symbol']
                 } else {
                     var cur = "$"
-                    var separator = ","
                 }
-                if (recommendation.costNanos < 0) {
-                    recommendation.costNanos = recommendation.costNanos * -1
-                }
-                if (recommendation.costUnits < 0) {
-                    recommendation.costUnits = recommendation.costUnits * -1
-                }
-                var strNano = "." + recommendation.costNanos
-                var combine = recommendation.costUnits + parseFloat(strNano)
-                var monthsDuration = parseFloat(recommendation.duration.replace("s", "")) / 2628288
-                var monthlySavings = combine / monthsDuration
-                total = total + monthlySavings
-                database['savings'] = (Math.round(monthlySavings * 1000) / 1000)
                 database['savingsCurrency'] = cur
-                database['priority'] = recommendation['priority']
-                database['primaryImpact'] = recommendation['primaryImpact']
-                database['recommenderSubtype'] = recommendation['recommenderSubtype']
-                database['state'] = recommendation['state']
-                database['region'] = recommendation['region']
-                database['service'] = "SQL"
-                var tags = []
-                if (database['tags'] != null) {
-                    Object.keys(database.tags).forEach(function (key) {
-                        tags.push(key + '=' + database.tags[key])
-                    });
-                }
-                database['tags'] = tags
-                instances.push(database)
+            } else {
+                var cur = "$"
+                var separator = ","
             }
-        })
+            if (recommendation.costNanos < 0) {
+                recommendation.costNanos = recommendation.costNanos * -1
+            }
+            if (recommendation.costUnits < 0) {
+                recommendation.costUnits = recommendation.costUnits * -1
+            }
+            var strNano = "." + recommendation.costNanos
+            var combine = recommendation.costUnits + parseFloat(strNano)
+            var monthsDuration = parseFloat(recommendation.duration.replace("s", "")) / 2628288
+            var monthlySavings = combine / monthsDuration
+            total = total + monthlySavings
+            database['savings'] = (Math.round(monthlySavings * 1000) / 1000)
+            database['savingsCurrency'] = cur
+            database['priority'] = recommendation['priority']
+            database['primaryImpact'] = recommendation['primaryImpact']
+            database['recommenderSubtype'] = recommendation['recommenderSubtype']
+            database['state'] = recommendation['state']
+            database['region'] = recommendation['region']
+            database['service'] = "SQL"
+            var tags = []
+            if (database['tags'] != null) {
+                Object.keys(database.tags).forEach(function (key) {
+                    tags.push(key + '=' + database.tags[key])
+                });
+            }
+            database['tags'] = tags
+            instances.push(database)
+        }
     })
     if (instances.length != 0) {
         if (count) {

--- a/cost/google/idle_ip_address_recommendations/CHANGELOG.md
+++ b/cost/google/idle_ip_address_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.7
+
+- Fix: Duplicated entries from incident report were removed.
+
 ## v2.6
 
 - Changed list API to aggregatedList API to get addresses

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
@@ -359,8 +359,8 @@ script "js_addresses_cost_mapping", type:"javascript" do
           if (recommendation.costUnits < 0) {
               recommendation.costUnits = recommendation.costUnits * -1
           }
-          var strNano = "." + recommendation.costNanos
-          var combine = recommendation.costUnits + parseFloat(strNano)
+          var cost_nano = recommendation.costNanos * Math.pow(10, -9)
+          var combine = Number(recommendation.costUnits) + Number(parseFloat(cost_nano))
           var monthsDuration = parseFloat(recommendation.duration.replace("s", "")) / 2628288
           var monthlySavings = combine / monthsDuration
           total = total + monthlySavings

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
@@ -83,7 +83,7 @@ pagination "google_pagination" do
 end
 
 ###############################################################################
-# Datasources
+# Datasources & Scripts
 ###############################################################################
 
 datasource "ds_currency_reference" do
@@ -94,7 +94,7 @@ datasource "ds_currency_reference" do
   end
 end
 
-# Gets all projects filtered by "lifecycleState:ACTIVE".
+#GET LIST OF GCP PROJECTS (filtered by "lifecycleState:ACTIVE" and "param_project".)
 datasource "ds_all_projects" do
   request do
     auth $auth_google
@@ -113,72 +113,11 @@ datasource "ds_all_projects" do
   end
 end
 
-# Removes projects that aren't in "param_project_ids" (In case it isn't empty).
+#FILTER PROJECTS USING PARAM_PROJECT_IDS PARAMETER (IF APPLICABLE)
 datasource "ds_projects" do
     run_script $js_projects, $ds_all_projects, $param_project_ids
 end
 
-# Aggregated addresses by project, returns them by region.
-datasource "ds_all_addresses" do
-  iterate $ds_projects
-  request do
-    run_script $js_aggregated_addresses_call, val(iter_item, "accountID"), $param_exclude_tags
-  end
-  result do
-    encoding "json"
-    field "accountID", val(iter_item, "accountID")
-    field "projectNumber", val(iter_item, "projectNumber")
-    field "accountName", val(iter_item, "accountName")
-    field "items", jq(response, ".items")
-  end
-end
-
-# Removes addresses that aren't in "param_regions" (In case it isn't empty).
-datasource "ds_addresses" do
-  run_script $js_addresses, $ds_all_addresses, $param_regions
-end
-
-# Creates unique relationship between accountID and region.
-datasource "ds_recommenders" do
-  run_script $js_recommenders, $ds_addresses
-end
-
-# Gets recommendations from Recommender API for each "ds_recommender".
-datasource "ds_recommendations" do
-  iterate $ds_recommenders
-  request do
-    run_script $js_recommender_call, val(iter_item,"accountID"), val(iter_item, "region")
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "recommendations[*]") do
-      field "accountID", val(iter_item, "accountID")
-      field "projectNumber", val(iter_item, "projectNumber")
-      field "region", val(iter_item, "region")
-      field "id", jmes_path(col_item, "name")
-      field "description", jmes_path(col_item, "description")
-      field "resourceLink", jmes_path(col_item, "content.overview.resource")
-      field "resourceName", jmes_path(col_item, "content.overview.resourceName")
-      field "primaryImpact", jmes_path(col_item, "primaryImpact")
-      field "costUnits", jmes_path(col_item, "primaryImpact.costProjection.cost.units")
-      field "costNanos", jmes_path(col_item, "primaryImpact.costProjection.cost.nanos")
-      field "duration", jmes_path(col_item, "primaryImpact.costProjection.duration")
-      field "currency", jmes_path(col_item, "primaryImpact.costProjection.cost.currencyCode")
-      field "priority", jmes_path(col_item, "priority")
-      field "recommenderSubtype", jmes_path(col_item, "recommenderSubtype")
-      field "state", jmes_path(col_item, "stateInfo.state")
-    end
-  end
-end
-
-# Gets estimated monthly savings.
-datasource "ds_addresses_cost_mapping" do
-  run_script $js_addresses_cost_mapping, $ds_addresses, $ds_recommendations, $ds_currency_reference
-end
-
-###############################################################################
-# Scripts
-###############################################################################
 script "js_projects", type: "javascript" do
   parameters "ds_all_projects", "param_project_ids"
   result "projects"
@@ -194,6 +133,21 @@ script "js_projects", type: "javascript" do
         })
     }
   EOF
+end
+
+##GET LIST OF ADDRESSES FOR EACH PROJECT ID
+datasource "ds_all_addresses" do
+  iterate $ds_projects
+  request do
+    run_script $js_aggregated_addresses_call, val(iter_item, "accountID"), $param_exclude_tags
+  end
+  result do
+    encoding "json"
+    field "accountID", val(iter_item, "accountID")
+    field "projectNumber", val(iter_item, "projectNumber")
+    field "accountName", val(iter_item, "accountName")
+    field "items", jq(response, ".items")
+  end
 end
 
 script "js_aggregated_addresses_call", type: "javascript" do
@@ -221,6 +175,11 @@ script "js_aggregated_addresses_call", type: "javascript" do
         }
     }
   EOF
+end
+
+#FILTER LIST OF VMS BY REGIONS PARAMETER (IF APPLICABLE)
+datasource "ds_addresses" do
+  run_script $js_addresses, $ds_all_addresses, $param_regions
 end
 
 script "js_addresses", type: "javascript" do
@@ -264,6 +223,11 @@ script "js_addresses", type: "javascript" do
   EOF
 end
 
+#CREATE LIST OF RECOMMENDER DETAILS FOR RECOMMENDER API CALL USING COMPUTE DISK DATA
+datasource "ds_recommenders" do
+  run_script $js_recommenders, $ds_addresses
+end
+
 script "js_recommenders", type: "javascript" do
   parameters "ds_addresses"
   result "recommenders"
@@ -283,6 +247,34 @@ script "js_recommenders", type: "javascript" do
   EOF
 end
 
+#GET LIST OF RECOMMENDATIONS
+datasource "ds_recommendations" do
+  iterate $ds_recommenders
+  request do
+    run_script $js_recommender_call, val(iter_item,"accountID"), val(iter_item, "region")
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "recommendations[*]") do
+      field "accountID", val(iter_item, "accountID")
+      field "projectNumber", val(iter_item, "projectNumber")
+      field "region", val(iter_item, "region")
+      field "id", jmes_path(col_item, "name")
+      field "description", jmes_path(col_item, "description")
+      field "resourceLink", jmes_path(col_item, "content.overview.resource")
+      field "resourceName", jmes_path(col_item, "content.overview.resourceName")
+      field "primaryImpact", jmes_path(col_item, "primaryImpact")
+      field "costUnits", jmes_path(col_item, "primaryImpact.costProjection.cost.units")
+      field "costNanos", jmes_path(col_item, "primaryImpact.costProjection.cost.nanos")
+      field "duration", jmes_path(col_item, "primaryImpact.costProjection.duration")
+      field "currency", jmes_path(col_item, "primaryImpact.costProjection.cost.currencyCode")
+      field "priority", jmes_path(col_item, "priority")
+      field "recommenderSubtype", jmes_path(col_item, "recommenderSubtype")
+      field "state", jmes_path(col_item, "stateInfo.state")
+    end
+  end
+end
+
 script "js_recommender_call", type: "javascript" do
   parameters "accountID", "region"
   result "request"
@@ -298,105 +290,129 @@ script "js_recommender_call", type: "javascript" do
     path: "/v1/projects/"+ accountID +"/locations/" + region + "/recommenders/google.compute.address.IdleResourceRecommender/recommendations",
     query_strings: { alt: "json" }
   }
-EOF
+  EOF
+end
+
+#GET IP ADDRESS COST MAPPING 
+datasource "ds_addresses_cost_mapping" do
+  run_script $js_addresses_cost_mapping, $ds_addresses, $ds_recommendations, $ds_currency_reference
 end
 
 script "js_addresses_cost_mapping", type:"javascript" do
   result "result"
   parameters  "addresses", "recommendations", "ds_currency_reference"
   code <<-EOS
-  var instances = [];
-  var result = {};
-  var message = ''
-  var count = 0;
-  
-  function formatNumber(number, separator) {
-      var numString = number.toString();
-      var values = numString.split(".");
-      var result = ''
-      while (values[0].length > 3) {
-          var chunk = values[0].substr(-3)
-          values[0] = values[0].substr(0, values[0].length - 3)
-          result = separator + chunk + result
-      }
-      if (values[0].length > 0) {
-          result = values[0] + result
-      }
-      if (values[1] == undefined) {
-          return result;
-      }
-      return result + "." + values[1];
-  }
-  var total = 0
-  var cur = ""
+    var instances = [];
+    var result = {};
+    var message = ''
+    var count = 0;
+    
+    function formatNumber(number, separator) {
+        var numString = number.toString();
+        var values = numString.split(".");
+        var result = ''
+        while (values[0].length > 3) {
+            var chunk = values[0].substr(-3)
+            values[0] = values[0].substr(0, values[0].length - 3)
+            result = separator + chunk + result
+        }
+        if (values[0].length > 0) {
+            result = values[0] + result
+        }
+        if (values[1] == undefined) {
+            return result;
+        }
+        return result + "." + values[1];
+    }
+    var total = 0
+    var cur = ""
 
-  _.each(addresses, function(addr) {
-    var resource_link = addr.selfLink.replace("https://www.googleapis.com/compute/v1/", "")
-    addr["resourceLink"] = resource_link
-  })
+    _.each(addresses, function(addr) {
+      var resource_link = addr.selfLink.replace("https://www.googleapis.com/compute/v1/", "")
+      addr["resourceLink"] = resource_link
+    })
 
-  _.each(recommendations, function (recommendation) {
-      count ++
-      var rec_resource_link = recommendation.resourceLink.replace("//compute.googleapis.com/", "")
-      var address = _.find(addresses, function(addr) {
-        return addr.resourceLink == rec_resource_link
-      })
-      if (!(address == undefined || address == null)) {
-          if (recommendation['currency'] !== undefined) {
+    _.each(recommendations, function (recommendation) {
+        count++
+        var rec_resource_link = recommendation.resourceLink.replace("//compute.googleapis.com/", "")
+        var address = _.find(addresses, function(addr) {
+          return addr.resourceLink == rec_resource_link
+        })
+        if (!(address == undefined || address == null)) {
+            if (recommendation['currency'] !== undefined) {
               if (ds_currency_reference[recommendation['currency']] !== undefined) {
-                  var cur = ds_currency_reference[recommendation['currency']]['symbol']
+                  cur = ds_currency_reference[recommendation['currency']]['symbol']
               } else {
-                  var cur = "$"
+                  cur = "$"
               }
               address['savingsCurrency'] = cur
-          } else {
-              var cur = "$"
+            } else {
+              cur = "$"
               var separator = ","
-          }
-          if (recommendation.costNanos < 0) {
-              recommendation.costNanos = recommendation.costNanos * -1
-          }
-          if (recommendation.costUnits < 0) {
-              recommendation.costUnits = recommendation.costUnits * -1
-          }
-          var cost_nano = recommendation.costNanos * Math.pow(10, -9)
-          var combine = Number(recommendation.costUnits) + Number(parseFloat(cost_nano))
-          var monthsDuration = parseFloat(recommendation.duration.replace("s", "")) / 2628288
-          var monthlySavings = combine / monthsDuration
-          total = total + monthlySavings
-          address['savings'] = (Math.round(monthlySavings * 1000) / 1000)
-          address['savingsCurrency'] = cur
-          address['priority'] = recommendation['priority']
-          address['primaryImpact'] = recommendation['primaryImpact']
-          address['recommenderSubtype'] = recommendation['recommenderSubtype']
-          address['state'] = recommendation['state']
-          address['service'] = "Other"
-          var tags = []
-          if (address['tags'] != null) {
-              Object.keys(address.tags).forEach(function (key) {
-                  tags.push(key + '=' + address.tags[key])
-              });
-          }
-          address['tags'] = tags
-          instances.push(address)
-      }
-  })
-  if (instances.length != 0) {
-      if (count) {
-          total = cur + ' ' + formatNumber((Math.round(total * 100) / 100));
-          message = "The total estimated monthly savings are " + total;
-      } else {
-          message = "The Flexera Optima system does not have any data to calculate savings for these resources";
-      }
-  } else {
-      message = "unable to find resources between recommender and resource api";
-  }
-  result = {
-      "instances": instances,
-      "message": message
-  };
-  result.instances = _.sortBy(result.instances, "region");
-  result.instances = _.sortBy(result.instances, "accountName");
+            }
+
+            //Convert Costs from Negative to Positive and add Units and Nanos
+            if (!(recommendation.costNanos == null || recommendation.costNanos == undefined)) {
+              if (recommendation.costNanos != 0) {
+                recommendation.costNanos = recommendation.costNanos * -1
+              }
+            } else {
+              recommendation.costNanos = 0
+            }
+
+            if (!(recommendation.costUnits == null || recommendation.costUnits == undefined)) {
+              if (recommendation.costUnits != 0) {
+                recommendation.costUnits = recommendation.costUnits * -1
+              }
+            } else {
+              console.log("Cost Units is null")
+              recommendation.costUnits = 0
+            }
+
+            var cost_nano = recommendation.costNanos * Math.pow(10, -9)
+            var combine = Number(recommendation.costUnits) + Number(parseFloat(cost_nano))
+            var monthsDuration = parseFloat(recommendation.duration.replace("s", "")) / 2628288
+            
+            var monthlySavings = 0
+            if ( monthsDuration != 0 ) {
+              monthlySavings = combine / monthsDuration
+            }
+            total = total + monthlySavings
+
+            address['savings'] = (Math.round(monthlySavings * 1000) / 1000)
+            address['savingsCurrency'] = cur
+            address['description'] = recommendation['description']
+            address['priority'] = recommendation['priority']
+            address['primaryImpact'] = recommendation['primaryImpact']
+            address['recommenderSubtype'] = recommendation['recommenderSubtype']
+            address['state'] = recommendation['state']
+            address['service'] = "Other"
+            var tags = []
+            if (address['tags'] != null) {
+                Object.keys(address.tags).forEach(function (key) {
+                    tags.push(key + '=' + address.tags[key])
+                });
+            }
+            address['tags'] = tags
+            instances.push(address)
+        }
+    })
+    if (instances.length != 0) {
+        if (count) {
+            total = cur + ' ' + formatNumber((Math.round(total * 100) / 100));
+            message = "The total estimated monthly savings are " + total;
+        } else {
+            message = "The Flexera Optima system does not have any data to calculate savings for these resources";
+        }
+    } else {
+        message = "unable to find resources between recommender and resource api";
+    }
+    result = {
+        "instances": instances,
+        "message": message
+    };
+    result.instances = _.sortBy(result.instances, "region");
+    result.instances = _.sortBy(result.instances, "accountName");
   EOS
 end
 
@@ -432,6 +448,10 @@ policy "policy_recommendations" do
       end
       field "region" do
         label "Region"
+      end
+      field "primaryImpactCategory" do
+        label "Recommendation Primary Impact Category"
+        path "primaryImpact.category"
       end
       field "description" do
         label "Description"

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
@@ -365,7 +365,6 @@ script "js_addresses_cost_mapping", type:"javascript" do
                 recommendation.costUnits = recommendation.costUnits * -1
               }
             } else {
-              console.log("Cost Units is null")
               recommendation.costUnits = 0
             }
 

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.6",
+  version: "2.7",
   provider: "Google",
   service: "Compute",
   policy_set: "Unused IP Addresses"
@@ -157,6 +157,7 @@ datasource "ds_recommendations" do
       field "region", val(iter_item, "region")
       field "id", jmes_path(col_item, "name")
       field "description", jmes_path(col_item, "description")
+      field "resourceLink", jmes_path(col_item, "content.overview.resource")
       field "resourceName", jmes_path(col_item, "content.overview.resourceName")
       field "primaryImpact", jmes_path(col_item, "primaryImpact")
       field "costUnits", jmes_path(col_item, "primaryImpact.costProjection.cost.units")
@@ -328,49 +329,57 @@ script "js_addresses_cost_mapping", type:"javascript" do
   }
   var total = 0
   var cur = ""
-  _.each(addresses, function (address) {
-      _.each(recommendations, function (recommendation) {
-          if (address.name == recommendation.resourceName) {
-              count++
-              if (recommendation['currency'] !== undefined) {
-                  if (ds_currency_reference[recommendation['currency']] !== undefined) {
-                      var cur = ds_currency_reference[recommendation['currency']]['symbol']
-                  } else {
-                      var cur = "$"
-                  }
-                  address['savingsCurrency'] = cur
+
+  _.each(addresses, function(addr) {
+    var resource_link = addr.selfLink.replace("https://www.googleapis.com/compute/v1/", "")
+    addr["resourceLink"] = resource_link
+  })
+
+  _.each(recommendations, function (recommendation) {
+      count ++
+      var rec_resource_link = recommendation.resourceLink.replace("//compute.googleapis.com/", "")
+      var address = _.find(addresses, function(addr) {
+        return addr.resourceLink == rec_resource_link
+      })
+      if (!(address == undefined || address == null)) {
+          if (recommendation['currency'] !== undefined) {
+              if (ds_currency_reference[recommendation['currency']] !== undefined) {
+                  var cur = ds_currency_reference[recommendation['currency']]['symbol']
               } else {
                   var cur = "$"
-                  var separator = ","
               }
-              if (recommendation.costNanos < 0) {
-                  recommendation.costNanos = recommendation.costNanos * -1
-              }
-              if (recommendation.costUnits < 0) {
-                  recommendation.costUnits = recommendation.costUnits * -1
-              }
-              var strNano = "." + recommendation.costNanos
-              var combine = recommendation.costUnits + parseFloat(strNano)
-              var monthsDuration = parseFloat(recommendation.duration.replace("s", "")) / 2628288
-              var monthlySavings = combine / monthsDuration
-              total = total + monthlySavings
-              address['savings'] = (Math.round(monthlySavings * 1000) / 1000)
               address['savingsCurrency'] = cur
-              address['priority'] = recommendation['priority']
-              address['primaryImpact'] = recommendation['primaryImpact']
-              address['recommenderSubtype'] = recommendation['recommenderSubtype']
-              address['state'] = recommendation['state']
-              address['service'] = "Other"
-              var tags = []
-              if (address['tags'] != null) {
-                  Object.keys(address.tags).forEach(function (key) {
-                      tags.push(key + '=' + address.tags[key])
-                  });
-              }
-              address['tags'] = tags
-              instances.push(address)
+          } else {
+              var cur = "$"
+              var separator = ","
           }
-      })
+          if (recommendation.costNanos < 0) {
+              recommendation.costNanos = recommendation.costNanos * -1
+          }
+          if (recommendation.costUnits < 0) {
+              recommendation.costUnits = recommendation.costUnits * -1
+          }
+          var strNano = "." + recommendation.costNanos
+          var combine = recommendation.costUnits + parseFloat(strNano)
+          var monthsDuration = parseFloat(recommendation.duration.replace("s", "")) / 2628288
+          var monthlySavings = combine / monthsDuration
+          total = total + monthlySavings
+          address['savings'] = (Math.round(monthlySavings * 1000) / 1000)
+          address['savingsCurrency'] = cur
+          address['priority'] = recommendation['priority']
+          address['primaryImpact'] = recommendation['primaryImpact']
+          address['recommenderSubtype'] = recommendation['recommenderSubtype']
+          address['state'] = recommendation['state']
+          address['service'] = "Other"
+          var tags = []
+          if (address['tags'] != null) {
+              Object.keys(address.tags).forEach(function (key) {
+                  tags.push(key + '=' + address.tags[key])
+              });
+          }
+          address['tags'] = tags
+          instances.push(address)
+      }
   })
   if (instances.length != 0) {
       if (count) {

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
@@ -135,7 +135,7 @@ script "js_projects", type: "javascript" do
   EOF
 end
 
-##GET LIST OF ADDRESSES FOR EACH PROJECT ID
+#GET LIST OF ADDRESSES FOR EACH PROJECT ID
 datasource "ds_all_addresses" do
   iterate $ds_projects
   request do

--- a/cost/google/idle_persistent_disk_recommendations/CHANGELOG.md
+++ b/cost/google/idle_persistent_disk_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.7
+
+- Fix: Duplicated entries from incident report were removed.
+
 ## v2.6
 
 - Fixed error getting zone name as region

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
@@ -376,8 +376,8 @@ script "js_disk_cost_mapping", type:"javascript" do
             if (recommendation.costUnits < 0) {
                 recommendation.costUnits = recommendation.costUnits * -1
             }
-            var strNano = "." + recommendation.costNanos
-            var combine = recommendation.costUnits + parseFloat(strNano)
+            var cost_nano = recommendation.costNanos * Math.pow(10, -9)
+            var combine = Number(recommendation.costUnits) + Number(parseFloat(cost_nano))
             var monthsDuration = parseFloat(recommendation.duration.replace("s", "")) / 2628288
             var monthlySavings = combine / monthsDuration
             total = total + monthlySavings

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
@@ -90,7 +90,7 @@ pagination "google_pagination" do
 end
 
 ###############################################################################
-# Datasources
+# Datasources & Scripts
 ###############################################################################
 
 datasource "ds_currency_reference" do
@@ -101,7 +101,7 @@ datasource "ds_currency_reference" do
   end
 end
 
-# Gets all projects filtered by "lifecycleState:ACTIVE".
+#GET LIST OF GCP PROJECTS (filtered by "lifecycleState:ACTIVE" and "param_project".)
 datasource "ds_all_projects" do
   request do
     auth $auth_google
@@ -120,69 +120,11 @@ datasource "ds_all_projects" do
   end
 end
 
-# Removes projects that aren't in "param_project_ids" (In case it isn't empty).
+#FILTER PROJECTS USING PARAM_PROJECT_IDS PARAMETER (IF APPLICABLE)
 datasource "ds_projects" do
   run_script $js_projects, $ds_all_projects, $param_project_ids
 end
 
-# Gets all disks of Google projects from "ds_projects".
-datasource "ds_all_disks" do
-  iterate $ds_projects
-  request do
-    run_script $js_aggregated_disks_call, val(iter_item, "accountID"), $param_exclude_tags
-  end
-  result do
-    encoding "json"
-    field "accountID", val(iter_item, "accountID")
-    field "projectNumber", val(iter_item, "projectNumber")
-    field "accountName", val(iter_item, "accountName")
-    field "items", jq(response, ".items")
-  end
-end
-
-# Removes disks that aren't in "param_zones" (In case it isn't empty).
-datasource "ds_disks" do
-  run_script $js_disks, $ds_all_disks, $param_zones
-end
-
-# Array of objects with Account ID and region each one to make a call to Recommender API.
-datasource "ds_recommenders" do
-  run_script $js_recommenders, $ds_disks
-end
-
-datasource "ds_recommendations" do
-  iterate $ds_recommenders
-  request do
-    run_script $js_recommender_call, val(iter_item,"accountID"), val(iter_item, "region")
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "recommendations[*]") do
-      field "accountID", val(iter_item, "accountID")
-      field "region", val(iter_item, "region")
-      field "id", jmes_path(col_item, "name")
-      field "description", jmes_path(col_item, "description")
-      field "resourceLink", jmes_path(col_item, "content.overview.resource")
-      field "resourceName", jmes_path(col_item, "content.overview.resourceName")
-      field "primaryImpact", jmes_path(col_item, "primaryImpact")
-      field "costUnits", jmes_path(col_item, "primaryImpact.costProjection.cost.units")
-      field "costNanos", jmes_path(col_item, "primaryImpact.costProjection.cost.nanos")
-      field "duration", jmes_path(col_item, "primaryImpact.costProjection.duration")
-      field "currency", jmes_path(col_item, "primaryImpact.costProjection.cost.currencyCode")
-      field "priority", jmes_path(col_item, "priority")
-      field "recommenderSubtype", jmes_path(col_item, "recommenderSubtype")
-      field "state", jmes_path(col_item, "stateInfo.state")
-    end
-  end
-end
-
-datasource "ds_disk_cost_mapping" do
-  run_script $js_disk_cost_mapping, $ds_disks, $ds_recommendations, $ds_currency_reference
-end
-
-###############################################################################
-# Scripts
-###############################################################################
 script "js_projects", type: "javascript" do
   parameters "ds_all_projects", "param_project_ids"
   result "projects"
@@ -198,6 +140,21 @@ script "js_projects", type: "javascript" do
         })
     }
   EOF
+end
+
+#GET LIST OF DISKS FOR EACH PROJECT ID
+datasource "ds_all_disks" do
+  iterate $ds_projects
+  request do
+    run_script $js_aggregated_disks_call, val(iter_item, "accountID"), $param_exclude_tags
+  end
+  result do
+    encoding "json"
+    field "accountID", val(iter_item, "accountID")
+    field "projectNumber", val(iter_item, "projectNumber")
+    field "accountName", val(iter_item, "accountName")
+    field "items", jq(response, ".items")
+  end
 end
 
 script "js_aggregated_disks_call", type: "javascript" do
@@ -225,6 +182,11 @@ script "js_aggregated_disks_call", type: "javascript" do
         }
     }
   EOF
+end
+
+#FILTER LIST OF VMS BY COMPUTE ZONES PARAMETER (IF APPLICABLE)
+datasource "ds_disks" do
+  run_script $js_disks, $ds_all_disks, $param_zones
 end
 
 script "js_disks", type: "javascript" do
@@ -276,6 +238,11 @@ script "js_disks", type: "javascript" do
   EOF
 end
 
+#CREATE LIST OF RECOMMENDER DETAILS FOR RECOMMENDER API CALL USING COMPUTE DISK DATA
+datasource "ds_recommenders" do
+  run_script $js_recommenders, $ds_disks
+end
+
 script "js_recommenders", type: "javascript" do
   parameters "ds_disks"
   result "recommenders"
@@ -294,6 +261,33 @@ script "js_recommenders", type: "javascript" do
   EOF
 end
 
+#GET LIST OF RECOMMENDATIONS
+datasource "ds_recommendations" do
+  iterate $ds_recommenders
+  request do
+    run_script $js_recommender_call, val(iter_item,"accountID"), val(iter_item, "region")
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "recommendations[*]") do
+      field "accountID", val(iter_item, "accountID")
+      field "region", val(iter_item, "region")
+      field "id", jmes_path(col_item, "name")
+      field "description", jmes_path(col_item, "description")
+      field "resourceLink", jmes_path(col_item, "content.overview.resource")
+      field "resourceName", jmes_path(col_item, "content.overview.resourceName")
+      field "primaryImpact", jmes_path(col_item, "primaryImpact")
+      field "costUnits", jmes_path(col_item, "primaryImpact.costProjection.cost.units")
+      field "costNanos", jmes_path(col_item, "primaryImpact.costProjection.cost.nanos")
+      field "duration", jmes_path(col_item, "primaryImpact.costProjection.duration")
+      field "currency", jmes_path(col_item, "primaryImpact.costProjection.cost.currencyCode")
+      field "priority", jmes_path(col_item, "priority")
+      field "recommenderSubtype", jmes_path(col_item, "recommenderSubtype")
+      field "state", jmes_path(col_item, "stateInfo.state")
+    end
+  end
+end
+
 script "js_recommender_call", type: "javascript" do
   parameters "accountID", "region"
   result "request"
@@ -310,6 +304,11 @@ script "js_recommender_call", type: "javascript" do
       query_strings: { alt: "json" }
     }
   EOF
+end
+
+#GET VM DISK COST MAPPING
+datasource "ds_disk_cost_mapping" do
+  run_script $js_disk_cost_mapping, $ds_disks, $ds_recommendations, $ds_currency_reference
 end
 
 script "js_disk_cost_mapping", type:"javascript" do
@@ -347,78 +346,101 @@ script "js_disk_cost_mapping", type:"javascript" do
     })
 
     _.each(recommendations, function (recommendation) {
-        count ++
-        var rec_resource_link = recommendation.resourceLink.replace("//compute.googleapis.com/", "")
-        var disk = _.find(disks, function(d) {
-            return d.resourceLink == rec_resource_link
-        })
-        if (!(disk == undefined || disk == null)) {
-            if (recommendation['currency'] !== undefined) {
-                if (recommendation['costUnits'] == null) {
-                    recommendation['costUnits'] = 0
-                }
-                if (recommendation['costNanos'] == null) {
-                    recommendation['costNanos'] = 0
-                }
-                if (ds_currency_reference[recommendation['currency']] !== undefined) {
-                    var cur = ds_currency_reference[recommendation['currency']]['symbol']
-                } else {
-                    var cur = "$"
-                }
-                disk['savingsCurrency'] = cur
-            } else {
-                var cur = "$"
-                var separator = ","
-            }
-            if (recommendation.costNanos < 0) {
-                recommendation.costNanos = recommendation.costNanos * -1
-            }
-            if (recommendation.costUnits < 0) {
-                recommendation.costUnits = recommendation.costUnits * -1
-            }
-            var cost_nano = recommendation.costNanos * Math.pow(10, -9)
-            var combine = Number(recommendation.costUnits) + Number(parseFloat(cost_nano))
-            var monthsDuration = parseFloat(recommendation.duration.replace("s", "")) / 2628288
-            var monthlySavings = combine / monthsDuration
-            total = total + monthlySavings
-            disk['savings'] = (Math.round(monthlySavings * 1000) / 1000)
-            disk['savingsCurrency'] = cur
-            disk['description'] = recommendation['description']
-            disk['priority'] = recommendation['priority']
-            disk['primaryImpact'] = recommendation['primaryImpact']
-            disk['recommenderSubtype'] = recommendation['recommenderSubtype']
-            disk['state'] = recommendation['state']
-            disk['service'] = "Storage"
-            var tags = []
-            if (disk['tags'] != null) {
-                if (typeof disk['tags'] == 'object') {
-                    Object.keys(disk.tags).forEach(function (key) {
-                        if (disk.tags[key] == null || disk.tags[key] == "") {
-                            disk.tags[key] = "null"
-                        }
-                        tags.push(String(key) + '=' + String(disk.tags[key]))
-                    });
-                } else {
-                    tags.push(disk["tags"].replace(":", "=null"))
-                }
-            }
-            disk['tags'] = tags
-            instances.push(disk)
-        }
-    })
-    if (instances.length != 0) {
-        if (count) {
-            total = cur + ' ' + formatNumber((Math.round(total * 100) / 100));
-            message = "The total estimated monthly savings are " + total;
+      count++
+      var rec_resource_link = recommendation.resourceLink.replace("//compute.googleapis.com/", "")
+      var disk = _.find(disks, function(d) {
+          return d.resourceLink == rec_resource_link
+      })
+      if (!(disk == undefined || disk == null)) {
+        if (recommendation['currency'] !== undefined) {
+          if (recommendation['costUnits'] == null) {
+              recommendation['costUnits'] = 0
+          }
+          if (recommendation['costNanos'] == null) {
+              recommendation['costNanos'] = 0
+          }
+          if (ds_currency_reference[recommendation['currency']] !== undefined) {
+              cur = ds_currency_reference[recommendation['currency']]['symbol']
+          } else {
+              cur = "$"
+          }
+          disk['savingsCurrency'] = cur
         } else {
-            message = "The Flexera Optima system does not have any data to calculate savings for these resources";
+          cur = "$"
+          var separator = ","
         }
+          
+        //Convert Costs from Negative to Positive and add Units and Nanos
+        if (!(recommendation.costNanos == null || recommendation.costNanos == undefined)) {
+          if (recommendation.costNanos != 0) {
+            recommendation.costNanos = recommendation.costNanos * -1
+          }
+        } else {
+          recommendation.costNanos = 0
+        }
+
+        if (!(recommendation.costUnits == null || recommendation.costUnits == undefined)) {
+          if (recommendation.costUnits != 0) {
+            recommendation.costUnits = recommendation.costUnits * -1
+          }
+        } else {
+          console.log("Cost Units is null")
+          recommendation.costUnits = 0
+        }
+
+        var cost_nano = recommendation.costNanos * Math.pow(10, -9)
+        var combine = Number(recommendation.costUnits) + Number(parseFloat(cost_nano))
+
+        var monthsDuration = 0
+        if (!(recommendation.duration == null || recommendation.duration == undefined)) {
+          monthsDuration = parseFloat(recommendation.duration.replace("s",""))/2628288
+        }
+
+        var monthlySavings = 0
+        if ( monthsDuration != 0 ) {
+          monthlySavings = combine / monthsDuration
+        }
+        total += monthlySavings
+
+        disk['savings'] = (Math.round(monthlySavings * 1000) / 1000)
+        disk['savingsCurrency'] = cur
+        disk['description'] = recommendation['description']
+        disk['priority'] = recommendation['priority']
+        disk['primaryImpact'] = recommendation['primaryImpact']
+        disk['recommenderSubtype'] = recommendation['recommenderSubtype']
+        disk['state'] = recommendation['state']
+        disk['service'] = "Storage"
+        var tags = []
+        if (disk['tags'] != null) {
+          if (typeof disk['tags'] == 'object') {
+            Object.keys(disk.tags).forEach(function (key) {
+              if (disk.tags[key] == null || disk.tags[key] == "") {
+                  disk.tags[key] = "null"
+              }
+              tags.push(String(key) + '=' + String(disk.tags[key]))
+            });
+          } else {
+            tags.push(disk["tags"].replace(":", "=null"))
+          }
+        }
+        disk['tags'] = tags
+        instances.push(disk)
+      }
+    })
+
+    if (instances.length != 0) {
+      if (count) {
+        total = cur + ' ' + formatNumber((Math.round(total * 100) / 100));
+        message = "The total estimated monthly savings are " + total;
+      } else {
+          message = "The Flexera Optima system does not have any data to calculate savings for these resources";
+      }
     } else {
-        message = "unable to find resources between recommender and resource api";
+      message = "unable to find resources between recommender and resource api";
     }
     result = {
-        "instances": instances,
-        "message": message
+      "instances": instances,
+      "message": message
     };
     result.instances = _.sortBy(result.instances, "region");
     result.instances = _.sortBy(result.instances, "accountName");
@@ -466,6 +488,10 @@ policy "policy_recommendations" do
       end
       field "tags" do
         label "Tags"
+      end
+      field "primaryImpactCategory" do
+        label "Recommendation Primary Impact Category"
+        path "primaryImpact.category"
       end
       field "description" do
         label "Description"

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
@@ -384,7 +384,6 @@ script "js_disk_cost_mapping", type:"javascript" do
             recommendation.costUnits = recommendation.costUnits * -1
           }
         } else {
-          console.log("Cost Units is null")
           recommendation.costUnits = 0
         }
 

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.6",
+  version: "2.7",
   provider:"Google",
   service: "Storage",
   policy_set: "Unused Volumes"
@@ -162,6 +162,7 @@ datasource "ds_recommendations" do
       field "region", val(iter_item, "region")
       field "id", jmes_path(col_item, "name")
       field "description", jmes_path(col_item, "description")
+      field "resourceLink", jmes_path(col_item, "content.overview.resource")
       field "resourceName", jmes_path(col_item, "content.overview.resourceName")
       field "primaryImpact", jmes_path(col_item, "primaryImpact")
       field "costUnits", jmes_path(col_item, "primaryImpact.costProjection.cost.units")
@@ -339,63 +340,71 @@ script "js_disk_cost_mapping", type:"javascript" do
     }
     var total = 0
     var cur = ""
-    _.each(disks, function (disk) {
-        _.each(recommendations, function (recommendation) {
-            if (disk.resourceName == recommendation.resourceName) {
-                count++
-                if (recommendation['currency'] !== undefined) {
-                    if (recommendation['costUnits'] == null) {
-                        recommendation['costUnits'] = 0
-                    }
-                    if (recommendation['costNanos'] == null) {
-                        recommendation['costNanos'] = 0
-                    }
-                    if (ds_currency_reference[recommendation['currency']] !== undefined) {
-                        var cur = ds_currency_reference[recommendation['currency']]['symbol']
-                    } else {
-                        var cur = "$"
-                    }
-                    disk['savingsCurrency'] = cur
+
+    _.each(disks, function(disk) {
+      var resource_link = disk.selfLink.replace("https://www.googleapis.com/compute/v1/", "")
+      disk["resourceLink"] = resource_link
+    })
+
+    _.each(recommendations, function (recommendation) {
+        count ++
+        var rec_resource_link = recommendation.resourceLink.replace("//compute.googleapis.com/", "")
+        var disk = _.find(disks, function(d) {
+            return d.resourceLink == rec_resource_link
+        })
+        if (!(disk == undefined || disk == null)) {
+            if (recommendation['currency'] !== undefined) {
+                if (recommendation['costUnits'] == null) {
+                    recommendation['costUnits'] = 0
+                }
+                if (recommendation['costNanos'] == null) {
+                    recommendation['costNanos'] = 0
+                }
+                if (ds_currency_reference[recommendation['currency']] !== undefined) {
+                    var cur = ds_currency_reference[recommendation['currency']]['symbol']
                 } else {
                     var cur = "$"
-                    var separator = ","
                 }
-                if (recommendation.costNanos < 0) {
-                    recommendation.costNanos = recommendation.costNanos * -1
-                }
-                if (recommendation.costUnits < 0) {
-                    recommendation.costUnits = recommendation.costUnits * -1
-                }
-                var strNano = "." + recommendation.costNanos
-                var combine = recommendation.costUnits + parseFloat(strNano)
-                var monthsDuration = parseFloat(recommendation.duration.replace("s", "")) / 2628288
-                var monthlySavings = combine / monthsDuration
-                total = total + monthlySavings
-                disk['savings'] = (Math.round(monthlySavings * 1000) / 1000)
                 disk['savingsCurrency'] = cur
-                disk['description'] = recommendation['description']
-                disk['priority'] = recommendation['priority']
-                disk['primaryImpact'] = recommendation['primaryImpact']
-                disk['recommenderSubtype'] = recommendation['recommenderSubtype']
-                disk['state'] = recommendation['state']
-                disk['service'] = "Storage"
-                var tags = []
-                if (disk['tags'] != null) {
-                    if (typeof disk['tags'] == 'object') {
-                        Object.keys(disk.tags).forEach(function (key) {
-                            if (disk.tags[key] == null || disk.tags[key] == "") {
-                                disk.tags[key] = "null"
-                            }
-                            tags.push(String(key) + '=' + String(disk.tags[key]))
-                        });
-                    } else {
-                        tags.push(disk["tags"].replace(":", "=null"))
-                    }
-                }
-                disk['tags'] = tags
-                instances.push(disk)
+            } else {
+                var cur = "$"
+                var separator = ","
             }
-        })
+            if (recommendation.costNanos < 0) {
+                recommendation.costNanos = recommendation.costNanos * -1
+            }
+            if (recommendation.costUnits < 0) {
+                recommendation.costUnits = recommendation.costUnits * -1
+            }
+            var strNano = "." + recommendation.costNanos
+            var combine = recommendation.costUnits + parseFloat(strNano)
+            var monthsDuration = parseFloat(recommendation.duration.replace("s", "")) / 2628288
+            var monthlySavings = combine / monthsDuration
+            total = total + monthlySavings
+            disk['savings'] = (Math.round(monthlySavings * 1000) / 1000)
+            disk['savingsCurrency'] = cur
+            disk['description'] = recommendation['description']
+            disk['priority'] = recommendation['priority']
+            disk['primaryImpact'] = recommendation['primaryImpact']
+            disk['recommenderSubtype'] = recommendation['recommenderSubtype']
+            disk['state'] = recommendation['state']
+            disk['service'] = "Storage"
+            var tags = []
+            if (disk['tags'] != null) {
+                if (typeof disk['tags'] == 'object') {
+                    Object.keys(disk.tags).forEach(function (key) {
+                        if (disk.tags[key] == null || disk.tags[key] == "") {
+                            disk.tags[key] = "null"
+                        }
+                        tags.push(String(key) + '=' + String(disk.tags[key]))
+                    });
+                } else {
+                    tags.push(disk["tags"].replace(":", "=null"))
+                }
+            }
+            disk['tags'] = tags
+            instances.push(disk)
+        }
     })
     if (instances.length != 0) {
         if (count) {

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
@@ -369,7 +369,7 @@ script "js_disk_cost_mapping", type:"javascript" do
           cur = "$"
           var separator = ","
         }
-          
+
         //Convert Costs from Negative to Positive and add Units and Nanos
         if (!(recommendation.costNanos == null || recommendation.costNanos == undefined)) {
           if (recommendation.costNanos != 0) {

--- a/cost/google/idle_vm_recommendations/CHANGELOG.md
+++ b/cost/google/idle_vm_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.7
+
+- Fix: Duplicated entries from incident report were removed.
+
 ## v2.6
 
 - Fixed the values shown at `cpuMaximum`, `cpuMinimum` and `cpuAverage`:

--- a/cost/google/idle_vm_recommendations/CHANGELOG.md
+++ b/cost/google/idle_vm_recommendations/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## v2.6
 
-- Fixed the values shown at `cpuMaximum` and `cpuMinimum`:
+- Fixed the values shown at `cpuMaximum`, `cpuMinimum` and `cpuAverage`:
 
 At version 2.5 we changed the way we calculated the CPU utilization, we retrieved the average of utilization of each day and then we selected the maximum average as the maximum and the minimum average as the minimum, now we show the actual maximum and minimum of the CPU utilization thanks to a change in our GCP MQL query.
+
+- Fixed the method to match the data of the resources and the cost data (this removes duplicated recommendations at the incident report).
 
 ## v2.5
 

--- a/cost/google/idle_vm_recommendations/CHANGELOG.md
+++ b/cost/google/idle_vm_recommendations/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.6
+
+- Fixed the values shown at `cpuMaximum` and `cpuMinimum`:
+
+At version 2.5 we changed the way we calculated the CPU utilization, we retrieved the average of utilization of each day and then we selected the maximum average as the maximum and the minimum average as the minimum, now we show the actual maximum and minimum of the CPU utilization thanks to a change in our GCP MQL query.
+
 ## v2.5
 
 - Modified to make this policy run faster by using aggregated GCP API endpoints.

--- a/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
+++ b/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
@@ -402,8 +402,8 @@ script "js_instance_cost_mapping", type:"javascript" do
       return result+"."+values[1];
     }
 
-    total = 0
-    cur = ""
+    var total = 0
+    var cur = ""
 
     _.each(vms, function(vm) {
         var resource_link = vm.selfLink.replace("https://www.googleapis.com/compute/v1/", "")
@@ -425,13 +425,13 @@ script "js_instance_cost_mapping", type:"javascript" do
             recommendation['costNanos'] = 0
           }
           if (ds_currency_reference[recommendation['currency']] !== undefined ) {
-          var cur = ds_currency_reference[recommendation['currency']]['symbol']
+          cur = ds_currency_reference[recommendation['currency']]['symbol']
           } else {
-            var cur = "$"
+            cur = "$"
           }
           vm['savingsCurrency'] = cur
         } else {
-          var cur = "$"
+          cur = "$"
           var separator = ","
         }
         if (recommendation.costNanos<0) {
@@ -521,6 +521,10 @@ policy "policy_recommendations" do
       end
       field "zone" do
         label "Zone"
+      end
+      field "primaryImpactCategory" do
+        label "Recommendation Primary Impact Category"
+        path "primaryImpact.category"
       end
       field "hostname" do
         label "Hostname"

--- a/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
+++ b/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
@@ -440,8 +440,8 @@ script "js_instance_cost_mapping", type:"javascript" do
         if (recommendation.costUnits<0) {
           recommendation.costUnits = recommendation.costUnits * -1
         }
-        strNano = "."+recommendation.costNanos
-        combine = recommendation.costUnits + parseFloat(strNano)
+        var cost_nano = recommendation.costNanos * Math.pow(10, -9)
+        var combine = Number(recommendation.costUnits) + Number(parseFloat(cost_nano))
         monthsDuration = parseFloat(recommendation.duration.replace("s",""))/2628288
         monthlySavings = combine / monthsDuration
         total = total+monthlySavings

--- a/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
+++ b/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.6",
+  version: "2.7",
   provider:"Google",
   service: "Compute",
   policy_set: "Idle Compute Instances"

--- a/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
+++ b/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.5",
+  version: "2.6",
   provider:"Google",
   service: "Compute",
   policy_set: "Idle Compute Instances"
@@ -138,32 +138,30 @@ datasource "ds_recommendations" do
   end
 end
 
-datasource "ds_compute_utilization" do
+datasource "ds_calculated_utilization" do
   iterate $ds_google_project
   request do
     auth $auth_google
     verb "POST"
     host "monitoring.googleapis.com"
     path join(["/v3/projects/", val(iter_item,"accountID"), "/timeSeries:query"])
-    body_field "query", "fetch gce_instance | metric 'compute.googleapis.com/instance/cpu/utilization' | within 14d | align | every 1d | group_by [instance_name, instance_id, zone], mean(value)"
+    body_field "query", "fetch gce_instance | metric compute.googleapis.com/instance/cpu/utilization | within 14d | { group_by sliding(14d), .mean ; group_by sliding(14d), .max  ; group_by sliding(14d), . min } | join"
     ignore_status [403, 404]
   end
   result do
     encoding "json"
     collect jmes_path(response, "timeSeriesData[*]") do
-      field "resourceName", jmes_path(col_item, "labelValues[0].stringValue")
-      field "resourceID", jmes_path(col_item, "labelValues[1].stringValue")
-      field "zone", jmes_path(col_item, "labelValues[2].stringValue")
-      field "accountID", val(iter_item,"accountID")
-      field "cpuPoints", jmes_path(col_item, "pointData[*].values[0].doubleValue")
-      field "accountName", val(iter_item,"accountName")
-      field "projectNumber", val(iter_item,"projectNumber")
+      field "resourceName", jmes_path(col_item, "labelValues[3].stringValue")
+      field "resourceID", jmes_path(col_item, "labelValues[2].stringValue")
+      field "zone", jmes_path(col_item, "labelValues[1].stringValue")
+      field "accountID", val(iter_item, "accountID")
+      field "accountName", val(iter_item, "accountName")
+      field "projectNumber", val(iter_item, "projectNumber")
+      field "cpuAverage", prod(jmes_path(col_item, "pointData[0].values[0].doubleValue"), 100)
+      field "cpuMaximum", prod(jmes_path(col_item, "pointData[0].values[1].doubleValue"), 100)
+      field "cpuMinimum", prod(jmes_path(col_item, "pointData[0].values[2].doubleValue"), 100)
     end
   end
-end
-
-datasource "ds_calculated_utilization" do
-  run_script $js_calculated_utilization, $ds_compute_utilization
 end
 
 datasource "ds_grouped_account_ids" do
@@ -280,52 +278,6 @@ script "js_recommender_call", type: "javascript" do
     query_strings: { alt: "json" }
   }
 EOF
-end
-
-script "js_calculated_utilization", type: "javascript" do
-  result "results"
-  parameters "ds_compute_utilization"
-  code <<-EOS
-  results = []
-  for (i = 0; i < ds_compute_utilization.length; i++) {
-    var resourceID = ds_compute_utilization[i].resourceID
-    if (resourceID === null || resourceID === undefined) {
-      // No instance id, continue
-    } else {
-      var points = ds_compute_utilization[i].cpuPoints
-      if (points === null || points === undefined) {
-        var cpuMaximum = "101"
-        var cpuAverage = "101"
-        var cpuMinimum = "101"
-      } else {
-        points = _.map(points, function(point) {
-          return point * 100
-        })
-        var cpuMaximum = parseFloat(points.reduce(function(x, y) {
-          return Math.max(x, y)
-        })).toFixed(2)
-        var cpu_sum = _.reduce(points, function(memo, num) {
-          return memo + num;
-        }, 0);
-        var cpuAverage = parseFloat(cpu_sum / points.length).toFixed(2)
-        var cpuMinimum = parseFloat(points.reduce(function(x, y) {
-          return Math.min(x, y)
-        })).toFixed(2)
-      }
-      results.push({
-        zone: ds_compute_utilization[i].zone,
-        accountID: ds_compute_utilization[i].accountID,
-        accountName: ds_compute_utilization[i].accountName,
-        projectNumber: ds_compute_utilization[i].projectNumber
-        resourceID: resourceID,
-        resourceName: ds_compute_utilization[i].resourceName
-        cpuAverage: cpuAverage,
-        cpuMaximum: cpuMaximum,
-        cpuMinimum: cpuMinimum
-      })
-    }
-  }
-EOS
 end
 
 script "js_collected_vms", type: "javascript" do

--- a/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
+++ b/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
@@ -125,6 +125,7 @@ datasource "ds_recommendations" do
       field "region", val(iter_item, "region")
       field "id", jmes_path(col_item, "name")
       field "description", jmes_path(col_item, "description")
+      field "resourceLink", jmes_path(col_item, "content.overview.resource")
       field "resourceName", jmes_path(col_item, "content.overview.resourceName")
       field "primaryImpact", jmes_path(col_item, "primaryImpact")
       field "costUnits", jmes_path(col_item, "primaryImpact.costProjection.cost.units")
@@ -400,65 +401,74 @@ script "js_instance_cost_mapping", type:"javascript" do
       }
       return result+"."+values[1];
     }
+
     total = 0
     cur = ""
+
     _.each(vms, function(vm) {
-      _.each(recommendations, function(recommendation){
-        if(vm.resourceName == recommendation.resourceName) {
-          count++
-          if(recommendation['currency'] !== undefined ) {
-            if (recommendation['costUnits'] == null) {
-              recommendation['costUnits'] = 0
-            }
-            if (recommendation['costNanos'] == null) {
-              recommendation['costNanos'] = 0
-            }
-            if (ds_currency_reference[recommendation['currency']] !== undefined ) {
-            var cur = ds_currency_reference[recommendation['currency']]['symbol']
-            } else {
-              var cur = "$"
-            }
-            vm['savingsCurrency'] = cur
+        var resource_link = vm.selfLink.replace("https://www.googleapis.com/compute/v1/", "")
+        vm["resourceLink"] = resource_link
+    })
+
+    _.each(recommendations, function(recommendation){
+      count ++
+      var rec_resource_link = recommendation.resourceLink.replace("//compute.googleapis.com/", "")
+      var vm = _.find(vms, function(v) {
+        return v.resourceLink == rec_resource_link
+      })
+      if (!(vm == undefined || vm == null)) {
+        if(recommendation['currency'] !== undefined ) {
+          if (recommendation['costUnits'] == null) {
+            recommendation['costUnits'] = 0
+          }
+          if (recommendation['costNanos'] == null) {
+            recommendation['costNanos'] = 0
+          }
+          if (ds_currency_reference[recommendation['currency']] !== undefined ) {
+          var cur = ds_currency_reference[recommendation['currency']]['symbol']
           } else {
             var cur = "$"
-            var separator = ","
           }
-          if (recommendation.costNanos<0) {
-            recommendation.costNanos = recommendation.costNanos * -1
-          }
-          if (recommendation.costUnits<0) {
-            recommendation.costUnits = recommendation.costUnits * -1
-          }
-          strNano = "."+recommendation.costNanos
-          combine = recommendation.costUnits + parseFloat(strNano)
-          monthsDuration = parseFloat(recommendation.duration.replace("s",""))/2628288
-          monthlySavings = combine / monthsDuration
-          total = total+monthlySavings
-          vm['savings']= (Math.round( monthlySavings * 1000) / 1000)
           vm['savingsCurrency'] = cur
-          vm['priority'] = recommendation['priority']
-          vm['region'] = recommendations['region']
-          vm['primaryImpact'] = recommendation['primaryImpact']
-          vm['recommenderSubtype'] = recommendation['recommenderSubtype']
-          vm['state'] = recommendation['state']
-          vm['service'] = "Compute"
-          tags = []
-          if (vm['tags'] != null) {
-            if( typeof vm['tags'] == 'object') {
-              Object.keys(vm.tags).forEach(function(key) {
-                if (vm.tags[key] == null || vm.tags[key]=="") {
-                  vm.tags[key] = "null"
-                }
-                tags.push(String(key)+'='+String(vm.tags[key]))
-              });
-            } else {
-              tags.push(vm["tags"].replace(":","=null"))
-            }
-          }
-          vm['tags'] = tags
-          instances.push(vm)
+        } else {
+          var cur = "$"
+          var separator = ","
         }
-      })
+        if (recommendation.costNanos<0) {
+          recommendation.costNanos = recommendation.costNanos * -1
+        }
+        if (recommendation.costUnits<0) {
+          recommendation.costUnits = recommendation.costUnits * -1
+        }
+        strNano = "."+recommendation.costNanos
+        combine = recommendation.costUnits + parseFloat(strNano)
+        monthsDuration = parseFloat(recommendation.duration.replace("s",""))/2628288
+        monthlySavings = combine / monthsDuration
+        total = total+monthlySavings
+        vm['savings']= (Math.round( monthlySavings * 1000) / 1000)
+        vm['savingsCurrency'] = cur
+        vm['priority'] = recommendation['priority']
+        vm['region'] = recommendations['region']
+        vm['primaryImpact'] = recommendation['primaryImpact']
+        vm['recommenderSubtype'] = recommendation['recommenderSubtype']
+        vm['state'] = recommendation['state']
+        vm['service'] = "Compute"
+        tags = []
+        if (vm['tags'] != null) {
+          if( typeof vm['tags'] == 'object') {
+            Object.keys(vm.tags).forEach(function(key) {
+              if (vm.tags[key] == null || vm.tags[key]=="") {
+                vm.tags[key] = "null"
+              }
+              tags.push(String(key)+'='+String(vm.tags[key]))
+            });
+          } else {
+            tags.push(vm["tags"].replace(":","=null"))
+          }
+        }
+        vm['tags'] = tags
+        instances.push(vm)
+      }
     })
     if (instances.length != 0){
       if(count){

--- a/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
+++ b/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
@@ -142,30 +142,6 @@ script "js_google_project", type: "javascript" do
   EOS
 end
 
-datasource "ds_recommenders" do
-  run_script $js_recommenders, $ds_vms_with_cpu_utilization
-end
-
-script "js_recommenders", type: "javascript" do
-  parameters "ds_vms_with_cpu_utilization"
-  result "results"
-  code <<-EOF
-  var results = []
-  for (var i = 0; i < ds_vms_with_cpu_utilization.length; i++) {
-    var result = {
-      projectNumber: ds_vms_with_cpu_utilization[i].projectNumber,
-      accountID: ds_vms_with_cpu_utilization[i].accountID,
-      region: ds_vms_with_cpu_utilization[i].zone,
-      requestNumber: results.length + 1,
-    }
-    var resultAtArray = _.find(results, function(r) { return r.projectNumber === result.projectNumber && r.accountID === result.accountID && r.region === result.region })
-    if (resultAtArray === undefined) {
-      results.push(result)
-    }
-  }
-  EOF
-end
-
 datasource "ds_recommendations" do
   iterate $ds_recommenders
   request do
@@ -325,6 +301,30 @@ script "js_vms_with_cpu_utilization", type: "javascript" do
     }
   }
   EOS
+end
+
+datasource "ds_recommenders" do
+  run_script $js_recommenders, $ds_vms_with_cpu_utilization
+end
+
+script "js_recommenders", type: "javascript" do
+  parameters "ds_vms_with_cpu_utilization"
+  result "results"
+  code <<-EOF
+  var results = []
+  for (var i = 0; i < ds_vms_with_cpu_utilization.length; i++) {
+    var result = {
+      projectNumber: ds_vms_with_cpu_utilization[i].projectNumber,
+      accountID: ds_vms_with_cpu_utilization[i].accountID,
+      region: ds_vms_with_cpu_utilization[i].zone,
+      requestNumber: results.length + 1,
+    }
+    var resultAtArray = _.find(results, function(r) { return r.projectNumber === result.projectNumber && r.accountID === result.accountID && r.region === result.region })
+    if (resultAtArray === undefined) {
+      results.push(result)
+    }
+  }
+  EOF
 end
 
 datasource "ds_sanitize_vms" do

--- a/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
+++ b/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
@@ -440,16 +440,22 @@ script "js_instance_cost_mapping", type:"javascript" do
           recommendation.costNanos = 0
         }
 
-        if (recommendation.costUnits<0) {
-          recommendation.costUnits = recommendation.costUnits * -1
+        if (!(recommendation.costUnits == null || recommendation.costUnits == undefined)) {
+          if (recommendation.costUnits != 0) {
+            recommendation.costUnits = recommendation.costUnits * -1
+          }
+        } else {
+          recommendation.costUnits = 0
         }
+
         var cost_nano = recommendation.costNanos * Math.pow(10, -9)
         var combine = Number(recommendation.costUnits) + Number(parseFloat(cost_nano))
         monthsDuration = parseFloat(recommendation.duration.replace("s",""))/2628288
         monthlySavings = combine / monthsDuration
-        total = total+monthlySavings
-        vm['savings']= (Math.round( monthlySavings * 1000) / 1000)
+        total = total + monthlySavings
+        vm['savings'] = (Math.round( monthlySavings * 1000) / 1000)
         vm['savingsCurrency'] = cur
+        vm['description'] = recommendation['description']
         vm['priority'] = recommendation['priority']
         vm['region'] = recommendations['region']
         vm['primaryImpact'] = recommendation['primaryImpact']

--- a/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
+++ b/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
@@ -142,6 +142,32 @@ script "js_google_project", type: "javascript" do
   EOS
 end
 
+# GET A LIST OF UNIQUE PARAMETERS TO MAKE CALLS TO THE RECOMMENDER API (UNIQUE ACCOUNT ID, REGION AND PROJECT NUMBER)
+datasource "ds_recommenders" do
+  run_script $js_recommenders, $ds_vms_with_cpu_utilization
+end
+
+script "js_recommenders", type: "javascript" do
+  parameters "ds_vms_with_cpu_utilization"
+  result "results"
+  code <<-EOF
+  var results = []
+  for (var i = 0; i < ds_vms_with_cpu_utilization.length; i++) {
+    var result = {
+      projectNumber: ds_vms_with_cpu_utilization[i].projectNumber,
+      accountID: ds_vms_with_cpu_utilization[i].accountID,
+      region: ds_vms_with_cpu_utilization[i].zone,
+      requestNumber: results.length + 1,
+    }
+    var resultAtArray = _.find(results, function(r) { return r.projectNumber === result.projectNumber && r.accountID === result.accountID && r.region === result.region })
+    if (resultAtArray === undefined) {
+      results.push(result)
+    }
+  }
+  EOF
+end
+
+# GET A LIST OF GCP RECOMMENDATIONS FOR IDLE VMS IN EACH ACCOUNT AND REGION
 datasource "ds_recommendations" do
   iterate $ds_recommenders
   request do
@@ -190,6 +216,7 @@ script "js_recommender_call", type: "javascript" do
 EOF
 end
 
+# GET THE MAXIMUM, MINIMUM AND AVERAGE CPU UTILIZATION OF EVERY VM INSTANCE OF EACH ACCOUNT AND REGION
 datasource "ds_calculated_utilization" do
   iterate $ds_google_project
   request do
@@ -216,6 +243,7 @@ datasource "ds_calculated_utilization" do
   end
 end
 
+# GET A LIST OF UNIQUE ACCOUNT IDS TO REDUCE THE NUMBER OF CALLS WE NEED TO DO TO API TO GET VM DATA
 datasource "ds_grouped_account_ids" do
   run_script $js_grouped_account_ids, $ds_calculated_utilization
 end
@@ -228,6 +256,7 @@ script "js_grouped_account_ids", type: "javascript" do
   EOS
 end
 
+# GET A LIST OF THE VMS OF EVERY ACCOUNT ID IN EVERY ZONE
 datasource "ds_get_vms" do
   iterate $ds_grouped_account_ids
   request do
@@ -245,6 +274,7 @@ datasource "ds_get_vms" do
   end
 end
 
+# THIS IS A HELPER FOR ds_get_vms, IT HELPS PROCESSING THE API RESPONSE AND DELIVERS A LIST OF VMS
 datasource "ds_collected_vms" do
   run_script $js_collected_vms, $ds_get_vms, $param_zones
 end
@@ -270,6 +300,7 @@ script "js_collected_vms", type: "javascript" do
   EOS
 end
 
+# MAP THE LIST OF VMS WITH ITS CPU UTILIZATION (MIN, MAX & AVG)
 datasource "ds_vms_with_cpu_utilization" do
   run_script $js_vms_with_cpu_utilization, $ds_collected_vms, $ds_calculated_utilization
 end
@@ -303,52 +334,23 @@ script "js_vms_with_cpu_utilization", type: "javascript" do
   EOS
 end
 
-datasource "ds_recommenders" do
-  run_script $js_recommenders, $ds_vms_with_cpu_utilization
-end
-
-script "js_recommenders", type: "javascript" do
-  parameters "ds_vms_with_cpu_utilization"
-  result "results"
-  code <<-EOF
-  var results = []
-  for (var i = 0; i < ds_vms_with_cpu_utilization.length; i++) {
-    var result = {
-      projectNumber: ds_vms_with_cpu_utilization[i].projectNumber,
-      accountID: ds_vms_with_cpu_utilization[i].accountID,
-      region: ds_vms_with_cpu_utilization[i].zone,
-      requestNumber: results.length + 1,
-    }
-    var resultAtArray = _.find(results, function(r) { return r.projectNumber === result.projectNumber && r.accountID === result.accountID && r.region === result.region })
-    if (resultAtArray === undefined) {
-      results.push(result)
-    }
-  }
-  EOF
-end
-
+# GET A FILTERED LIST OF THE VMS BASED ON THE PARAMETERS THE USER PROVIDED
 datasource "ds_sanitize_vms" do
   run_script $js_sanitize_data, $ds_vms_with_cpu_utilization, $param_exclude_tags
 end
 
 script "js_sanitize_data", type: "javascript" do
   result "results"
-    parameters "ds_get_vms", "param_exclusion_tag_key"
-    code <<-EOS
-    tag_key = param_exclusion_tag_key.split(':')[0]
-    tag_value = param_exclusion_tag_key.split(':')[1]
+  parameters "ds_get_vms", "param_exclusion_tag_key"
+  code <<-EOS
+  tag_key = param_exclusion_tag_key.split(':')[0]
+  tag_value = param_exclusion_tag_key.split(':')[1]
   
-    results = _.filter(ds_get_vms, function (vm) {
-      if (vm.status == "RUNNING") {
-        if (vm.tags != null && vm.tags !== undefined) {
-          if (vm.tags[tag_key] != null && vm.tags[tag_key] !== undefined) {
-            if (vm.tags[tag_key] != tag_value) {
-              if (vm.hostname == undefined) {
-                vm.hostname = vm.resourceID;
-              }
-              return vm
-            }
-          } else {
+  results = _.filter(ds_get_vms, function (vm) {
+    if (vm.status == "RUNNING") {
+      if (vm.tags != null && vm.tags !== undefined) {
+        if (vm.tags[tag_key] != null && vm.tags[tag_key] !== undefined) {
+          if (vm.tags[tag_key] != tag_value) {
             if (vm.hostname == undefined) {
               vm.hostname = vm.resourceID;
             }
@@ -360,13 +362,20 @@ script "js_sanitize_data", type: "javascript" do
           }
           return vm
         }
+      } else {
+        if (vm.hostname == undefined) {
+          vm.hostname = vm.resourceID;
+        }
+        return vm
       }
-    })
-    results = _.sortBy(results, 'zone');
-    results = _.sortBy(results, 'accountID');
-    EOS
-  end
+    }
+  })
+  results = _.sortBy(results, 'zone');
+  results = _.sortBy(results, 'accountID');
+  EOS
+end
 
+# CREATE A LIST OF THE DATA OF THE VMS GROUPED WITH ITS UTILIZATION DATA (CPU MAXIMUM, CPU MINIMUM, CPU AVERAGE) AND ITS RECOMMENDATION DATA
 datasource "ds_vm_cost_mapping" do
   run_script $js_instance_cost_mapping, $ds_sanitize_vms, $ds_recommendations, $ds_currency_reference
 end

--- a/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
+++ b/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
@@ -109,103 +109,6 @@ datasource "ds_google_project" do
   end
 end
 
-datasource "ds_recommenders" do
-  run_script $js_recommenders, $ds_vms_with_cpu_utilization
-end
-
-datasource "ds_recommendations" do
-  iterate $ds_recommenders
-  request do
-    run_script $js_recommender_call, val(iter_item,"accountID"), val(iter_item, "region"), val(iter_item, "requestNumber")
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "recommendations[*]") do
-      field "accountID", val(iter_item, "accountID")
-      field "region", val(iter_item, "region")
-      field "id", jmes_path(col_item, "name")
-      field "description", jmes_path(col_item, "description")
-      field "resourceLink", jmes_path(col_item, "content.overview.resource")
-      field "resourceName", jmes_path(col_item, "content.overview.resourceName")
-      field "primaryImpact", jmes_path(col_item, "primaryImpact")
-      field "costUnits", jmes_path(col_item, "primaryImpact.costProjection.cost.units")
-      field "costNanos", jmes_path(col_item, "primaryImpact.costProjection.cost.nanos")
-      field "duration", jmes_path(col_item, "primaryImpact.costProjection.duration")
-      field "currency", jmes_path(col_item, "primaryImpact.costProjection.cost.currencyCode")
-      field "priority", jmes_path(col_item, "priority")
-      field "recommenderSubtype", jmes_path(col_item, "recommenderSubtype")
-      field "state", jmes_path(col_item, "stateInfo.state")
-    end
-  end
-end
-
-datasource "ds_calculated_utilization" do
-  iterate $ds_google_project
-  request do
-    auth $auth_google
-    verb "POST"
-    host "monitoring.googleapis.com"
-    path join(["/v3/projects/", val(iter_item,"accountID"), "/timeSeries:query"])
-    body_field "query", "fetch gce_instance | metric compute.googleapis.com/instance/cpu/utilization | within 14d | { group_by sliding(14d), .mean ; group_by sliding(14d), .max  ; group_by sliding(14d), . min } | join"
-    ignore_status [403, 404]
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "timeSeriesData[*]") do
-      field "resourceName", jmes_path(col_item, "labelValues[3].stringValue")
-      field "resourceID", jmes_path(col_item, "labelValues[2].stringValue")
-      field "zone", jmes_path(col_item, "labelValues[1].stringValue")
-      field "accountID", val(iter_item, "accountID")
-      field "accountName", val(iter_item, "accountName")
-      field "projectNumber", val(iter_item, "projectNumber")
-      field "cpuAverage", prod(jmes_path(col_item, "pointData[0].values[0].doubleValue"), 100)
-      field "cpuMaximum", prod(jmes_path(col_item, "pointData[0].values[1].doubleValue"), 100)
-      field "cpuMinimum", prod(jmes_path(col_item, "pointData[0].values[2].doubleValue"), 100)
-    end
-  end
-end
-
-datasource "ds_grouped_account_ids" do
-  run_script $js_grouped_account_ids, $ds_calculated_utilization
-end
-
-datasource "ds_get_vms" do
-  iterate $ds_grouped_account_ids
-  request do
-    auth $auth_google
-    host "compute.googleapis.com"
-    verb "GET"
-    path join(["/compute/v1/projects/", iter_item, "/aggregated/instances"])
-    ignore_status [403, 404]
-    header "User-Agent", "RS Policies"
-    header "Content-Type", "application/json"
-  end
-  result do
-    encoding "json"
-    field "vms", jq(response, "[ .items | to_entries | map_values(.value) | map(select(has(\"instances\"))) | .[].instances | .[] | {id,name,selfLink,status,tags,zone,kind}]")
-  end
-end
-
-datasource "ds_collected_vms" do
-  run_script $js_collected_vms, $ds_get_vms, $param_zones
-end
-
-datasource "ds_vms_with_cpu_utilization" do
-  run_script $js_vms_with_cpu_utilization, $ds_collected_vms, $ds_calculated_utilization
-end
-
-datasource "ds_sanitize_vms" do
-  run_script $js_sanitize_data, $ds_vms_with_cpu_utilization, $param_exclude_tags
-end
-
-datasource "ds_vm_cost_mapping" do
-  run_script $js_instance_cost_mapping, $ds_sanitize_vms, $ds_recommendations, $ds_currency_reference
-end
-
-###############################################################################
-# Scripts
-###############################################################################
-
 script "js_google_project", type: "javascript" do
   parameters "param_project"
   result "request"
@@ -239,6 +142,10 @@ script "js_google_project", type: "javascript" do
   EOS
 end
 
+datasource "ds_recommenders" do
+  run_script $js_recommenders, $ds_vms_with_cpu_utilization
+end
+
 script "js_recommenders", type: "javascript" do
   parameters "ds_vms_with_cpu_utilization"
   result "results"
@@ -257,6 +164,32 @@ script "js_recommenders", type: "javascript" do
     }
   }
   EOF
+end
+
+datasource "ds_recommendations" do
+  iterate $ds_recommenders
+  request do
+    run_script $js_recommender_call, val(iter_item,"accountID"), val(iter_item, "region"), val(iter_item, "requestNumber")
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "recommendations[*]") do
+      field "accountID", val(iter_item, "accountID")
+      field "region", val(iter_item, "region")
+      field "id", jmes_path(col_item, "name")
+      field "description", jmes_path(col_item, "description")
+      field "resourceLink", jmes_path(col_item, "content.overview.resource")
+      field "resourceName", jmes_path(col_item, "content.overview.resourceName")
+      field "primaryImpact", jmes_path(col_item, "primaryImpact")
+      field "costUnits", jmes_path(col_item, "primaryImpact.costProjection.cost.units")
+      field "costNanos", jmes_path(col_item, "primaryImpact.costProjection.cost.nanos")
+      field "duration", jmes_path(col_item, "primaryImpact.costProjection.duration")
+      field "currency", jmes_path(col_item, "primaryImpact.costProjection.cost.currencyCode")
+      field "priority", jmes_path(col_item, "priority")
+      field "recommenderSubtype", jmes_path(col_item, "recommenderSubtype")
+      field "state", jmes_path(col_item, "stateInfo.state")
+    end
+  end
 end
 
 script "js_recommender_call", type: "javascript" do
@@ -281,6 +214,65 @@ script "js_recommender_call", type: "javascript" do
 EOF
 end
 
+datasource "ds_calculated_utilization" do
+  iterate $ds_google_project
+  request do
+    auth $auth_google
+    verb "POST"
+    host "monitoring.googleapis.com"
+    path join(["/v3/projects/", val(iter_item,"accountID"), "/timeSeries:query"])
+    body_field "query", "fetch gce_instance | metric compute.googleapis.com/instance/cpu/utilization | within 14d | { group_by sliding(14d), .mean ; group_by sliding(14d), .max  ; group_by sliding(14d), . min } | join"
+    ignore_status [403, 404]
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "timeSeriesData[*]") do
+      field "resourceName", jmes_path(col_item, "labelValues[3].stringValue")
+      field "resourceID", jmes_path(col_item, "labelValues[2].stringValue")
+      field "zone", jmes_path(col_item, "labelValues[1].stringValue")
+      field "accountID", val(iter_item, "accountID")
+      field "accountName", val(iter_item, "accountName")
+      field "projectNumber", val(iter_item, "projectNumber")
+      field "cpuAverage", prod(jmes_path(col_item, "pointData[0].values[0].doubleValue"), 100)
+      field "cpuMaximum", prod(jmes_path(col_item, "pointData[0].values[1].doubleValue"), 100)
+      field "cpuMinimum", prod(jmes_path(col_item, "pointData[0].values[2].doubleValue"), 100)
+    end
+  end
+end
+
+datasource "ds_grouped_account_ids" do
+  run_script $js_grouped_account_ids, $ds_calculated_utilization
+end
+
+script "js_grouped_account_ids", type: "javascript" do
+  result "grouped_account_ids"
+  parameters "ds_calculated_utilization"
+  code <<-EOS
+  grouped_account_ids = _.keys(_.groupBy(ds_calculated_utilization, "accountID"))
+  EOS
+end
+
+datasource "ds_get_vms" do
+  iterate $ds_grouped_account_ids
+  request do
+    auth $auth_google
+    host "compute.googleapis.com"
+    verb "GET"
+    path join(["/compute/v1/projects/", iter_item, "/aggregated/instances"])
+    ignore_status [403, 404]
+    header "User-Agent", "RS Policies"
+    header "Content-Type", "application/json"
+  end
+  result do
+    encoding "json"
+    field "vms", jq(response, "[ .items | to_entries | map_values(.value) | map(select(has(\"instances\"))) | .[].instances | .[] | {id,name,selfLink,status,tags,zone,kind}]")
+  end
+end
+
+datasource "ds_collected_vms" do
+  run_script $js_collected_vms, $ds_get_vms, $param_zones
+end
+
 script "js_collected_vms", type: "javascript" do
   result "collected_vms"
   parameters "ds_get_vms", "param_zones"
@@ -300,6 +292,10 @@ script "js_collected_vms", type: "javascript" do
     }
   }
   EOS
+end
+
+datasource "ds_vms_with_cpu_utilization" do
+  run_script $js_vms_with_cpu_utilization, $ds_collected_vms, $ds_calculated_utilization
 end
 
 script "js_vms_with_cpu_utilization", type: "javascript" do
@@ -331,26 +327,28 @@ script "js_vms_with_cpu_utilization", type: "javascript" do
   EOS
 end
 
-script "js_grouped_account_ids", type: "javascript" do
-  result "grouped_account_ids"
-  parameters "ds_calculated_utilization"
-  code <<-EOS
-  grouped_account_ids = _.keys(_.groupBy(ds_calculated_utilization, "accountID"))
-  EOS
+datasource "ds_sanitize_vms" do
+  run_script $js_sanitize_data, $ds_vms_with_cpu_utilization, $param_exclude_tags
 end
 
 script "js_sanitize_data", type: "javascript" do
-result "results"
-  parameters "ds_get_vms", "param_exclusion_tag_key"
-  code <<-EOS
-  tag_key = param_exclusion_tag_key.split(':')[0]
-  tag_value = param_exclusion_tag_key.split(':')[1]
-
-  results = _.filter(ds_get_vms, function (vm) {
-    if (vm.status == "RUNNING") {
-      if (vm.tags != null && vm.tags !== undefined) {
-        if (vm.tags[tag_key] != null && vm.tags[tag_key] !== undefined) {
-          if (vm.tags[tag_key] != tag_value) {
+  result "results"
+    parameters "ds_get_vms", "param_exclusion_tag_key"
+    code <<-EOS
+    tag_key = param_exclusion_tag_key.split(':')[0]
+    tag_value = param_exclusion_tag_key.split(':')[1]
+  
+    results = _.filter(ds_get_vms, function (vm) {
+      if (vm.status == "RUNNING") {
+        if (vm.tags != null && vm.tags !== undefined) {
+          if (vm.tags[tag_key] != null && vm.tags[tag_key] !== undefined) {
+            if (vm.tags[tag_key] != tag_value) {
+              if (vm.hostname == undefined) {
+                vm.hostname = vm.resourceID;
+              }
+              return vm
+            }
+          } else {
             if (vm.hostname == undefined) {
               vm.hostname = vm.resourceID;
             }
@@ -362,17 +360,15 @@ result "results"
           }
           return vm
         }
-      } else {
-        if (vm.hostname == undefined) {
-          vm.hostname = vm.resourceID;
-        }
-        return vm
       }
-    }
-  })
-  results = _.sortBy(results, 'zone');
-  results = _.sortBy(results, 'accountID');
-  EOS
+    })
+    results = _.sortBy(results, 'zone');
+    results = _.sortBy(results, 'accountID');
+    EOS
+  end
+
+datasource "ds_vm_cost_mapping" do
+  run_script $js_instance_cost_mapping, $ds_sanitize_vms, $ds_recommendations, $ds_currency_reference
 end
 
 script "js_instance_cost_mapping", type:"javascript" do
@@ -434,9 +430,16 @@ script "js_instance_cost_mapping", type:"javascript" do
           cur = "$"
           var separator = ","
         }
-        if (recommendation.costNanos<0) {
-          recommendation.costNanos = recommendation.costNanos * -1
+
+        //Convert Costs from Negative to Positive and add Units and Nanos
+        if (!(recommendation.costNanos == null || recommendation.costNanos == undefined)) {
+          if (recommendation.costNanos != 0) {
+            recommendation.costNanos = recommendation.costNanos * -1
+          }
+        } else {
+          recommendation.costNanos = 0
         }
+
         if (recommendation.costUnits<0) {
           recommendation.costUnits = recommendation.costUnits * -1
         }


### PR DESCRIPTION
### Description

The current method we use to match data is producing duplicated entries because the resource name attribute is being used to match recommendations data and resource data, a more unique identifier such as an id needs to be used instead.

### Issues Resolved

- The method to match resource data and cost data was changed in the policies:
  - Google Idle VM Recommender
  - Google Idle IP Address Recommender
  - Google Idle Persistent Disk Recommender
  - Google Cloud SQL Idle Instance Recommender

- The method to calculate savings using cost_nano and combine was changed.

### Link to Example Applied Policy

- [Google Idle VM Recommender](https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/107982?policyId=645e1102d4f90e00019637c2)
- [Google Idle IP Address Recommender](https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/107982?policyId=645e1031d4f90e00019637c0)
- [Google Idle Persistent Disk Recommender](https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/107982?policyId=645e0f67d4f90e00019637bf)
- [Google Cloud SQL Idle Instance Recommender](https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/107982?policyId=645e10d0d4f90e00019637c1)

### Contribution Check List

- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
