### PR TITLE
FOPTS-681 Homologate the requests to GCP recommender API before waiting to prevent API limit quota errors

### DIFF
--- a/cost/google/cud_recommendations/CHANGELOG.md
+++ b/cost/google/cud_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.3
+
+- Modified the number of GCP recommender API calls that can be done before waiting to prevent a quota limit error: 100 request per minute.
+
 ## v3.2
 
 - Updated recommendation service from 'Storage' to 'Compute'.

--- a/cost/google/cud_recommendations/google_committed_use_discount_recommendations.pt
+++ b/cost/google/cud_recommendations/google_committed_use_discount_recommendations.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "3.2",
+  version: "3.3",
   provider: "Google",
   service: "Compute",
   recommendation_type: "Rate Reduction",
@@ -153,7 +153,8 @@ script "js_recommenders", type: "javascript" do
           projectNumber: project.projectNumber,
           accountID: project.accountID,
           accountName: project.accountName
-          region: region
+          region: region,
+          requestNumber: results.length + 1
         })
       })
     }
@@ -165,7 +166,7 @@ end
 datasource "ds_recommendations" do
   iterate $ds_recommenders
   request do
-    run_script $js_recommender_call, val(iter_item,"accountID"), val(iter_item, "region")
+    run_script $js_recommender_call, val(iter_item,"accountID"), val(iter_item, "region"), val(iter_item, "requestNumber")
   end
   result do
     encoding "json"
@@ -190,12 +191,15 @@ datasource "ds_recommendations" do
 end
 
 script "js_recommender_call", type: "javascript" do
-  parameters "accountID", "region"
+  parameters "accountID", "region", "requestNumber"
   result "request"
   code <<-EOF
-  var now = new Date().getTime();
-  var sleepDuration = 10000
-  while(new Date().getTime() < now + sleepDuration){ /* Do nothing */ }
+  // If 100 requests have been made, wait
+  if (requestNumber % 100 === 0) {
+    var now = new Date().getTime();
+    var sleepDuration = 60000
+    while(new Date().getTime() < now + sleepDuration){ /* Do nothing */ }
+  }
   var request = {
     auth: "auth_google",
     pagination: "google_pagination",

--- a/cost/google/idle_ip_address_recommendations/CHANGELOG.md
+++ b/cost/google/idle_ip_address_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.10
+
+- Modified the number of GCP recommender API calls that can be done before waiting to prevent a quota limit error: 100 request per minute.
+
 ## v2.9
 
 - Added `IP Address` incident field.

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.9",
+  version: "2.10",
   provider: "Google",
   service: "Compute",
   policy_set: "Unused IP Addresses",
@@ -243,6 +243,7 @@ script "js_recommenders", type: "javascript" do
       // If record with same accountID-region was found we don't add it to recommenders,
       // it help us to prevent duplicates and avoid extra calls to Recommender API.
       if (!found) {
+          objectToFind["requestNumber"] = recommenders.length + 1
           recommenders.push(objectToFind)
       }
   })
@@ -253,7 +254,7 @@ end
 datasource "ds_recommendations" do
   iterate $ds_recommenders
   request do
-    run_script $js_recommender_call, val(iter_item,"accountID"), val(iter_item, "region")
+    run_script $js_recommender_call, val(iter_item,"accountID"), val(iter_item, "region"), val(iter_item, "requestNumber")
   end
   result do
     encoding "json"
@@ -278,12 +279,15 @@ datasource "ds_recommendations" do
 end
 
 script "js_recommender_call", type: "javascript" do
-  parameters "accountID", "region"
+  parameters "accountID", "region", "requestNumber"
   result "request"
   code <<-EOF
-  var now = new Date().getTime();
-  var sleepDuration = 10000
-  while(new Date().getTime() < now + sleepDuration){ /* Do nothing */ }
+  // If 100 requests have been made, wait 1 minute
+  if (requestNumber % 100 === 0) {
+    var now = new Date().getTime();
+    var sleepDuration = 60000
+    while(new Date().getTime() < now + sleepDuration){ /* Do nothing to prevent quota error */ }
+  }
   var request = {
     auth: "auth_google",
     pagination: "google_pagination",

--- a/cost/google/idle_persistent_disk_recommendations/CHANGELOG.md
+++ b/cost/google/idle_persistent_disk_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.9
+
+- Modified the number of GCP recommender API calls that can be done before waiting to prevent a quota limit error: 100 request per minute.
+
 ## v2.8
 
 - Updated policy metadata to facilitate scraping of incidents for Recommendations dashboard

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.8",
+  version: "2.9",
   provider:"Google",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -256,6 +256,7 @@ script "js_recommenders", type: "javascript" do
         // If record with same accountID-region was found we don't add it to recommenders,
         // it help us to prevent duplicates and avoid extra calls to Recommender API.
         if (!found) {
+            objectToFind["requestNumber"] = recommenders.length + 1
             recommenders.push(objectToFind)
         }
     })
