### PR TITLE
Azure Price File Fix and AHUB Update

### DIFF
--- a/data/azure/azure_vm_pricing.py
+++ b/data/azure/azure_vm_pricing.py
@@ -1,11 +1,14 @@
 # Instructions for updating the price list:
 #   (1) Download the flexera-public/policy_templates repository locally.
-#   (2) Run this Python script. It should replace azure_vm_pricing.json with a new updated file.
-#   (3) Add and commit the new file, push it to the repository, and then make a pull request.
+#   (2) Create a new local branch of the repository.
+#   (3) Run this Python script. It should replace azure_vm_pricing.json with a new updated file.
+#   (4) Add and commit the new file, push it to the repository, and then make a pull request.
 
 import requests
 import json
 import os
+
+print("Gathering Consumption data from Azure Price API...")
 
 output_filename = "azure_vm_pricing.json"
 
@@ -25,30 +28,80 @@ while(nextPage):
 
 final_list = {}
 
+print("Processing Consumption data from Azure Price API...")
+
 for item in price_list:
   region = item['location']
   instanceType = item['armSkuName']
   sku = item['productId']
   pricePerUnit = item['retailPrice']
+  productName = item['productName']
+  meterName = item['meterName']
   operatingSystem = ""
 
-  if "Windows" in item['productName']:
+  if "Windows" in productName:
     operatingSystem = "Windows"
   else:
     operatingSystem = "Linux"
 
   if region != "" and instanceType != "" and operatingSystem != "" and sku != "":
-    if not region in final_list:
-      final_list[region] = {}
+    if not ("Spot" in meterName or "Low Priority" in meterName or "Expired" in meterName or
+            "Free" in meterName or "Promo" in meterName or "SPECIAL" in meterName):
+      if not region in final_list:
+        final_list[region] = {}
 
-    if not instanceType in final_list[region]:
-      final_list[region][instanceType] = {}
+      if not instanceType in final_list[region]:
+        final_list[region][instanceType] = {}
 
-    final_list[region][instanceType][operatingSystem] = {
-      "sku": sku,
-      "pricePerUnit": pricePerUnit
-    }
+      final_list[region][instanceType][operatingSystem] = {
+        "sku": sku,
+        "pricePerUnit": pricePerUnit,
+        "pricePerUnitAHUB": None
+      }
+
+print("Gathering DevTestConsumption (AHUB) data from Azure Price API...")
+
+query = "serviceName eq 'Virtual Machines' and priceType eq 'DevTestConsumption'"
+response = requests.get(api_url, params={'$filter': query})
+json_data = json.loads(response.text)
+
+price_list = json_data['Items']
+nextPage = json_data['NextPageLink']
+
+while(nextPage):
+  response = requests.get(nextPage)
+  json_data = json.loads(response.text)
+  nextPage = json_data['NextPageLink']
+  price_list.extend(json_data['Items'])
+
+print("Processing DevTestConsumption (AHUB) data from Azure Price API...")
+
+for item in price_list:
+  region = item['location']
+  instanceType = item['armSkuName']
+  sku = item['productId']
+  pricePerUnit = item['retailPrice']
+  productName = item['productName']
+  meterName = item['meterName']
+  operatingSystem = ""
+
+  if "Windows" in productName:
+    operatingSystem = "Windows"
+  else:
+    operatingSystem = "Linux"
+
+  if region != "" and instanceType != "" and operatingSystem != "" and sku != "":
+    if not ("Spot" in meterName or "Low Priority" in meterName or "Expired" in meterName or
+            "Free" in meterName or "Promo" in meterName or "SPECIAL" in meterName):
+      if region in final_list:
+        if instanceType in final_list[region]:
+          if operatingSystem in final_list[region][instanceType]:
+            final_list[region][instanceType][operatingSystem]["pricePerUnitAHUB"] = pricePerUnit
+
+print("Writing results to file...")
 
 price_file = open(output_filename, "w")
 price_file.write(json.dumps(final_list, sort_keys=True, indent=2))
 price_file.close()
+
+print("DONE!")


### PR DESCRIPTION
It was discovered that certain prices were wrong due to the inclusion of specialized pricing (such as spot pricing). This has been fixed; now every instance should be listed with its standard on-demand price.

In addition, a new field has been added containing the AHUB price. This was determined by looking at the DevTestConsumption price, which MS has confirmed is the same as AHUB pricing in the below URL. pricePerUnitAHUB is set to null for instance types that do not qualify for AHUB.

The script has also been updated to include the above changes.

https://learn.microsoft.com/en-us/answers/questions/1178829/can-i-consider-devtestconsumption-price-from-retai