### PR TITLE
FOPTS-939 - Add policy to refresh Turbonomic authentication token

### DIFF
--- a/cost/turbonomics/credential_refresh/CHANGELOG.md
+++ b/cost/turbonomics/credential_refresh/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1
+
+- Initial Release

--- a/cost/turbonomics/credential_refresh/README.md
+++ b/cost/turbonomics/credential_refresh/README.md
@@ -1,12 +1,12 @@
 # Turbonomic Credential Refresh Policy
 
-The Turbonomic Credential Refresh policy is designed to refresh the cookie used to authenticate with Turbonomic APIs. This policy ensures that the authentication token remains up to date for accessing Turbonomic services.
+The Turbonomic Credential Refresh policy is designed to refresh the cookie used to authenticate with Turbonomic APIs. It ensures that the authentication token remains up to date for accessing Turbonomic services.
 
-This policy is designed to refresh the authentication cookie used to authenticate with Turbonomic APIs. It addresses the challenge of using a cookie-based authentication method in Turbonomic, which is not supported by Flexera due to its outdated nature and the industry trend of switching to newer and more secure authentication methods. As Turbonomic plans to implement bearer token authentication in the future, this policy serves as a temporary workaround for the integration to connect to Turbonomic APIs.
+The purpose of this policy is to refresh the authentication cookie used to authenticate with Turbonomic APIs. It addresses the challenge of using a cookie-based authentication method in Turbonomic, which is not supported by Flexera due to its outdated nature and the industry trend of switching to newer and more secure authentication methods. As Turbonomic plans to implement bearer token authentication in the future, this policy serves as a temporary workaround for the integration to connect to Turbonomic APIs.
 
 ## What it does
 
-The policy periodically checks for applied policies in the project that are related to Turbonomic. If any Turbonomic policies are found, the policy triggers an escalation process to update the authentication cookie used for Turbonomic APIs. The policy retrieves the necessary credentials and makes API calls to Turbonomic to obtain a fresh cookie. It then updates the applied Turbonomic policies with the new authentication cookie, ensuring seamless authentication for Turbonomic API calls.
+The policy periodically checks for applied policies in the project that are related to Turbonomic. If any Turbonomic policies are found, the policy initiates an escalation process to update the authentication cookie used for Turbonomic APIs. The policy retrieves the necessary credentials and makes API calls to Turbonomic to obtain a fresh cookie. It then updates the applied Turbonomic policies with the new authentication cookie, ensuring seamless authentication for Turbonomic API calls.
 
 ## Prerequisites
 

