### PR TITLE
Pol 796 superseded policy detect upgrades

### DIFF
--- a/cost/superseded_instance/CHANGELOG.md
+++ b/cost/superseded_instance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1
+
+- Added check to determine if the instance has been upgraded or not
+
 ## v3.0
 
 - Deprecated `auth_rs` authentication (type: `rightscale`) and replaced with `auth_flexera` (type: `oauth2`).  This is a breaking change which requires a Credential for `auth_flexera` [`provider=flexera`] before the policy can be applied.  Please see docs for setting up [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm)

--- a/cost/superseded_instance/superseded_instance.pt
+++ b/cost/superseded_instance/superseded_instance.pt
@@ -493,7 +493,7 @@ policy "pol_aws_superseded_instance" do
         label "New Instance Type"
       end
       field "has_instance_size_changed" do
-        label "Instance has been adjusted"
+        label "Instance Has Been Adjusted"
       end
       field "vpc_incompatible_move" do
         label "VPC Required"

--- a/cost/superseded_instance/superseded_instance.pt
+++ b/cost/superseded_instance/superseded_instance.pt
@@ -421,6 +421,7 @@ script "js_merge_instance_data", type: "javascript" do
           } else {
             var vpc_incompatible_move = "false"
           }
+          var hasInstanceSizeChanged = instance_type === new_instance_type;
 
           results.push(
             {
@@ -435,6 +436,7 @@ script "js_merge_instance_data", type: "javascript" do
               table_cost: cur + ' '+formatNumber(instance.run_rate, separator)
               vpc_incompatible_move: vpc_incompatible_move,
               ena_incompatible: ena_incompatible,
+              has_instance_size_changed: hasInstanceSizeChanged,
             }
           )
         }
@@ -489,6 +491,9 @@ policy "pol_aws_superseded_instance" do
       end
       field "new_instance_type" do
         label "New Instance Type"
+      end
+      field "has_instance_size_changed" do
+        label "Instance has been adjusted"
       end
       field "vpc_incompatible_move" do
         label "VPC Required"

--- a/cost/superseded_instance/superseded_instance.pt
+++ b/cost/superseded_instance/superseded_instance.pt
@@ -1,5 +1,3 @@
-const { iteratee } = require("underscore")
-
 name "Superseded Instances"
 rs_pt_ver 20180301
 type "policy"
@@ -75,7 +73,7 @@ end
 ###############################################################################
 
 ###############################################################################
-# Datasources
+# Datasources & Scripts
 ###############################################################################
 
 datasource "ds_billing_centers" do
@@ -84,14 +82,29 @@ datasource "ds_billing_centers" do
   end
 end
 
+script "js_get_billing_centers", type: "javascript" do
+  parameters "rs_org_id","rs_optima_host"
+  result "request"
+  code <<-EOS
+    request = {
+      "auth": "auth_flexera",
+      "verb": "GET",
+      "host": rs_optima_host,
+      "path": "/analytics/orgs/"+rs_org_id+"/billing_centers",
+      "headers": {"Api-Version": "1.0" },
+      "query_params":{"view":"allocation_table"}
+    }
+  EOS
+end
+
 datasource "ds_costs_time_periods" do
   request do
-    run_script $js_costs_time_periods
+    run_script $js_costs_time_periods, rs_org_id, rs_optima_host
   end
 end
 
 script "js_costs_time_periods", type: "javascript" do
-  #parameters "rs_org_id","rs_optima_host"
+  parameters "rs_org_id", "rs_optima_host"
   result "results"
   code <<-EOS
     // Get todays date
@@ -99,8 +112,9 @@ script "js_costs_time_periods", type: "javascript" do
     var results = [];
 
     // Setup time periods for collecting costs
-    var thirtyDaysAgo = Date().setMonth(date.getMonth()-1);
-    var sevenDaysAgo = Date().setDate(date.getDate()-7);
+    var date = new Date();
+    var thirtyDaysAgo = new Date(date.getFullYear(), date.getMonth() - 1, date.getDate());
+    var sevenDaysAgo = new Date(date.getFullYear(), date.getMonth(), date.getDate() - 7);
     var timePeriods = [thirtyDaysAgo, sevenDaysAgo];
 
     // For each time period, push the items
@@ -127,10 +141,8 @@ script "js_costs_time_periods", type: "javascript" do
         "next_month": next_month,
         "current_month": current_month
       })
-    }
-
-
-
+    })
+    //console.log(results)
   EOS
 end
 
@@ -231,6 +243,7 @@ script "js_new_costs_request", type: "javascript" do
         "User-Agent": "RS Policies",
       }
     }
