### PR TITLE
FOPTS-1123 Add the required fields to 3 Google policies

### DIFF
--- a/cost/google/cloud_sql_idle_instance_recommendations/CHANGELOG.md
+++ b/cost/google/cloud_sql_idle_instance_recommendations/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.9
+
+- Added `Lookback Period In Days` incident field.
+- Added `Platform` incident field.
+
 ## v2.8
 
 - Updated policy metadata to facilitate scraping of incidents for Recommendations dashboard

--- a/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations.pt
+++ b/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.8",
+  version: "2.9",
   provider:"Google",
   service: "SQL",
   policy_set: "Unused Database Services",
@@ -155,6 +155,7 @@ datasource "ds_all_sql_instances" do
       field "resourceType", val(col_item, "instanceType")
       field "resourceName", jmes_path(col_item, "name")
       field "resourceType", jmes_path(col_item, "instanceType")
+      field "platform", jmes_path(col_item, "databaseVersion")
       field "status", jmes_path(col_item, "state")
     end
   end
@@ -399,6 +400,7 @@ script "js_sql_instances_cost_mapping", type:"javascript" do
             database['state'] = recommendation['state']
             database['region'] = recommendation['region']
             database['service'] = "SQL"
+            database['lookBackPeriodInDays'] = '30'
             var tags = []
             if (database['tags'] != null) {
                 Object.keys(database.tags).forEach(function (key) {
@@ -458,6 +460,10 @@ policy "policy_recommendations" do
       field "resourceType" do
         label "Resource Type"
       end
+      field "lookBackPeriod" do
+        label "Lookback Period In Days"
+        path "lookBackPeriodInDays"
+      end
       field "region" do
         label "Region"
       end
@@ -467,6 +473,9 @@ policy "policy_recommendations" do
       end
       field "tags" do
         label "Tags"
+      end
+      field "platform" do
+        label "Platform"
       end
       field "description" do
         label "Description"

--- a/cost/google/idle_ip_address_recommendations/CHANGELOG.md
+++ b/cost/google/idle_ip_address_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.9
+
+- Added `IP Address` incident field.
+
 ## v2.8
 
 - Updated policy metadata to facilitate scraping of incidents for Recommendations dashboard

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.8",
+  version: "2.9",
   provider: "Google",
   service: "Compute",
   policy_set: "Unused IP Addresses",
@@ -212,6 +212,7 @@ script "js_addresses", type: "javascript" do
                         address.resourceID = address.address
                         address.resourceName = address.name
                         address.resourceType = address.kind
+                        address.address = address.address
 
                         return address
                     }
@@ -445,6 +446,9 @@ policy "policy_recommendations" do
       end
       field "resourceType" do
         label "Resource Type"
+      end
+      field "ipAddress" do
+        label "IP Address"
       end
       field "region" do
         label "Region"

--- a/cost/google/idle_vm_recommendations/CHANGELOG.md
+++ b/cost/google/idle_vm_recommendations/CHANGELOG.md
@@ -3,8 +3,6 @@
 ## v2.9
 
 - Added `Lookback Period In Days` incident field.
-- Added `Platform` incident field.
-- Added `Threshold` incident field.
 
 ## v2.8
 

--- a/cost/google/idle_vm_recommendations/CHANGELOG.md
+++ b/cost/google/idle_vm_recommendations/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.9
+
+- Added `Lookback Period In Days` incident field.
+- Added `Platform` incident field.
+- Added `Threshold` incident field.
+
 ## v2.8
 
 - Updated policy metadata to facilitate scraping of incidents for Recommendations dashboard

--- a/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
+++ b/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
@@ -472,8 +472,6 @@ script "js_instance_cost_mapping", type:"javascript" do
         vm['recommenderSubtype'] = recommendation['recommenderSubtype']
         vm['state'] = recommendation['state']
         vm['service'] = "Compute"
-        vm['platform'] = "Unknown"
-        vm['threshold'] = "Threshold given by the recommender google.compute.instance.IdleResourceRecommender"
         tags = []
         if (vm['tags'] != null) {
           if( typeof vm['tags'] == 'object') {
@@ -567,12 +565,6 @@ policy "policy_recommendations" do
       end
       field "tags" do
         label "Tags"
-      end
-      field "platform" do
-        label "Platform"
-      end
-      field "threshold" do
-        label "Threshold"
       end
       field "description" do
         label "Description"

--- a/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
+++ b/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
@@ -472,6 +472,8 @@ script "js_instance_cost_mapping", type:"javascript" do
         vm['recommenderSubtype'] = recommendation['recommenderSubtype']
         vm['state'] = recommendation['state']
         vm['service'] = "Compute"
+        vm['platform'] = "Unknown"
+        vm['threshold'] = "Threshold given by the recommender google.compute.instance.IdleResourceRecommender"
         tags = []
         if (vm['tags'] != null) {
           if( typeof vm['tags'] == 'object') {
@@ -567,8 +569,10 @@ policy "policy_recommendations" do
         label "Tags"
       end
       field "platform" do
+        label "Platform"
       end
       field "threshold" do
+        label "Threshold"
       end
       field "description" do
         label "Description"

--- a/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
+++ b/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.8",
+  version: "2.9",
   provider:"Google",
   service: "Compute",
   policy_set: "Idle Compute Instances",
@@ -486,6 +486,7 @@ script "js_instance_cost_mapping", type:"javascript" do
           }
         }
         vm['tags'] = tags
+        vm['lookBackPeriodInDays'] = '14'
         instances.push(vm)
       }
     })
@@ -538,6 +539,10 @@ policy "policy_recommendations" do
       field "resourceType" do
         label "Resource Type"
       end
+      field "lookBackPeriod" do
+        label "Lookback Period In Days"
+        path "lookBackPeriodInDays"
+      end 
       field "region" do
         label "Zone"
         path "zone"
@@ -560,6 +565,10 @@ policy "policy_recommendations" do
       end
       field "tags" do
         label "Tags"
+      end
+      field "platform" do
+      end
+      field "threshold" do
       end
       field "description" do
         label "Description"


### PR DESCRIPTION
### Description

We are adding some fields for the normalization of the Google policies, the fields are the following:

**cloud_sql_idle_instance_recommendations**

- Added `Lookback Period In Days` incident field.
- Added `Platform` incident field.

**idle_ip_address_recommendations**

- Added `IP Address` incident field.

**idle_vm_recommendations**

- Added `Lookback Period In Days` incident field.

### Issues Resolved

- https://flexera.atlassian.net/browse/FOPTS-1123

### Link to Example Applied Policy

[cloud_sql_idle_instance_recommendations](https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/107982?policyId=64909fbe99c555000141b076)

[idle_ip_address_recommendations](https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/107982?policyId=64909c0a44e32e000102c6e5)

[idle_vm_recommendations](https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/107982?policyId=6493082299c555000141b098)

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
