### PR TITLE
Meta Parent Policy: Consolidated Incidents

### DIFF
--- a/README_META_POLICIES.md
+++ b/README_META_POLICIES.md
@@ -905,7 +905,7 @@ end
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
-# Could also just have one incident and use meta_status to determine which esclation happens
+# Could also just have one incident and use meta_status to determine which escalation happens
 policy "policy_scheduled_report" do
   # Combined incident with all of the data from the child incidents.
   # Replace RESOURCE_NAMES in the summary_template with the resources the specific child policy
@@ -923,6 +923,8 @@ policy "policy_scheduled_report" do
     export do
       resource_level true
       # Put fields from child policy export here but with any path statements removed.
+      # This is because we're actually pulling the incidents directly, where the path
+      # has already been changed.
     end
   end
   validate $ds_take_in_parameters do

--- a/README_META_POLICIES.md
+++ b/README_META_POLICIES.md
@@ -890,6 +890,10 @@ datasource "ds_child_incidents_combined" do
   run_script $js_child_incidents_combined, $ds_child_incident_details
 end
 
+# Note: Below datasource might need to be modified to include multiple results
+# if child policy raises multiple incidents.
+# The "summary" of each incident can be used to find out which one
+# individual incidents belong to.
 script "js_child_incidents_combined", type: "javascript" do
   parameters "ds_child_incident_details"
   result "result"
@@ -906,6 +910,12 @@ policy "policy_scheduled_report" do
   # Combined incident with all of the data from the child incidents.
   # Replace RESOURCE_NAMES in the summary_template with the resources the specific child policy
   # would be reporting on. For example, AWS Old Snapshots.
+
+  # Note: If child policy raises multiple incidents, be sure to put multiple incidents here too.
+  # In those cases, modify js_child_incidents_combined to return an object instead of a list
+  # with each key containing the list specific to that particular incident type.
+  # {{ len data }} in the summary_template, the check statement, and the export do statement
+  # should also be modified accordingly.
   validate $ds_child_incidents_combined do
     summary_template "Consolidated Incident: {{ len data }} RESOURCE_NAMES Found"
     escalate $esc_email

--- a/README_META_POLICIES.md
+++ b/README_META_POLICIES.md
@@ -898,7 +898,7 @@ script "js_child_incidents_combined", type: "javascript" do
   parameters "ds_child_incident_details"
   result "result"
   code <<-EOS
-  result = _.flatten(_.pluck(ds_child_incident_details, 'violation_data'))
+  result = _.flatten(_.pluck(ds_child_incident_details, 'violation_data')).slice(0, 100000)
 EOS
 end
 

--- a/README_META_POLICIES.md
+++ b/README_META_POLICIES.md
@@ -331,8 +331,8 @@ script "js_child_policy_options", type: "javascript" do
   code <<-EOS
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
-    // param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/README_META_POLICIES.md
+++ b/README_META_POLICIES.md
@@ -981,7 +981,7 @@ EOS
     detail_template <<-EOS
     Policies Being Created:
 
-    | Appplied Policy |
+    | Applied Policy |
     | --------------- |
     {{ range data -}}
     | {{ .name }} |
@@ -995,7 +995,7 @@ EOS
     detail_template <<-EOS
     Policies Being Updated:
 
-    | Appplied Policy |
+    | Applied Policy |
     | --------------- |
     {{ range data -}}
     | {{ .name }} |
@@ -1009,7 +1009,7 @@ EOS
     detail_template <<-EOS
     Policies being Deleted:
 
-    | Appplied Policy |
+    | Applied Policy |
     | --------------- |
     {{ range data -}}
     | {{ .name }} |

