### PR TITLE
FOPTS-1121 Azure Usage Reduction Policies (Azure Unused Compute Instances and Rightsize Compute Instances)

### DIFF
--- a/cost/azure/idle_compute_instances/CHANGELOG.md
+++ b/cost/azure/idle_compute_instances/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v4.7
+
+- Added `Lookback Period` incident field.
+- Added `Threshold` incident field.
+- Added `Platform` incident field.
+- Changed internal names of several incident fields to ensure that they are properly scraped for dashboards.
+
 ## v4.6
 
 - New escalations are no longer created if Estimated Monthly Savings or CPU Average have changed, but nothing else has.

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
@@ -144,6 +144,8 @@ datasource "ds_azure_virtualmachines" do
       field "name", jmes_path(col_item,"name")
       field "region", jmes_path(col_item, "location")
       field "tags", jmes_path(col_item,"tags")
+      field "platform", jmes_path(col_item,"properties.storageProfile.osDisk.osType")
+      field "vmSize", jmes_path(col_item, "properties.hardwareProfile.vmSize")
       field "subscriptionID",val(iter_item,"subscriptionID")
       field "subscriptionName",val(iter_item,"displayName")
     end
@@ -178,6 +180,8 @@ datasource "ds_azure_instance_performance" do
     field "region", val(iter_item, "region")
     field "tags", val(iter_item, "tags")
     field "service", val(iter_item, "service")
+    field "platform", val(iter_item, "platform")
+    field "vmSize", jmes_path(iter_item, "vmSize")
     field "subscriptionID",val(iter_item,"subscriptionID")
     field "subscriptionName",val(iter_item,"subscriptionName")
     field "averages" do
@@ -257,7 +261,7 @@ datasource "ds_combineddata" do
 end
 
 datasource "ds_instance_cost_mapping" do
-  run_script $js_instance_cost_mapping, $ds_combineddata, $ds_instance_costs, $ds_currency_code, $ds_currency_reference, $ds_billing_centers
+  run_script $js_instance_cost_mapping, $ds_combineddata, $ds_instance_costs, $ds_currency_code, $ds_currency_reference, $ds_billing_centers, $param_cpu_average_percentage
 end
 
 datasource "ds_only_instances" do
@@ -403,7 +407,7 @@ EOS
 end
 
 script "js_instance_cost_mapping", type:"javascript" do
-  parameters  "instance_list","instance_costs","ds_currency_code","ds_currency_reference", "ds_billing_centers"
+  parameters  "instance_list","instance_costs","ds_currency_code","ds_currency_reference", "ds_billing_centers", "param_cpu_average_percentage"
   result "result"
   code <<-EOS
     var result = {};
