### PR TITLE
Oracle Bill Upload Fix

### DIFF
--- a/cost/oracle/oracle_cbi/CHANGELOG.md
+++ b/cost/oracle/oracle_cbi/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1
+
+- Fixed issue where bill upload would sometimes not commit
+
 ## v3.0
 
 - Fixed bug that occasionally caused duplicate or missing cost data

--- a/cost/oracle/oracle_cbi/oracle_cbi.pt
+++ b/cost/oracle/oracle_cbi/oracle_cbi.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "15 minutes"
 info(
-  version: "3.0",
+  version: "3.1",
   provider: "Oracle",
   service: "Common Bill Ingestion",
   policy_set: "Common Bill Ingestion"
@@ -353,7 +353,7 @@ script "js_commit_assess", type: "javascript" do
 
   time_difference = (now - bill_upload_created) / 1000 / 60 / 60
 
-  if (bill_upload_length == ds_cost_object_list_current_month.length && time_difference >= param_commit_delay) {
+  if (bill_upload_length >= ds_cost_object_list_current_month.length && time_difference >= param_commit_delay) {
     result = [ds_bill_upload]
   }
 EOS


### PR DESCRIPTION
### Description

Fixes an issue where, if OCI actually removes files between runs of the policy, the policy would never commit the bill upload because the number of files uploaded would be greater than, rather than equal to, the number of files in the bucket for that month.

The policy now commits the upload if the number of files is greater than or equal to instead. Extremely simple fix.