--- a/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
+++ b/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
@@ -16,6 +16,13 @@ info(
 
 ## Meta Parent Parameters
 ## These are params specific to the meta parent policy.
+parameter "param_combined_incident_email" do
+  type "list"
+  label "Email addresses for combined incident"
+  description "A list of email addresses to notify with the consolidated child policy incident."
+  default []
+end
+
 parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
@@ -730,12 +737,126 @@ script "js_only_delete", type: "javascript" do
   EOS
 end
 
+# The following datasources consolidate the child incident output into a single incident.
+# This is because it is more convenient for many users to have a single incident with all of the data.
+datasource "ds_child_incident_details" do
+  iterate $ds_get_existing_policies_incidents
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/incidents/", val(iter_item, 'incident_id')])
+    verb "GET"
+    header "User-Agent", "RS Policies"
+    header "Api-Version", "1.0"
+    query "view", "extended"
+  end
+end
+
+datasource "ds_child_incidents_combined" do
+  run_script $js_child_incidents_combined, $ds_child_incident_details
+end
+
+script "js_child_incidents_combined", type: "javascript" do
+  parameters "ds_child_incident_details"
+  result "result"
+  code <<-EOS
+  result = _.flatten(_.pluck(ds_child_incident_details, 'violation_data'))
+EOS
+end
 
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
 # Could also just have one incident and use meta_status to determine which esclation happens
 policy "policy_scheduled_report" do
+  # Combined incident with all of the data from the child incidents
+  validate $ds_child_incidents_combined do
+    summary_template "Consolidated Incident: {{ len data }} Idle AWS EC2 Instances Found"
+    escalate $esc_email
+    check eq(size(data), 0)
+    export do
+      resource_level true
+      field "accountID" do
+        label "Account Id"
+      end
+      field "accountName" do
+        label "Account Name"
+      end
+      field "resourceID" do
+        label "Resource ID"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "platform" do
+        label "Platform"
+      end
+      field "hostname" do
+        label "Hostname"
+      end
+      field "resourceType" do
+        label "Resource Type"
+      end
+      field "savings" do
+        label "Estimated Monthly Savings"
+      end
+      field "savingsCurrency" do
+        label "Savings Currency"
+      end
+      field "privateDnsName" do
+        label "Private DNS Name"
+      end
+      field "launchTime" do
+        label "Launch Time"
+      end
+      field "cpu_maximum" do
+        label "CPU Maximum %"
+      end
+      field "cpu_minimum" do
+        label "CPU Minimum %"
+      end
+      field "cpu_average" do
+        label "CPU Average %"
+      end
+      field "cpu_p99" do
+        label "CPU p99"
+      end
+      field "cpu_p95" do
+        label "CPU p95"
+      end
+      field "cpu_p90" do
+        label "CPU p90"
+      end
+      field "mem_maximum" do
+        label "Memory Maximum %"
+      end
+      field "mem_minimum" do
+        label "Memory Minimum %"
+      end
+      field "mem_average" do
+        label "Memory Average %"
+      end
+      field "mem_p99" do
+        label "Memory p99"
+      end
+      field "mem_p95" do
+        label "Memory p95"
+      end
+      field "mem_p90" do
+        label "Memory p90"
+      end
+      field "tags" do
+        label "Tags"
+      end
+      field "id" do
+        label "ID"
+        path "resourceID"
+      end
+      field "service" do
+        label "Service"
+      end
+    end
+  end
   validate $ds_take_in_parameters do
     summary_template "{{ data.parent_policy.name }}: Status of Child Policies"
     detail_template <<-EOS
@@ -829,6 +950,14 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Used only for emailing the combined child incident if so desired
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_combined_incident_email
 end
 
 escalation "create_policies" do

--- a/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
+++ b/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
@@ -913,7 +913,7 @@ EOS
     detail_template <<-EOS
     Policies Being Created:
 
-    | Appplied Policy |
+    | Applied Policy |
     | --------------- |
     {{ range data -}}
     | {{ .name }} |
@@ -927,7 +927,7 @@ EOS
     detail_template <<-EOS
     Policies Being Updated:
 
-    | Appplied Policy |
+    | Applied Policy |
     | --------------- |
     {{ range data -}}
     | {{ .name }} |
@@ -941,7 +941,7 @@ EOS
     detail_template <<-EOS
     Policies being Deleted:
 
-    | Appplied Policy |
+    | Applied Policy |
     | --------------- |
     {{ range data -}}
     | {{ .name }} |

--- a/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
+++ b/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
@@ -760,7 +760,7 @@ script "js_child_incidents_combined", type: "javascript" do
   parameters "ds_child_incident_details"
   result "result"
   code <<-EOS
-  result = _.flatten(_.pluck(ds_child_incident_details, 'violation_data'))
+  result = _.flatten(_.pluck(ds_child_incident_details, 'violation_data')).slice(0, 100000)
 EOS
 end
 

--- a/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
+++ b/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
@@ -194,8 +194,8 @@ script "js_child_policy_options", type: "javascript" do
   code <<-EOS
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
-    // param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
@@ -16,6 +16,13 @@ info(
 
 ## Meta Parent Parameters
 ## These are params specific to the meta parent policy.
+parameter "param_combined_incident_email" do
+  type "list"
+  label "Email addresses for combined incident"
+  description "A list of email addresses to notify with the consolidated child policy incident."
+  default []
+end
+
 parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
@@ -679,12 +686,74 @@ script "js_only_delete", type: "javascript" do
   EOS
 end
 
+# The following datasources consolidate the child incident output into a single incident.
+# This is because it is more convenient for many users to have a single incident with all of the data.
+datasource "ds_child_incident_details" do
+  iterate $ds_get_existing_policies_incidents
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/incidents/", val(iter_item, 'incident_id')])
+    verb "GET"
+    header "User-Agent", "RS Policies"
+    header "Api-Version", "1.0"
+    query "view", "extended"
+  end
+end
+
+datasource "ds_child_incidents_combined" do
+  run_script $js_child_incidents_combined, $ds_child_incident_details
+end
+
+script "js_child_incidents_combined", type: "javascript" do
+  parameters "ds_child_incident_details"
+  result "result"
+  code <<-EOS
+  result = _.flatten(_.pluck(ds_child_incident_details, 'violation_data'))
+EOS
+end
 
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
 # Could also just have one incident and use meta_status to determine which esclation happens
 policy "policy_scheduled_report" do
+  # Combined incident with all of the data from the child incidents
+  validate $ds_child_incidents_combined do
+    summary_template "Consolidated Incident: {{ len data }} Opportunities for AWS Object Storage Optimization Found"
+    escalate $esc_email
+    check eq(size(data), 0)
+    export do
+      resource_level true
+      field "accountId" do
+        label "Account Id"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "id" do
+        label "Bucket Name"
+      end
+      field "object_key" do
+        label "Object Key"
+      end
+      field "storage_class" do
+        label "Current Storage Class"
+      end
+      field "last_modified" do
+        label "Last Modified Date"
+      end
+      field "modify_storage_class_to" do
+        label "Move Storage Class To"
+      end
+      field "tagKeyValue" do
+        label "Tags"
+      end
+      field "host" do
+        label "Host"
+      end
+    end
+  end
   validate $ds_take_in_parameters do
     summary_template "{{ data.parent_policy.name }}: Status of Child Policies"
     detail_template <<-EOS
@@ -778,6 +847,14 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Used only for emailing the combined child incident if so desired
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_combined_incident_email
 end
 
 escalation "create_policies" do

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
@@ -810,7 +810,7 @@ EOS
     detail_template <<-EOS
     Policies Being Created:
 
-    | Appplied Policy |
+    | Applied Policy |
     | --------------- |
     {{ range data -}}
     | {{ .name }} |
@@ -824,7 +824,7 @@ EOS
     detail_template <<-EOS
     Policies Being Updated:
 
-    | Appplied Policy |
+    | Applied Policy |
     | --------------- |
     {{ range data -}}
     | {{ .name }} |
@@ -838,7 +838,7 @@ EOS
     detail_template <<-EOS
     Policies being Deleted:
 
-    | Appplied Policy |
+    | Applied Policy |
     | --------------- |
     {{ range data -}}
     | {{ .name }} |

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
@@ -143,8 +143,8 @@ script "js_child_policy_options", type: "javascript" do
   code <<-EOS
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
-    // param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
@@ -709,7 +709,7 @@ script "js_child_incidents_combined", type: "javascript" do
   parameters "ds_child_incident_details"
   result "result"
   code <<-EOS
-  result = _.flatten(_.pluck(ds_child_incident_details, 'violation_data'))
+  result = _.flatten(_.pluck(ds_child_incident_details, 'violation_data')).slice(0, 100000)
 EOS
 end
 

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
@@ -716,12 +716,33 @@ end
 
 # The following datasources consolidate the child incident output into a single incident.
 # This is because it is more convenient for many users to have a single incident with all of the data.
-datasource "ds_child_incident_details" do
-  iterate $ds_get_existing_policies_incidents
+# Technically ds_child_incidents is redundant but it impacts execution order of other functionality
+# of the policy if we use the existing datasource, so we have a dedicated one here for
+# the combined incident.
+datasource "ds_child_incidents" do
   request do
     auth $auth_flexera
     host rs_governance_host
-    path join(["/api/governance/projects/", rs_project_id, "/incidents/", val(iter_item, 'incident_id')])
+    path join(["/api/governance/projects/", rs_project_id, "/incidents"])
+    verb "GET"
+    header "User-Agent", "RS Policies"
+    header "Api-Version", "1.0"
+    query "meta_parent_policy_id", policy_id
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "items") do
+      field "id", jmes_path(col_item, "id")
+    end
+  end
+end
+
+datasource "ds_child_incident_details" do
+  iterate $ds_child_incidents
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/incidents/", val(iter_item, 'id')])
     verb "GET"
     header "User-Agent", "RS Policies"
     header "Api-Version", "1.0"

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
@@ -171,8 +171,8 @@ script "js_child_policy_options", type: "javascript" do
   code <<-EOS
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
-    // param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -716,33 +716,12 @@ end
 
 # The following datasources consolidate the child incident output into a single incident.
 # This is because it is more convenient for many users to have a single incident with all of the data.
-# Technically ds_child_incidents is redundant but it impacts execution order of other functionality
-# of the policy if we use the existing datasource, so we have a dedicated one here for
-# the combined incident.
-datasource "ds_child_incidents" do
-  request do
-    auth $auth_flexera
-    host rs_governance_host
-    path join(["/api/governance/projects/", rs_project_id, "/incidents"])
-    verb "GET"
-    header "User-Agent", "RS Policies"
-    header "Api-Version", "1.0"
-    query "meta_parent_policy_id", policy_id
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "items") do
-      field "id", jmes_path(col_item, "id")
-    end
-  end
-end
-
 datasource "ds_child_incident_details" do
