### PR TITLE
FOPTS-1072 - Turbonomic policies with token refreshed follow schedule

### DIFF
--- a/cost/turbonomics/credential_refresh/CHANGELOG.md
+++ b/cost/turbonomics/credential_refresh/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2
 
-- The refresh policy will decide if update is needed based on its frequency and next scheduled run of the policy to update
+- The refresh policy updates the applied policies only when necessary, taking into account their next scheduled execution
 
 ## v0.1
 

--- a/cost/turbonomics/credential_refresh/CHANGELOG.md
+++ b/cost/turbonomics/credential_refresh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2
+
+- The refresh policy will decide if update is needed based on its frequency and next scheduled run of the policy to update
+
 ## v0.1
 
 - Initial Release

--- a/cost/turbonomics/credential_refresh/README.md
+++ b/cost/turbonomics/credential_refresh/README.md
@@ -6,7 +6,7 @@ The purpose of this policy is to refresh the authentication cookie used to authe
 
 ## What it does
 
-The policy periodically checks for applied policies in the project that are related to Turbonomic. If any Turbonomic policies are found, the policy initiates an escalation process to update the authentication cookie used for Turbonomic APIs. The policy retrieves the necessary credentials and makes API calls to Turbonomic to obtain a fresh cookie. It then updates the applied Turbonomic policies with the new authentication cookie, ensuring seamless authentication for Turbonomic API calls.
+The policy periodically checks for applied policies in the project that are related to Turbonomic. If any Turbonomic policies are found, the policy checks the scheduled run times of these policies and determines if an update is necessary. If the next scheduled run of a Turbonomic policy is before the next refresh by the credential updater, it initiates an escalation process to update the authentication cookie used for Turbonomic APIs. The policy retrieves the necessary credentials and makes API calls to Turbonomic to obtain a fresh cookie. It then updates the applied Turbonomic policies with the new authentication cookie, ensuring seamless authentication for Turbonomic API calls.
 
 ## Prerequisites
 
@@ -28,7 +28,8 @@ The policy performs the following actions:
 
 - Retrieves all applied policies in the project where this policy is applied.
 - Filters the applied policies to find policies associated with Turbonomic.
-- Updates the authentication cookie parameter for Turbonomic policies with a refreshed cookie.
+- Evaluates the refresh frequency of the credential's updater and the next scheduled run time of each Turbonomic policy.
+- If the next scheduled run of a Turbonomic policy is before the next refresh by the credential updater, the policy updates the authentication cookie parameter with a refreshed cookie.
 
 ### Required Flexera Roles
 

--- a/cost/turbonomics/credential_refresh/README.md
+++ b/cost/turbonomics/credential_refresh/README.md
@@ -24,12 +24,9 @@ This policy requires the following input parameters:
 
 ## Policy Actions
 
-The policy performs the following actions:
+The policy performs the following action:
 
-- Retrieves all applied policies in the project where this policy is applied.
-- Filters the applied policies to find policies associated with Turbonomic.
-- Evaluates the refresh frequency of the credential's updater and the next scheduled run time of each Turbonomic policy.
-- If the next scheduled run of a Turbonomic policy is before the next refresh by the credential updater, the policy updates the authentication cookie parameter with a refreshed cookie.
+- Updates the authentication cookie parameter for Turbonomic policies with a refreshed cookie.
 
 ### Required Flexera Roles
 

--- a/cost/turbonomics/credential_refresh/turbonomic_cred_refresh.pt
+++ b/cost/turbonomics/credential_refresh/turbonomic_cred_refresh.pt
@@ -10,7 +10,7 @@ info(
   provider: "",
   service: "",
   policy_set: "",
-	publish: "false"
+  publish: "false"
 )
 
 parameter "param_turbonomic_username" do
@@ -67,10 +67,10 @@ end
 
 # Filters the applied policy where the info.source is set to either "Turbonomic" or "Turbonomics"
 datasource "ds_turbo_applied_policies" do
-  run_script $js_filter_turbo_policies, $ds_applied_policies
+  run_script $js_turbo_applied_policies, $ds_applied_policies
 end
 
-script "js_filter_turbo_policies", type: "javascript" do
+script "js_turbo_applied_policies", type: "javascript" do
   parameters "applied_policies"
   result "filtered_policies"
   code <<-EOS
@@ -80,21 +80,109 @@ script "js_filter_turbo_policies", type: "javascript" do
   EOS
 end
 