+    console.log(request)
 EOS
 end
 
@@ -261,56 +274,6 @@ end
 datasource "ds_format_costs" do
   run_script $js_format_costs, $ds_new_bc_costs, $ds_billing_centers
 end
-
-datasource "ds_aws_instance_size_map" do
-  request do
-    verb "GET"
-    host "raw.githubusercontent.com"
-    path "/rightscale/policy_templates/master/data/aws/instance_types.json"
-    header "User-Agent", "RS Policies"
-  end
-end
-
-datasource "ds_google_instance_size_map" do
-  request do
-    verb "GET"
-    host "raw.githubusercontent.com"
-    path "/rightscale/policy_templates/master/data/google/instance_types.json"
-  end
-end
-
-datasource "ds_azure_instance_size_map" do
-  request do
-    verb "GET"
-    host "raw.githubusercontent.com"
-    path "/rightscale/policy_templates/master/data/azure/instance_types.json"
-    header "User-Agent", "RS Policies"
-  end
-end
-
-datasource "ds_combined_instance_data" do
-  run_script $js_merge_instance_data, $ds_format_costs, $ds_aws_instance_size_map, $ds_azure_instance_size_map, $ds_google_instance_size_map, $param_new_instancetype_category, $ds_currency_code, $ds_currency_reference
-end
-
-###############################################################################
-# Scripts
-###############################################################################
-
-script "js_get_billing_centers", type: "javascript" do
-  parameters "rs_org_id","rs_optima_host"
-  result "request"
-  code <<-EOS
-    request = {
-      "auth": "auth_flexera",
-      "verb": "GET",
-      "host": rs_optima_host,
-      "path": "/analytics/orgs/"+rs_org_id+"/billing_centers",
-      "headers": {"Api-Version": "1.0" },
-      "query_params":{"view":"allocation_table"}
-    }
-  EOS
-end
-
 
 script "js_format_costs", type: "javascript" do
   parameters "new_bc_costs", "ds_billing_centers"
@@ -356,6 +319,36 @@ script "js_format_costs", type: "javascript" do
     })
   })
 EOS
+end
+
+datasource "ds_aws_instance_size_map" do
+  request do
+    verb "GET"
+    host "raw.githubusercontent.com"
+    path "/rightscale/policy_templates/master/data/aws/instance_types.json"
+    header "User-Agent", "RS Policies"
+  end
+end
+
+datasource "ds_google_instance_size_map" do
+  request do
+    verb "GET"
+    host "raw.githubusercontent.com"
+    path "/rightscale/policy_templates/master/data/google/instance_types.json"
+  end
+end
+
+datasource "ds_azure_instance_size_map" do
+  request do
+    verb "GET"
+    host "raw.githubusercontent.com"
+    path "/rightscale/policy_templates/master/data/azure/instance_types.json"
+    header "User-Agent", "RS Policies"
+  end
+end
+
+datasource "ds_combined_instance_data" do
+  run_script $js_merge_instance_data, $ds_format_costs, $ds_aws_instance_size_map, $ds_azure_instance_size_map, $ds_google_instance_size_map, $param_new_instancetype_category, $ds_currency_code, $ds_currency_reference
 end
 
 script "js_merge_instance_data", type: "javascript" do

--- a/cost/superseded_instance/superseded_instance.pt
+++ b/cost/superseded_instance/superseded_instance.pt
@@ -8,7 +8,7 @@ severity "low"
 default_frequency "daily"
 tenancy "single"
 info(
-  version: "3.0",
+  version: "3.1",
   provider: "Flexera Optima",
   service: "",
   policy_set: ""

--- a/cost/superseded_instance/superseded_instance.pt
+++ b/cost/superseded_instance/superseded_instance.pt
@@ -69,10 +69,6 @@ credentials "auth_flexera" do
 end
 
 ###############################################################################
-# Resources
-###############################################################################
-
-###############################################################################
 # Datasources & Scripts
 ###############################################################################
 
@@ -98,13 +94,11 @@ script "js_get_billing_centers", type: "javascript" do
 end
 
 datasource "ds_costs_time_periods" do
-  request do
-    run_script $js_costs_time_periods, rs_org_id, rs_optima_host
-  end
+    run_script $js_costs_time_periods, rs_org_id, rs_optima_host, $ds_billing_centers
 end
 
 script "js_costs_time_periods", type: "javascript" do
-  parameters "rs_org_id", "rs_optima_host"
+  parameters "rs_org_id", "rs_optima_host", "ds_billing_centers"
   result "results"
   code <<-EOS
     // Get todays date
@@ -142,14 +136,13 @@ script "js_costs_time_periods", type: "javascript" do
         "current_month": current_month
       })
     })