-  iterate $ds_child_incidents
+  iterate $ds_get_existing_policies_incidents
   request do
     auth $auth_flexera
     host rs_governance_host
-    path join(["/api/governance/projects/", rs_project_id, "/incidents/", val(iter_item, 'id')])
+    path join(["/api/governance/projects/", rs_project_id, "/incidents/", val(iter_item, 'incident_id')])
     verb "GET"
     header "User-Agent", "RS Policies"
     header "Api-Version", "1.0"

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
@@ -737,7 +737,7 @@ script "js_child_incidents_combined", type: "javascript" do
   parameters "ds_child_incident_details"
   result "result"
   code <<-EOS
-  result = _.flatten(_.pluck(ds_child_incident_details, 'violation_data'))
+  result = _.flatten(_.pluck(ds_child_incident_details, 'violation_data')).slice(0, 100000)
 EOS
 end
 

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
@@ -856,7 +856,7 @@ EOS
     detail_template <<-EOS
     Policies Being Created:
 
-    | Appplied Policy |
+    | Applied Policy |
     | --------------- |
     {{ range data -}}
     | {{ .name }} |
@@ -870,7 +870,7 @@ EOS
     detail_template <<-EOS
     Policies Being Updated:
 
-    | Appplied Policy |
+    | Applied Policy |
     | --------------- |
     {{ range data -}}
     | {{ .name }} |
