### PR TITLE
mysql_flexible_tier_types.json Updates/Fixes

### DIFF
--- a/data/azure/mysql_flexible_tier_types.json
+++ b/data/azure/mysql_flexible_tier_types.json
@@ -71,8 +71,8 @@
     "Standard_D8ds_v4": {
       "up": "16",
       "down": "4",
-      "up_sku": "Standard_D4ds_v4",
-      "down_sku": "Standard_D16ds_v4"
+      "up_sku": "Standard_D16ds_v4",
+      "down_sku": "Standard_D4ds_v4"
     },
     "Standard_D16ds_v4": {
       "up": "32",
@@ -89,8 +89,8 @@
     "Standard_D48ds_v4": {
       "up": "64",
       "down": "32",
-      "up_sku": "Standard_D32ds_v4",
-      "down_sku": "Standard_D64ds_v4"
+      "up_sku": "Standard_D64ds_v4",
+      "down_sku": "Standard_D32ds_v4"
     },
     "Standard_D64ds_v4": {
       "up": null,

--- a/data/azure/mysql_flexible_tier_types.json
+++ b/data/azure/mysql_flexible_tier_types.json
@@ -2,191 +2,283 @@
   "Burstable": {
     "Standard_B1s": {
       "up": "2",
-      "down": null
+      "down": null,
+      "up_sku": "Standard_B2s",
+      "down_sku": null
     },
     "Standard_B1ms": {
       "up": "2",
-      "down": null
+      "down": null,
+      "up_sku": "Standard_B2ms",
+      "down_sku": null
     },
     "Standard_B2s": {
       "up": "4",
-      "down": "1"
+      "down": "1",
+      "up_sku": "Standard_B4ms",
+      "down_sku": "Standard_B1s"
     },
     "Standard_B2ms": {
       "up": "4",
-      "down": "1"
+      "down": "1",
+      "up_sku": "Standard_B4ms",
+      "down_sku": "Standard_B1ms"
     },
     "Standard_B4ms": {
       "up": "8",
-      "down": "2"
+      "down": "2",
+      "up_sku": "Standard_B8ms",
+      "down_sku": "Standard_B2ms"
     },
     "Standard_B8ms": {
       "up": "12",
-      "down": "4"
+      "down": "4",
+      "up_sku": "Standard_B12ms",
+      "down_sku": "Standard_B4ms"
     },
     "Standard_B12ms": {
       "up": "16",
-      "down": "8"
+      "down": "8",
+      "up_sku": "Standard_B16ms",
+      "down_sku": "Standard_B8ms"
     },
     "Standard_B16ms": {
       "up": "20",
-      "down": "12"
+      "down": "12",
+      "up_sku": "Standard_B20ms",
+      "down_sku": "Standard_B12ms"
     },
     "Standard_B20ms": {
       "up": null,
-      "down": "16"
+      "down": "16",
+      "up_sku": null,
+      "down_sku": "Standard_B16ms"
     }
   },
   "GeneralPurpose": {
-    "Standard_D2ads_v5": {
-      "up": "4",
-      "down": null
-    },
     "Standard_D2ds_v4": {
       "up": "4",
-      "down": null
-    },
-    "Standard_D4ads_v5": {
-      "up": "8",
-      "down": "2"
+      "down": null,
+      "up_sku": "Standard_D4ds_v4",
+      "down_sku": null
     },
     "Standard_D4ds_v4": {
       "up": "8",
-      "down": "2"
-    },
-    "Standard_D8ads_v5": {
-      "up": "16",
-      "down": "4"
+      "down": "2",
+      "up_sku": "Standard_D8ds_v4",
+      "down_sku": "Standard_D2ds_v4"
     },
     "Standard_D8ds_v4": {
       "up": "16",
-      "down": "4"
-    },
-    "Standard_D16ads_v5": {
-      "up": "32",
-      "down": "8"
+      "down": "4",
+      "up_sku": "Standard_D4ds_v4",
+      "down_sku": "Standard_D16ds_v4"
     },
     "Standard_D16ds_v4": {
       "up": "32",
-      "down": "8"
-    },
-    "Standard_D32ads_v5": {
-      "up": "48",
-      "down": "16"
+      "down": "8",
+      "up_sku": "Standard_D32ds_v4",
+      "down_sku": "Standard_D8ds_v4"
     },
     "Standard_D32ds_v4": {
       "up": "48",
-      "down": "16"
-    },
-    "Standard_D48ads_v5": {
-      "up": "64",
-      "down": "32"
+      "down": "16",
+      "up_sku": "Standard_D48ds_v4",
+      "down_sku": "Standard_D16ds_v4"
     },
     "Standard_D48ds_v4": {
       "up": "64",
-      "down": "32"
-    },
-    "Standard_D64ads_v5": {
-      "up": null,
-      "down": "48"
+      "down": "32",
+      "up_sku": "Standard_D32ds_v4",
+      "down_sku": "Standard_D64ds_v4"
     },
     "Standard_D64ds_v4": {
       "up": null,
-      "down": "48"
+      "down": "48",
+      "up_sku": null,
+      "down_sku": "Standard_D48ds_v4"
+    },
+    "Standard_D2ads_v5": {
+      "up": "4",
+      "down": null,
+      "up_sku": "Standard_D4ads_v5",
+      "down_sku": null
+    },
+    "Standard_D4ads_v5": {
+      "up": "8",
+      "down": "2",
+      "up_sku": "Standard_D8ads_v5",
+      "down_sku": "Standard_D2ads_v5"
+    },
+    "Standard_D8ads_v5": {
+      "up": "16",
+      "down": "4",
+      "up_sku": "Standard_D16ads_v5",
+      "down_sku": "Standard_D4ads_v5"
+    },
+    "Standard_D16ads_v5": {
+      "up": "32",
+      "down": "8",
+      "up_sku": "Standard_D32ads_v5",
+      "down_sku": "Standard_D8ads_v5"
+    },
+    "Standard_D32ads_v5": {
+      "up": "48",
+      "down": "16",
+      "up_sku": "Standard_D48ads_v5",
+      "down_sku": "Standard_D16ads_v5"
+    },
+    "Standard_D48ads_v5": {
+      "up": "64",
+      "down": "32",
+      "up_sku": "Standard_D64ads_v5",
+      "down_sku": "Standard_D32ads_v5"
+    },
+    "Standard_D64ads_v5": {
+      "up": null,
+      "down": "48",
+      "up_sku": null,
+      "down_sku": "Standard_D48ads_v5"
     }
   },
   "MemoryOptimized": {
     "Standard_E2ds_v4": {
       "up": "4",
-      "down": null
-    },
-    "Standard_E2ads_v5": {
-      "up": "4",
-      "down": null
+      "down": null,
+      "up_sku": "Standard_E4ds_v4",
+      "down_sku": null
     },
     "Standard_E4ds_v4": {
       "up": "8",
-      "down": "2"
-    },
-    "Standard_E4ads_v5": {
-      "up": "8",
-      "down": "2"
+      "down": "2",
+      "up_sku": "Standard_E8ds_v4",
+      "down_sku": "Standard_E2ds_v4"
     },
     "Standard_E8ds_v4": {
       "up": "16",
-      "down": "4"
-    },
-    "Standard_E8ads_v5": {
-      "up": "16",
-      "down": "4"
+      "down": "4",
+      "up_sku": "Standard_E16ds_v4",
+      "down_sku": "Standard_E4ds_v4"
     },
     "Standard_E16ds_v4": {
       "up": "32",
-      "down": "8"
-    },
-    "Standard_E16ads_v5": {
-      "up": "32",
-      "down": "8"
+      "down": "8",
+      "up_sku": "Standard_E32ds_v4",
+      "down_sku": "Standard_E8ds_v4"
     },
     "Standard_E32ds_v4": {
       "up": "48",
-      "down": "16"
-    },
-    "Standard_E32ads_v5": {
-      "up": "48",
-      "down": "16"
+      "down": "16",
+      "up_sku": "Standard_E48ds_v4",
+      "down_sku": "Standard_E16ds_v4"
     },
     "Standard_E48ds_v4": {
       "up": "64",
-      "down": "32"
-    },
-    "Standard_E48ads_v5": {
-      "up": "64",
-      "down": "32"
+      "down": "32",
+      "up_sku": "Standard_E64ds_v4",
+      "down_sku": "Standard_E32ds_v4"
     },
     "Standard_E64ds_v4": {
-      "up": "80",
-      "down": "48"
-    },
-    "Standard_E64ads_v5": {
-      "up": "80",
-      "down": "48"
-    },
-    "Standard_E80ids_v4": {
-      "up": null,
-      "down": "64"
+      "up": "96",
+      "down": "48",
+      "up_sku": "Standard_E96ds_v5",
+      "down_sku": "Standard_E48ds_v4"
     },
     "Standard_E2ds_v5": {
       "up": "4",
-      "down": null
+      "down": null,
+      "up_sku": "Standard_E4ds_v5",
+      "down_sku": null
     },
     "Standard_E4ds_v5": {
       "up": "8",
-      "down": "2"
+      "down": "2",
+      "up_sku": "Standard_E8ds_v5",
+      "down_sku": "Standard_E2ds_v5"
     },
     "Standard_E8ds_v5": {
       "up": "16",
-      "down": "4"
+      "down": "4",
+      "up_sku": "Standard_E16ds_v5",
+      "down_sku": "Standard_E4ds_v5"
     },
     "Standard_E16ds_v5": {
       "up": "32",
-      "down": "8"
+      "down": "8",
+      "up_sku": "Standard_E32ds_v5",
+      "down_sku": "Standard_E8ds_v5"
     },
     "Standard_E32ds_v5": {
       "up": "48",
-      "down": "16"
+      "down": "16",
+      "up_sku": "Standard_E48ds_v5",
+      "down_sku": "Standard_E16ds_v5"
     },
     "Standard_E48ds_v5": {
       "up": "64",
-      "down": "32"
+      "down": "32",
+      "up_sku": "Standard_E64ds_v5",
+      "down_sku": "Standard_E32ds_v5"
     },
     "Standard_E64ds_v5": {
       "up": "96",
-      "down": "48"
+      "down": "48",
+      "up_sku": "Standard_E96ds_v5",
+      "down_sku": "Standard_E48ds_v5"
     },
     "Standard_E96ds_v5": {
       "up": null,
-      "down": "64"
+      "down": "64",
+      "up_sku": null,
+      "down_sku": "Standard_E64ds_v5"
+    },
+    "Standard_E2ads_v5": {
+      "up": "4",
+      "down": null,
+      "up_sku": "Standard_E4ads_v5",
+      "down_sku": null
+    },
+    "Standard_E4ads_v5": {
+      "up": "8",
+      "down": "2",
+      "up_sku": "Standard_E8ads_v5",
+      "down_sku": "Standard_E2ads_v5"
+    },
+    "Standard_E8ads_v5": {
+      "up": "16",
+      "down": "4",
+      "up_sku": "Standard_E16ads_v5",
+      "down_sku": "Standard_E4ads_v5"
+    },
+    "Standard_E16ads_v5": {
+      "up": "32",
+      "down": "8",
+      "up_sku": "Standard_E32ads_v5",
+      "down_sku": "Standard_E8ads_v5"
+    },
+    "Standard_E32ads_v5": {
+      "up": "48",
+      "down": "16",
+      "up_sku": "Standard_E48ads_v5",
+      "down_sku": "Standard_E16ads_v5"
+    },
+    "Standard_E48ads_v5": {
+      "up": "64",
+      "down": "32",
+      "up_sku": "Standard_E64ads_v5",
+      "down_sku": "Standard_E32ads_v5"
+    },
+    "Standard_E64ads_v5": {
+      "up": "96",
+      "down": "48",
+      "up_sku": "Standard_E96ds_v5",
+      "down_sku": "Standard_E48ads_v5"
+    },
+    "Standard_E80ids_v4": {
+      "up": "96",
+      "down": "64",
+      "up_sku": "Standard_E96ds_v5",
+      "down_sku": "Standard_E64ds_v5"
     }
   }
 }

--- a/data/azure/mysql_flexible_tier_types.json
+++ b/data/azure/mysql_flexible_tier_types.json
@@ -6,17 +6,17 @@
       "up_sku": "Standard_B2s",
       "down_sku": null
     },
-    "Standard_B1ms": {
-      "up": "2",
-      "down": null,
-      "up_sku": "Standard_B2ms",
-      "down_sku": null
-    },
     "Standard_B2s": {
       "up": "4",
       "down": "1",
       "up_sku": "Standard_B4ms",
       "down_sku": "Standard_B1s"
+    },
+    "Standard_B1ms": {
+      "up": "2",
+      "down": null,
+      "up_sku": "Standard_B2ms",
+      "down_sku": null
     },
     "Standard_B2ms": {
       "up": "4",


### PR DESCRIPTION
### Description

mysql_flexible_tier_types.json has been updated with the following fixes and improvements:

- up_sku and down_sku keys have been added, since not every sku cleanly upscales or downscales to something with the same name.
- Lists were resorted to be more logical and readable.
- Standard_E80ids_v4 is no longer listed as a recommended SKU size for any of the other SKUs, since it is an odd one-off SKU. There are upsize/downsize recommendations for this SKU though.