-    //console.log(results)
   EOS
 end
 
 datasource "ds_new_bc_costs" do
   iterate $ds_costs_time_periods
   request do
-    run_script $js_new_costs_request, rs_org_id, $ds_billing_centers, $param_billing_centers, rs_optima_host, iter_item
+    run_script $js_new_costs_request, iter_item, rs_org_id, $ds_billing_centers, $param_billing_centers, rs_optima_host, $ds_costs_time_periods
   end
   result do
     encoding "json"
@@ -167,7 +160,7 @@ datasource "ds_new_bc_costs" do
 end
 
 script "js_new_costs_request", type: "javascript" do
-  parameters "org_id","ds_billing_centers", "param_billing_centers", "optima_host", "iter_item"
+  parameters "iter_item", "org_id", "ds_billing_centers", "param_billing_centers", "rs_optima_host", "ds_costs_time_periods"
   result "request"
   code <<-EOS
     var next_month = iter_item.next_month
@@ -222,7 +215,7 @@ script "js_new_costs_request", type: "javascript" do
 
     var request = {
       auth: "auth_flexera",
-      host: optima_host,
+      host: rs_optima_host,
       verb: "POST",
       path: "/bill-analysis/orgs/" + org_id + "/costs/select",
       body_fields: {
@@ -243,7 +236,7 @@ script "js_new_costs_request", type: "javascript" do
         "User-Agent": "RS Policies",
       }
     }
-    console.log(request)
+
 EOS
 end
 
@@ -356,7 +349,7 @@ script "js_merge_instance_data", type: "javascript" do
   result "results"
   code <<-EOS
     var results = []