@@ -884,7 +884,7 @@ EOS
     detail_template <<-EOS
     Policies being Deleted:
 
-    | Appplied Policy |
+    | Applied Policy |
     | --------------- |
     {{ range data -}}
     | {{ .name }} |

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
@@ -16,6 +16,13 @@ info(
 
 ## Meta Parent Parameters
 ## These are params specific to the meta parent policy.
+parameter "param_combined_incident_email" do
+  type "list"
+  label "Email addresses for combined incident"
+  description "A list of email addresses to notify with the consolidated child policy incident."
+  default []
+end
+
 parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
@@ -707,12 +714,92 @@ script "js_only_delete", type: "javascript" do
   EOS
 end
 
+# The following datasources consolidate the child incident output into a single incident.
+# This is because it is more convenient for many users to have a single incident with all of the data.
+datasource "ds_child_incident_details" do
+  iterate $ds_get_existing_policies_incidents
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/incidents/", val(iter_item, 'incident_id')])
+    verb "GET"
+    header "User-Agent", "RS Policies"
+    header "Api-Version", "1.0"
+    query "view", "extended"
+  end
+end
+
+datasource "ds_child_incidents_combined" do
+  run_script $js_child_incidents_combined, $ds_child_incident_details
+end
+
+script "js_child_incidents_combined", type: "javascript" do
+  parameters "ds_child_incident_details"
+  result "result"
+  code <<-EOS
+  result = _.flatten(_.pluck(ds_child_incident_details, 'violation_data'))
+EOS
+end
 
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
 # Could also just have one incident and use meta_status to determine which esclation happens
 policy "policy_scheduled_report" do
+  # Combined incident with all of the data from the child incidents
+  validate $ds_child_incidents_combined do
+    summary_template "Consolidated Incident: {{ len data }} AWS Old Snapshots Found"
+    escalate $esc_email
+    check eq(size(data), 0)
+    export do
+      resource_level true
+      field "accountID" do
+        label "Account ID"
+      end
+      field "accountName" do
+        label "Account Name"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "daysOld" do
+        label "Days Old"
+      end
+      field "volumeSize" do
+        label "Size"
+      end
+      field "resourceID" do
+        label "Resource ID"
+      end
+      field "resourceType" do
+        label "Resource Type"
+      end
+      field "imageId" do
+        label "AMI"
+      end
+      field "dbClusterId" do
+        label "RDS DB Cluster ID"
+      end
+      field "dbInstanceId" do
+        label "RDS DB Instance ID"
+      end
+      field "savings" do
+        label "Estimated Monthly Savings"
+      end
+      field "savingsCurrency" do
+        label "Savings Currency"
+      end
+      field "tags" do
+        label "Tags"
+      end
+      field "id" do
+        label "ID"
+      end
+      field "service" do
+        label "Service"
+      end
+    end
+  end
   validate $ds_take_in_parameters do
     summary_template "{{ data.parent_policy.name }}: Status of Child Policies"
     detail_template <<-EOS
@@ -806,6 +893,14 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Used only for emailing the combined child incident if so desired
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_combined_incident_email
 end
 
 escalation "create_policies" do

--- a/cost/aws/rightsize_compute_instances/rightsize_compute_instances_meta_parent.pt
+++ b/cost/aws/rightsize_compute_instances/rightsize_compute_instances_meta_parent.pt
@@ -16,6 +16,13 @@ info(
 
 ## Meta Parent Parameters
 ## These are params specific to the meta parent policy.
+parameter "param_combined_incident_email" do
+  type "list"
+  label "Email addresses for combined incident"
+  description "A list of email addresses to notify with the consolidated child policy incident."
+  default []
+end
+
 parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
@@ -757,12 +764,231 @@ script "js_only_delete", type: "javascript" do
   EOS
 end
 
+# The following datasources consolidate the child incident output into a single incident.
+# This is because it is more convenient for many users to have a single incident with all of the data.
+datasource "ds_child_incident_details" do
+  iterate $ds_get_existing_policies_incidents
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/incidents/", val(iter_item, 'incident_id')])
+    verb "GET"
+    header "User-Agent", "RS Policies"
+    header "Api-Version", "1.0"
+    query "view", "extended"
+  end
+end
+
+datasource "ds_child_incidents_combined" do
+  run_script $js_child_incidents_combined, $ds_child_incident_details
+end
+
+script "js_child_incidents_combined", type: "javascript" do
+  parameters "ds_child_incident_details"
+  result "result"
+  code <<-EOS
+  underutil_incidents = _.filter(ds_child_incident_details, function(incident) {
+    return _.contains(incident["summary"].split(' '), 'underutilized')
+  })
+
+  idle_incidents = _.filter(ds_child_incident_details, function(incident) {
+    return _.contains(incident["summary"].split(' '), 'idle')
+  })
+
+  result = {
+    underutil: _.flatten(_.pluck(underutil_incidents, 'violation_data')),
+    idle: _.flatten(_.pluck(idle_incidents, 'violation_data'))
+  }
+EOS
+end
 
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
 # Could also just have one incident and use meta_status to determine which esclation happens
 policy "policy_scheduled_report" do
+  # Combined incidents with all of the data from the child incidents
+  validate $ds_child_incidents_combined do
+    summary_template "Consolidated Incident: {{ len data.underutil }} AWS Underutilized Compute Instances Found"
+    escalate $esc_email
+    check eq(size(val(data, 'underutil')), 0)
+    export 'underutil' do
+      resource_level true
+      field "accountID" do
+        label "Account ID"
+      end
+      field "accountName" do
+        label "Account Name"
+      end
+      field "resourceID" do
+        label "Resource ID"
+      end
+      field "resourceType" do
+        label "Instance Size"
+      end
+      field "recommendedVmSize" do
+        label "Recommended Instance Size"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "platform" do
+        label "Platform"
+      end
+      field "hostname" do
+        label "Hostname"
+      end
+      field "savings" do
+        label "Estimated Monthly Savings"
+      end
+      field "savingsCurrency" do
+        label "Savings Currency"
+      end
+      field "privateDnsName" do
+        label "Private DNS Name"
+      end
+      field "launchTime" do
+        label "Launch Time"
+      end
+      field "cpu_maximum" do
+        label "CPU Maximum %"
+      end
+      field "cpu_minimum" do
+        label "CPU Minimum %"
+      end
+      field "cpu_average" do
+        label "CPU Average %"
+      end
+      field "cpu_p99" do
+        label "CPU p99"
+      end
+      field "cpu_p95" do
+        label "CPU p95"
+      end
+      field "cpu_p90" do
+        label "CPU p90"
+      end
+      field "mem_maximum" do
+        label "Memory Maximum %"
+      end
+      field "mem_minimum" do
+        label "Memory Minimum %"
+      end
+      field "mem_average" do
+        label "Memory Average %"
+      end
+      field "mem_p99" do
+        label "Memory p99"
+      end
+      field "mem_p95" do
+        label "Memory p95"
+      end
+      field "mem_p90" do
+        label "Memory p90"
+      end
+      field "tags" do
+        label "Tags"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "id" do
+        label "ID"
+      end
+    end
+  end
+  validate $ds_child_incidents_combined do
+    summary_template "Consolidated Incident: {{ len data.idle }} AWS Idle Compute Instances Found"
+    escalate $esc_email
+    check eq(size(val(data, 'idle')), 0)
+    export 'idle' do
+      resource_level true
+      field "accountID" do
+        label "Account ID"
+      end
+      field "accountName" do
+        label "Account Name"
+      end
+      field "resourceID" do
+        label "Resource ID"
+      end
+      field "resourceType" do
+        label "Resource Type"
+      end
+      field "vmSize" do
+        label "Instance Size"
+      end
+      field "recommendedVmSize" do
+        label "Recommended Instance Size"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "platform" do
+        label "Platform"
+      end
+      field "hostname" do
+        label "Hostname"
+      end
+      field "savings" do
+        label "Estimated Monthly Savings"
+      end
+      field "savingsCurrency" do
+        label "Savings Currency"
+      end
+      field "privateDnsName" do
+        label "Private DNS Name"
+      end
+      field "launchTime" do
+        label "Launch Time"
+      end
+      field "cpu_maximum" do
+        label "CPU Maximum %"
+      end
+      field "cpu_minimum" do
+        label "CPU Minimum %"
+      end
+      field "cpu_average" do
+        label "CPU Average %"
+      end
+      field "cpu_p99" do
+        label "CPU p99"
+      end
+      field "cpu_p95" do
+        label "CPU p95"
+      end
+      field "cpu_p90" do
+        label "CPU p90"
+      end
+      field "mem_maximum" do
+        label "Memory Maximum %"
+      end
+      field "mem_minimum" do
+        label "Memory Minimum %"
+      end
+      field "mem_average" do
+        label "Memory Average %"
+      end
+      field "mem_p99" do
+        label "Memory p99"
+      end
+      field "mem_p95" do
+        label "Memory p95"
+      end
+      field "mem_p90" do
+        label "Memory p90"
+      end
+      field "tags" do
+        label "Tags"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "id" do
+        label "ID"
+      end
+    end
+  end
   validate $ds_take_in_parameters do
     summary_template "{{ data.parent_policy.name }}: Status of Child Policies"
     detail_template <<-EOS
@@ -856,6 +1082,14 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Used only for emailing the combined child incident if so desired
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_combined_incident_email
 end
 
 escalation "create_policies" do

--- a/cost/aws/rightsize_compute_instances/rightsize_compute_instances_meta_parent.pt
+++ b/cost/aws/rightsize_compute_instances/rightsize_compute_instances_meta_parent.pt
@@ -219,8 +219,8 @@ script "js_child_policy_options", type: "javascript" do
   code <<-EOS
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
-    // param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/aws/rightsize_compute_instances/rightsize_compute_instances_meta_parent.pt
+++ b/cost/aws/rightsize_compute_instances/rightsize_compute_instances_meta_parent.pt
@@ -796,8 +796,8 @@ script "js_child_incidents_combined", type: "javascript" do
   })
 
   result = {
-    underutil: _.flatten(_.pluck(underutil_incidents, 'violation_data')),
-    idle: _.flatten(_.pluck(idle_incidents, 'violation_data'))
+    underutil: _.flatten(_.pluck(underutil_incidents, 'violation_data')).slice(0, 100000),
+    idle: _.flatten(_.pluck(idle_incidents, 'violation_data')).slice(0, 100000)
   }
 EOS
 end

