### PR TITLE
Fix: AWS Rightsize Compute Instances Pt Tags output

### DIFF
--- a/cost/aws/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_compute_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.2
+
+- Fixed issue with Tags output
+- Added default values for parameters that are not required
+
 ## v3.1
 
 - Fixed issue where savings would always be 0 if policy were executed at the end of the month.

--- a/cost/aws/rightsize_compute_instances/aws_compute_rightsizing.pt
+++ b/cost/aws/rightsize_compute_instances/aws_compute_rightsizing.pt
@@ -936,6 +936,23 @@ script "js_get_idle_and_underutil_instances", type:"javascript" do
       }
       instance["recommendedVmSize"] = vm_size_down
 
+      // Check if tags is already a string
+      // It shouldn't be, but have seen cases where this is a string already
+      if (typeof instance["tags"] != "string") {
+        // If not, then lets convert the object or list into a TagKey=TagValue string
+        tags_string = []
+        // Loop through each tag
+        for (var i = 0; i < instance["tags"].length; i++) {
+          // Get tag key and tag value
+          t_key = instance["tags"][i]["key"]
+          t_val = instance["tags"][i]["value"]
+          // Add to list of TagKey=TagValue strings
+          tags_string.push(t_key + "=" + t_val)
+        }
+        // Return tags as a string
+        // Join the list of TagKey=TagValue strings separated by a space
+        instance["tags"] = tags_string.join(" ")
+      }
     })
 
     //Sort By Region and then by Account Name

--- a/cost/aws/rightsize_compute_instances/aws_compute_rightsizing.pt
+++ b/cost/aws/rightsize_compute_instances/aws_compute_rightsizing.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.1",
+  version: "3.2",
   provider: "AWS",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",

--- a/cost/aws/rightsize_compute_instances/aws_compute_rightsizing.pt
+++ b/cost/aws/rightsize_compute_instances/aws_compute_rightsizing.pt
@@ -38,6 +38,7 @@ parameter "param_02_allowed_regions" do
   label "Regions"
   allowed_pattern /^([a-zA-Z-_]+-[a-zA-Z0-9-_]+-[0-9-_]+,*|)+$/
   description "A list of allowed or denied regions. See the README for more details"
+  default []
 end
 
 #IDLE INSTANCE THRESHOLD PARAMETERS##########
@@ -136,6 +137,7 @@ parameter "param_email" do
   type "list"
   label "Email addresses to notify"
   description "Email addresses of the recipients you wish to notify when new incidents are created"
+  default []
 end
 
 ###############################################################################


### PR DESCRIPTION
### Description

Fixes the object type for the Tags output


### Link to Example Applied Policy

https://app.flexera.com/orgs/34608/automation/incidents/projects/136331?incidentId=64936925ac3de30001d10d14
and
https://app.flexera.com/orgs/34608/automation/incidents/projects/136331?incidentId=64936926ac3de30001d10d15

See the Tags output


### Contribution Check List

- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
