### PR TITLE
Google Committed Use Discount Recommender Catalog Fix

### DIFF
--- a/cost/google/cud_recommendations/CHANGELOG.md
+++ b/cost/google/cud_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1
+
+- Fixed issue preventing policy from updating in the public catalog
+
 ## v3.0
 
 - Added **Term** parameter, now filtering the recommendations by 1 year or 3 year term is possible.

--- a/cost/google/cud_recommendations/google_committed_use_discount_recommendations.pt
+++ b/cost/google/cud_recommendations/google_committed_use_discount_recommendations.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "3.0",
+  version: "3.1",
   provider: "Google",
   service: "Compute",
   recommendation_type: "Rate Reduction",


### PR DESCRIPTION
### Description

Somehow, multiple 3.0 versions of this policy have ended up in the catalog in various places. This is a version bump to get everything properly synced to the current version.