### PR TITLE
AWS Rightsize Cost Gathering Date Fix

### DIFF
--- a/cost/aws/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_compute_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1
+
+- Fixed issue where savings would always be 0 if policy were executed at the end of the month.
+
 ## v3.0
 
 - Added parameter to enable Allow or Deny filtering by user entered regions

--- a/cost/aws/rightsize_compute_instances/aws_compute_rightsizing.pt
+++ b/cost/aws/rightsize_compute_instances/aws_compute_rightsizing.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.0",
+  version: "3.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",

--- a/cost/aws/rightsize_compute_instances/aws_compute_rightsizing.pt
+++ b/cost/aws/rightsize_compute_instances/aws_compute_rightsizing.pt
@@ -638,8 +638,7 @@ script "js_get_instance_costs", type: "javascript" do
   code <<-EOS
     //Get Start and End dates
     start_date = new Date(), end_date = new Date()
-    start_date.setMonth(start_date.getMonth() - 1)
-    end_date.setMonth(end_date.getMonth() - 0)
+    start_date.setDate(start_date.getDate() - 31)
     //some questions around best start/finish date - one day does not seem like long enough, and one month prior seems too far in past
 
     var request = {


### PR DESCRIPTION
### Description

Fixed issue where savings would always be 0 if policy were executed at the end of the month.

### Issues Resolved

The above.

### Link to Example Applied Policy

Tested in customer environment. Fix works as expected.

### Contribution Check List

- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
