### PR TITLE
FOPTS-834 Add X2iedn AWS instance types

### DIFF
--- a/data/aws/instance_types.json
+++ b/data/aws/instance_types.json
@@ -4579,6 +4579,78 @@
     "vcpu": "128",
     "nfu": "256"
   },
+  "x2iedn.xlarge": {
+    "up": "x2iedn.2xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8"
+  },
+  "x2iedn.2xlarge": {
+    "up": "x2iedn.4xlarge",
+    "down": "x2iedn.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16"
+  },
+  "x2iedn.4xlarge": {
+    "up": "x2iedn.8xlarge",
+    "down": "x2iedn.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32"
+  },
+  "x2iedn.8xlarge": {
+    "up": "x2iedn.16xlarge",
+    "down": "x2iedn.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64"
+  },
+  "x2iedn.16xlarge": {
+    "up": "x2iedn.24xlarge",
+    "down": "x2iedn.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128"
+  },
+  "x2iedn.24xlarge": {
+    "up": "x2iedn.32xlarge",
+    "down": "x2iedn.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192"
+  },
+  "x2iedn.32xlarge": {
+    "up": null,
+    "down": "x2iedn.24xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256"
+  },
+  "x2iedn.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256"
+  },
   "x2iezn.2xlarge": {
     "up": "x2iezn.4xlarge",
     "down": null,


### PR DESCRIPTION
### Description

X2iedn instance types were added to our EC2 reference file. This work was done using the following documents:

- https://aws.amazon.com/ec2/instance-types/
- https://aws.amazon.com/blogs/aws/new-instance-size-flexibility-for-ec2-reserved-instances/
- https://aws.amazon.com/ec2/previous-generation/

According to those, X2iedn.* instances have the following features:

- They are NOT compatible with EC2 classic (`"ec2_classic": false`)
- They all have enhanced networking(`"enhanced_networking: true`)
- They do NOT have an upgrade path (`"superseded": null`)

Here are some screenshots:
![image](https://github.com/flexera-public/policy_templates/assets/54189123/10f243e7-e928-4e52-9277-ce585ae31bcf)
![image](https://github.com/flexera-public/policy_templates/assets/54189123/0e169c63-864d-4e86-b431-67147d3aac84)
![image](https://github.com/flexera-public/policy_templates/assets/54189123/b86ce0a6-65ca-4244-bbe3-1df975694cb2)



### Issues Resolved

- https://flexera.atlassian.net/browse/FOPTS-843

### Link to Example Applied Policy

This change only adds data to a JSON file.

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
