### PR TITLE
FOPTS-765 Low-usage Account Policy

### DIFF
--- a/cost/low_account_usage/CHANGELOG.md
+++ b/cost/low_account_usage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1
+
+- Made `Billing Center Name` parameter optional
+
 ## v2.0
 
 - Deprecated `auth_rs` authentication (type: `rightscale`) and replaced with `auth_flexera` (type: `oauth2`).  This is a breaking change which requires a Credential for `auth_flexera` [`provider=flexera`] before the policy can be applied.  Please see docs for setting up [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm)

--- a/cost/low_account_usage/low_account_usage.pt
+++ b/cost/low_account_usage/low_account_usage.pt
@@ -31,8 +31,9 @@ end
 
 parameter "param_billing_centers" do
   label "Billing Center Name"
-  description "List of Billing Center Names to check"
+  description "List of Billing Center Names to check. Leave blank to run policy against all Billing Centers"
   type "list"
+  default []
 end
 
 parameter "param_minimum_savings_threshold" do

--- a/cost/low_account_usage/low_account_usage.pt
+++ b/cost/low_account_usage/low_account_usage.pt
@@ -8,7 +8,7 @@ category "Cost"
 default_frequency "daily"
 tenancy "single"
 info(
-  version: "2.0",
+  version: "2.1",
   provider: "Flexera Optima",
   service: "",
   policy_set: ""

--- a/cost/low_account_usage/low_account_usage.pt
+++ b/cost/low_account_usage/low_account_usage.pt
@@ -33,7 +33,6 @@ parameter "param_billing_centers" do
   label "Billing Center Name"
   description "List of Billing Center Names to check"
   type "list"
-  min_length 1
 end
 
 parameter "param_minimum_savings_threshold" do


### PR DESCRIPTION
### Description

Enhancement request to make Billing Centers parameter optional for Low Account Usage Policy

### Issues Resolved

Made the billing center parameter optional and reflected the UI Changes with Mock Data.

### Link to Example Applied Policy

- Low Account Usage Policy (Mock Data): https://app.flexera.com/orgs/1105/automation/applied-policies/projects/60073?policyId=64a854701268830001676b4f
- Low Account Usage Policy: https://app.flexera.com/orgs/1105/automation/applied-policies/projects/60073?policyId=64a853d91268830001676b4e

### Contribution Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