+# collect additional data for the applied policies
+datasource "ds_turbo_policies_with_next_start" do
+  iterate $ds_turbo_applied_policies
+  request do
+    run_script $js_turbo_policies_with_next_start, val(iter_item, "id"), rs_project_id, rs_governance_host
+  end
+  result do
+    encoding "json"
+    collect jq(response, ".") do
+      field "id", val(iter_item, "id")
+      field "info_source", val(iter_item, "info_source")
+      field "name", val(iter_item, "name")
+      field "time", val(iter_item, "time")
+      field "next_evaluation_start", jq(col_item, ".next_evaluation_start")
+    end
+  end
+end
+
+script "js_turbo_policies_with_next_start", type: "javascript" do
+  result "result"
+  parameters "policy_id", "rs_project_id", "rs_governance_host"
+  code <<-EOS
+  result = {
+    auth: "auth_flexera",
+    host: rs_governance_host,
+    path: "/api/governance/projects/" + rs_project_id + "/applied_policies/" + policy_id + "/status",
+    headers: {
+      "API-Version": "1.0",
+      "Content-Type":"application/json"
+    },
+  }
+  EOS
+end
+
+# Get Current Policy Details
+datasource "ds_self_policy_info" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    header "Api-Version", "1.0"
+    header "Content-Type", "application/json"
+    ignore_status [403,404]
+  end
+  result do
+    encoding "json"
+    field "frequency", jmes_path(response, "frequency")
+  end
+end
+
+# Filters the applied policy by next_evaluation_start
+datasource "ds_filtered_turbo_policies" do
+  run_script $js_filter_turbo_policies, $ds_turbo_policies_with_next_start, $ds_self_policy_info
+end
+
+script "js_filter_turbo_policies", type: "javascript" do
+  parameters "policies_with_next_start", "ds_self_policy_info"
+  result "results"
+  code <<-EOS
+  var nextStart = function (interval) {
+    var currentDate = new Date();
+    var newDate = new Date(currentDate);
+    switch (interval) {
+      case '15 minutes':
+        newDate.setMinutes(currentDate.getMinutes() + 15);
+        break;
+      case 'hourly':
+        newDate.setHours(currentDate.getHours() + 1);
+        break;
+      case 'daily':
+        newDate.setDate(currentDate.getDate() + 1);
+        break;
+      case 'weekly':
+        newDate.setDate(currentDate.getDate() + 7);
+        break;
+      case 'monthly':
+        newDate.setMonth(currentDate.getMonth() + 1);
+        break;
+    }
+    return newDate.getTime();
+  }
+
+  var results = _.filter(policies_with_next_start, function(policy) {
+    return new Date(policy.next_evaluation_start).getTime() <= nextStart(ds_self_policy_info.frequency)
+  });
+  EOS
+end
+
 ###############################################################################
 # Policy
 ###############################################################################
 
-policy "pol_turbo_applied_policies" do
-  validate $ds_turbo_applied_policies do
+policy "pol_filtered_turbo_policies" do
+  validate $ds_filtered_turbo_policies do
     summary_template "Turbo policies found"
     detail_template <<-EOS
-    The following applied policies are running for Turbonomics. The auth_token parameter will be updated
-    with refreshed cookie.
+    The following applied policies are running for Turbonomics and require the auth_token parameter to be
+    updated before the next run. It will be updated with refreshed cookie.
 
-    | ID | Name | Source |
-    | -- | ---- | ------ |
+    | ID | Name | Source | Next start |
+    | -- | ---- | ------ | ---------- |
 {{ range data -}}
-  | {{.id}} | {{.name}} | {{.info_source}} |
+  | {{.id}} | {{.name}} | {{.info_source}} | {{.next_evaluation_start}} |
 {{ end -}}
 EOS
     check eq(size(data), 0)

--- a/cost/turbonomics/credential_refresh/turbonomic_cred_refresh.pt
+++ b/cost/turbonomics/credential_refresh/turbonomic_cred_refresh.pt
@@ -179,10 +179,10 @@ policy "pol_filtered_turbo_policies" do
     The following applied policies are running for Turbonomics and require the auth_token parameter to be
     updated before the next run. It will be updated with refreshed cookie.
 
-    | ID | Name | Source | Next start |
-    | -- | ---- | ------ | ---------- |
+    | ID | Name | Source |
+    | -- | ---- | ------ |
 {{ range data -}}
-  | {{.id}} | {{.name}} | {{.info_source}} | {{.next_evaluation_start}} |
+  | {{.id}} | {{.name}} | {{.info_source}} |
 {{ end -}}
 EOS
     check eq(size(data), 0)

--- a/cost/turbonomics/credential_refresh/turbonomic_cred_refresh.pt
+++ b/cost/turbonomics/credential_refresh/turbonomic_cred_refresh.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Operational"
 default_frequency "hourly"
 info(
-  version: "0.1",
+  version: "0.2",
   provider: "",
   service: "",
   policy_set: "",


### PR DESCRIPTION
### Description

Refreshing a cookie causes Turbonomic applied policies to restart, so in case the refresh policy runs more often than the turbonomic policy, we get unnecessary runs. In this PR we try to minimize the number of refreshes based on the frequency of policy runs (the refresh policy will decide if update is needed based on its frequency and next scheduled run of the policy to update).

### Issues Resolved

https://flexera.atlassian.net/browse/FOPTS-1072

### Link to Example Applied Policy

https://app.flexera.com/orgs/1105/automation/applied-policies/projects/60073?policyId=64a238374466b10001e23975

### Contribution Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