--- a/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
@@ -704,7 +704,7 @@ script "js_child_incidents_combined", type: "javascript" do
   parameters "ds_child_incident_details"
   result "result"
   code <<-EOS
-  result = _.flatten(_.pluck(ds_child_incident_details, 'violation_data'))
+  result = _.flatten(_.pluck(ds_child_incident_details, 'violation_data')).slice(0, 100000)
 EOS
 end
 

--- a/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
@@ -136,8 +136,8 @@ script "js_child_policy_options", type: "javascript" do
   code <<-EOS
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
-    // param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
@@ -16,6 +16,13 @@ info(
 
 ## Meta Parent Parameters
 ## These are params specific to the meta parent policy.
+parameter "param_combined_incident_email" do
+  type "list"
+  label "Email addresses for combined incident"
+  description "A list of email addresses to notify with the consolidated child policy incident."
+  default []
+end
+
 parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
@@ -674,12 +681,89 @@ script "js_only_delete", type: "javascript" do
   EOS
 end
 
+# The following datasources consolidate the child incident output into a single incident.
+# This is because it is more convenient for many users to have a single incident with all of the data.
+datasource "ds_child_incident_details" do
+  iterate $ds_get_existing_policies_incidents
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/incidents/", val(iter_item, 'incident_id')])
+    verb "GET"
+    header "User-Agent", "RS Policies"
+    header "Api-Version", "1.0"
+    query "view", "extended"
+  end
+end
+
+datasource "ds_child_incidents_combined" do
+  run_script $js_child_incidents_combined, $ds_child_incident_details
+end
+
+script "js_child_incidents_combined", type: "javascript" do
+  parameters "ds_child_incident_details"
+  result "result"
+  code <<-EOS
+  result = _.flatten(_.pluck(ds_child_incident_details, 'violation_data'))
+EOS
+end
 
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
 # Could also just have one incident and use meta_status to determine which esclation happens
 policy "policy_scheduled_report" do
+  # Combined incident with all of the data from the child incidents
+  validate $ds_child_incidents_combined do
+    summary_template "Consolidated Incident: {{ len data }} AWS Underutilized EBS Volumes Found"
+    escalate $esc_email
+    check eq(size(data), 0)
+    export do
+      resource_level true
+      field "accountID" do
+        label "Account ID"
+      end
+      field "resourceID" do
+        label "Volume ID"
+      end
+      field "size" do
+        label "Volume Size (GB)"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "status" do
+        label "Volume Status"
+      end
+      field "attachmentStatus" do
+        label "Volume Attachment Status"
+      end
+      field "resourceType" do
+        label "Volume Type"
+      end
+      field "gp2Price" do
+        label "Monthly Cost"
+      end
+      field "gp3Price" do
+        label "Monthly Cost if moved to GP3"
+      end
+      field "savings" do
+        label "Estimated Monthly Savings from moving to GP3"
+      end
+      field "tags" do
+        label "Tags"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "cloudwatchDataWarning" do
+        label "CloudWatch Data Warning"
+      end
+      field "id" do
+        label "Volume ID"
+      end
+    end
+  end
   validate $ds_take_in_parameters do
     summary_template "{{ data.parent_policy.name }}: Status of Child Policies"
     detail_template <<-EOS
@@ -773,6 +857,14 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Used only for emailing the combined child incident if so desired
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_combined_incident_email
 end
 
 escalation "create_policies" do

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
@@ -822,7 +822,7 @@ EOS
     detail_template <<-EOS
     Policies Being Created:
 
-    | Appplied Policy |
+    | Applied Policy |
     | --------------- |
     {{ range data -}}
     | {{ .name }} |
@@ -836,7 +836,7 @@ EOS
     detail_template <<-EOS
     Policies Being Updated:
 
-    | Appplied Policy |
+    | Applied Policy |
     | --------------- |
     {{ range data -}}
     | {{ .name }} |
@@ -850,7 +850,7 @@ EOS
     detail_template <<-EOS
     Policies being Deleted:
 
-    | Appplied Policy |
+    | Applied Policy |
     | --------------- |
     {{ range data -}}
     | {{ .name }} |

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
@@ -16,6 +16,13 @@ info(
 
 ## Meta Parent Parameters
 ## These are params specific to the meta parent policy.
+parameter "param_combined_incident_email" do
+  type "list"
+  label "Email addresses for combined incident"
+  description "A list of email addresses to notify with the consolidated child policy incident."
+  default []
+end
+
 parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
@@ -682,12 +689,83 @@ script "js_only_delete", type: "javascript" do
   EOS
 end
 
+# The following datasources consolidate the child incident output into a single incident.
+# This is because it is more convenient for many users to have a single incident with all of the data.
+datasource "ds_child_incident_details" do
+  iterate $ds_get_existing_policies_incidents
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/incidents/", val(iter_item, 'incident_id')])
+    verb "GET"
+    header "User-Agent", "RS Policies"
+    header "Api-Version", "1.0"
+    query "view", "extended"
+  end
+end
+
+datasource "ds_child_incidents_combined" do
+  run_script $js_child_incidents_combined, $ds_child_incident_details
+end
+
+script "js_child_incidents_combined", type: "javascript" do
+  parameters "ds_child_incident_details"
+  result "result"
+  code <<-EOS
+  result = _.flatten(_.pluck(ds_child_incident_details, 'violation_data'))
+EOS
+end
 
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
 # Could also just have one incident and use meta_status to determine which esclation happens
 policy "policy_scheduled_report" do
+  # Combined incident with all of the data from the child incidents
+  validate $ds_child_incidents_combined do
+    summary_template "Consolidated Incident: {{ len data }} AWS Unused IP Addresses Found"
+    escalate $esc_email
+    check eq(size(data), 0)
+    export do
+      resource_level true
+      field "accountID" do
+        label "Account Id"
+      end
+      field "accountName" do
+        label "Account Name"
+      end
+      field "resourceID" do
+        label "Resource ID"
+      end
+      field "resourceType" do
+        label "Resource Type"
+      end
+      field "domain" do
+        label "Domain"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "tags" do
+        label "Tags"
+      end
+      field "allocationID" do
+        label "Allocation Id"
+      end
+      field "savings" do
+        label "Estimated Monthly Savings"
+      end
+      field "savingsCurrency" do
+        label "Savings Currency"
+      end
+      field "id" do
+        label "ID"
+      end
+      field "service" do
+        label "Service"
+      end
+    end
+  end
   validate $ds_take_in_parameters do
     summary_template "{{ data.parent_policy.name }}: Status of Child Policies"
     detail_template <<-EOS
@@ -781,6 +859,14 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Used only for emailing the combined child incident if so desired
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_combined_incident_email
 end
 
 escalation "create_policies" do

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
@@ -712,7 +712,7 @@ script "js_child_incidents_combined", type: "javascript" do
   parameters "ds_child_incident_details"
   result "result"
   code <<-EOS
-  result = _.flatten(_.pluck(ds_child_incident_details, 'violation_data'))
+  result = _.flatten(_.pluck(ds_child_incident_details, 'violation_data')).slice(0, 100000)
 EOS
 end
 

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
@@ -146,8 +146,8 @@ script "js_child_policy_options", type: "javascript" do
   code <<-EOS
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
-    // param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/aws/unused_rds/unused_rds_meta_parent.pt
+++ b/cost/aws/unused_rds/unused_rds_meta_parent.pt
@@ -16,6 +16,13 @@ info(
 
 ## Meta Parent Parameters
 ## These are params specific to the meta parent policy.
+parameter "param_combined_incident_email" do
+  type "list"
+  label "Email addresses for combined incident"
+  description "A list of email addresses to notify with the consolidated child policy incident."
+  default []
+end
+
 parameter "param_dimension_filter_includes" do
   type "list"
   default []
@@ -685,12 +692,89 @@ script "js_only_delete", type: "javascript" do
   EOS
 end
 
+# The following datasources consolidate the child incident output into a single incident.
+# This is because it is more convenient for many users to have a single incident with all of the data.
+datasource "ds_child_incident_details" do
+  iterate $ds_get_existing_policies_incidents
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/incidents/", val(iter_item, 'incident_id')])
+    verb "GET"
+    header "User-Agent", "RS Policies"
+    header "Api-Version", "1.0"
+    query "view", "extended"
+  end
+end
+
+datasource "ds_child_incidents_combined" do
+  run_script $js_child_incidents_combined, $ds_child_incident_details
+end
+
+script "js_child_incidents_combined", type: "javascript" do
+  parameters "ds_child_incident_details"
+  result "result"
+  code <<-EOS
+  result = _.flatten(_.pluck(ds_child_incident_details, 'violation_data'))
+EOS
+end
 
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
 # Could also just have one incident and use meta_status to determine which esclation happens
 policy "policy_scheduled_report" do
+  # Combined incident with all of the data from the child incidents
+  validate $ds_child_incidents_combined do
+    summary_template "Consolidated Incident: {{ len data }} AWS Unused RDS Instances Found"
+    escalate $esc_email
+    check eq(size(data), 0)
+    export do
+      resource_level true
+      field "accountID" do
+        label "Account ID"
+      end
+      field "accountName" do
+        label "Account Name"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "name" do
+        label "Name"
+      end
+      field "status" do
+        label "Status"
+      end
+      field "savings" do
+        label "Estimated Monthly Savings"
+      end
+      field "savingsCurrency" do
+        label "Savings Currency"
+      end
+      field "resourceID" do
+        label "Resource Id"
+      end
+      field "privateDnsName" do
+        label "Private DNS Name"
+      end
+      field "resourceType" do
+        label "Resource Type"
+      end
+      field "arn" do
+        label "ARN"
+      end
+      field "tags" do
+        label "Tags"
+      end
+      field "id" do
+        label "id"
+      end
+      field "service" do
+        label "Service"
+      end
+    end
+  end
   validate $ds_take_in_parameters do
     summary_template "{{ data.parent_policy.name }}: Status of Child Policies"
     detail_template <<-EOS
@@ -784,6 +868,14 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Used only for emailing the combined child incident if so desired
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_combined_incident_email
 end
 
 escalation "create_policies" do

--- a/cost/aws/unused_rds/unused_rds_meta_parent.pt
+++ b/cost/aws/unused_rds/unused_rds_meta_parent.pt
@@ -149,8 +149,8 @@ script "js_child_policy_options", type: "javascript" do
   code <<-EOS
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
-    // param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/aws/unused_rds/unused_rds_meta_parent.pt
+++ b/cost/aws/unused_rds/unused_rds_meta_parent.pt
@@ -831,7 +831,7 @@ EOS
     detail_template <<-EOS
     Policies Being Created:
 
-    | Appplied Policy |
+    | Applied Policy |
     | --------------- |
     {{ range data -}}
     | {{ .name }} |
@@ -845,7 +845,7 @@ EOS
     detail_template <<-EOS
     Policies Being Updated:
 
-    | Appplied Policy |
+    | Applied Policy |
     | --------------- |
     {{ range data -}}
     | {{ .name }} |
@@ -859,7 +859,7 @@ EOS
     detail_template <<-EOS
     Policies being Deleted:
 
-    | Appplied Policy |
+    | Applied Policy |
     | --------------- |
     {{ range data -}}
     | {{ .name }} |

--- a/cost/aws/unused_rds/unused_rds_meta_parent.pt
+++ b/cost/aws/unused_rds/unused_rds_meta_parent.pt
@@ -715,7 +715,7 @@ script "js_child_incidents_combined", type: "javascript" do
   parameters "ds_child_incident_details"
   result "result"
   code <<-EOS
-  result = _.flatten(_.pluck(ds_child_incident_details, 'violation_data'))
+  result = _.flatten(_.pluck(ds_child_incident_details, 'violation_data')).slice(0, 100000)
 EOS
 end
 

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
@@ -868,7 +868,7 @@ EOS
     detail_template <<-EOS
     Policies Being Created:
 
-    | Appplied Policy |
+    | Applied Policy |
     | --------------- |
     {{ range data -}}
     | {{ .name }} |
@@ -882,7 +882,7 @@ EOS
     detail_template <<-EOS
     Policies Being Updated:
 
-    | Appplied Policy |
+    | Applied Policy |
     | --------------- |
     {{ range data -}}
     | {{ .name }} |
@@ -896,7 +896,7 @@ EOS
     detail_template <<-EOS
     Policies being Deleted:
 
-    | Appplied Policy |
+    | Applied Policy |
     | --------------- |
     {{ range data -}}
     | {{ .name }} |

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
@@ -16,6 +16,13 @@ info(
 
 ## Meta Parent Parameters
 ## These are params specific to the meta parent policy.
+parameter "param_combined_incident_email" do
+  type "list"
+  label "Email addresses for combined incident"
+  description "A list of email addresses to notify with the consolidated child policy incident."
+  default []
+end
+
 parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
@@ -728,12 +735,83 @@ script "js_only_delete", type: "javascript" do
   EOS
 end
 
+# The following datasources consolidate the child incident output into a single incident.
+# This is because it is more convenient for many users to have a single incident with all of the data.
+datasource "ds_child_incident_details" do
+  iterate $ds_get_existing_policies_incidents
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/incidents/", val(iter_item, 'incident_id')])
+    verb "GET"
+    header "User-Agent", "RS Policies"
+    header "Api-Version", "1.0"
+    query "view", "extended"
+  end
+end
+
+datasource "ds_child_incidents_combined" do
+  run_script $js_child_incidents_combined, $ds_child_incident_details
+end
+
+script "js_child_incidents_combined", type: "javascript" do
+  parameters "ds_child_incident_details"
+  result "result"
+  code <<-EOS
+  result = _.flatten(_.pluck(ds_child_incident_details, 'violation_data'))
+EOS
+end
 
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
 # Could also just have one incident and use meta_status to determine which esclation happens
 policy "policy_scheduled_report" do
+  # Combined incident with all of the data from the child incidents
+  validate $ds_child_incidents_combined do
+    summary_template "Consolidated Incident: {{ len data }} AWS Unused Volumes Found"
+    escalate $esc_email
+    check eq(size(data), 0)
+    export do
+      resource_level true
+      field "accountID" do
+        label "Account Id"
+      end
+      field "accountName" do
+        label "Account Name"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "resourceID" do
+        label "Resource Id"
+      end
+      field "resourceType" do
+        label "Resource Type"
+      end
+      field "status" do
+        label "Status"
+      end
+      field "size" do
+        label "Size"
+      end
+      field "tags" do
+        label "Tags"
+      end
+      field "savings" do
+        label "Estimated Monthly Savings"
+      end
+      field "savingsCurrency" do
+        label "Savings Currency"
+      end
+      field "id" do
+        label "ID"
+      end
+      field "service" do
+        label "Service"
+      end
+    end
+  end
   validate $ds_take_in_parameters do
     summary_template "{{ data.parent_policy.name }}: Status of Child Policies"
     detail_template <<-EOS
@@ -827,6 +905,14 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Used only for emailing the combined child incident if so desired
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_combined_incident_email
 end
 
 escalation "create_policies" do

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
@@ -758,7 +758,7 @@ script "js_child_incidents_combined", type: "javascript" do
   parameters "ds_child_incident_details"
   result "result"
   code <<-EOS
-  result = _.flatten(_.pluck(ds_child_incident_details, 'violation_data'))
+  result = _.flatten(_.pluck(ds_child_incident_details, 'violation_data')).slice(0, 100000)
 EOS
 end
 

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
@@ -192,8 +192,8 @@ script "js_child_policy_options", type: "javascript" do
   code <<-EOS
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
-    // param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });


### PR DESCRIPTION
### Description

This modifies the meta parent policies to include a consolidated incident containing all of the incident results from all of the child policies, as well as optionally email that consolidated incident.

This should greatly improve the user experience, since it eliminates the need to navigate through several layers of the UI to get to each individual child incident.

I've also modified the template in the Meta Policy README to include these changes.

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