--- a/cost/turbonomics/credential_refresh/README.md
+++ b/cost/turbonomics/credential_refresh/README.md
@@ -1,0 +1,39 @@
+# Turbonomic Credential Refresh Policy
+
+The Turbonomic Credential Refresh policy is designed to refresh the cookie used to authenticate with Turbonomic APIs. This policy ensures that the authentication token remains up to date for accessing Turbonomic services.
+
+This policy is designed to refresh the authentication cookie used to authenticate with Turbonomic APIs. It addresses the challenge of using a cookie-based authentication method in Turbonomic, which is not supported by Flexera due to its outdated nature and the industry trend of switching to newer and more secure authentication methods. As Turbonomic plans to implement bearer token authentication in the future, this policy serves as a temporary workaround for the integration to connect to Turbonomic APIs.
+
+## What it does
+
+The policy periodically checks for applied policies in the project that are related to Turbonomic. If any Turbonomic policies are found, the policy triggers an escalation process to update the authentication cookie used for Turbonomic APIs. The policy retrieves the necessary credentials and makes API calls to Turbonomic to obtain a fresh cookie. It then updates the applied Turbonomic policies with the new authentication cookie, ensuring seamless authentication for Turbonomic API calls.
+
+## Prerequisites
+
+This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).
+
+- [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (_provider=flexera_)
+
+## Input Parameters
+
+This policy requires the following input parameters:
+
+- **Turbonomic Username** - username associated with your Turbonomic API credentials.
+- **Turbonomic Password** - password associated with your Turbonomic API credentials.
+- **Turbonomic Host** - turbonomic hostname or IP address.
+
+## Policy Actions
+
+The policy performs the following actions:
+
+- Retrieves all applied policies in the project where this policy is applied.
+- Filters the applied policies to find policies associated with Turbonomic.
+- Updates the authentication cookie parameter for Turbonomic policies with a refreshed cookie.
+
+### Required Flexera Roles
+
+- policy_manager
+
+## Cost
+
+This Policy Template does not incur any additional costs.

--- a/cost/turbonomics/credential_refresh/turbonomic_cred_refresh.pt
+++ b/cost/turbonomics/credential_refresh/turbonomic_cred_refresh.pt
@@ -140,14 +140,14 @@ define update_cookie($turbo_policies, $param_turbonomic_username, $param_turbono
     $found = false
     if $options != null
       foreach $option in $options do
-        if $option["name"] == "auth_cookie" || $option["name"] == "param_turbonomic_auth_cookie"
+        if $option["name"] == "auth_cookie" || $option["name"] == "param_auth_cookie"
           $option["value"] = $cookie
           $found = true
         end
         $modified << $option
       end
       if $found
-        # If the applied policy has the auth_cookie or param_turbonomic_auth_cookie parameter, we'll update with a fresh value
+        # If the applied policy has the auth_cookie or param_auth_cookie parameter, we'll update with a fresh value
         $response = http_patch(
           url: "https://" + $gov_host + "/api/governance/projects/" + $proj_id + "/applied_policies/" + $policy["id"],
           headers: {

--- a/cost/turbonomics/credential_refresh/turbonomic_cred_refresh.pt
+++ b/cost/turbonomics/credential_refresh/turbonomic_cred_refresh.pt
@@ -1,0 +1,167 @@
+name "Turbonomic Credential Refresh"
+rs_pt_ver 20180301
+type "policy"
+short_description "A policy that refreshes the cookie used to authenticate with Turbonomic APIs"
+severity "low"
+category "Operational"
+default_frequency "hourly"
+info(
+  version: "0.1",
+  provider: "",
+  service: "",
+  policy_set: "",
+	publish: "false"
+)
+
+parameter "param_turbonomic_username" do
+  type "string"
+  label "Turbonomic Username"
+  description "The username used to authenticate with Turbonomic APIs"
+end
+
+parameter "param_turbonomic_password" do
+  type "string"
+  no_echo true
+  label "Turbonomic Password"
+  description "The password used to authenticate with Turbonomic APIs"
+end
+
+parameter "param_turbonomic_host" do
+  type "string"
+  label "Turbonomic Host"
+  description "Your Turbonomic host or IP."
+end
+
+###############################################################################
+# Authentication
+###############################################################################
+
+credentials "auth_flexera" do
+  schemes "oauth2"
+  label "flexera"
+  description "Select Flexera One OAuth2 credentials"
+  tags "provider=flexera"
+end
+
+###############################################################################
+# Datasources & Scripts
+###############################################################################
+
+# Retrieves all applied policies in the project where this policy is applied
+datasource "ds_applied_policies" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies"], "")
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    collect jq(response, ".items[]") do
+      field "id", val(col_item, "id")
+      field "name", val(col_item, "name")
+      field "info_source", jq(col_item, ".info.source")
+    end
+  end
+end
+
+# Filters the applied policy where the info.source is set to either "Turbonomic" or "Turbonomics"
+datasource "ds_turbo_applied_policies" do
+  run_script $js_filter_turbo_policies, $ds_applied_policies
+end
+
+script "js_filter_turbo_policies", type: "javascript" do
+  parameters "applied_policies"
+  result "filtered_policies"
+  code <<-EOS
+  var filtered_policies = _.map(_.filter(applied_policies, function(applied_policy) {
+    return applied_policy.info_source == "Turbonomics" || applied_policy.info_source == "Turbonomic"
+  }), function(policy){policy.time = Date.now(); return policy});
+  EOS
+end
+
+###############################################################################
+# Policy & Escalation
+###############################################################################
+
+policy "pol_turbo_applied_policies" do
+  validate $ds_turbo_applied_policies do
+    summary_template "Turbo policies found"
+    detail_template <<-EOS
+    The following applied policies are running for Turbonomics. The auth_token parameter will be updated
+    with refreshed cookie.
+
+    | ID | Name | Source |
+    | -- | ---- | ------ |
+{{ range data -}}
+  | {{.id}} | {{.name}} | {{.info_source}} |
+{{ end -}}
+EOS
+    check eq(size(data), 0)
+    escalate $esc_update_cookie
+  end
+end
+
+escalation "esc_update_cookie" do
+  run "update_cookie", data, $param_turbonomic_username, $param_turbonomic_password, $param_turbonomic_host, rs_governance_host, rs_project_id
+end
+
+define update_cookie($turbo_policies, $param_turbonomic_username, $param_turbonomic_password, $param_turbonomic_host, $gov_host, $proj_id) do
+  # Authenticate with Turbonomic API and get a fresh cookie
+  $response = http_request(
+    verb: "post",
+    https: true,
+    host: $param_turbonomic_host,
+    href: "/api/v3/login",
+    body: "username=" + $param_turbonomic_username + "&password=" + $param_turbonomic_password,
+    headers: {
+      "content-type": "application/x-www-form-urlencoded"
+    }
+  )
+  if $response["code"] != 200
+    raise "Unexpected response code from Turbo login endpoint: " + $response["code"] + " body: " + to_s($response["body"])
+  end
+  $cookie = split($response["headers"]["Set-Cookie"], ";")[0]
+  # Go through all Turbonomic policies
+  foreach $policy in $turbo_policies do
+    # Retrieve the policy details so we can patch it with updated auth_cookie
+    $response = http_get(
+      url: "https://" + $gov_host + "/api/governance/projects/" + $proj_id + "/applied_policies/" + $policy["id"],
+      headers: {
+        "Api-Version": "1.0"
+      },
+      auth: $$auth_flexera
+    )
+    if $response["code"] != 200
+      raise "Unexpected response code from policy template show: " + $response["code"] + " body: " + to_s($response["body"])
+    end
+    $options = $response["body"]["options"]
+    $modified = []
+    $found = false
+    if $options != null
+      foreach $option in $options do
+        if $option["name"] == "auth_cookie" || $option["name"] == "param_turbonomic_auth_cookie"
+          $option["value"] = $cookie
+          $found = true
+        end
+        $modified << $option
+      end
+      if $found
+        # If the applied policy has the auth_cookie or param_turbonomic_auth_cookie parameter, we'll update with a fresh value
+        $response = http_patch(
+          url: "https://" + $gov_host + "/api/governance/projects/" + $proj_id + "/applied_policies/" + $policy["id"],
+          headers: {
+            "Api-Version": "1.0"
+          },
+          auth: $$auth_flexera,
+          body: {
+            options: $modified
+          }
+        )
+        if $response["code"] != 204
+          raise "Unexpected response code from policy template update: " + $response["code"] + " body: " + to_s($response["body"])
+        end
+      end
+    end
+  end
+end

--- a/cost/turbonomics/credential_refresh/turbonomic_cred_refresh.pt
+++ b/cost/turbonomics/credential_refresh/turbonomic_cred_refresh.pt
@@ -81,7 +81,7 @@ script "js_filter_turbo_policies", type: "javascript" do
 end
 
 ###############################################################################
-# Policy & Escalation
+# Policy
 ###############################################################################
 
 policy "pol_turbo_applied_policies" do
@@ -101,6 +101,10 @@ EOS
     escalate $esc_update_cookie
   end
 end
+
+###############################################################################
+# Escalations
+###############################################################################
 
 escalation "esc_update_cookie" do
   run "update_cookie", data, $param_turbonomic_username, $param_turbonomic_password, $param_turbonomic_host, rs_governance_host, rs_project_id


### PR DESCRIPTION
### Description

This policy is designed to refresh the authentication cookie used to authenticate with Turbonomic APIs. It addresses the challenge of using a cookie-based authentication method in Turbonomic, which is not supported by Flexera due to its outdated nature and the industry trend of switching to newer and more secure authentication methods. As Turbonomic plans to implement bearer token authentication in the future, this policy serves as a temporary workaround for the integration to connect to Turbonomic APIs.

### Issues Resolved

https://flexera.atlassian.net/browse/FOPTS-939

### Link to Example Applied Policy

https://app.flexera.com/orgs/1105/automation/applied-policies/projects/60073?policyId=6481f829a9fd7a0001706578

### Contribution Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