@@ -459,6 +463,8 @@ script "js_instance_cost_mapping", type:"javascript" do
       var total_savings=0;
       _.each(instance_list, function(instance){
         var cost_objects = costs_by_resource_id[instance.resourceID];
+        instance['lookBackPeriod'] = "30 days"
+        instance['threshold'] = param_cpu_average_percentage
         if (_.size(cost_objects) > 0){
           count++;
           var sum = _.reduce(_.compact(_.map(cost_objects, function(value){return value.cost_nonamortized_unblended_adj})), function(memo, num){ return memo + num; }, 0);
@@ -533,8 +539,9 @@ EOS
       field "resourceName" do
         label "Resource Name"
       end
-      field "resourceType" do
-        label "Resource Type"
+      field "resourceKind" do
+        label "Resource Kind"
+        path "resourceType"
       end
       field "region" do
         label "Region"
@@ -545,8 +552,9 @@ EOS
       field "savingsCurrency" do
         label "Savings Currency"
       end
-      field "averageCPU" do
+      field "cpuAverage" do
         label "CPU Average"
+        path "averageCPU"
       end
       field "resourceGroup" do
         label "Resource Group"
@@ -560,6 +568,19 @@ EOS
       field "id" do
         label "ID"
         path "resourceID"
+      end
+      field "lookBackPeriod" do
+        label "Lookback Period"
+      end
+      field "threshold" do
+        label "Threshold"
+      end
+      field "platform" do
+        label "Platform"
+      end
+      field "resourceType" do
+        label "Resource Type"
+        path "vmSize"
       end
     end
   end

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "4.6",
+  version: "4.7",
   provider: "Azure",
   service: "Compute",
   policy_set: "Idle Compute Instances",

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
@@ -140,12 +140,12 @@ datasource "ds_azure_virtualmachines" do
     collect jmes_path(response, "value[*]") do
       field "resourceID", jmes_path(col_item,"id")
       field "resourceGroup", get(4,split(jmes_path(col_item,"id"),'/'))
-      field "resourceType", jmes_path(col_item,"type")
+      field "resourceKind", jmes_path(col_item,"type")
       field "name", jmes_path(col_item,"name")
       field "region", jmes_path(col_item, "location")
       field "tags", jmes_path(col_item,"tags")
       field "platform", jmes_path(col_item,"properties.storageProfile.osDisk.osType")
-      field "vmSize", jmes_path(col_item, "properties.hardwareProfile.vmSize")
+      field "resourceType", jmes_path(col_item, "properties.hardwareProfile.vmSize")
       field "subscriptionID",val(iter_item,"subscriptionID")
       field "subscriptionName",val(iter_item,"displayName")
     end
@@ -176,12 +176,12 @@ datasource "ds_azure_instance_performance" do
     field "resourceName", val(iter_item,"name")
     field "resourceGroup", val(iter_item, "resourceGroup")
     field "resourceID", val(iter_item, "resourceID")
-    field "resourceType", val(iter_item, "resourceType")
+    field "resourceKind", val(iter_item, "resourceKind")
     field "region", val(iter_item, "region")
     field "tags", val(iter_item, "tags")
     field "service", val(iter_item, "service")
     field "platform", val(iter_item, "platform")
-    field "vmSize", jmes_path(iter_item, "vmSize")
+    field "resourceType", val(iter_item, "resourceType")
     field "subscriptionID",val(iter_item,"subscriptionID")
     field "subscriptionName",val(iter_item,"subscriptionName")
     field "averages" do
@@ -541,7 +541,6 @@ EOS
       end
       field "resourceKind" do
         label "Resource Kind"
-        path "resourceType"
       end
       field "region" do
         label "Region"
@@ -580,7 +579,6 @@ EOS
       end
       field "resourceType" do
         label "Resource Type"
-        path "vmSize"
       end
     end
   end

--- a/cost/azure/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.3
+
+- Added `Lookback Period` incident field.
+- Added `Threshold` incident field.
+- Changed internal names of several incident fields to ensure that they are properly scraped for dashboards.
+
 ## v2.2
 
 - Fixed bug with parameter_subscription_allowlist script

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "2.2",
+  version: "2.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -640,6 +640,9 @@ script "js_combine_data", type: "javascript" do
 
   _.each(result, function(item) {
     item['summaryData'] = summary_data
+    item['underutilThreshold'] = param_underutil_prc
+    item['idleThreshold'] = param_idle_prc
+    item['lookBackPeriod'] = "30 days"
   })
 EOS
 end
@@ -674,17 +677,21 @@ policy "policy_azure_rightsizing_data" do
       field "resourceName" do
         label "Resource Name"
       end
-      field "resourceType" do
+      field "resourceKind" do
         label "Resource Type"
+        path "resourceType"
       end
-      field "vmSize" do
+      field "resourceType" do
         label "Instance Size"
+        path "vmSize"
       end
-      field "recommendedVmSize" do
+      field "recommendedResourceType" do
         label "Recommended Instance Size"
+        path "recommendedVmSize"
       end
-      field "osType" do
+      field "platform" do
         label "OS Type"
+        path "osType"
       end
       field "region" do
         label "Region"
@@ -698,8 +705,9 @@ policy "policy_azure_rightsizing_data" do
       field "minCPU" do
         label "CPU Minimum (%)"
       end
-      field "averageCPU" do
+      field "cpuAverage" do
         label "CPU Average (%)"
+        path "averageCPU"
       end
       field "maxCPU" do
         label "CPU Maximum (%)"
@@ -724,6 +732,13 @@ policy "policy_azure_rightsizing_data" do
       field "accountID" do
         label "Account ID"
         path "subscriptionId"
+      end
+      field "lookBackPeriod" do
+        label "Lookback Period"
+      end
+      field "threshold" do
+        label "Underutilized Threshold"
+        path "underutilThreshold"
       end
     end
   end
@@ -752,17 +767,21 @@ EOS
       field "resourceName" do
         label "Resource Name"
       end
-      field "resourceType" do
+      field "resourceKind" do
         label "Resource Type"
+        path "resourceType"
       end
-      field "vmSize" do
+      field "resourceType" do
         label "Instance Size"
+        path "vmSize"
       end
-      field "recommendedVmSize" do
+      field "recommendedResourceType" do
         label "Recommended Instance Size"
+        path "recommendedVmSize"
       end
-      field "osType" do
+      field "platform" do
         label "OS Type"
+        path "osType"
       end
       field "region" do
         label "Region"
@@ -776,8 +795,9 @@ EOS
       field "minCPU" do
         label "CPU Minimum (%)"
       end
-      field "averageCPU" do
+      field "cpuAverage" do
         label "CPU Average (%)"
+        path "averageCPU"
       end
       field "maxCPU" do
         label "CPU Maximum (%)"
@@ -802,6 +822,13 @@ EOS
       field "accountID" do
         label "Account ID"
         path "subscriptionId"
+      end
+      field "lookBackPeriod" do
+        label "Lookback Period"
+      end
+      field "threshold" do
+        label "Idle Threshold"
+        path "idleThreshold"
       end
     end
   end

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -216,11 +216,11 @@ datasource "ds_azure_instances" do
     collect jmes_path(response, "value[*]") do
       field "resourceId", jmes_path(col_item, "id")
       field "resourceGroup", get(4, split(jmes_path(col_item, "id"), '/'))
-      field "resourceType", jmes_path(col_item, "type")
+      field "resourceKind", jmes_path(col_item, "type")
       field "name", jmes_path(col_item, "name")
       field "region", jmes_path(col_item, "location")
       field "osType", jmes_path(col_item, "properties.storageProfile.osDisk.osType")
-      field "vmSize", jmes_path(col_item, "properties.hardwareProfile.vmSize")
+      field "resourceType", jmes_path(col_item, "properties.hardwareProfile.vmSize")
       field "tags", jmes_path(col_item, "tags")
       field "subscriptionId",val(iter_item, "subscriptionId")
       field "subscriptionName",val(iter_item, "subscriptionName")
@@ -249,8 +249,8 @@ script "js_filter_instances", type: "javascript" do
         })
 
         instance['tags'] = tags
-        resourceTypeSplit = instance['resourceType'].split("/")
-        service = resourceTypeSplit[0]
+        resourceKindSplit = instance['resourceKind'].split("/")
+        service = resourceKindSplit[0]
         instance['service'] = service
 
         return instance
@@ -281,11 +281,11 @@ datasource "ds_azure_instance_utilization" do
     field "resourceName", val(iter_item, "name")
     field "resourceGroup", val(iter_item, "resourceGroup")
     field "resourceId", val(iter_item, "resourceId")
-    field "resourceType", val(iter_item, "resourceType")
+    field "resourceKind", val(iter_item, "resourceKind")
     field "region", val(iter_item, "region")
     field "tags", val(iter_item, "tags")
     field "osType", val(iter_item, "osType")
-    field "vmSize", val(iter_item, "vmSize")
+    field "resourceType", val(iter_item, "resourceType")
     field "service", val(iter_item, "service")
     field "subscriptionId",val(iter_item, "subscriptionId")
     field "subscriptionName",val(iter_item, "subscriptionName")
@@ -383,8 +383,8 @@ script "js_add_instance_downsize_data", type: "javascript" do
     }
 
     if (cpuValue >= param_cpu_idle_avg_percentage) {
-      if (instance_size_map[instance['vmSize']] != undefined && instance_size_map[instance['vmSize']] != null) {
-        next_vm_size = instance_size_map[instance['vmSize']]['down']
+      if (instance_size_map[instance['resourceType']] != undefined && instance_size_map[instance['resourceType']] != null) {
+        next_vm_size = instance_size_map[instance['resourceType']]['down']
       }
     } else {
       next_vm_size = "Terminate Instance"
@@ -678,15 +678,13 @@ policy "policy_azure_rightsizing_data" do
         label "Resource Name"
       end
       field "resourceKind" do
-        label "Resource Type"
-        path "resourceType"
+        label "Resource Kind"
       end
       field "resourceType" do
-        label "Instance Size"
-        path "vmSize"
+        label "Resource Type"
       end
       field "recommendedResourceType" do
-        label "Recommended Instance Size"
+        label "Recommended Resource Type"
         path "recommendedVmSize"
       end
       field "platform" do
@@ -768,15 +766,13 @@ EOS
         label "Resource Name"
       end
       field "resourceKind" do
-        label "Resource Type"
-        path "resourceType"
+        label "Resource Kind"
       end
       field "resourceType" do
-        label "Instance Size"
-        path "vmSize"
+        label "Resource Type"
       end
       field "recommendedResourceType" do
-        label "Recommended Instance Size"
+        label "Recommended Resource Type"
         path "recommendedVmSize"
       end
       field "platform" do


### PR DESCRIPTION
### Description

Update and standardize Azure usage reduction policies (Azure Unused Compute Instances and Rightsize Compute Instances).

### Issues Resolved

Standardized Azure Unused Compute Instances and Azure Rightsize Compute Instances policy templates.

### Link to Example Applied Policy

- Azure Unused Compute Instances: https://app.flexera.com/orgs/1105/automation/applied-policies/projects/60073?policyId=648c9add4466b10001e212e1
- Azure Rightsize Compute Instances: https://app.flexera.com/orgs/1105/automation/applied-policies/projects/60073?policyId=648c99e24466b10001e212e0

### Contribution Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