-    var superseded_instance_map = _.extend(ds_aws_instance_size_map,ds_azure_instance_size_map, ds_google_instance_size_map)
+    var superseded_instance_map = _.extend(ds_aws_instance_size_map, ds_azure_instance_size_map, ds_google_instance_size_map)
     var ds_instances = ds_format_costs
 
     function formatNumber(number, separator){

--- a/cost/superseded_instance/superseded_instance.pt
+++ b/cost/superseded_instance/superseded_instance.pt
@@ -1,3 +1,5 @@
+const { iteratee } = require("underscore")
+
 name "Superseded Instances"
 rs_pt_ver 20180301
 type "policy"
@@ -82,9 +84,60 @@ datasource "ds_billing_centers" do
   end
 end
 
-datasource "ds_new_bc_costs" do
+datasource "ds_costs_time_periods" do
   request do
-    run_script $js_new_costs_request, rs_org_id, $ds_billing_centers, $param_billing_centers, rs_optima_host
+    run_script $js_costs_time_periods
+  end
+end
+
+script "js_costs_time_periods", type: "javascript" do
+  #parameters "rs_org_id","rs_optima_host"
+  result "results"
+  code <<-EOS
+    // Get todays date
+    var date = new Date();
+    var results = [];
+
+    // Setup time periods for collecting costs
+    var thirtyDaysAgo = Date().setMonth(date.getMonth()-1);
+    var sevenDaysAgo = Date().setDate(date.getDate()-7);
+    var timePeriods = [thirtyDaysAgo, sevenDaysAgo];
+
+    // For each time period, push the items
+    _.each(timePeriods, function(date) {
+      // Make sure we get at least a month worth of costs
+      var year = date.getUTCFullYear();
+      var month =  (date.getUTCMonth()==11)?1:2 + date.getUTCMonth();
+
+      if (month == 1){
+        var lmonth = 12;
+        var lyear = year ;
+        year=year+1;
+      } else {
+        var lmonth = month-1;
+        var lyear = year ;
+      }
+
+      mo = month.toString().length > 1 ? month : '0' + month;
+      lmo = lmonth.toString().length > 1 ? lmonth : '0' + lmonth;
+      var next_month = year + "-" + mo
+      var current_month = lyear + "-" + lmo
+
+      results.push({
+        "next_month": next_month,
+        "current_month": current_month
+      })
+    }
+
+
+
+  EOS
+end
+
+datasource "ds_new_bc_costs" do
+  iterate $ds_costs_time_periods
+  request do
+    run_script $js_new_costs_request, rs_org_id, $ds_billing_centers, $param_billing_centers, rs_optima_host, iter_item
   end
   result do
     encoding "json"
@@ -99,6 +152,86 @@ datasource "ds_new_bc_costs" do
       field "resource_id", jmes_path(col_item, "dimensions.resource_id")
     end
   end
+end
+
+script "js_new_costs_request", type: "javascript" do
+  parameters "org_id","ds_billing_centers", "param_billing_centers", "optima_host", "iter_item"
+  result "request"
+  code <<-EOS
+    var next_month = iter_item.next_month
+    var current_month = iter_item.current_month
+    var billing_center_ids = []
+    if (param_billing_centers.length === 0){
+      var top_billing_centers = _.reject(ds_billing_centers, function(bc){ return bc.parent_id != null });
+      billing_center_ids = _.map(top_billing_centers, function(value, key){ return value.id });
+    } else {
+      // get array of billing center id's that match the names in param_billing_centers.
+      billing_center_names = _.map(param_billing_centers, function(name){ return name.toLowerCase(); });
+      billing_center_ids = _.compact(_.map(ds_billing_centers, function(value){ if(_.contains(billing_center_names, value.name.toLowerCase())){return value.id} }));
+    }
+
+    var dimensions = ["billing_center_id","vendor","vendor_account","vendor_account_name", "category","instance_type","region","resource_type","service","usage_type","usage_unit","resource_id"]
+    var expression = [
+      {"type" : "and", "expressions" : [
+        {"dimension":"category","type":"equal","value":"Compute"},
+        {"dimension":"vendor","type":"equal","value":"Azure"},
+        {"dimension":"service", "type":"equal", value:"Microsoft.Compute"},
+        {"dimension":"resource_type","type":"substring","substring":"Virtual Machines"}
+      ]},
+      {"type" : "and", "expressions" : [
+        {"dimension":"category","type":"equal","value":"Compute"},
+        {"dimension":"vendor","type":"equal","value":"AzureCSP"},
+        {"dimension":"service", "type":"equal", value:"Microsoft.Compute"},
+        {"dimension":"resource_type","type":"substring","substring":"Virtual Machines"}
+      ]},
+      {"type" : "and", "expressions" : [
+        {"dimension":"category","type":"equal","value":"Compute"},
+        {"dimension":"resource_type","type":"equal","value":"Compute Instance"},
+        {"dimension":"vendor","type":"equal","value":"AWS"}
+      ]},
+      {"type" : "and", "expressions" : [
+        {"dimension":"category","type":"equal","value":"Compute"},
+        {"dimension":"vendor","type":"equal","value":"AzureMCA-Enterprise"},
+        {"dimension":"service", "type":"equal", value:"Microsoft.Compute"},
+        {"dimension":"resource_type","type":"substring","substring":"Virtual Machines"}
+      ]},
+        {"type" : "and", "expressions" : [
+        {"dimension":"category","type":"equal","value":"Compute"},
+        {"dimension":"vendor","type":"equal","value":"AzureMCA-CSP"},
+        {"dimension":"service", "type":"equal", value:"Microsoft.Compute"},
+        {"dimension":"resource_type","type":"substring","substring":"Virtual Machines"}
+      ]},
+      {"type" : "and", "expressions" : [
+        {"dimension":"vendor","type":"equal","value":"GCP"},
+        {"dimension":"service", "type":"equal", value:"Compute Engine"},
+        {"dimension":"resource_type","type":"substring","substring":"*running*"}
+      ]},
+    ]
+
+    var request = {
+      auth: "auth_flexera",
+      host: optima_host,
+      verb: "POST",
+      path: "/bill-analysis/orgs/" + org_id + "/costs/select",
+      body_fields: {
+        "billing_center_ids": billing_center_ids,
+        "dimensions": dimensions,
+        "metrics": ["usage_amount", "cost_amortized_unblended_adj"],
+        "granularity": "month",
+        "start_at": current_month,
+        "end_at": next_month,
+        "limit": 100000,
+        "filter": {
+          "type":"or",
+          "expressions": expression
+        }
+      },
+      headers: {
+        "Api-Version": "1.0",
+        "User-Agent": "RS Policies",
+      }
+    }
+EOS
 end
 
 datasource "ds_currency_reference" do
@@ -178,102 +311,6 @@ script "js_get_billing_centers", type: "javascript" do
   EOS
 end
 
-script "js_new_costs_request", type: "javascript" do
-  parameters "org_id","ds_billing_centers", "param_billing_centers", "optima_host"
-  result "request"
-  code <<-EOS
-    var date = new Date();
-    // Make sure we get at least a month worth of costs
-    date.setMonth(date.getMonth()-1);
-    var year = date.getUTCFullYear();
-    var month =  (date.getUTCMonth()==11)?1:2 + date.getUTCMonth();
-
-    if (month == 1){
-      var lmonth = 12;
-      var lyear = year ;
-      year=year+1;
-    } else {
-      var lmonth = month-1;
-      var lyear = year ;
-    }
-
-    mo = month.toString().length > 1 ? month : '0' + month;
-    lmo = lmonth.toString().length > 1 ? lmonth : '0' + lmonth;
-    var next_month = year + "-" + mo
-    var current_month = lyear + "-" + lmo
-    var billing_center_ids = []
-    if (param_billing_centers.length === 0){
-      var top_billing_centers = _.reject(ds_billing_centers, function(bc){ return bc.parent_id != null });
-      billing_center_ids = _.map(top_billing_centers, function(value, key){ return value.id });
-    } else {
-      // get array of billing center id's that match the names in param_billing_centers.
-      billing_center_names = _.map(param_billing_centers, function(name){ return name.toLowerCase(); });
-      billing_center_ids = _.compact(_.map(ds_billing_centers, function(value){ if(_.contains(billing_center_names, value.name.toLowerCase())){return value.id} }));
-    }
-
-    var dimensions = ["billing_center_id","vendor","vendor_account","vendor_account_name", "category","instance_type","region","resource_type","service","usage_type","usage_unit","resource_id"]
-    var expression = [
-      {"type" : "and", "expressions" : [
-        {"dimension":"category","type":"equal","value":"Compute"},
-        {"dimension":"vendor","type":"equal","value":"Azure"},
-        {"dimension":"service", "type":"equal", value:"Microsoft.Compute"},
-        {"dimension":"resource_type","type":"substring","substring":"Virtual Machines"}
-      ]},
-      {"type" : "and", "expressions" : [
-        {"dimension":"category","type":"equal","value":"Compute"},
-        {"dimension":"vendor","type":"equal","value":"AzureCSP"},
-        {"dimension":"service", "type":"equal", value:"Microsoft.Compute"},
-        {"dimension":"resource_type","type":"substring","substring":"Virtual Machines"}
-      ]},
-      {"type" : "and", "expressions" : [
-        {"dimension":"category","type":"equal","value":"Compute"},
-        {"dimension":"resource_type","type":"equal","value":"Compute Instance"},
-        {"dimension":"vendor","type":"equal","value":"AWS"}
-      ]},
-      {"type" : "and", "expressions" : [
-        {"dimension":"category","type":"equal","value":"Compute"},
-        {"dimension":"vendor","type":"equal","value":"AzureMCA-Enterprise"},
-        {"dimension":"service", "type":"equal", value:"Microsoft.Compute"},
-        {"dimension":"resource_type","type":"substring","substring":"Virtual Machines"}
-      ]},
-        {"type" : "and", "expressions" : [
-        {"dimension":"category","type":"equal","value":"Compute"},
-        {"dimension":"vendor","type":"equal","value":"AzureMCA-CSP"},
-        {"dimension":"service", "type":"equal", value:"Microsoft.Compute"},
-        {"dimension":"resource_type","type":"substring","substring":"Virtual Machines"}
-      ]},
-      {"type" : "and", "expressions" : [
-        {"dimension":"vendor","type":"equal","value":"GCP"},
-        {"dimension":"service", "type":"equal", value:"Compute Engine"},
-        {"dimension":"resource_type","type":"substring","substring":"*running*"}
-      ]},
-    ]
-
-    var request = {
-      auth: "auth_flexera",
-      host: optima_host,
-      verb: "POST",
-      path: "/bill-analysis/orgs/" + org_id + "/costs/select",
-      body_fields: {
-        "billing_center_ids": billing_center_ids,
-        "dimensions": dimensions,
-        "metrics": ["usage_amount", "cost_amortized_unblended_adj"],
-        "granularity": "month",
-        "start_at": current_month,
-        "end_at": next_month,
-        "limit": 100000,
-        "filter": {
-          "type":"or",
-          "expressions": expression
-        }
-      },
-      headers: {
-        "Api-Version": "1.0",
-        "User-Agent": "RS Policies",
-      }
-    }
-EOS
-end
 
 script "js_format_costs", type: "javascript" do
   parameters "new_bc_costs", "ds_billing_centers"


### PR DESCRIPTION
### Description

Added check if instance has been upgraded or not. 2 calls are made to optima, one for 30 days and one for 7 days. The data is then evaluated to see if the instance type has changed at all to the `new_instance_type`.

### Issues Resolved

[<!-- List any existing issues this PR resolves below -->]
(https://flexera.atlassian.net/browse/POL-796?search_id=ce79fdcd-cb6e-4a6f-b6c5-222fd3d4da60)

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
https://app.flexera.com/orgs/27018/automation/incidents/projects/116186?incidentId=646295fb0da9b30001e2ba1b

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
