### PR TITLE
fix: Meta Parent Parser GitHub README URLs

### DIFF
--- a/.github/workflows/generate-meta-parent-policy-templates.yaml
+++ b/.github/workflows/generate-meta-parent-policy-templates.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - fix/bk_meta_parent_github_url
 
   # Workflow dispatch trigger allows manually running workflow
   workflow_dispatch:

--- a/.github/workflows/generate-meta-parent-policy-templates.yaml
+++ b/.github/workflows/generate-meta-parent-policy-templates.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - fix/bk_meta_parent_github_url
 
   # Workflow dispatch trigger allows manually running workflow
   workflow_dispatch:

--- a/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
+++ b/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
@@ -172,8 +172,11 @@ def compile_meta_parent_policy(file_path)
   # This would only work if the pt file is located under the `policy_templates` repo directory
   # If it is not, then the URL will be incorrect
   pt_path_expanded = File.expand_path(file_path) # Get full path to the pt file provided
+  print("pt_path_expanded: #{pt_path_expanded}\n")
   pt_path_repo_file = pt_path_expanded.split("policy_templates")[1] # Get the path to the pt file relative to the policy_templates directory
+  print("pt_path_repo_file: #{pt_path_repo_file}\n")
   pt_path_repo_dir = pt_path_repo_file.split("/")[0..-2].join("/") # Get the path to the directory containing the child pt file
+  print("pt_path_repo_dir: #{pt_path_repo_dir}\n")
   github_url = "https://github.com/flexera-public/policy_templates/tree/master#{pt_path_repo_dir}" # Build the github URL
   output_pt = output_pt.gsub("__PLACEHOLDER_FOR_CHILD_POLICY_GITHUB_URL__", github_url) # Replace the placeholder with the github URL
   # Build a list of parameter block strings for the output pt

--- a/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
+++ b/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
@@ -172,11 +172,8 @@ def compile_meta_parent_policy(file_path)
   # This would only work if the pt file is located under the `policy_templates` repo directory
   # If it is not, then the URL will be incorrect
   pt_path_expanded = File.expand_path(file_path) # Get full path to the pt file provided
-  print("pt_path_expanded: #{pt_path_expanded}\n")
   pt_path_repo_file = pt_path_expanded.gsub(/^.*policy_templates\//, "") # Get the path to the pt file relative to the policy_templates directory
-  print("pt_path_repo_file: #{pt_path_repo_file}\n")
   pt_path_repo_dir = pt_path_repo_file.split("/")[0..-2].join("/") # Get the path to the directory containing the child pt file
-  print("pt_path_repo_dir: #{pt_path_repo_dir}\n")
   github_url = "https://github.com/flexera-public/policy_templates/tree/master/#{pt_path_repo_dir}" # Build the github URL
   output_pt = output_pt.gsub("__PLACEHOLDER_FOR_CHILD_POLICY_GITHUB_URL__", github_url) # Replace the placeholder with the github URL
   # Build a list of parameter block strings for the output pt

--- a/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
+++ b/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
@@ -172,9 +172,9 @@ def compile_meta_parent_policy(file_path)
   # This would only work if the pt file is located under the `policy_templates` repo directory
   # If it is not, then the URL will be incorrect
   pt_path_expanded = File.expand_path(file_path) # Get full path to the pt file provided
-  pt_path_repo_file = pt_path_expanded.split("policy_templates/")[1] # Get the path to the pt file relative to the policy_templates directory
+  pt_path_repo_file = pt_path_expanded.split("policy_templates")[1] # Get the path to the pt file relative to the policy_templates directory
   pt_path_repo_dir = pt_path_repo_file.split("/")[0..-2].join("/") # Get the path to the directory containing the child pt file
-  github_url = "https://github.com/flexera-public/policy_templates/tree/master/#{pt_path_repo_dir}" # Build the github URL
+  github_url = "https://github.com/flexera-public/policy_templates/tree/master#{pt_path_repo_dir}" # Build the github URL
   output_pt = output_pt.gsub("__PLACEHOLDER_FOR_CHILD_POLICY_GITHUB_URL__", github_url) # Replace the placeholder with the github URL
   # Build a list of parameter block strings for the output pt
   # We need to do this because we need to exclude the param_email and param_aws_account_number params from meta parent pt

--- a/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
+++ b/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
@@ -173,11 +173,11 @@ def compile_meta_parent_policy(file_path)
   # If it is not, then the URL will be incorrect
   pt_path_expanded = File.expand_path(file_path) # Get full path to the pt file provided
   print("pt_path_expanded: #{pt_path_expanded}\n")
-  pt_path_repo_file = pt_path_expanded.split("policy_templates")[1] # Get the path to the pt file relative to the policy_templates directory
+  pt_path_repo_file = pt_path_expanded.gsub(/^.*policy_templates\//, "") # Get the path to the pt file relative to the policy_templates directory
   print("pt_path_repo_file: #{pt_path_repo_file}\n")
   pt_path_repo_dir = pt_path_repo_file.split("/")[0..-2].join("/") # Get the path to the directory containing the child pt file
   print("pt_path_repo_dir: #{pt_path_repo_dir}\n")
-  github_url = "https://github.com/flexera-public/policy_templates/tree/master#{pt_path_repo_dir}" # Build the github URL
+  github_url = "https://github.com/flexera-public/policy_templates/tree/master/#{pt_path_repo_dir}" # Build the github URL
   output_pt = output_pt.gsub("__PLACEHOLDER_FOR_CHILD_POLICY_GITHUB_URL__", github_url) # Replace the placeholder with the github URL
   # Build a list of parameter block strings for the output pt
   # We need to do this because we need to exclude the param_email and param_aws_account_number params from meta parent pt


### PR DESCRIPTION
### Description

On GitHub Actions the path to policy template included multiple matches for `policy_templates/` -- i.e. `/.../policy_templates/policy_templates/.../`.  This was causing the script to fail because it was using `split("policy_templates/")[1]` -- which is not correct.

### Issues Resolved

This change uses regex to find and replace everything from the start of the fully expanded path, up to the last `policy_templates/` -- which should work better.

- [X] New functionality includes testing.