@@ -266,7 +267,7 @@ end
 datasource "ds_recommendations" do
   iterate $ds_recommenders
   request do
-    run_script $js_recommender_call, val(iter_item,"accountID"), val(iter_item, "region")
+    run_script $js_recommender_call, val(iter_item,"accountID"), val(iter_item, "region"), val(iter_item, "requestNumber")
   end
   result do
     encoding "json"
@@ -290,12 +291,15 @@ datasource "ds_recommendations" do
 end
 
 script "js_recommender_call", type: "javascript" do
-  parameters "accountID", "region"
+  parameters "accountID", "region", "requestNumber"
   result "request"
   code <<-EOF
-    var now = new Date().getTime();
-    var sleepDuration = 10000
-    while(new Date().getTime() < now + sleepDuration){ /* Do nothing */ }
+    // If 100 requests have been made, wait 1 minute
+    if (requestNumber % 100 === 0) {
+      var now = new Date().getTime();
+      var sleepDuration = 60000
+      while(new Date().getTime() < now + sleepDuration){ /* Do nothing to prevent quota error */ }
+    }
     var request = {
       auth: "auth_google",
       pagination: "google_pagination",

--- a/cost/google/idle_vm_recommendations/CHANGELOG.md
+++ b/cost/google/idle_vm_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.10
+
+- Modified the number of GCP recommender API calls that can be done before waiting to prevent a quota limit error: 100 request per minute.
+
 ## v2.9
 
 - Added `Lookback Period In Days` incident field.

--- a/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
+++ b/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.9",
+  version: "2.10",
   provider:"Google",
   service: "Compute",
   policy_set: "Idle Compute Instances",
@@ -199,11 +199,10 @@ script "js_recommender_call", type: "javascript" do
   parameters "accountID", "region", "requestNumber"
   result "request"
   code <<-EOF
-  // If 150 requests have been made, wait
-  if (requestNumber % 150 === 0) {
+  // If 100 requests have been made, wait
+  if (requestNumber % 100 === 0) {
     var now = new Date().getTime();
-    // 1 minute and 30 seconds
-    var sleepDuration = 90000
+    var sleepDuration = 60000
     while (new Date().getTime() < now + sleepDuration) { /* Do nothing to prevent quota error */ }
   }
   var request = {

--- a/cost/google/recommender/CHANGELOG.md
+++ b/cost/google/recommender/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.5
+
+- Modified the number of GCP recommender API calls that can be done before waiting to prevent a quota limit error: 100 request per minute.
+
 ## v2.4
 
 - Replaced references `github.com/rightscale/policy_templates` and `github.com/flexera/policy_templates` with `github.com/flexera-public/policy_templates`

--- a/cost/google/recommender/recommender.pt
+++ b/cost/google/recommender/recommender.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.4",
+  version: "2.5",
   provider:"Google",
   service: "Storage",
   policy_set: "Native Recommendations"
@@ -82,7 +82,7 @@ pagination "google_pagination" do
 end
 
 ###############################################################################
-# Datasources
+# Datasources & Scripts
 ###############################################################################
 
 #get all google project
@@ -102,39 +102,10 @@ datasource "ds_google_project" do
   end
 end
 
-
 datasource "ds_recommenders" do
   run_script $js_recommenders, $param_location_whitelist, $param_recommenders, $ds_google_project, $param_project
 end
 
-datasource "ds_recommendations" do
-  iterate $ds_recommenders
-  request do
-    run_script $js_recommender_call, val(iter_item,"projectId"), val(iter_item, "location"), val(iter_item, "recommender")
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "recommendations[*]") do
-      field "projectId", val(iter_item, "projectId")
-      field "projectNumber", val(iter_item, "projectNumber")
-      field "location", val(iter_item, "location")
-      field "id", jmes_path(col_item, "name")
-      field "resource", jmes_path(col_item, "content.overview.resource")
-      field "resourceName", jmes_path(col_item, "content.overview.resourceName")
-      field "description", jmes_path(col_item, "description")
-      field "primaryImpact", jmes_path(col_item, "primaryImpact")
-      field "costUnits", jmes_path(col_item, "primaryImpact.costProjection.cost.units")
-      field "currency", jmes_path(col_item, "primaryImpact.costProjection.cost.currencyCode")
-      field "priority", jmes_path(col_item, "priority")
-      field "recommenderSubtype", jmes_path(col_item, "recommenderSubtype")
-      field "state", jmes_path(col_item, "stateInfo.state")
-    end
-  end
-end
-
-###############################################################################
-# Scripts
-###############################################################################
 script "js_recommenders", type: "javascript" do
   parameters "param_location_whitelist", "param_recommenders", "ds_google_project", "param_project"
   result "results"
@@ -165,7 +136,8 @@ script "js_recommenders", type: "javascript" do
           projectNumber: project.projectNumber,
           projectId: project.projectId,
           location: location,
-          recommender: recommenders
+          recommender: recommenders,
+          requestNumber: results.length + 1
         })
       })
     }
@@ -173,13 +145,41 @@ script "js_recommenders", type: "javascript" do
 EOF
 end
 
+datasource "ds_recommendations" do
+  iterate $ds_recommenders
+  request do
+    run_script $js_recommender_call, val(iter_item,"projectId"), val(iter_item, "location"), val(iter_item, "recommender"), val(iter_item, "requestNumber")
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "recommendations[*]") do
+      field "projectId", val(iter_item, "projectId")
+      field "projectNumber", val(iter_item, "projectNumber")
+      field "location", val(iter_item, "location")
+      field "id", jmes_path(col_item, "name")
+      field "resource", jmes_path(col_item, "content.overview.resource")
+      field "resourceName", jmes_path(col_item, "content.overview.resourceName")
+      field "description", jmes_path(col_item, "description")
+      field "primaryImpact", jmes_path(col_item, "primaryImpact")
+      field "costUnits", jmes_path(col_item, "primaryImpact.costProjection.cost.units")
+      field "currency", jmes_path(col_item, "primaryImpact.costProjection.cost.currencyCode")
+      field "priority", jmes_path(col_item, "priority")
+      field "recommenderSubtype", jmes_path(col_item, "recommenderSubtype")
+      field "state", jmes_path(col_item, "stateInfo.state")
+    end
+  end
+end
+
 script "js_recommender_call", type: "javascript" do
-  parameters "projectId", "location", "recommender"
+  parameters "projectId", "location", "recommender", "requestNumber"
   result "request"
   code <<-EOF
-  var now = new Date().getTime();
-  var sleepDuration = 10000
-  while(new Date().getTime() < now + sleepDuration){ /* Do nothing */ }
+  // If 100 requests have been made, wait
+  if (requestNumber % 100 === 0) {
+    var now = new Date().getTime();
+    var sleepDuration = 60000
+    while(new Date().getTime() < now + sleepDuration){ /* Do nothing */ }
+  }
   var request = {
     auth: "auth_google",
     pagination: "google_pagination",

--- a/cost/google/rightsize_vm_recommendations/CHANGELOG.md
+++ b/cost/google/rightsize_vm_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Google Rightsize VM Recommender
 
+## v1.1
+
+- Modified the number of GCP recommender API calls that can be done before waiting to prevent a quota limit error: 100 request per minute.
+
 ## v1.0
 
 - Initial release.

--- a/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations.pt
+++ b/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "1.0",
+  version: "1.1",
   provider:"GCP",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -312,11 +312,10 @@ script "js_recommender_call", type: "javascript" do
   parameters "accountID", "region", "requestNumber"
   result "request"
   code <<-EOF
-    // If 150 requests have been made, wait
-    if (requestNumber % 150 === 0) {
+    // If 100 requests have been made, wait
+    if (requestNumber % 100 === 0) {
       var now = new Date().getTime();
-      // 1 minute and 30 seconds
-      var sleepDuration = 90000
+      var sleepDuration = 60000
       while (new Date().getTime() < now + sleepDuration) { /* Do nothing to prevent quota error */ }
     }
     var request = {


### PR DESCRIPTION
### Description

This change homologates the number of requests done to GCP recommender API before waiting in order to prevent API quota limit errors.

Now the next three GCP recommender policies make 100 request to recommender API before waiting.

- Google Idle IP Address Recommender
- Google Idle Persistent Disk Recommender
- Google Idle VM Recommender

Request number was determined using the documentation: https://cloud.google.com/recommender/quotas

### Issues Resolved

- [FOPTS-681 Google Recommender policies - optimize recommender API throttling](https://flexera.atlassian.net/browse/FOPTS-681)

### Link to Example Applied Policy

- [Google Idle IP Address Recommender](https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/107982?policyId=64a4958a4cfc2d000111c929)
- [Google Idle Persistent Disk Recommender](https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/107982?policyId=64a496c14cfc2d000111c92a)
- [Google Idle VM Recommender](https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/107982?policyId=64a4971248e0bd00019a35fd)

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
