### PR TITLE
POL-878: Azure Rightsize Compute Instances Memory Support and General Improvements

### DIFF
--- a/cost/azure/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances/CHANGELOG.md
@@ -5,14 +5,13 @@
 - Several parameters altered to be more descriptive and human-readable
 - Removed deprecated "Log to CM Audit Entries" parameter
 - Added ability to only report recommendations that meet a minimum savings threshold
-- Added support for memory metrics
+- Added support for memory metrics along with relevant parameters
 - Added ability to configure how many days to consider CPU/memory statistics for
 - Added ability to filter resources by multiple tag key:value pairs
 - Added ability to make recommendations based on maximum CPU/memory usage
 - Added additional context to incident description
 - Normalized incident export to be consistent with other policies
 - Added human-readable recommendation to incident export
-- Added additional fields to incident export to facilitate scraping for dashboards
 - Policy no longer raises new escalations if statistics or savings data changed but nothing else has
 - Streamlined code for better readability and faster execution
 

--- a/cost/azure/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v3.0
+
+- Several parameters altered to be more descriptive and human-readable
+- Removed deprecated "Log to CM Audit Entries" parameter
+- Added ability to only report recommendations that meet a minimum savings threshold
+- Added support for memory metrics
+- Added ability to configure how many days to consider CPU/memory statistics for
+- Added ability to filter resources by multiple tag key:value pairs
+- Added ability to make recommendations based on maximum CPU/memory usage
+- Added additional context to incident description
+- Normalized incident export to be consistent with other policies
+- Added human-readable recommendation to incident export
+- Added additional fields to incident export to facilitate scraping for dashboards
+- Policy no longer raises new escalations if statistics or savings data changed but nothing else has
+- Streamlined code for better readability and faster execution
+
 ## v2.4
 
 - Changed internal names of several incident fields to ensure that they are properly scraped for dashboards.

--- a/cost/azure/rightsize_compute_instances/README.md
+++ b/cost/azure/rightsize_compute_instances/README.md
@@ -2,11 +2,11 @@
 
 ## What it does
 
-This policy checks all the instances in Azure Subscriptions for the average CPU and/or memory usage over a user-specified number of days. If the usage is less than the user provided Idle Instance CPU and/or memory percentage threshold then the Virtual Machine is recommended for deletion. If the usage is less than the user provided Underutilized Instance CPU and/or Memory percentage threshold then the Virtual Machine is recommended for downsizing. Both sets of Virtual Machines returned from this policy are emailed to the user.
+This policy checks all the instances in Azure Subscriptions for the average or maximum CPU and/or memory usage over a user-specified number of days. If the usage is less than the user provided Idle Instance CPU and/or memory percentage threshold then the Virtual Machine is recommended for deletion. If the usage is less than the user provided Underutilized Instance CPU and/or Memory percentage threshold then the Virtual Machine is recommended for downsizing. Both sets of Virtual Machines returned from this policy are emailed to the user.
 
 ## Functional Details
 
-- The policy leverages the Azure API to check all instances and then checks the instance average CPU and memory utilization over a user-specified number of days.
+- The policy leverages the Azure API to check all instances and then checks the instance average or maximum CPU and memory utilization over a user-specified number of days.
 - The policy identifies all instances that have CPU and/or memory utilization below the user-specified idle thresholds and provides the relevant recommendation.
 - The recommendation provided for Idle Instances is a deletion action. These instances can be deleted in an automated manner or after approval.
 - The policy identifies all instances that have CPU and/or memory utilization below the user-specified underutilized thresholds and provides the relevant recommendation.

--- a/cost/azure/rightsize_compute_instances/README.md
+++ b/cost/azure/rightsize_compute_instances/README.md
@@ -54,7 +54,7 @@ For administrators [creating and managing credentials](https://docs.flexera.com/
   - `Microsoft.Compute/virtualMachines/read`
   - `Microsoft.Compute/virtualMachines/write`*
   - `Microsoft.Compute/skus/read`
-  - `Microsoft.Insights/Metrics/Read`
+  - `Microsoft.Insights/metrics/Read`
 
 \* Only required for taking action (deleting or downsizing); the policy will still function in a read-only capacity without these permissions.
 

--- a/cost/azure/rightsize_compute_instances/README.md
+++ b/cost/azure/rightsize_compute_instances/README.md
@@ -14,27 +14,32 @@ This policy checks all the instances in Azure Subscriptions for the average CPU 
 
 ### Policy savings details
 
-The policy includes the estimated savings. The estimated savings is recognized if the resource is deleted or downsized. Optima is used to receive the estimated savings which is the cost of the resource for the last full month. The savings is displayed in the Estimated Monthly Savings column. If the resource can not be found in Optima the value is 0.0. The incident message detail includes the sum of each resource Estimated Monthly Savings as Total Estimated Monthly Savings.
+The policy includes the estimated monthly savings. The estimated monthly savings is recognized if the resource is deleted or downsized. Optima is used to retrieve and calculate the estimated savings which is the cost of the resource for a full day (3 days ago) multiplied by 30.44 (the average number of days in a month) or 0 if no cost information for the resource was found in Optima. The savings is displayed in the Estimated Monthly Savings column. The incident message detail includes the sum of each resource *Estimated Monthly Savings* as *Potential Monthly Savings*.
 
 ## Input Parameters
 
-- *Email addresses* - Email addresses of the recipients you wish to notify when new incidents are created.
-- *Idle Instance CPU Threshold (%)* - CPU threshold at which to trigger instance termination.
-- *Inefficient Instance CPU Threshold (%)* - CPU threshold at which to trigger instance downsize.
-- *Exclusion Tag Key* - An Azure-native instance tag key to ignore instances that you don't want to consider for downsizing. Example: exclude_utilization.
-- *Threshold Statistics* - Determines whether to use minimum CPU usage, maximum CPU usage, or average CPU usage when determining recommendations.
-- *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).
-- *Subscription Allowed List* - Allowed Subscriptions, if empty, all subscriptions will be checked.
+- *Email addresses to notify* - Email addresses of the recipients you wish to notify when new incidents are created.
 - *Azure Endpoint* - The endpoint to send Azure API requests to. Recommended to leave this at default unless using this policy with Azure China.
-- *Log to CM Audit Entries* - Boolean for whether or not to log any debugging information from actions to CM Audit Entries, this should be left set to No on Flexera EU.
+- *Minimum Savings Threshold* - Minimum potential savings required to generate a recommendation.
+- *Allow/Deny Subscriptions* - Determines whether the Allow/Deny Subscriptions List parameter functions as an allow list (only providing results for the listed subscriptions) or a deny list (providing results for all subscriptions except for the listed subscriptions).
+- *Allow/Deny Subscriptions List* - A list of allowed or denied Subscription IDs/names. If empty, no filtering will occur and recommendations will be produced for all subscriptions.
+- *Idle Instance CPU Threshold (%)* - The CPU threshold at which to consider an instance to be 'idle' and therefore be flagged for deletion. Set to -1 to ignore CPU utilization for idle instance recommendations.
+- *Idle Instance Memory Threshold (%)* - The Memory threshold at which to consider an instance to be 'idle' and therefore be flagged for deletion. Set to -1 to ignore memory utilization for idle instance recommendations.
+- *Underutilized Instance CPU Threshold (%)* - The CPU threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing. Set to -1 to ignore CPU utilization for underutilized instance recommendations.
+- *Underutilized Instance Memory Threshold (%)* - The Memory threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing. Set to -1 to ignore memory utilization for underutilized instance recommendations.
+- *Idle/Utilized for both CPU/Memory or either* - Set whether an instance should be considered idle and/or underutilized only if both CPU and memory are under the thresholds or if either CPU or memory are under. Has no effect if other parameters are configured such that only CPU or memory is being considered.
+- *Threshold Statistic* - Statistic to use when determining if an instance is idle/underutilized.
+- *Statistic Lookback Period* - How many days back to look at CPU and/or memory data for instances. This value cannot be set higher than 90 because Azure does not retain metrics for longer than 90 days.
+- *Exclusion Tags (Key:Value)* - Cloud native tags to ignore instances that you don't want to consider for downsizing or deletion. Format: Key:Value
+- *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).
 
 Please note that the "Automatic Actions" parameter contains a list of action(s) that can be performed on the resources. When it is selected, the policy will automatically execute the corresponding action on the data that failed the checks, post incident generation. Please leave it blank for *manual* action.
-For example if a user selects the "Terminate Instances" action while applying the policy, all the resources that didn't satisfy the policy condition will be terminated.
+For example if a user selects the "Delete Instances" action while applying the policy, all the resources that didn't satisfy the policy condition will be deleted.
 
 ## Policy Actions
 
 - Sends an email notification
-- Terminate virtual machines (if idle) after approval
+- Delete virtual machines (if idle) after approval
 - Downsize virtual machines (if underutilized) after approval
 
 ## Prerequisites
@@ -47,7 +52,11 @@ For administrators [creating and managing credentials](https://docs.flexera.com/
 
 - [**Azure Resource Manager Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_109256743_1124668) (*provider=azure_rm*) which has the following permissions:
   - `Microsoft.Compute/virtualMachines/read`
-  - `Microsoft.Compute/virtualMachines/write`
+  - `Microsoft.Compute/virtualMachines/write`*
+  - `Microsoft.Compute/skus/read`
+  - `Microsoft.Insights/Metrics/Read`
+
+\* Only required for taking action (deleting or downsizing); the policy will still function in a read-only capacity without these permissions.
 
 - [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
   - `billing_center_viewer`

--- a/cost/azure/rightsize_compute_instances/README.md
+++ b/cost/azure/rightsize_compute_instances/README.md
@@ -2,19 +2,19 @@
 
 ## What it does
 
-This policy checks all the instances in Azure Subscriptions for the average CPU usage over the last 30 days. If the usage is less than the user provided Idle Instance CPU percentage threshold then the Virtual Machine is recommended for termination. If the usage is less than the user provided Inefficient Instance CPU percentage threshold then the Virtual Machine is recommended for downsizing. Both sets of Virtual Machines returned from this policy are emailed to the user.
+This policy checks all the instances in Azure Subscriptions for the average CPU and/or memory usage over a user-specified number of days. If the usage is less than the user provided Idle Instance CPU and/or memory percentage threshold then the Virtual Machine is recommended for deletion. If the usage is less than the user provided Underutilized Instance CPU and/or Memory percentage threshold then the Virtual Machine is recommended for downsizing. Both sets of Virtual Machines returned from this policy are emailed to the user.
 
 ## Functional Details
 
-- The policy leverages the Azure API to check all instances and then checks the instance average CPU utilization over the past 30 days
-- The policy identifies all instances that have CPU utilization below the Idle Instance CPU Threshold defined by the user, to provide a recommendation.
-- The recommendation provided for Idle Instances is a termination action. These instances can be terminated in an automated manner or after approval.
-- The policy identifies all instances that have CPU utilization below the Inefficient Instance CPU Threshold defined by the user, to provide a recommendation.
-- The recommendation provided for Inefficient/Underutilized Instances is a downsize action. These instances can be downsized in an automated manner or after approval.
+- The policy leverages the Azure API to check all instances and then checks the instance average CPU and memory utilization over a user-specified number of days.
+- The policy identifies all instances that have CPU and/or memory utilization below the user-specified idle thresholds and provides the relevant recommendation.
+- The recommendation provided for Idle Instances is a deletion action. These instances can be deleted in an automated manner or after approval.
+- The policy identifies all instances that have CPU and/or memory utilization below the user-specified underutilized thresholds and provides the relevant recommendation.
+- The recommendation provided for Underutilized Instances is a downsize action. These instances can be downsized in an automated manner or after approval.
 
 ### Policy savings details
 
-The policy includes the estimated savings. The estimated savings is recognized if the resource is terminated, or downsized. Optima is used to receive the estimated savings which is the cost of the resource for the last full month. The savings is displayed in the Estimated Monthly Savings column. If the resource can not be found in Optima the value is 0.0. The incident message detail includes the sum of each resource Estimated Monthly Savings as Total Estimated Monthly Savings.
+The policy includes the estimated savings. The estimated savings is recognized if the resource is deleted or downsized. Optima is used to receive the estimated savings which is the cost of the resource for the last full month. The savings is displayed in the Estimated Monthly Savings column. If the resource can not be found in Optima the value is 0.0. The incident message detail includes the sum of each resource Estimated Monthly Savings as Total Estimated Monthly Savings.
 
 ## Input Parameters
 

--- a/cost/azure/rightsize_compute_instances/README.md
+++ b/cost/azure/rightsize_compute_instances/README.md
@@ -54,7 +54,7 @@ For administrators [creating and managing credentials](https://docs.flexera.com/
   - `Microsoft.Compute/virtualMachines/read`
   - `Microsoft.Compute/virtualMachines/write`*
   - `Microsoft.Compute/skus/read`
-  - `Microsoft.Insights/metrics/Read`
+  - `Microsoft.Insights/metrics/read`
 
 \* Only required for taking action (deleting or downsizing); the policy will still function in a read-only capacity without these permissions.
 

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -110,20 +110,11 @@ parameter "param_stats_check_both" do
   default "Either CPU or Memory"
 end
 
-parameter "param_stats_threshold_cpu" do
+parameter "param_stats_threshold" do
   type "string"
   category "Statistics"
-  label "Threshold Statistic (CPU)"
-  description "CPU statistic to use when determining if an instance is idle/underutilized."
-  allowed_values "Average", "Maximum"
-  default "Average"
-end
-
-parameter "param_stats_threshold_mem" do
-  type "string"
-  category "Statistics"
-  label "Threshold Statistic (Memory)"
-  description "Memory statistic to use when determining if an instance is idle/underutilized. Maximum is not recommended because most VMs will have a value of 100% for maximum memory."
+  label "Threshold Statistic"
+  description "Statistic to use when determining if an instance is idle/underutilized."
   allowed_values "Average", "Maximum"
   default "Average"
 end
@@ -533,61 +524,73 @@ script "js_azure_instances_metrics_organized", type: "javascript" do
       }
     })
 
+    // Default to 0 in case there are no stats because instance is not powered on
     cpu_min = 0
     cpu_max = 0
     cpu_avg = 0
-    cpu_count = 0
+    cpu_min_count = 0
+    cpu_max_count = 0
+    cpu_avg_count = 0
 
     if (cpu_stats != null && cpu_stats != undefined) {
       _.each(cpu_stats, function(item) {
         if (item["average"] != undefined && item["average"] != null) {
-          cpu_min += item["minimum"]
-          cpu_max += item["maximum"]
           cpu_avg += item["average"]
-          cpu_count += 1
+          cpu_avg_count += 1
+        }
+
+        if (item["minimum"] != undefined && item["minimum"] != null) {
+          cpu_min += item["minimum"]
+          cpu_min_count += 1
+        }
+
+        if (item["maximum"] != undefined && item["maximum"] != null) {
+          cpu_max += item["maximum"]
+          cpu_max_count += 1
         }
       })
     }
 
-    if (cpu_count == 0) {
-      cpu_min = 0
-      cpu_max = 0
-      cpu_avg = 0
-    } else {
-      cpu_min = cpu_min / cpu_count
-      cpu_max = cpu_max / cpu_count
-      cpu_avg = cpu_avg / cpu_count
-    }
+    if (cpu_min_count != 0) { cpu_min = cpu_min / cpu_min_count }
+    if (cpu_max_count != 0) { cpu_max = cpu_max / cpu_max_count }
+    if (cpu_avg_count != 0) { cpu_avg = cpu_avg / cpu_avg_count }
 
+    // Default to 0 in case there are no stats because instance is not powered on
     mem_min = 0
     mem_max = 0
     mem_avg = 0
-    mem_count = 0
+    mem_min_count = 0
+    mem_max_count = 0
+    mem_avg_count = 0
+
+    total_memory = ds_azure_sku_memory[vm['resourceType'].toLowerCase()]
 
     if (mem_stats != null && mem_stats != undefined) {
       _.each(mem_stats, function(item) {
+        // Convert available memory in bytes to used memory in percentage
+        // Note: The switch between min and max is intentional because
+        // the maximum available memory is equivalent to the minumum
+        // memory used.
         if (item["average"] != undefined && item["average"] != null) {
-          mem_min += item["minimum"]
-          mem_max += item["maximum"]
-          mem_avg += item["average"]
-          mem_count += 1
+          mem_avg += (total_memory - item["average"]) / total_memory
+          mem_avg_count += 1
+        }
+
+        if (item["minimum"] != undefined && item["minimum"] != null) {
+          mem_max += (total_memory - item["minimum"]) / total_memory
+          mem_max_count += 1
+        }
+
+        if (item["maximum"] != undefined && item["maximum"] != null) {
+          mem_min += (total_memory - item["maximum"]) / total_memory
+          mem_min_count += 1
         }
       })
     }
 
-    total_memory = ds_azure_sku_memory[vm['resourceType'].toLowerCase()]
-
-    if (mem_count == 0) {
-      mem_min = 0
-      mem_max = 0
-      mem_avg = 0
-    } else {
-      // Convert available memory in bytes to used memory in percentage
-      // Note: The switch between min and max is intentional
-      mem_min = (total_memory - (mem_max / mem_count)) / total_memory * 100
-      mem_max = (total_memory - (mem_min / mem_count)) / total_memory * 100
-      mem_avg = (total_memory - (mem_avg / mem_count)) / total_memory * 100
-    }
+    if (mem_min_count != 0) { mem_min = mem_min / mem_min_count * 100 }
+    if (mem_max_count != 0) { mem_max = mem_max / mem_max_count * 100 }
+    if (mem_avg_count != 0) { mem_avg = mem_avg / mem_avg_count * 100 }
 
     vm_tags = []
 
@@ -625,7 +628,6 @@ script "js_azure_instances_metrics_organized", type: "javascript" do
 EOS
 end
 
-
 datasource "ds_instance_costs" do
   iterate $ds_azure_subscriptions_filtered
   request do
@@ -633,7 +635,7 @@ datasource "ds_instance_costs" do
   end
   result do
     encoding "json"
-    collect jmes_path(response,"rows[*]") do
+    collect jmes_path(response, "rows[*]") do
       field "resourceId", jmes_path(col_item, "dimensions.resource_id")
       field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
     end
@@ -732,11 +734,11 @@ datasource "ds_azure_instance_size_map" do
 end
 
 datasource "ds_idle_and_underutil_instances" do
-  run_script $js_idle_and_underutil_instances, $ds_azure_instances_filtered, $ds_azure_instances_metrics_organized, $ds_instance_costs_grouped, $ds_azure_instance_size_map, $ds_currency, $ds_applied_policy, $param_stats_idle_threshold_cpu_value, $param_stats_idle_threshold_mem_value, $param_stats_underutil_threshold_cpu_value, $param_stats_underutil_threshold_mem_value, $param_stats_check_both, $param_stats_threshold_cpu, $param_stats_threshold_mem, $param_min_savings, $param_stats_lookback
+  run_script $js_idle_and_underutil_instances, $ds_azure_instances_filtered, $ds_azure_instances_metrics_organized, $ds_instance_costs_grouped, $ds_azure_instance_size_map, $ds_currency, $ds_applied_policy, $param_stats_idle_threshold_cpu_value, $param_stats_idle_threshold_mem_value, $param_stats_underutil_threshold_cpu_value, $param_stats_underutil_threshold_mem_value, $param_stats_check_both, $param_stats_threshold, $param_min_savings, $param_stats_lookback
 end
 
 script "js_idle_and_underutil_instances", type:"javascript" do
-  parameters "ds_azure_instances_filtered", "ds_azure_instances_metrics_organized", "ds_instance_costs_grouped", "ds_azure_instance_size_map", "ds_currency", "ds_applied_policy", "param_stats_idle_threshold_cpu_value", "param_stats_idle_threshold_mem_value", "param_stats_underutil_threshold_cpu_value", "param_stats_underutil_threshold_mem_value", "param_stats_check_both", "param_stats_threshold_cpu", "param_stats_threshold_mem", "param_min_savings", "param_stats_lookback"
+  parameters "ds_azure_instances_filtered", "ds_azure_instances_metrics_organized", "ds_instance_costs_grouped", "ds_azure_instance_size_map", "ds_currency", "ds_applied_policy", "param_stats_idle_threshold_cpu_value", "param_stats_idle_threshold_mem_value", "param_stats_underutil_threshold_cpu_value", "param_stats_underutil_threshold_mem_value", "param_stats_check_both", "param_stats_threshold", "param_min_savings", "param_stats_lookback"
   result "result"
   code <<-'EOS'
   // Used for formatting numbers to look pretty
@@ -758,8 +760,7 @@ script "js_idle_and_underutil_instances", type:"javascript" do
   }
 
   // The key name is lowercase, param value needs to be lowercase.
-  threshold_statistic_cpu = param_stats_threshold_cpu.toLowerCase()
-  threshold_statistic_mem = param_stats_threshold_mem.toLowerCase()
+  threshold_statistic = param_stats_threshold.toLowerCase()
 
   // Determine whether we're checking for CPU, memory, or both
   checking_cpu = param_stats_underutil_threshold_cpu_value != -1 || param_stats_idle_threshold_cpu_value != -1
@@ -784,12 +785,11 @@ script "js_idle_and_underutil_instances", type:"javascript" do
       // Add baked-in values
       instance['savingsCurrency'] = ds_currency['symbol']
       instance['lookbackPeriod'] = param_stats_lookback
-      instance['thresholdTypeCPU'] = param_stats_threshold_cpu
-      instance['thresholdTypeMemory'] = param_stats_threshold_mem
+      instance['thresholdType'] = param_stats_threshold
 
       // Store relevant CPU and memory stats into these variables for later use
-      cpu_value = instance['cpu_' + threshold_statistic_cpu]
-      mem_value = instance['mem_' + threshold_statistic_mem]
+      cpu_value = instance['cpu_' + threshold_statistic]
+      mem_value = instance['mem_' + threshold_statistic]
 
       // Test for whether to consider the instance idle or underutilized.
       // Assume instance is not idle or underutilized by default.
@@ -906,9 +906,9 @@ script "js_idle_and_underutil_instances", type:"javascript" do
 
       underutil_analysis_message = [
         "A virtual machine is considered underutilized if its CPU usage (",
-        param_stats_threshold_cpu.toLowerCase(), ") is below ",
+        param_stats_threshold.toLowerCase(), ") is below ",
         param_stats_underutil_threshold_cpu_value, "% ", message_boolean,
-        " its memory usage (", param_stats_threshold_cpu.toLowerCase(),
+        " its memory usage (", param_stats_threshold.toLowerCase(),
         ") is below ", param_stats_underutil_threshold_mem_value,
         "% but its CPU usage is still above or equal to ",
         param_stats_idle_threshold_cpu_value, "% ", message_boolean,
@@ -918,9 +918,9 @@ script "js_idle_and_underutil_instances", type:"javascript" do
 
       idle_analysis_message = [
         "A virtual machine is considered idle if its CPU usage (",
-        param_stats_threshold_cpu.toLowerCase(), ") is below ",
+        param_stats_threshold.toLowerCase(), ") is below ",
         param_stats_idle_threshold_cpu_value, "% ", message_boolean,
-        " its memory usage (", param_stats_threshold_cpu.toLowerCase(),
+        " its memory usage (", param_stats_threshold.toLowerCase(),
         ") is below ", param_stats_idle_threshold_mem_value, "%. "
       ].join('')
 
@@ -933,7 +933,7 @@ script "js_idle_and_underutil_instances", type:"javascript" do
     if (checking_cpu && !checking_mem) {
       underutil_analysis_message = [
         "A virtual machine is considered underutilized if its CPU usage (",
-        param_stats_threshold_cpu.toLowerCase(), ") is below ",
+        param_stats_threshold.toLowerCase(), ") is below ",
         param_stats_underutil_threshold_cpu_value,
         "% but its CPU usage is still above or equal to ",
         param_stats_idle_threshold_cpu_value, "%. "
@@ -941,7 +941,7 @@ script "js_idle_and_underutil_instances", type:"javascript" do
 
       idle_analysis_message = [
         "A virtual machine is considered idle if its CPU usage (",
-        param_stats_threshold_cpu.toLowerCase(), ") is below ",
+        param_stats_threshold.toLowerCase(), ") is below ",
         param_stats_idle_threshold_cpu_value, "%. "
       ].join('')
 
@@ -954,7 +954,7 @@ script "js_idle_and_underutil_instances", type:"javascript" do
     if (!checking_cpu && checking_mem) {
       underutil_analysis_message = [
         "A virtual machine is considered underutilized if its memory usage (",
-        param_stats_threshold_cpu.toLowerCase(), ") is below ",
+        param_stats_threshold.toLowerCase(), ") is below ",
         param_stats_underutil_threshold_mem_value,
         "% but its memory usage is still above or equal to ",
         param_stats_idle_threshold_mem_value, "%. "
@@ -962,7 +962,7 @@ script "js_idle_and_underutil_instances", type:"javascript" do
 
       idle_analysis_message = [
         "A virtual machine is considered idle if its memory usage (",
-        param_stats_threshold_cpu.toLowerCase(), ") is below ",
+        param_stats_threshold.toLowerCase(), ") is below ",
         param_stats_idle_threshold_mem_value, "%. "
       ].join('')
 
@@ -1109,11 +1109,7 @@ policy "pol_utilization" do
         path "mem_average"
       end
       field "thresholdType" do
-        label "Threshold Statistic (CPU)"
-        path "thresholdTypeCPU"
-      end
-      field "thresholdTypeMemory" do
-        label "Threshold Statistic (Memory)"
+        label "Threshold Statistic"
       end
       field "threshold" do
         label "CPU Threshold"
@@ -1213,11 +1209,7 @@ policy "pol_utilization" do
         path "mem_average"
       end
       field "thresholdType" do
-        label "Threshold Statistic (CPU)"
-        path "thresholdTypeCPU"
-      end
-      field "thresholdTypeMemory" do
-        label "Threshold Statistic (Memory)"
+        label "Threshold Statistic"
       end
       field "threshold" do
         label "CPU Threshold"
@@ -1301,7 +1293,7 @@ define downsize_instances($data, $param_azure_endpoint) return $all_responses do
             }
           }
         )
-      call sys_log(join([$syslog_subject, "Response"]),to_s($response))
+      call sys_log(join([$syslog_subject, "Response"]), to_s($response))
       end
   end
   end
@@ -1325,7 +1317,7 @@ define delete_instances($data, $param_azure_endpoint) return $all_responses do
         verb: "delete",
         host: $param_azure_endpoint,
         auth: $$auth_azure,
-        href: join(["/subscriptions/", $item['subscriptionId'], "/resourceGroups/", $item["resourceGroup"], "/providers/Microsoft.Compute/virtualMachines/",$item["resourceName"]]),
+        href: $item["id"],
         https: true,
         query_strings: {
           "api-version": "2018-06-01"
@@ -1338,7 +1330,7 @@ define delete_instances($data, $param_azure_endpoint) return $all_responses do
       $all_responses << $response
     end
   end
-  call sys_log(join([$syslog_subject, "Responses"]),to_s($all_responses))
+  call sys_log(join([$syslog_subject, "Responses"]), to_s($all_responses))
 end
 
 #function to log

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -1,7 +1,7 @@
 name "Azure Rightsize Compute Instances"
 rs_pt_ver 20180301
 type "policy"
-short_description "Checks for instances that have inefficient utilization for the last 30 days and rightsizes or terminates them after approval. \n See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/rightsize_compute_instances/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "Checks for instances that have inefficient utilization for the last 30 days and rightsizes or deletes them after approval. \n See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/rightsize_compute_instances/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 category "Cost"
 severity "low"
@@ -110,11 +110,20 @@ parameter "param_stats_check_both" do
   default "Either CPU or Memory"
 end
 
-parameter "param_stats_threshold" do
+parameter "param_stats_threshold_cpu" do
   type "string"
   category "Statistics"
-  label "Threshold Statistic"
-  description "Statistic to use when determining if an instance is idle/underutilized"
+  label "Threshold Statistic (CPU)"
+  description "CPU statistic to use when determining if an instance is idle/underutilized."
+  allowed_values "Average", "Maximum"
+  default "Average"
+end
+
+parameter "param_stats_threshold_mem" do
+  type "string"
+  category "Statistics"
+  label "Threshold Statistic (Memory)"
+  description "Memory statistic to use when determining if an instance is idle/underutilized. Maximum is not recommended because most VMs will have a value of 100% for maximum memory."
   allowed_values "Average", "Maximum"
   default "Average"
 end
@@ -123,7 +132,7 @@ parameter "param_stats_lookback" do
   type "number"
   category "Statistics"
   label "Statistic Lookback Period"
-  description "How many days back to look at CPU and/or memory data for instances. This value cannot be set higher than 90 because AWS does not retain metrics for longer than 90 days."
+  description "How many days back to look at CPU and/or memory data for instances. This value cannot be set higher than 90 because Azure does not retain metrics for longer than 90 days."
   default 30
   min_value 1
   max_value 90
@@ -142,7 +151,7 @@ parameter "param_automatic_action" do
   category "Actions"
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action."
-  allowed_values ["Downsize Instances", "Terminate Instances"]
+  allowed_values ["Downsize Instances", "Delete Instances"]
   default []
 end
 
@@ -348,7 +357,6 @@ datasource "ds_azure_instances" do
       field "region", jmes_path(col_item, "location")
       field "osType", jmes_path(col_item, "properties.storageProfile.osDisk.osType")
       field "resourceType", jmes_path(col_item, "properties.hardwareProfile.vmSize")
-      field "timeCreated", jmes_path(col_item, "properties.timeCreated")
       field "tags", jmes_path(col_item, "tags")
       field "subscriptionId",val(iter_item, "id")
       field "subscriptionName",val(iter_item, "name")
@@ -454,7 +462,6 @@ datasource "ds_azure_instances_metrics" do
     field "tags", val(iter_item, "tags")
     field "osType", val(iter_item, "osType")
     field "resourceType", val(iter_item, "resourceType")
-    field "service", val(iter_item, "service")
     field "subscriptionId",val(iter_item, "subscriptionId")
     field "subscriptionName",val(iter_item, "subscriptionName")
   end
@@ -511,12 +518,19 @@ script "js_azure_instances_metrics_organized", type: "javascript" do
   result = []
 
   _.each(ds_azure_instances_metrics, function(vm) {
-    cpu_stats = _.find(vm['value'], function(stat) {
-      return stat['name']['value'] == "Percentage CPU"
-    })
+    cpu_stats = null
+    mem_stats = null
 
-    mem_stats = _.find(vm['value'], function(stat) {
-      return stat['name']['value'] == "Available Memory Bytes"
+    _.each(vm['value'], function(stat) {
+      if (stat["timeseries"][0] != undefined) {
+        if (stat['name']['value'] == "Percentage CPU") {
+          cpu_stats = stat["timeseries"][0]["data"]
+        }
+
+        if (stat['name']['value'] == "Available Memory Bytes") {
+          mem_stats = stat["timeseries"][0]["data"]
+        }
+      }
     })
 
     cpu_min = 0
@@ -524,19 +538,21 @@ script "js_azure_instances_metrics_organized", type: "javascript" do
     cpu_avg = 0
     cpu_count = 0
 
-    _.each(cpu_stats["timeseries"][0]["data"], function(item) {
-      if (item["average"] != undefined && item["average"] != null) {
-        cpu_min += item["minimum"]
-        cpu_max += item["maximum"]
-        cpu_avg += item["average"]
-        cpu_count += 1
-      }
-    })
+    if (cpu_stats != null && cpu_stats != undefined) {
+      _.each(cpu_stats, function(item) {
+        if (item["average"] != undefined && item["average"] != null) {
+          cpu_min += item["minimum"]
+          cpu_max += item["maximum"]
+          cpu_avg += item["average"]
+          cpu_count += 1
+        }
+      })
+    }
 
     if (cpu_count == 0) {
-      cpu_min = null
-      cpu_max = null
-      cpu_avg = null
+      cpu_min = 0
+      cpu_max = 0
+      cpu_avg = 0
     } else {
       cpu_min = cpu_min / cpu_count
       cpu_max = cpu_max / cpu_count
@@ -548,25 +564,29 @@ script "js_azure_instances_metrics_organized", type: "javascript" do
     mem_avg = 0
     mem_count = 0
 
-    _.each(mem_stats["timeseries"][0]["data"], function(item) {
-      if (item["average"] != undefined && item["average"] != null) {
-        mem_min += item["minimum"]
-        mem_max += item["maximum"]
-        mem_avg += item["average"]
-        mem_count += 1
-      }
-    })
+    if (mem_stats != null && mem_stats != undefined) {
+      _.each(mem_stats, function(item) {
+        if (item["average"] != undefined && item["average"] != null) {
+          mem_min += item["minimum"]
+          mem_max += item["maximum"]
+          mem_avg += item["average"]
+          mem_count += 1
+        }
+      })
+    }
 
-    max_memory = ds_azure_sku_memory[vm['resourceType'].toLowerCase()]
+    total_memory = ds_azure_sku_memory[vm['resourceType'].toLowerCase()]
 
-    if (mem_count == 0 || max_memory == undefined) {
-      mem_min = null
-      mem_max = null
-      mem_avg = null
+    if (mem_count == 0) {
+      mem_min = 0
+      mem_max = 0
+      mem_avg = 0
     } else {
-      mem_min = (mem_min / mem_count) / max_memory * 100
-      mem_max = (mem_max / mem_count) / max_memory * 100
-      mem_avg = (mem_avg / mem_count) / max_memory * 100
+      // Convert available memory in bytes to used memory in percentage
+      // Note: The switch between min and max is intentional
+      mem_min = (total_memory - (mem_max / mem_count)) / total_memory * 100
+      mem_max = (total_memory - (mem_min / mem_count)) / total_memory * 100
+      mem_avg = (total_memory - (mem_avg / mem_count)) / total_memory * 100
     }
 
     vm_tags = []
@@ -585,17 +605,21 @@ script "js_azure_instances_metrics_organized", type: "javascript" do
       region: vm['region'],
       osType: vm['osType'],
       resourceType: vm['resourceType'],
-      service: vm['service'],
       subscriptionId: vm['subscriptionId'],
       subscriptionName: vm['subscriptionName'],
       timeCreated: vm['timeCreated']
       tags: vm_tags.join(', '),
-      cpu_minimum: cpu_min,
-      cpu_maximum: cpu_max,
-      cpu_average: cpu_avg,
-      mem_minimum: mem_min,
-      mem_maximum: mem_max,
-      mem_average: mem_avg
+      cpu_minimum: parseFloat(cpu_min.toFixed(2)),
+      cpu_maximum: parseFloat(cpu_max.toFixed(2)),
+      cpu_average: parseFloat(cpu_avg.toFixed(2)),
+      mem_minimum: parseFloat(mem_min.toFixed(2)),
+      mem_maximum: parseFloat(mem_max.toFixed(2)),
+      mem_average: parseFloat(mem_avg.toFixed(2)),
+      service: "Microsoft.Compute",
+      underutil_message: "",
+      idle_message: "",
+      underutil_total_savings: "",
+      idle_total_savings: ""
     })
   })
 EOS
@@ -708,11 +732,11 @@ datasource "ds_azure_instance_size_map" do
 end
 
 datasource "ds_idle_and_underutil_instances" do
-  run_script $js_idle_and_underutil_instances, $ds_azure_instances_filtered, $ds_azure_instances_metrics_organized, $ds_instance_costs_grouped, $ds_azure_instance_size_map, $ds_currency, $ds_applied_policy, $param_stats_idle_threshold_cpu_value, $param_stats_idle_threshold_mem_value, $param_stats_underutil_threshold_cpu_value, $param_stats_underutil_threshold_mem_value, $param_stats_check_both, $param_stats_threshold, $param_min_savings, $param_stats_lookback
+  run_script $js_idle_and_underutil_instances, $ds_azure_instances_filtered, $ds_azure_instances_metrics_organized, $ds_instance_costs_grouped, $ds_azure_instance_size_map, $ds_currency, $ds_applied_policy, $param_stats_idle_threshold_cpu_value, $param_stats_idle_threshold_mem_value, $param_stats_underutil_threshold_cpu_value, $param_stats_underutil_threshold_mem_value, $param_stats_check_both, $param_stats_threshold_cpu, $param_stats_threshold_mem, $param_min_savings, $param_stats_lookback
 end
 
 script "js_idle_and_underutil_instances", type:"javascript" do
-  parameters "ds_azure_instances_filtered", "ds_azure_instances_metrics_organized", "ds_instance_costs_grouped", "ds_azure_instance_size_map", "ds_currency", "ds_applied_policy", "param_stats_idle_threshold_cpu_value", "param_stats_idle_threshold_mem_value", "param_stats_underutil_threshold_cpu_value", "param_stats_underutil_threshold_mem_value", "param_stats_check_both", "param_stats_threshold", "param_min_savings", "param_stats_lookback"
+  parameters "ds_azure_instances_filtered", "ds_azure_instances_metrics_organized", "ds_instance_costs_grouped", "ds_azure_instance_size_map", "ds_currency", "ds_applied_policy", "param_stats_idle_threshold_cpu_value", "param_stats_idle_threshold_mem_value", "param_stats_underutil_threshold_cpu_value", "param_stats_underutil_threshold_mem_value", "param_stats_check_both", "param_stats_threshold_cpu", "param_stats_threshold_mem", "param_min_savings", "param_stats_lookback"
   result "result"
   code <<-'EOS'
   // Used for formatting numbers to look pretty
@@ -734,7 +758,8 @@ script "js_idle_and_underutil_instances", type:"javascript" do
   }
 
   // The key name is lowercase, param value needs to be lowercase.
-  threshold_statistic = param_stats_threshold.toLowerCase()
+  threshold_statistic_cpu = param_stats_threshold_cpu.toLowerCase()
+  threshold_statistic_mem = param_stats_threshold_mem.toLowerCase()
 
   // Determine whether we're checking for CPU, memory, or both
   checking_cpu = param_stats_underutil_threshold_cpu_value != -1 || param_stats_idle_threshold_cpu_value != -1
@@ -750,7 +775,7 @@ script "js_idle_and_underutil_instances", type:"javascript" do
   if (checking_cpu || checking_mem) {
     // Loop through metrics data, appending cost data
     _.each(ds_azure_instances_metrics_organized, function(instance) {
-      id = instance['id'].toLowerCase()
+      id = instance['resourceId'].toLowerCase()
 
       // Assume cost is 0 unless we have cost data for the instance
       total_cost = 0.0
@@ -759,11 +784,12 @@ script "js_idle_and_underutil_instances", type:"javascript" do
       // Add baked-in values
       instance['savingsCurrency'] = ds_currency['symbol']
       instance['lookbackPeriod'] = param_stats_lookback
-      instance['thresholdType'] = param_stats_threshold
+      instance['thresholdTypeCPU'] = param_stats_threshold_cpu
+      instance['thresholdTypeMemory'] = param_stats_threshold_mem
 
       // Store relevant CPU and memory stats into these variables for later use
-      cpu_value = instance['cpu_' + threshold_statistic]
-      mem_value = instance['mem_' + threshold_statistic]
+      cpu_value = instance['cpu_' + threshold_statistic_cpu]
+      mem_value = instance['mem_' + threshold_statistic_mem]
 
       // Test for whether to consider the instance idle or underutilized.
       // Assume instance is not idle or underutilized by default.
@@ -802,12 +828,12 @@ script "js_idle_and_underutil_instances", type:"javascript" do
       // and then add it to the appropriate list
       if (is_idle) {
         instance["savings"] = parseFloat(parseFloat(total_cost).toFixed(3))
-        instance["recommendationType"] = "Terminate"
+        instance["recommendationType"] = "Delete"
         instance["threshold"] = param_stats_idle_threshold_cpu_value
         instance["memoryThreshold"] = param_stats_idle_threshold_mem_value
 
         recommendationDetails = [
-          "Terminate virtual machine ", instance["resourceId"], " ",
+          "Delete Azure virtual machine ", instance["resourceName"], " ",
           "in Azure Subscription ", instance["subscriptionName"], " ",
           "(", instance["subscriptionId"], ")"
         ]
@@ -829,7 +855,7 @@ script "js_idle_and_underutil_instances", type:"javascript" do
         }
 
         recommendationDetails = [
-          "Change instance type of virtual machine ", instance["resourceId"], " ",
+          "Resize Azure virtual machine ", instance["resourceName"], " ",
           "in Azure Subscription ", instance["subscriptionName"], " ",
           "(", instance["subscriptionId"], ") ",
           "from ", instance["resourceType"], " ",
@@ -860,13 +886,13 @@ script "js_idle_and_underutil_instances", type:"javascript" do
     idle_total_savings = ds_currency['symbol'] + ' ' + formatNumber(parseFloat(idle_total_savings).toFixed(2), ds_currency['separator'])
 
     underutil_findings = [
-      "Out of ", instances_total, " virtual machines analyzed, ",
+      "Out of ", instances_total, " Azure virtual machines analyzed, ",
       underutil_instances_total, " (", underutil_instances_percentage,
       ") are underutilized and recommended for downsizing. "
     ].join('')
 
     idle_findings = [
-      "Out of ", instances_total, " virtual machines analyzed, ",
+      "Out of ", instances_total, " Azure virtual machines analyzed, ",
       idle_instances_total, " (", idle_instances_percentage,
       ") are idle and recommended for termination. "
     ].join('')
@@ -880,9 +906,9 @@ script "js_idle_and_underutil_instances", type:"javascript" do
 
       underutil_analysis_message = [
         "A virtual machine is considered underutilized if its CPU usage (",
-        param_stats_threshold.toLowerCase(), ") is below ",
+        param_stats_threshold_cpu.toLowerCase(), ") is below ",
         param_stats_underutil_threshold_cpu_value, "% ", message_boolean,
-        " its memory usage (", param_stats_threshold.toLowerCase(),
+        " its memory usage (", param_stats_threshold_cpu.toLowerCase(),
         ") is below ", param_stats_underutil_threshold_mem_value,
         "% but its CPU usage is still above or equal to ",
         param_stats_idle_threshold_cpu_value, "% ", message_boolean,
@@ -892,9 +918,9 @@ script "js_idle_and_underutil_instances", type:"javascript" do
 
       idle_analysis_message = [
         "A virtual machine is considered idle if its CPU usage (",
-        param_stats_threshold.toLowerCase(), ") is below ",
+        param_stats_threshold_cpu.toLowerCase(), ") is below ",
         param_stats_idle_threshold_cpu_value, "% ", message_boolean,
-        " its memory usage (", param_stats_threshold.toLowerCase(),
+        " its memory usage (", param_stats_threshold_cpu.toLowerCase(),
         ") is below ", param_stats_idle_threshold_mem_value, "%. "
       ].join('')
 
@@ -907,7 +933,7 @@ script "js_idle_and_underutil_instances", type:"javascript" do
     if (checking_cpu && !checking_mem) {
       underutil_analysis_message = [
         "A virtual machine is considered underutilized if its CPU usage (",
-        param_stats_threshold.toLowerCase(), ") is below ",
+        param_stats_threshold_cpu.toLowerCase(), ") is below ",
         param_stats_underutil_threshold_cpu_value,
         "% but its CPU usage is still above or equal to ",
         param_stats_idle_threshold_cpu_value, "%. "
@@ -915,7 +941,7 @@ script "js_idle_and_underutil_instances", type:"javascript" do
 
       idle_analysis_message = [
         "A virtual machine is considered idle if its CPU usage (",
-        param_stats_threshold.toLowerCase(), ") is below ",
+        param_stats_threshold_cpu.toLowerCase(), ") is below ",
         param_stats_idle_threshold_cpu_value, "%. "
       ].join('')
 
@@ -928,7 +954,7 @@ script "js_idle_and_underutil_instances", type:"javascript" do
     if (!checking_cpu && checking_mem) {
       underutil_analysis_message = [
         "A virtual machine is considered underutilized if its memory usage (",
-        param_stats_threshold.toLowerCase(), ") is below ",
+        param_stats_threshold_cpu.toLowerCase(), ") is below ",
         param_stats_underutil_threshold_mem_value,
         "% but its memory usage is still above or equal to ",
         param_stats_idle_threshold_mem_value, "%. "
@@ -936,7 +962,7 @@ script "js_idle_and_underutil_instances", type:"javascript" do
 
       idle_analysis_message = [
         "A virtual machine is considered idle if its memory usage (",
-        param_stats_threshold.toLowerCase(), ") is below ",
+        param_stats_threshold_cpu.toLowerCase(), ") is below ",
         param_stats_idle_threshold_mem_value, "%. "
       ].join('')
 
@@ -961,13 +987,17 @@ script "js_idle_and_underutil_instances", type:"javascript" do
 
   // Add these to both lists to ensure the first item that fails validation for each
   // contains the necessary data for the summary and detail templates
-  idle_list[0]['idle_message'] = idle_message
-  idle_list[0]['idle_total_savings'] = idle_total_savings
-  idle_list[0]['policy_name'] = ds_applied_policy['name']
+  if (idle_list.length > 0) {
+    idle_list[0]['idle_message'] = idle_message
+    idle_list[0]['idle_total_savings'] = idle_total_savings
+    idle_list[0]['policy_name'] = ds_applied_policy['name']
+  }
 
-  underutil_list[0]['underutil_message'] = underutil_message
-  underutil_list[0]['underutil_total_savings'] = underutil_total_savings
-  underutil_list[0]['policy_name'] = ds_applied_policy['name']
+  if (underutil_list.length > 0) {
+    underutil_list[0]['underutil_message'] = underutil_message
+    underutil_list[0]['underutil_total_savings'] = underutil_total_savings
+    underutil_list[0]['policy_name'] = ds_applied_policy['name']
+  }
 
   result = idle_list.concat(underutil_list)
 
@@ -1054,10 +1084,6 @@ policy "pol_utilization" do
       field "savingsCurrency" do
         label "Savings Currency"
       end
-      field "launchTime" do
-        label "Launch Time"
-        path "timeCreated"
-      end
       field "cpuMaximum" do
         label "CPU Maximum %"
         path "cpu_maximum"
@@ -1083,7 +1109,11 @@ policy "pol_utilization" do
         path "mem_average"
       end
       field "thresholdType" do
-        label "Threshold Statistic"
+        label "Threshold Statistic (CPU)"
+        path "thresholdTypeCPU"
+      end
+      field "thresholdTypeMemory" do
+        label "Threshold Statistic (Memory)"
       end
       field "threshold" do
         label "CPU Threshold"
@@ -1104,15 +1134,15 @@ policy "pol_utilization" do
     end
   end
   validate_each $ds_idle_and_underutil_instances do
-    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} AWS Idle Virtual Machiness Found"
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Azure Idle Virtual Machiness Found"
     detail_template <<-'EOS'
     **Potential Monthly Savings:** {{ with index data 0 }}{{ .idle_total_savings }}{{ end }}
 
     {{ with index data 0 }}{{ .idle_message }}{{ end }}
     EOS
-    check ne(val(item, "recommendationType"), "Terminate")
+    check ne(val(item, "recommendationType"), "Delete")
     escalate $esc_email
-    escalate $esc_terminate_instances
+    escalate $esc_delete_instances
     hash_exclude "underutil_message", "idle_message", "underutil_total_savings", "idle_total_savings", "tags", "savings", "savingsCurrency", "cpu_maximum", "cpu_minimum", "cpu_average", "mem_maximum", "mem_minimum", "mem_average"
     export do
       resource_level true
@@ -1158,10 +1188,6 @@ policy "pol_utilization" do
       field "savingsCurrency" do
         label "Savings Currency"
       end
-      field "launchTime" do
-        label "Launch Time"
-        path "timeCreated"
-      end
       field "cpuMaximum" do
         label "CPU Maximum %"
         path "cpu_maximum"
@@ -1187,7 +1213,11 @@ policy "pol_utilization" do
         path "mem_average"
       end
       field "thresholdType" do
-        label "Threshold Statistic"
+        label "Threshold Statistic (CPU)"
+        path "thresholdTypeCPU"
+      end
+      field "thresholdTypeMemory" do
+        label "Threshold Statistic (Memory)"
       end
       field "threshold" do
         label "CPU Threshold"
@@ -1227,11 +1257,11 @@ escalation "esc_downsize_instances" do
   run "downsize_instances", data, $param_azure_endpoint
 end
 
-escalation "esc_terminate_instances" do
-  automatic contains($param_automatic_action, "Terminate Instances")
-  label "Terminate Instances"
-  description "Approval to terminate all selected instances"
-  run "terminate_instances", data, $param_azure_endpoint
+escalation "esc_delete_instances" do
+  automatic contains($param_automatic_action, "Delete Instances")
+  label "Delete Instances"
+  description "Approval to delete all selected instances"
+  run "delete_instances", data, $param_azure_endpoint
 end
 
 ###############################################################################
@@ -1278,7 +1308,7 @@ define downsize_instances($data, $param_azure_endpoint) return $all_responses do
 end
 
 #TERMINATE AZURE VM INSTANCE DEFINITION
-define terminate_instances($data, $param_azure_endpoint) return $all_responses do
+define delete_instances($data, $param_azure_endpoint) return $all_responses do
   # Change "No" to "Yes" to enable CWF debug logging
   $log_to_cm_audit_entries = "No"
 
@@ -1286,7 +1316,7 @@ define terminate_instances($data, $param_azure_endpoint) return $all_responses d
 
   $$log = []
   $all_responses = []
-  $syslog_subject = "Azure Terminate Instance: "
+  $syslog_subject = "Azure Delete Instance: "
   call sys_log(join([$syslog_subject, "Identified Instances"]),to_s($data))
   $all_responses = []
   foreach $item in $data do

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -44,6 +44,15 @@ parameter "param_min_savings" do
   default 0
 end
 
+parameter "param_exclusion_tags" do
+  type "list"
+  category "Filters"
+  label "Exclusion Tags (Key:Value)"
+  description "Cloud native tags to ignore instances that you don't want to consider for downsizing or termination. Format: Key:Value"
+  allowed_pattern /(^$)|([\w]?)+\:([\w]?)+/
+  default []
+end
+
 parameter "param_subscriptions_allow_or_deny" do
   type "string"
   category "Filters"
@@ -127,14 +136,6 @@ parameter "param_stats_lookback" do
   default 30
   min_value 1
   max_value 90
-end
-
-parameter "param_exclusion_tags" do
-  category "User Inputs"
-  label "Exclusion Tag Key"
-  description "An Azure-native instance tag key to ignore instances that you don't want to consider for downsizing. Example: exclude_utilization"
-  type "string"
-  default ""
 end
 
 parameter "param_automatic_action" do

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "2.4",
+  version: "3.0",
   provider: "Azure",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -20,8 +20,9 @@ info(
 
 parameter "param_email" do
   type "list"
+  category "Policy Settings"
   label "Email addresses"
-  description "Email addresses of the recipients you wish to notify when new incidents are created"
+  description "A list of email addresses to notify."
   default []
 end
 
@@ -80,14 +81,6 @@ parameter "param_azure_endpoint" do
   description "The Azure Resource Manager API endpoint to use."
   allowed_values "management.azure.com", "management.chinacloudapi.cn"
   default "management.azure.com"
-end
-
-parameter "param_log_to_cm_audit_entries" do
-  type "string"
-  label "Log to CM Audit Entries"
-  description "Boolean for whether or not to log any debugging information from actions to CM Audit Entries, this should be left set to No on Flexera EU"
-  default "No"
-  allowed_values "Yes", "No"
 end
 
 ###############################################################################
@@ -845,14 +838,14 @@ escalation "esc_downsize_instances" do
   automatic contains($param_automatic_action, "Downsize Instances")
   label "Downsize Instances"
   description "Approval to downsize all selected instances"
-  run "downsize_instance", data, $param_log_to_cm_audit_entries, $param_azure_endpoint
+  run "downsize_instance", data, $param_azure_endpoint
 end
 
 escalation "esc_terminate_instances" do
   automatic contains($param_automatic_action, "Terminate Instances")
   label "Terminate Instances"
   description "Approval to terminate all selected instances"
-  run "delete_instance", data, $param_log_to_cm_audit_entries, $param_azure_endpoint
+  run "delete_instance", data, $param_azure_endpoint
 end
 
 ###############################################################################
@@ -860,9 +853,14 @@ end
 ###############################################################################
 
 #DOWNSIZE AZURE VM INSTANCE DEFINITION
-define downsize_instance($data, $param_log_to_cm_audit_entries, $param_azure_endpoint) return $all_responses do
+define downsize_instance($data, $param_azure_endpoint) return $all_responses do
+  # Change "No" to "Yes" to enable CWF debug logging
+  $log_to_cm_audit_entries = "No"
+
+  $$debug = $log_to_cm_audit_entries == "Yes"
+
   $response={}
-  $$debug = $param_log_to_cm_audit_entries == "Yes"
+
   $syslog_subject = "Azure Instance Utilization with Log Analytics Policy: "
   foreach $item in $data do
     if $item["recommendedVmSize"] != "N/A"
@@ -894,8 +892,12 @@ define downsize_instance($data, $param_log_to_cm_audit_entries, $param_azure_end
 end
 
 #TERMINATE AZURE VM INSTANCE DEFINITION
-define delete_instance($data, $param_log_to_cm_audit_entries, $param_azure_endpoint) return $all_responses do
-  $$debug = $param_log_to_cm_audit_entries == "Yes"
+define delete_instance($data, $param_azure_endpoint) return $all_responses do
+  # Change "No" to "Yes" to enable CWF debug logging
+  $log_to_cm_audit_entries = "No"
+
+  $$debug = $log_to_cm_audit_entries == "Yes"
+
   $$log = []
   $all_responses = []
   $syslog_subject = "Azure Terminate Instance: "

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -26,40 +26,110 @@ parameter "param_email" do
   default []
 end
 
-parameter "param_cpu_idle_avg_percentage" do
-  type "number"
-  label "Idle Instance CPU Threshold (%)"
-  description "Average CPU threshold at which to trigger instance termination"
-  default 5
-  min_value 0
-  max_value 100
-end
-
-parameter "param_cpu_underutil_avg_percentage" do
-  type "number"
-  label "Inefficient Instance CPU Threshold (%)"
-  description "Average CPU threshold at which to trigger instance downsize"
-  default 40
-  min_value 0
-  max_value 100
-end
-
-parameter "param_threshold_statistic" do
+parameter "param_azure_endpoint" do
   type "string"
-  label "Threshold Statistic"
-  description "Statistic to use for the metric threshold"
-  default "Average"
-  allowed_values "Average", "Minimum", "Maximum"
+  category "Policy Settings"
+  label "Azure Endpoint"
+  description "Select the API endpoint to use for Azure. Use default value of management.azure.com unless using Azure China."
+  allowed_values "management.azure.com", "management.chinacloudapi.cn"
+  default "management.azure.com"
 end
 
-parameter "param_subscription_allowed_list" do
-  label "Subscription Allowed List"
+parameter "param_min_savings" do
+  type "number"
+  category "Policy Settings"
+  label "Minimum Savings Threshold"
+  description "Minimum potential savings required to generate a recommendation"
+  min_value 0
+  default 0
+end
+
+parameter "param_subscriptions_allow_or_deny" do
+  type "string"
+  category "Filters"
+  label "Allow/Deny Subscriptions"
+  description "Allow or Deny entered Subscriptions. See the README for more details."
+  allowed_values "Allow", "Deny"
+  default "Allow"
+end
+
+parameter "param_subscriptions_list" do
   type "list"
-  description "Allowed Subscriptions, if empty, all subscriptions will be checked"
+  category "Filters"
+  label "Allow/Deny Subscriptions List"
+  description "A list of allowed or denied Subscription IDs/names. See the README for more details."
   default []
 end
 
-parameter "param_exclusion_tag_key" do
+parameter "param_stats_idle_threshold_cpu_value" do
+  type "number"
+  category "Statistics"
+  label "Idle Instance CPU Threshold (%)"
+  description "The CPU threshold at which to consider an instance to be 'idle' and therefore be flagged for termination. Set to -1 to ignore CPU utilization"
+  min_value -1
+  max_value 100
+  default 5
+end
+
+parameter "param_stats_idle_threshold_mem_value" do
+  type "number"
+  category "Statistics"
+  label "Idle Instance Memory Threshold (%)"
+  description "The Memory threshold at which to consider an instance to be 'idle' and therefore be flagged for termination. Set to -1 to ignore memory utilization"
+  min_value -1
+  max_value 100
+  default 5
+end
+
+parameter "param_stats_underutil_threshold_cpu_value" do
+  type "number"
+  category "Statistics"
+  label "Underutilized Instance CPU Threshold (%)"
+  description "The CPU threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing. Set to -1 to ignore CPU utilization"
+  min_value -1
+  max_value 100
+  default 40
+end
+
+parameter "param_stats_underutil_threshold_mem_value" do
+  type "number"
+  category "Statistics"
+  label "Underutilized Instance Memory Threshold (%)"
+  description "The Memory threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing. Set to -1 to ignore memory utilization"
+  min_value -1
+  max_value 100
+  default 40
+end
+
+parameter "param_stats_check_both" do
+  type "string"
+  category "Statistics"
+  label "Idle/Utilized for both CPU/Memory or either"
+  description "Set whether an instance should be considered idle and/or underutilized only if both CPU and memory are under the thresholds or if either CPU or memory are under. Note: this parameter is only valid when at least one Memory Utilization threshold and one CPU Utilization threshold is NOT set to -1"
+  allowed_values "Both CPU and Memory", "Either CPU or Memory"
+  default "Either CPU or Memory"
+end
+
+parameter "param_stats_threshold" do
+  type "string"
+  category "Statistics"
+  label "Threshold Statistic"
+  description "Statistic to use when determining if an instance is idle/underutilized"
+  allowed_values "Average", "Maximum"
+  default "Average"
+end
+
+parameter "param_stats_lookback" do
+  type "number"
+  category "Statistics"
+  label "Statistic Lookback Period"
+  description "How many days back to look at CPU and/or memory data for instances. This value cannot be set higher than 90 because AWS does not retain metrics for longer than 90 days."
+  default 30
+  min_value 1
+  max_value 90
+end
+
+parameter "param_exclusion_tags" do
   category "User Inputs"
   label "Exclusion Tag Key"
   description "An Azure-native instance tag key to ignore instances that you don't want to consider for downsizing. Example: exclude_utilization"
@@ -69,37 +139,28 @@ end
 
 parameter "param_automatic_action" do
   type "list"
+  category "Actions"
   label "Automatic Actions"
-  description "When this value is set, this policy will automatically take the selected action(s)"
-  allowed_values ["Terminate Instances"]
+  description "When this value is set, this policy will automatically take the selected action."
+  allowed_values ["Downsize Instances", "Terminate Instances"]
   default []
-end
-
-parameter "param_azure_endpoint" do
-  type "string"
-  label "Azure Endpoint"
-  description "The Azure Resource Manager API endpoint to use."
-  allowed_values "management.azure.com", "management.chinacloudapi.cn"
-  default "management.azure.com"
 end
 
 ###############################################################################
 # Authentication
 ###############################################################################
 
-#AUTHENTICATE WITH AZURE
-credentials "azure_auth" do
+credentials "auth_azure" do
   schemes "oauth2"
   label "Azure"
   description "Select the Azure Resource Manager Credential from the list."
   tags "provider=azure_rm"
 end
 
-#AUTHENTICATE WITH RIGHTSCALE/OPTIMA
 credentials "auth_flexera" do
   schemes "oauth2"
-  label "Flexera_Automation"
-  description "Select FlexeraOne OAuth2 credentials"
+  label "Flexera"
+  description "Select Flexera One OAuth2 credentials"
   tags "provider=flexera"
 end
 
@@ -107,8 +168,7 @@ end
 # Pagination
 ###############################################################################
 
-#PAGINATION FOR AZURE APIS
-pagination "azure_pagination" do
+pagination "pagination_azure" do
   get_page_marker do
     body_path "nextLink"
   end
@@ -121,7 +181,54 @@ end
 # Datasources & Scripts
 ###############################################################################
 
-#GET CURRENCY REFERENCE AND CURRENCY CODE FOR ORG
+# Get applied policy metadata for use later
+datasource "ds_applied_policy" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    header "Api-Version", "1.0"
+  end
+end
+
+datasource "ds_billing_centers" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/analytics/orgs/", rs_org_id, "/billing_centers"])
+    header "Api-Version", "1.0"
+    header "User-Agent", "RS Policies"
+    query "view", "allocation_table"
+    ignore_status [403]
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "href", jmes_path(col_item, "href")
+      field "id", jmes_path(col_item, "id")
+      field "name", jmes_path(col_item, "name")
+      field "parent_id", jmes_path(col_item, "parent_id")
+    end
+  end
+end
+
+# Gather top level billing center IDs for when we pull cost data
+datasource "ds_top_level_bcs" do
+  run_script $js_top_level_bcs, $ds_billing_centers
+end
+
+script "js_top_level_bcs", type: "javascript" do
+  parameters "ds_billing_centers"
+  result "result"
+  code <<-EOS
+  filtered_bcs = _.filter(ds_billing_centers, function(bc) {
+    return bc['parent_id'] == null || bc['parent_id'] == undefined
+  })
+
+  result = _.compact(_.pluck(filtered_bcs, 'id'))
+EOS
+end
+
 datasource "ds_currency_reference" do
   request do
     host "raw.githubusercontent.com"
@@ -146,11 +253,40 @@ datasource "ds_currency_code" do
   end
 end
 
-#GET ALL SUBSCRIPTION DETAILS
-datasource "ds_subscriptions" do
+datasource "ds_currency" do
+  run_script $js_currency, $ds_currency_reference, $ds_currency_code
+end
+
+script "js_currency", type:"javascript" do
+  parameters "ds_currency_reference", "ds_currency_code"
+  result "result"
+  code <<-EOS
+  symbol = "$"
+  separator = ","
+
+  if (ds_currency_code['value'] != undefined) {
+    if (ds_currency_reference[ds_currency_code['value']] != undefined) {
+      symbol = ds_currency_reference[ds_currency_code['value']]['symbol']
+
+      if (ds_currency_reference[ds_currency_code['value']]['t_separator'] != undefined) {
+        separator = ds_currency_reference[ds_currency_code['value']]['t_separator']
+      } else {
+        separator = ""
+      }
+    }
+  }
+
+  result = {
+    symbol: symbol,
+    separator: separator
+  }
+EOS
+end
+
+datasource "ds_azure_subscriptions" do
   request do
-    auth $azure_auth
-    pagination $azure_pagination
+    auth $auth_azure
+    pagination $pagination_azure
     host $param_azure_endpoint
     path "/subscriptions/"
     query "api-version","2020-01-01"
@@ -159,46 +295,44 @@ datasource "ds_subscriptions" do
   result do
     encoding "json"
     collect jmes_path(response, "value[*]") do
-      field "subscriptionId", jmes_path(col_item, "subscriptionId")
-      field "subscriptionName", jmes_path(col_item, "displayName")
+      field "id", jmes_path(col_item, "subscriptionId")
+      field "name", jmes_path(col_item, "displayName")
       field "state", jmes_path(col_item, "state")
     end
   end
 end
 
-#FILTER SUBSCRIPTION BASED ON ALLOWED LIST PARAMETER
-datasource "ds_filtered_subscriptions" do
-  run_script $js_filtered_subscriptions, $ds_subscriptions, $param_subscription_allowed_list
+datasource "ds_azure_subscriptions_filtered" do
+  run_script $js_azure_subscriptions_filtered, $ds_azure_subscriptions, $param_subscriptions_allow_or_deny, $param_subscriptions_list
 end
 
-script "js_filtered_subscriptions", type: "javascript" do
-  parameters "ds_subscriptions", "param_subscription_allowed_list"
+script "js_azure_subscriptions_filtered", type: "javascript" do
+  parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-EOS
-  result = []
+  if (param_subscriptions_list.length > 0) {
+    result = _.filter(ds_azure_subscriptions, function(subscription) {
+      include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
 
-  if (param_subscription_allowed_list.length != 0) {
-    _.each(param_subscription_allowed_list, function(sub) {
-      found = _.find(ds_subscriptions, function(item) {
-        return item['subscriptionId'] == sub || item['subscriptionName'].toLowerCase() == sub.toLowerCase()
-      })
+      if (param_subscriptions_allow_or_deny == "Deny") {
+        include_subscription = !include_subscription
+      }
 
-      result.push(found)
+      return include_subscription
     })
   } else {
-    result = ds_subscriptions
+    result = ds_azure_subscriptions
   }
 EOS
 end
 
-#GET AZURE VIRTUAL MACHINE INSTANCES FOR EACH SUBSCRIPTION
 datasource "ds_azure_instances" do
-  iterate $ds_filtered_subscriptions
+  iterate $ds_azure_subscriptions_filtered
   request do
-    auth $azure_auth
-    pagination $azure_pagination
+    auth $auth_azure
+    pagination $pagination_azure
     host $param_azure_endpoint
-    path join(["/subscriptions/", val(iter_item, "subscriptionId"), "/providers/Microsoft.Compute/virtualMachines"])
+    path join(["/subscriptions/", val(iter_item, "id"), "/providers/Microsoft.Compute/virtualMachines"])
     query "api-version", "2019-03-01"
     header "User-Agent", "RS Policies"
     # Ignore status 400, 403, and 404 which can be returned in certain (legacy) types of Azure Subscriptions
@@ -214,63 +348,104 @@ datasource "ds_azure_instances" do
       field "region", jmes_path(col_item, "location")
       field "osType", jmes_path(col_item, "properties.storageProfile.osDisk.osType")
       field "resourceType", jmes_path(col_item, "properties.hardwareProfile.vmSize")
+      field "timeCreated", jmes_path(col_item, "properties.timeCreated")
       field "tags", jmes_path(col_item, "tags")
-      field "subscriptionId",val(iter_item, "subscriptionId")
-      field "subscriptionName",val(iter_item, "subscriptionName")
+      field "subscriptionId",val(iter_item, "id")
+      field "subscriptionName",val(iter_item, "name")
     end
   end
 end
 
-#FILTER VIRTUAL MACHINE INSTANCES ON EXCLUSING TAG KEY PARAMETER
-datasource "ds_filtered_instances" do
-  run_script $js_filter_instances, $ds_azure_instances, $param_exclusion_tag_key
+datasource "ds_azure_instances_filtered" do
+  run_script $js_azure_instances_filtered, $ds_azure_instances, $param_exclusion_tags
 end
 
-script "js_filter_instances", type: "javascript" do
-  parameters "ds_azure_virtualmachines", "param_exclusion_tag_key"
-  result "results"
+script "js_azure_instances_filtered", type: "javascript" do
+  parameters "ds_azure_instances", "param_exclusion_tags"
+  result "result"
   code <<-EOS
-  results = _.filter(ds_azure_virtualmachines, function(instance) {
-    tags = []
+  if (param_exclusion_tags.length > 0) {
+    result = _.reject(ds_azure_instances, function(vm) {
+      vm_tags = []
 
-    if (!(_.has(instance['tags'], param_exclusion_tag_key))) {
-      if (typeof instance['tags'] === "undefined" || instance['tags'] === null) {
-        instance['tags'] = tags
-      } else {
-        Object.keys(instance['tags']).forEach(function(key) {
-          tags.push(key + '=' + instance['tags'][key])
+      if (typeof(vm['tags']) == 'object') {
+        _.each(Object.keys(vm['tags']), function(key) {
+          vm_tags.push([key, ":", vm['tags'][key]].join(''))
         })
-
-        instance['tags'] = tags
-        resourceKindSplit = instance['resourceKind'].split("/")
-        service = resourceKindSplit[0]
-        instance['service'] = service
-
-        return instance
       }
-    }
-  })
+
+      exclude_vm = false
+
+      _.each(param_exclusion_tags, function(exclusion_tag) {
+        if (_.contains(vm_tags, exclusion_tag)) {
+          exclude_vm = true
+        }
+      })
+
+      return exclude_vm
+    })
+  } else {
+    result = ds_azure_instances
+  }
 EOS
 end
 
-#GET CPU PERFORMANCE STATS
-datasource "ds_azure_instance_utilization" do
-  iterate $ds_filtered_instances
+datasource "ds_azure_skus" do
+  iterate $ds_azure_subscriptions_filtered
   request do
-    auth $azure_auth
-    pagination $azure_pagination
+    auth $auth_azure
+    pagination $pagination_azure
     host $param_azure_endpoint
-    path join(["/subscriptions/", val(iter_item, "subscriptionId"), "/resourceGroups/", val(iter_item, "resourceGroup"), "/providers/Microsoft.Compute/virtualMachines/", val(iter_item, "name"), "/providers/microsoft.insights/metrics"])
-    query "api-version", "2018-01-01"
-    query "timespan", "P30D"
-    query "interval", "P1D"
-    query "aggregation", "average,maximum,minimum"
+    path join(["/subscriptions/", val(iter_item, "id"), "/providers/Microsoft.Compute/skus"])
+    query "api-version", "2017-09-01"
     header "User-Agent", "RS Policies"
     # Ignore status 400, 403, and 404 which can be returned in certain (legacy) types of Azure Subscriptions
     ignore_status [400, 403, 404]
   end
   result do
     encoding "json"
+    collect jmes_path(response, "value") do
+      field "resourceType", jmes_path(col_item, "resourceType")
+      field "name", jmes_path(col_item, "name")
+      field "locations", jmes_path(col_item, "locations")
+      field "capabilities", jmes_path(col_item, "capabilities")
+      field "restrictions", jmes_path(col_item, "restrictions")
+    end
+  end
+end
+
+datasource "ds_azure_sku_memory" do
+  run_script $js_azure_sku_memory, $ds_azure_skus
+end
+
+script "js_azure_sku_memory", type: "javascript" do
+  parameters "ds_azure_skus"
+  result "result"
+  code <<-EOS
+  result = {}
+
+  _.each(ds_azure_skus, function(sku) {
+    name = sku['name'].toLowerCase()
+
+    if (result[name] == undefined && sku["resourceType"] == "virtualMachines") {
+      memory = _.find(sku['capabilities'], function(item) {
+        return item["name"] == "MemoryGB"
+      })
+
+      result[name] = memory["value"] * 1024 * 1024 * 1024
+    }
+  })
+EOS
+end
+
+datasource "ds_azure_instances_metrics" do
+  iterate $ds_azure_instances_filtered
+  request do
+    run_script $js_azure_instances_metrics, val(iter_item, "resourceId"), $param_azure_endpoint, $param_stats_lookback
+  end
+  result do
+    encoding "json"
+    field "value", val(response, "value")
     field "resourceName", val(iter_item, "name")
     field "resourceGroup", val(iter_item, "resourceGroup")
     field "resourceId", val(iter_item, "resourceId")
@@ -282,193 +457,192 @@ datasource "ds_azure_instance_utilization" do
     field "service", val(iter_item, "service")
     field "subscriptionId",val(iter_item, "subscriptionId")
     field "subscriptionName",val(iter_item, "subscriptionName")
-    field "statistics" do
-      collect jmes_path(response, "value[].timeseries[].data[]") do
-        field "average", jmes_path(col_item, "average")
-        field "minimum", jmes_path(col_item, "minimum")
-        field "maximum", jmes_path(col_item, "maximum")
-      end
-    end
   end
 end
 
-#FILTER VIRTUAL MACHINE INSTANCES ON CPU UTILIZATION PARAMETER
-datasource "ds_filtered_instance_utilization" do
-  run_script $js_filter_instance_utilization, $ds_azure_instance_utilization, $param_cpu_underutil_avg_percentage, $param_threshold_statistic
-end
-
-script "js_filter_instance_utilization", type: "javascript" do
-  parameters "ds_azure_instance_utilization", "param_cpu_underutil_avg_percentage", "param_threshold_statistic"
-  result "result"
+script "js_azure_instances_metrics", type: "javascript" do
+  parameters "resourceId", "param_azure_endpoint", "param_stats_lookback"
+  result "request"
   code <<-EOS
-  var result = [];
-  //Calculate average CPU for each instance
-  _.each(ds_azure_instance_utilization, function(data) {
-    total_of_avgs = 0, count = 0
-    total_of_min = 0, count1 = 0
-    total_of_max = 0, count2 = 0
-    _.each(data.statistics, function(stat){
-      if (stat.average != null) {
-        total_of_avgs += stat.average;
-        count++;
-      }
-      if (stat.minimum != null) {
-        total_of_min += stat.minimum;
-        count1++;
-      }
-      if (stat.maximum != null) {
-        total_of_max += stat.maximum;
-        count2++;
-      }
-    });
-    data.averageCPU = count > 0 ? total_of_avgs / count : null;
-    data.minCPU = count1 > 0 ? total_of_min / count1 : null;
-    data.maxCPU = count2 > 0 ? total_of_max / count2 : null;
-    data["savings"] = 0.0
-    data = _.omit(data, "averages")
-    result.push(data);
-  })
+  end_date = new Date()
+  end_date.setMilliseconds(999)
+  end_date.setSeconds(59)
+  end_date.setMinutes(59)
+  end_date.setHours(23)
 
-  //Filter out instances if the CPU usage is above the Underutilized CPU threshold
-  result = _.reject(result, function(util_data) {
-    if (param_threshold_statistic.toLowerCase() === "minimum") {
-      return  util_data.minCPU >= param_cpu_underutil_avg_percentage
-    }
-    if (param_threshold_statistic.toLowerCase() === "average") {
-      return util_data.averageCPU >= param_cpu_underutil_avg_percentage
-    }
-    if (param_threshold_statistic.toLowerCase() === "maximum") {
-      return util_data.maxCPU >= param_cpu_underutil_avg_percentage
-    }
-  })
+  start_date = new Date()
+  start_date.setDate(start_date.getDate() - param_stats_lookback)
+  start_date.setMilliseconds(0)
+  start_date.setSeconds(0)
+  start_date.setMinutes(0)
+
+  timespan = start_date.toISOString() + "/" + end_date.toISOString()
+
+  var request = {
+    auth: "auth_azure",
+    pagination: "pagination_azure",
+    host: param_azure_endpoint,
+    verb: "GET",
+    path: resourceId + "/providers/microsoft.insights/metrics",
+    query_params: {
+      "api-version": "2018-01-01",
+      "timespan": timespan,
+      "interval": "P1D",
+      "metricnames": "Percentage CPU,Available Memory Bytes",
+      "aggregation": "average,maximum,minimum"
+    },
+    headers: {
+      "User-Agent": "RS Policies"
+    },
+    // Ignore status 400, 403, and 404 which can be returned in certain (legacy) types of Azure Subscriptions
+    ignore_status: [400, 403, 404]
+  }
 EOS
 end
 
-#GET AZURE INSTANCE SIZE MAP
-datasource "ds_azure_instance_size_map" do
-  request do
-    verb "GET"
-    host "raw.githubusercontent.com"
-    path "/rightscale/policy_templates/master/data/azure/instance_types.json"
-    header "User-Agent", "RS Policies"
-  end
+datasource "ds_azure_instances_metrics_organized" do
+  run_script $js_azure_instances_metrics_organized, $ds_azure_instances_metrics, $ds_azure_sku_memory
 end
 
-#ADD AZURE INSTANCE DOWNSIZE DATA
-datasource "ds_rightsizing_and_utilization_data" do
-  run_script $js_add_instance_downsize_data, $ds_filtered_instance_utilization, $ds_azure_instance_size_map, $param_cpu_idle_avg_percentage, $param_threshold_statistic
-end
-
-script "js_add_instance_downsize_data", type: "javascript" do
+script "js_azure_instances_metrics_organized", type: "javascript" do
+  parameters "ds_azure_instances_metrics", "ds_azure_sku_memory"
   result "result"
-  parameters "data", "instance_size_map", "param_cpu_idle_avg_percentage", "param_threshold_statistic"
   code <<-EOS
   result = []
-  _.each(data, function(instance) {
-    next_vm_size = null
-    cpuValue = null;
-    if (param_threshold_statistic.toLowerCase() === 'average') {
-      cpuValue = instance.averageCPU;
-    } else if (param_threshold_statistic.toLowerCase() === 'minimum') {
-      cpuValue = instance.minCPU;
-    } else if (param_threshold_statistic.toLowerCase() === 'maximum') {
-      cpuValue = instance.maxCPU;
-    }
 
-    if (cpuValue >= param_cpu_idle_avg_percentage) {
-      if (instance_size_map[instance['resourceType']] != undefined && instance_size_map[instance['resourceType']] != null) {
-        next_vm_size = instance_size_map[instance['resourceType']]['down']
+  _.each(ds_azure_instances_metrics, function(vm) {
+    cpu_stats = _.find(vm['value'], function(stat) {
+      return stat['name']['value'] == "Percentage CPU"
+    })
+
+    mem_stats = _.find(vm['value'], function(stat) {
+      return stat['name']['value'] == "Available Memory Bytes"
+    })
+
+    cpu_min = 0
+    cpu_max = 0
+    cpu_avg = 0
+    cpu_count = 0
+
+    _.each(cpu_stats["timeseries"][0]["data"], function(item) {
+      if (item["average"] != undefined && item["average"] != null) {
+        cpu_min += item["minimum"]
+        cpu_max += item["maximum"]
+        cpu_avg += item["average"]
+        cpu_count += 1
       }
+    })
+
+    if (cpu_count == 0) {
+      cpu_min = null
+      cpu_max = null
+      cpu_avg = null
     } else {
-      next_vm_size = "Terminate Instance"
+      cpu_min = cpu_min / cpu_count
+      cpu_max = cpu_max / cpu_count
+      cpu_avg = cpu_avg / cpu_count
     }
 
-    if (next_vm_size != null) {
-      instance['recommendedVmSize'] = next_vm_size
-      result.push(instance)
+    mem_min = 0
+    mem_max = 0
+    mem_avg = 0
+    mem_count = 0
+
+    _.each(mem_stats["timeseries"][0]["data"], function(item) {
+      if (item["average"] != undefined && item["average"] != null) {
+        mem_min += item["minimum"]
+        mem_max += item["maximum"]
+        mem_avg += item["average"]
+        mem_count += 1
+      }
+    })
+
+    max_memory = ds_azure_sku_memory[vm['resourceType'].toLowerCase()]
+
+    if (mem_count == 0 || max_memory == undefined) {
+      mem_min = null
+      mem_max = null
+      mem_avg = null
+    } else {
+      mem_min = (mem_min / mem_count) / max_memory * 100
+      mem_max = (mem_max / mem_count) / max_memory * 100
+      mem_avg = (mem_avg / mem_count) / max_memory * 100
     }
+
+    vm_tags = []
+
+    if (typeof(vm['tags']) == 'object') {
+      _.each(Object.keys(vm['tags']), function(key) {
+        vm_tags.push(key + '=' + vm['tags'][key])
+      })
+    }
+
+    result.push({
+      resourceName: vm['resourceName'],
+      resourceGroup: vm['resourceGroup'],
+      resourceId: vm['resourceId'],
+      resourceKind: vm['resourceKind'],
+      region: vm['region'],
+      osType: vm['osType'],
+      resourceType: vm['resourceType'],
+      service: vm['service'],
+      subscriptionId: vm['subscriptionId'],
+      subscriptionName: vm['subscriptionName'],
+      timeCreated: vm['timeCreated']
+      tags: vm_tags.join(', '),
+      cpu_minimum: cpu_min,
+      cpu_maximum: cpu_max,
+      cpu_average: cpu_avg,
+      mem_minimum: mem_min,
+      mem_maximum: mem_max,
+      mem_average: mem_avg
+    })
   })
 EOS
 end
 
-#GET BILLING CENTERS FOR ORG
-datasource "ds_billing_centers" do
-  request do
-    auth $auth_flexera
-    host rs_optima_host
-    path join(["/analytics/orgs/", rs_org_id, "/billing_centers"])
-    header "Api-Version", "1.0"
-    header "User-Agent", "RS Policies"
-    query "view", "allocation_table"
-    ignore_status [403]
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "[*]") do
-      field "href", jmes_path(col_item, "href")
-      field "id", jmes_path(col_item, "id")
-      field "name", jmes_path(col_item, "name")
-      field "parent_id", jmes_path(col_item, "parent_id")
-    end
-  end
-end
 
-#FILTER BILLING CENTERS FOR TOP LEVEL BCS
-datasource "ds_top_level_billing_centers" do
-  run_script $js_top_level_bc, $ds_billing_centers
-end
-
-script "js_top_level_bc", type: "javascript" do
-  parameters "billing_centers"
-  result "filtered_billing_centers"
-  code <<-EOS
-  filtered_billing_centers = _.reject(billing_centers, function(bc) {
-    return bc.parent_id != null
-  })
-EOS
-end
-
-#GET INSTANCE COSTS FOR EACH BILLING CENTER
 datasource "ds_instance_costs" do
-  iterate $ds_filtered_subscriptions
+  iterate $ds_azure_subscriptions_filtered
   request do
-    run_script $js_get_costs, val(iter_item, "subscriptionId"), $ds_top_level_billing_centers, rs_org_id, rs_optima_host
+    run_script $js_instance_costs, val(iter_item, 'id'), $ds_top_level_bcs, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
     collect jmes_path(response,"rows[*]") do
-      field "resource_id", jmes_path(col_item, "dimensions.resource_id")
+      field "resourceId", jmes_path(col_item, "dimensions.resource_id")
       field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
     end
   end
 end
 
-script "js_get_costs", type: "javascript" do
-  parameters "account_id", "billing_centers", "org", "optima_host"
+script "js_instance_costs", type: "javascript" do
+  parameters "subscription_id", "ds_top_level_bcs", "rs_org_id", "rs_optima_host"
   result "request"
   code <<-EOS
-  //Get Start and End dates
-  start_date = new Date()
-  start_date.setMonth(start_date.getMonth() - 1)
-  start_date = start_date.toISOString().split('-')[0] + '-' + start_date.toISOString().split('-')[1]
-
   end_date = new Date()
-  end_date = end_date.toISOString().split('-')[0] + '-' + end_date.toISOString().split('-')[1]
+  end_date.setDate(end_date.getDate() - 2)
+  end_date = end_date.toISOString().split('T')[0]
 
-  request = {
+  start_date = new Date()
+  start_date.setDate(start_date.getDate() - 3)
+  start_date = start_date.toISOString().split('T')[0]
+
+  var request = {
     auth: "auth_flexera",
-    host: optima_host,
+    host: rs_optima_host,
     verb: "POST",
-    path: "/bill-analysis/orgs/" + org + "/costs/select",
+    path: "/bill-analysis/orgs/" + rs_org_id + "/costs/select",
     body_fields: {
-      "dimensions": ["resource_id"],
-      "granularity": "month",
-      "start_at": start_date,
-      "end_at": end_date,
-      "metrics": ["cost_amortized_unblended_adj"],
-      "billing_center_ids": _.compact(_.map(billing_centers, function(value) { return value.id })),
-      "limit": 100000,
-      "filter": {
+      dimensions: ["resource_id"],
+      granularity: "day",
+      start_at: start_date,
+      end_at: end_date,
+      metrics: ["cost_amortized_unblended_adj"],
+      billing_center_ids: ds_top_level_bcs,
+      limit: 100000,
+      filter: {
+        "type": "and",
         "expressions": [
           {
             "dimension": "service",
@@ -478,7 +652,7 @@ script "js_get_costs", type: "javascript" do
           {
             "dimension": "vendor_account",
             "type": "equal",
-            "value": account_id
+            "value": subscription_id
           },
           {
             "type": "not",
@@ -488,154 +662,331 @@ script "js_get_costs", type: "javascript" do
               "substring": "Shared"
             }
           }
-        ],
-        "type": "and"
+        ]
       }
     },
     headers: {
-      "User-Agent": "RS Policies",
-      "Api-Version": "1.0"
+      'User-Agent': "RS Policies",
+      'Api-Version': "1.0"
     },
     ignore_status: [400]
   }
 EOS
 end
 
-datasource "ds_cost_object" do
-  run_script $js_cost_object, $ds_instance_costs
+datasource "ds_instance_costs_grouped" do
+  run_script $js_instance_costs_grouped, $ds_instance_costs
 end
 
-script "js_cost_object", type: "javascript" do
-  parameters "instance_cost_data"
+script "js_instance_costs_grouped", type: "javascript" do
+  parameters "ds_instance_costs"
   result "result"
   code <<-EOS
+  // Multiple a single day's cost by the average number of days in a month.
+  // The 0.25 is to account for leap years for extra precision.
+  cost_multiplier = 365.25 / 12
+
+  // Group cost data by resourceId for later use
   result = {}
 
-  _.each(instance_cost_data, function(item) {
-    resource_id = item['resource_id'].toLowerCase()
+  _.each(ds_instance_costs, function(item) {
+    id = item['resourceId'].toLowerCase()
 
-    if (result[resource_id] == undefined) {
-      result[resource_id] = 0
-    }
-
-    result[resource_id] += item['cost']
+    if (result[id] == undefined) { result[id] = 0.0 }
+    result[id] += item['cost'] * cost_multiplier
   })
 EOS
 end
 
-#COMBINE INSTANCE UTILIZATION DATA WITH INSTANCE COST DATA
-datasource "ds_combined_data" do
-  run_script $js_combine_data, $ds_rightsizing_and_utilization_data, $ds_cost_object, $ds_currency_code, $ds_currency_reference, $ds_billing_centers, $param_cpu_idle_avg_percentage, $param_cpu_underutil_avg_percentage
+datasource "ds_azure_instance_size_map" do
+  request do
+    verb "GET"
+    host "raw.githubusercontent.com"
+    path "/rightscale/policy_templates/master/data/azure/instance_types.json"
+    header "User-Agent", "RS Policies"
+  end
 end
 
-script "js_combine_data", type: "javascript" do
-  parameters "instance_utilization_data", "instance_costs", "ds_currency_code", "ds_currency_reference", "ds_billing_centers", "param_idle_prc", "param_underutil_prc"
+datasource "ds_idle_and_underutil_instances" do
+  run_script $js_idle_and_underutil_instances, $ds_azure_instances_filtered, $ds_azure_instances_metrics_organized, $ds_instance_costs_grouped, $ds_azure_instance_size_map, $ds_currency, $ds_applied_policy, $param_stats_idle_threshold_cpu_value, $param_stats_idle_threshold_mem_value, $param_stats_underutil_threshold_cpu_value, $param_stats_underutil_threshold_mem_value, $param_stats_check_both, $param_stats_threshold, $param_min_savings, $param_stats_lookback
+end
+
+script "js_idle_and_underutil_instances", type:"javascript" do
+  parameters "ds_azure_instances_filtered", "ds_azure_instances_metrics_organized", "ds_instance_costs_grouped", "ds_azure_instance_size_map", "ds_currency", "ds_applied_policy", "param_stats_idle_threshold_cpu_value", "param_stats_idle_threshold_mem_value", "param_stats_underutil_threshold_cpu_value", "param_stats_underutil_threshold_mem_value", "param_stats_check_both", "param_stats_threshold", "param_min_savings", "param_stats_lookback"
   result "result"
-  code <<-EOS
-  function formatNumber(number, separator) {
+  code <<-'EOS'
+  // Used for formatting numbers to look pretty
+  function formatNumber(number, separator){
     numString = number.toString()
     values = numString.split(".")
-    formattedNumber = ''
+    formatted_number = ''
 
     while (values[0].length > 3) {
-      chunk = values[0].substr(-3)
+      var chunk = values[0].substr(-3)
       values[0] = values[0].substr(0, values[0].length - 3)
-      formattedNumber = separator + chunk + formattedNumber
+      formatted_number = separator + chunk + formatted_number
     }
 
-    if (values[0].length > 0) {
-      formattedNumber = values[0] + formattedNumber
-    }
+    if (values[0].length > 0) { formatted_number = values[0] + formatted_number }
+    if (values[1] == undefined) { return formatted_number }
 
-    if (values[1] == undefined) {
-      return formattedNumber
-    }
-
-    return formattedNumber + "." + values[1]
+    return formatted_number + "." + values[1]
   }
 
-  //Format costs with currency symbol and thousands separator
-  if (ds_currency_code['value'] !== undefined) {
-    if (ds_currency_reference[ds_currency_code['value']] !== undefined) {
-      cur = ds_currency_reference[ds_currency_code['value']]['symbol']
+  // The key name is lowercase, param value needs to be lowercase.
+  threshold_statistic = param_stats_threshold.toLowerCase()
 
-      if (ds_currency_reference[ds_currency_code['value']]['t_separator'] !== undefined) {
-        separator = ds_currency_reference[ds_currency_code['value']]['t_separator']
-      } else {
-        separator = ""
+  // Determine whether we're checking for CPU, memory, or both
+  checking_cpu = param_stats_underutil_threshold_cpu_value != -1 || param_stats_idle_threshold_cpu_value != -1
+  checking_mem = param_stats_underutil_threshold_mem_value != -1 || param_stats_idle_threshold_mem_value != -1
+
+  underutil_total_savings = 0.0
+  idle_total_savings = 0.0
+
+  underutil_list = []
+  idle_list = []
+
+  // Only bother doing anything if we're checking at least one metric
+  if (checking_cpu || checking_mem) {
+    // Loop through metrics data, appending cost data
+    _.each(ds_azure_instances_metrics_organized, function(instance) {
+      id = instance['id'].toLowerCase()
+
+      // Assume cost is 0 unless we have cost data for the instance
+      total_cost = 0.0
+      if (ds_instance_costs_grouped[id] != undefined) { total_cost = ds_instance_costs_grouped[id] }
+
+      // Add baked-in values
+      instance['savingsCurrency'] = ds_currency['symbol']
+      instance['lookbackPeriod'] = param_stats_lookback
+      instance['thresholdType'] = param_stats_threshold
+
+      // Store relevant CPU and memory stats into these variables for later use
+      cpu_value = instance['cpu_' + threshold_statistic]
+      mem_value = instance['mem_' + threshold_statistic]
+
+      // Test for whether to consider the instance idle or underutilized.
+      // Assume instance is not idle or underutilized by default.
+      is_idle = false
+      is_underutil = false
+
+      // Determine if the instance is idle or underutilized for each category.
+      // Store boolean result for later use.
+      is_idle_cpu = cpu_value < param_stats_idle_threshold_cpu_value
+      is_underutil_cpu = cpu_value < param_stats_underutil_threshold_cpu_value
+      is_idle_mem = mem_value < param_stats_idle_threshold_mem_value
+      is_underutil_mem = mem_value < param_stats_underutil_threshold_mem_value
+
+      // If we're only checking CPU, simply set is_idle/is_underutil to their CPU equivalents
+      if (!checking_mem) { is_idle = is_idle_cpu }
+      if (!checking_mem) { is_underutil = is_underutil_cpu }
+
+      // If we're only checking memory, simply set is_idle/is_underutil to their memory equivalents
+      if (!checking_cpu) { is_idle = is_idle_mem }
+      if (!checking_cpu) { is_underutil = is_underutil_mem }
+
+      // If we're checking both, do an 'and' or an 'or' depending on the value of param_stats_check_both
+      if (checking_cpu && checking_mem) {
+        if (param_stats_check_both == "Both CPU and Memory") {
+          is_idle = is_idle_cpu && is_idle_mem
+          is_underutil = is_underutil_cpu && is_underutil_mem
+        } else {
+          is_idle = is_idle_cpu || is_idle_mem
+          is_underutil = is_underutil_cpu || is_underutil_mem
+        }
       }
-    } else {
-      cur = ""
-      separator = ""
+
+      instance["newResourceType"] = null
+
+      // Set appropriate values based on whether instance is idle or underutilized
+      // and then add it to the appropriate list
+      if (is_idle) {
+        instance["savings"] = parseFloat(parseFloat(total_cost).toFixed(3))
+        instance["recommendationType"] = "Terminate"
+        instance["threshold"] = param_stats_idle_threshold_cpu_value
+        instance["memoryThreshold"] = param_stats_idle_threshold_mem_value
+
+        recommendationDetails = [
+          "Terminate virtual machine ", instance["resourceId"], " ",
+          "in Azure Subscription ", instance["subscriptionName"], " ",
+          "(", instance["subscriptionId"], ")"
+        ]
+
+        instance["recommendationDetails"] = recommendationDetails.join('')
+
+        if (instance['savings'] >= param_min_savings) {
+          idle_total_savings += total_cost
+          idle_list.push(instance)
+        }
+      } else if (is_underutil) {
+        instance["savings"] = parseFloat(parseFloat(total_cost / 2).toFixed(3))
+        instance["recommendationType"] = "Downsize"
+        instance["threshold"] = param_stats_underutil_threshold_cpu_value
+        instance["memoryThreshold"] = param_stats_underutil_threshold_mem_value
+
+        if (ds_azure_instance_size_map[instance['resourceType']]) {
+          instance["newResourceType"] = ds_azure_instance_size_map[instance['resourceType']]['down']
+        }
+
+        recommendationDetails = [
+          "Change instance type of virtual machine ", instance["resourceId"], " ",
+          "in Azure Subscription ", instance["subscriptionName"], " ",
+          "(", instance["subscriptionId"], ") ",
+          "from ", instance["resourceType"], " ",
+          "to ", instance["newResourceType"]
+        ]
+
+        instance["recommendationDetails"] = recommendationDetails.join('')
+
+        if (instance["newResourceType"] != null && instance["newResourceType"] != undefined) {
+          if (instance['savings'] >= param_min_savings) {
+            underutil_total_savings += total_cost / 2
+            underutil_list.push(instance)
+          }
+        }
+      }
+    })
+  }
+
+  // Build out the detail_template for the incidents
+  if (checking_cpu || checking_mem) {
+    instances_total = ds_azure_instances_filtered.length.toString()
+    underutil_instances_total = underutil_list.length.toString()
+    underutil_instances_percentage = (underutil_instances_total / instances_total * 100).toFixed(2).toString() + '%'
+    idle_instances_total = idle_list.length.toString()
+    idle_instances_percentage = (idle_instances_total / instances_total * 100).toFixed(2).toString() + '%'
+
+    underutil_total_savings = ds_currency['symbol'] + ' ' + formatNumber(parseFloat(underutil_total_savings).toFixed(2), ds_currency['separator'])
+    idle_total_savings = ds_currency['symbol'] + ' ' + formatNumber(parseFloat(idle_total_savings).toFixed(2), ds_currency['separator'])
+
+    underutil_findings = [
+      "Out of ", instances_total, " virtual machines analyzed, ",
+      underutil_instances_total, " (", underutil_instances_percentage,
+      ") are underutilized and recommended for downsizing. "
+    ].join('')
+
+    idle_findings = [
+      "Out of ", instances_total, " virtual machines analyzed, ",
+      idle_instances_total, " (", idle_instances_percentage,
+      ") are idle and recommended for termination. "
+    ].join('')
+
+    if (checking_cpu && checking_mem) {
+      message_boolean = "or"
+
+      if (param_stats_check_both == "Both CPU and Memory") {
+        message_boolean = "and"
+      }
+
+      underutil_analysis_message = [
+        "A virtual machine is considered underutilized if its CPU usage (",
+        param_stats_threshold.toLowerCase(), ") is below ",
+        param_stats_underutil_threshold_cpu_value, "% ", message_boolean,
+        " its memory usage (", param_stats_threshold.toLowerCase(),
+        ") is below ", param_stats_underutil_threshold_mem_value,
+        "% but its CPU usage is still above or equal to ",
+        param_stats_idle_threshold_cpu_value, "% ", message_boolean,
+        " its memory usage is still above or equal to ",
+        param_stats_idle_threshold_mem_value, "%. "
+      ].join('')
+
+      idle_analysis_message = [
+        "A virtual machine is considered idle if its CPU usage (",
+        param_stats_threshold.toLowerCase(), ") is below ",
+        param_stats_idle_threshold_cpu_value, "% ", message_boolean,
+        " its memory usage (", param_stats_threshold.toLowerCase(),
+        ") is below ", param_stats_idle_threshold_mem_value, "%. "
+      ].join('')
+
+      lookback_message = [
+        "CPU and memory usage was analyzed over the last ",
+        param_stats_lookback.toString(), " days.\n\n"
+      ].join('')
     }
+
+    if (checking_cpu && !checking_mem) {
+      underutil_analysis_message = [
+        "A virtual machine is considered underutilized if its CPU usage (",
+        param_stats_threshold.toLowerCase(), ") is below ",
+        param_stats_underutil_threshold_cpu_value,
+        "% but its CPU usage is still above or equal to ",
+        param_stats_idle_threshold_cpu_value, "%. "
+      ].join('')
+
+      idle_analysis_message = [
+        "A virtual machine is considered idle if its CPU usage (",
+        param_stats_threshold.toLowerCase(), ") is below ",
+        param_stats_idle_threshold_cpu_value, "%. "
+      ].join('')
+
+      lookback_message = [
+        "CPU usage was analyzed over the last ",
+        param_stats_lookback.toString() + " days.\n\n"
+      ].join('')
+    }
+
+    if (!checking_cpu && checking_mem) {
+      underutil_analysis_message = [
+        "A virtual machine is considered underutilized if its memory usage (",
+        param_stats_threshold.toLowerCase(), ") is below ",
+        param_stats_underutil_threshold_mem_value,
+        "% but its memory usage is still above or equal to ",
+        param_stats_idle_threshold_mem_value, "%. "
+      ].join('')
+
+      idle_analysis_message = [
+        "A virtual machine is considered idle if its memory usage (",
+        param_stats_threshold.toLowerCase(), ") is below ",
+        param_stats_idle_threshold_mem_value, "%. "
+      ].join('')
+
+      lookback_message = [
+        "Memory usage was analyzed over the last ",
+        param_stats_lookback.toString() + " days.\n\n"
+      ].join('')
+    }
+
+    disclaimer = "The above settings can be modified by editing the applied policy and changing the appropriate parameters."
+
+    underutil_message = underutil_findings + underutil_analysis_message + lookback_message + disclaimer
+    idle_message = idle_findings + idle_analysis_message + lookback_message + disclaimer
   } else {
-    cur = "$"
-    separator = ","
+    underutil_message = "No results were found because all CPU and memory parameters were set to -1 when this policy was applied. Please terminate and reapply this policy with one of these settings enabled."
+    idle_message = underutil_message
   }
 
-  result = []
-  underutil_total_savings = 0
-  idle_total_savings = 0
+  // Sort by descending order of savings value
+  idle_list = _.sortBy(idle_list, function(item) { return item['savings'] * -1 })
+  underutil_list = _.sortBy(underutil_list, function(item) { return item['savings'] * -1 })
 
-  underutil_count = 0
-  idle_count = 0
+  // Add these to both lists to ensure the first item that fails validation for each
+  // contains the necessary data for the summary and detail templates
+  idle_list[0]['idle_message'] = idle_message
+  idle_list[0]['idle_total_savings'] = idle_total_savings
+  idle_list[0]['policy_name'] = ds_applied_policy['name']
 
-  _.each(instance_utilization_data, function(util_data) {
-    instance_cost = instance_costs[util_data['resourceId'].toLowerCase()]
+  underutil_list[0]['underutil_message'] = underutil_message
+  underutil_list[0]['underutil_total_savings'] = underutil_total_savings
+  underutil_list[0]['policy_name'] = ds_applied_policy['name']
 
-    if (instance_cost != null && instance_cost != undefined) {
-      if (util_data['recommendedVmSize'] == "Terminate Instance") {
-        util_data['savings'] = parseFloat(instance_cost).toFixed(3)
-        idle_total_savings += instance_cost
-      } else {
-        util_data['savings'] = parseFloat(instance_cost / 2).toFixed(3)
-        underutil_total_savings += instance_cost / 2
-      }
-    } else {
-      util_data['savings'] = parseFloat(0).toFixed(3)
-    }
+  result = idle_list.concat(underutil_list)
 
-    util_data['savingsCurrency'] = cur
-    util_data['averageCPU'] = parseFloat(util_data['averageCPU']).toFixed(2)
-    util_data['minCPU'] = parseFloat(util_data['minCPU']).toFixed(2)
-    util_data['maxCPU'] = parseFloat(util_data['maxCPU']).toFixed(2)
-
-    if (util_data['averageCPU'] === "NaN") {
-      util_data['averageCPU'] = 0
-    }
-    if (util_data['minCPU'] === "NaN" ){
-      util_data['minCPU'] = 0
-    }
-    if (util_data['maxCPU'] === "NaN") {
-      util_data['maxCPU'] = 0
-    }
-    if (util_data['recommendedVmSize'] == "Terminate Instance") {
-      idle_count += 1
-    } else {
-      underutil_count += 1
-    }
-
-    result.push(util_data)
-  })
-
-  result = _.sortBy(result, "region")
-  result = _.sortBy(result, "subscriptionName")
-
-  underutil_total_savings = cur + ' ' + formatNumber((Math.round(underutil_total_savings * 100) / 100), separator)
-  idle_total_savings = cur + ' ' + formatNumber((Math.round(idle_total_savings * 100) / 100), separator)
-
-  summary_data = {
-    "underutilMessage": "The total estimated monthly savings is " + underutil_total_savings,
-    "idleMessage": "The total estimated monthly savings is " + idle_total_savings,
-    "underutilInstanceCount": underutil_count,
-    "idleInstanceCount": idle_count
-  }
-
-  _.each(result, function(item) {
-    item['summaryData'] = summary_data
-    item['underutilThreshold'] = param_underutil_prc
-    item['idleThreshold'] = param_idle_prc
-    item['lookbackPeriod'] = "30 days"
+  // Add a dummy entry to ensure that the policy's check statement executes at least once
+  result.push({
+    "recommendationType": "",
+    "underutil_message": "",
+    "idle_message": "",
+    "underutil_total_savings": "",
+    "idle_total_savings": "",
+    "tags": "",
+    "savings": "",
+    "savingsCurrency": "",
+    "cpu_maximum": "",
+    "cpu_minimum": "",
+    "cpu_average": "",
+    "mem_maximum": "",
+    "mem_minimum": "",
+    "mem_average": ""
   })
 EOS
 end
@@ -644,48 +995,58 @@ end
 # Policy
 ###############################################################################
 
-policy "policy_azure_rightsizing_data" do
-  validate_each $ds_combined_data do
-    summary_template <<-EOS
-    {{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ with index data 0 }}{{ .summaryData.underutilInstanceCount }}{{ end }} Azure underutilized compute instances found
-        EOS
-    detail_template <<-EOS
-    {{ with index data 0 }}{{ .summaryData.underutilMessage }}{{ end }}
-        EOS
-    check eq(val(item, "recommendedVmSize"), "Terminate Instance")
-    escalate $email
+policy "pol_utilization" do
+  validate_each $ds_idle_and_underutil_instances do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Azure Underutilized Virtual Machines Found"
+    detail_template <<-'EOS'
+    **Potential Monthly Savings:** {{ with index data 0 }}{{ .underutil_total_savings }}{{ end }}
+
+    {{ with index data 0 }}{{ .underutil_message }}{{ end }}
+    EOS
+    check ne(val(item, "recommendationType"), "Downsize")
+    escalate $esc_email
     escalate $esc_downsize_instances
+    hash_exclude "underutil_message", "idle_message", "underutil_total_savings", "idle_total_savings", "tags", "savings", "savingsCurrency", "cpu_maximum", "cpu_minimum", "cpu_average", "mem_maximum", "mem_minimum", "mem_average"
     export do
       resource_level true
-      field "subscriptionName" do
-        label "Subscription Name"
-      end
-      field "subscriptionId" do
+      field "accountID" do
         label "Subscription ID"
+        path "subscriptionId"
+      end
+      field "accountName" do
+        label "Subscription Name"
+        path "subscriptionName"
+      end
+      field "resourceGroup" do
+        label "Resource Group"
+      end
+      field "resourceName" do
+        label "Resource Name"
       end
       field "resourceID" do
         label "Resource ID"
         path "resourceId"
       end
-      field "resourceName" do
-        label "Resource Name"
+      field "tags" do
+        label "Resource Tags"
+      end
+      field "recommendationDetails" do
+        label "Recommendation"
+      end
+      field "resourceType" do
+        label "Instance Size"
+      end
+      field "newResourceType" do
+        label "Recommended Instance Size"
       end
       field "resourceKind" do
         label "Resource Kind"
       end
-      field "resourceType" do
-        label "Resource Type"
-      end
-      field "newResourceType" do
-        label "Recommended Resource Type"
-        path "recommendedVmSize"
-      end
-      field "platform" do
-        label "OS Type"
-        path "osType"
-      end
       field "region" do
         label "Region"
+      end
+      field "osType" do
+        label "Operating System"
       end
       field "savings" do
         label "Estimated Monthly Savings"
@@ -693,21 +1054,45 @@ policy "policy_azure_rightsizing_data" do
       field "savingsCurrency" do
         label "Savings Currency"
       end
-      field "minCPU" do
-        label "CPU Minimum (%)"
+      field "launchTime" do
+        label "Launch Time"
+        path "timeCreated"
+      end
+      field "cpuMaximum" do
+        label "CPU Maximum %"
+        path "cpu_maximum"
+      end
+      field "cpuMinimum" do
+        label "CPU Minimum %"
+        path "cpu_minimum"
       end
       field "cpuAverage" do
-        label "CPU Average (%)"
-        path "averageCPU"
+        label "CPU Average %"
+        path "cpu_average"
       end
-      field "maxCPU" do
-        label "CPU Maximum (%)"
+      field "memMaximum" do
+        label "Memory Maximum %"
+        path "mem_maximum"
       end
-      field "resourceGroup" do
-        label "Resource Group"
+      field "memMinimum" do
+        label "Memory Minimum %"
+        path "mem_minimum"
       end
-      field "tags" do
-        label "Tags"
+      field "memAverage" do
+        label "Memory Average %"
+        path "mem_average"
+      end
+      field "thresholdType" do
+        label "Threshold Statistic"
+      end
+      field "threshold" do
+        label "CPU Threshold"
+      end
+      field "memoryThreshold" do
+        label "Memory Threshold"
+      end
+      field "lookbackPeriod" do
+        label "Look Back Period (Days)"
       end
       field "service" do
         label "Service"
@@ -715,65 +1100,57 @@ policy "policy_azure_rightsizing_data" do
       field "id" do
         label "ID"
         path "resourceId"
-      end
-      field "accountName" do
-        label "Account Name"
-        path "subscriptionName"
-      end
-      field "accountID" do
-        label "Account ID"
-        path "subscriptionId"
-      end
-      field "lookbackPeriod" do
-        label "Lookback Period"
-      end
-      field "threshold" do
-        label "Underutilized Threshold"
-        path "underutilThreshold"
       end
     end
   end
-  validate_each $ds_combined_data do
-    summary_template <<-EOS
-{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ with index data 0 }}{{ .summaryData.idleInstanceCount }}{{end}} Azure idle compute instances found
-EOS
-    detail_template <<-EOS
-{{ with index data 0 }}{{ .summaryData.idleMessage }}{{ end }}
-EOS
-    check ne(val(item, "recommendedVmSize"), "Terminate Instance")
-    escalate $email
+  validate_each $ds_idle_and_underutil_instances do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} AWS Idle Virtual Machiness Found"
+    detail_template <<-'EOS'
+    **Potential Monthly Savings:** {{ with index data 0 }}{{ .idle_total_savings }}{{ end }}
+
+    {{ with index data 0 }}{{ .idle_message }}{{ end }}
+    EOS
+    check ne(val(item, "recommendationType"), "Terminate")
+    escalate $esc_email
     escalate $esc_terminate_instances
+    hash_exclude "underutil_message", "idle_message", "underutil_total_savings", "idle_total_savings", "tags", "savings", "savingsCurrency", "cpu_maximum", "cpu_minimum", "cpu_average", "mem_maximum", "mem_minimum", "mem_average"
     export do
       resource_level true
-      field "subscriptionName" do
-        label "Subscription Name"
-      end
-      field "subscriptionId" do
+      field "accountID" do
         label "Subscription ID"
+        path "subscriptionId"
+      end
+      field "accountName" do
+        label "Subscription Name"
+        path "subscriptionName"
+      end
+      field "resourceGroup" do
+        label "Resource Group"
+      end
+      field "resourceName" do
+        label "Resource Name"
       end
       field "resourceID" do
         label "Resource ID"
         path "resourceId"
       end
-      field "resourceName" do
-        label "Resource Name"
+      field "tags" do
+        label "Resource Tags"
+      end
+      field "recommendationDetails" do
+        label "Recommendation"
+      end
+      field "resourceType" do
+        label "Instance Size"
       end
       field "resourceKind" do
         label "Resource Kind"
       end
-      field "resourceType" do
-        label "Resource Type"
-      end
-      field "newResourceType" do
-        label "Recommended Resource Type"
-        path "recommendedVmSize"
-      end
-      field "platform" do
-        label "OS Type"
-        path "osType"
-      end
       field "region" do
         label "Region"
+      end
+      field "osType" do
+        label "Operating System"
       end
       field "savings" do
         label "Estimated Monthly Savings"
@@ -781,21 +1158,45 @@ EOS
       field "savingsCurrency" do
         label "Savings Currency"
       end
-      field "minCPU" do
-        label "CPU Minimum (%)"
+      field "launchTime" do
+        label "Launch Time"
+        path "timeCreated"
+      end
+      field "cpuMaximum" do
+        label "CPU Maximum %"
+        path "cpu_maximum"
+      end
+      field "cpuMinimum" do
+        label "CPU Minimum %"
+        path "cpu_minimum"
       end
       field "cpuAverage" do
-        label "CPU Average (%)"
-        path "averageCPU"
+        label "CPU Average %"
+        path "cpu_average"
       end
-      field "maxCPU" do
-        label "CPU Maximum (%)"
+      field "memMaximum" do
+        label "Memory Maximum %"
+        path "mem_maximum"
       end
-      field "resourceGroup" do
-        label "Resource Group"
+      field "memMinimum" do
+        label "Memory Minimum %"
+        path "mem_minimum"
       end
-      field "tags" do
-        label "Tags"
+      field "memAverage" do
+        label "Memory Average %"
+        path "mem_average"
+      end
+      field "thresholdType" do
+        label "Threshold Statistic"
+      end
+      field "threshold" do
+        label "CPU Threshold"
+      end
+      field "memoryThreshold" do
+        label "Memory Threshold"
+      end
+      field "lookbackPeriod" do
+        label "Look Back Period (Days)"
       end
       field "service" do
         label "Service"
@@ -803,21 +1204,6 @@ EOS
       field "id" do
         label "ID"
         path "resourceId"
-      end
-      field "accountName" do
-        label "Account Name"
-        path "subscriptionName"
-      end
-      field "accountID" do
-        label "Account ID"
-        path "subscriptionId"
-      end
-      field "lookbackPeriod" do
-        label "Lookback Period"
-      end
-      field "threshold" do
-        label "Idle Threshold"
-        path "idleThreshold"
       end
     end
   end
@@ -827,7 +1213,7 @@ end
 # Escalations
 ###############################################################################
 
-escalation "email" do
+escalation "esc_email" do
   automatic true
   label "Send Email"
   description "Send incident email"
@@ -838,14 +1224,14 @@ escalation "esc_downsize_instances" do
   automatic contains($param_automatic_action, "Downsize Instances")
   label "Downsize Instances"
   description "Approval to downsize all selected instances"
-  run "downsize_instance", data, $param_azure_endpoint
+  run "downsize_instances", data, $param_azure_endpoint
 end
 
 escalation "esc_terminate_instances" do
   automatic contains($param_automatic_action, "Terminate Instances")
   label "Terminate Instances"
   description "Approval to terminate all selected instances"
-  run "delete_instance", data, $param_azure_endpoint
+  run "terminate_instances", data, $param_azure_endpoint
 end
 
 ###############################################################################
@@ -853,7 +1239,7 @@ end
 ###############################################################################
 
 #DOWNSIZE AZURE VM INSTANCE DEFINITION
-define downsize_instance($data, $param_azure_endpoint) return $all_responses do
+define downsize_instances($data, $param_azure_endpoint) return $all_responses do
   # Change "No" to "Yes" to enable CWF debug logging
   $log_to_cm_audit_entries = "No"
 
@@ -866,7 +1252,7 @@ define downsize_instance($data, $param_azure_endpoint) return $all_responses do
     if $item["recommendedVmSize"] != "N/A"
       sub on_error: skip do
         $response = http_request(
-          auth: $$azure_auth,
+          auth: $$auth_azure,
           verb: "patch",
           host: $param_azure_endpoint,
           https: true,
@@ -892,7 +1278,7 @@ define downsize_instance($data, $param_azure_endpoint) return $all_responses do
 end
 
 #TERMINATE AZURE VM INSTANCE DEFINITION
-define delete_instance($data, $param_azure_endpoint) return $all_responses do
+define terminate_instances($data, $param_azure_endpoint) return $all_responses do
   # Change "No" to "Yes" to enable CWF debug logging
   $log_to_cm_audit_entries = "No"
 
@@ -908,7 +1294,7 @@ define delete_instance($data, $param_azure_endpoint) return $all_responses do
       $response = http_request(
         verb: "delete",
         host: $param_azure_endpoint,
-        auth: $$azure_auth,
+        auth: $$auth_azure,
         href: join(["/subscriptions/", $item['subscriptionId'], "/resourceGroups/", $item["resourceGroup"], "/providers/Microsoft.Compute/virtualMachines/",$item["resourceName"]]),
         https: true,
         query_strings: {

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -611,7 +611,6 @@ script "js_azure_instances_metrics_organized", type: "javascript" do
       resourceType: vm['resourceType'],
       subscriptionId: vm['subscriptionId'],
       subscriptionName: vm['subscriptionName'],
-      timeCreated: vm['timeCreated']
       tags: vm_tags.join(', '),
       cpu_minimum: parseFloat(cpu_min.toFixed(2)),
       cpu_maximum: parseFloat(cpu_max.toFixed(2)),

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -48,7 +48,7 @@ parameter "param_exclusion_tags" do
   type "list"
   category "Filters"
   label "Exclusion Tags (Key:Value)"
-  description "Cloud native tags to ignore instances that you don't want to consider for downsizing or termination. Format: Key:Value"
+  description "Cloud native tags to ignore instances that you don't want to consider for downsizing or deletion. Format: Key:Value"
   allowed_pattern /(^$)|([\w]?)+\:([\w]?)+/
   default []
 end

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -1,7 +1,7 @@
 name "Azure Rightsize Compute Instances"
 rs_pt_ver 20180301
 type "policy"
-short_description "Checks for instances that have inefficient utilization for the last 30 days and rightsizes or deletes them after approval. \n See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/rightsize_compute_instances/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "Checks for instances that have inefficient utilization for the last 30 days and downsizes or deletes them after approval. \n See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/rightsize_compute_instances/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 category "Cost"
 severity "low"


### PR DESCRIPTION
### Description

This adds support for memory metrics and brings over a bunch of the improvements being made for the AWS version of this policy to the Azure version.

Azure now supports memory usage ("Available Memory Bytes") via the Insights API, so this data is straightforwardly pulled from the same API that CPU data is pulled from. The percentage is calculated by finding the total memory of the instance's SKU via the Microsoft.Compute/skus API and then doing the appropriate calculations.

From the CHANGELOG:

- Several parameters altered to be more descriptive and human-readable
- Removed deprecated "Log to CM Audit Entries" parameter
- Added ability to only report recommendations that meet a minimum savings threshold
- Added support for memory metrics along with relevant parameters
- Added ability to configure how many days to consider CPU/memory statistics for
- Added ability to filter resources by multiple tag key:value pairs
- Added ability to make recommendations based on maximum CPU/memory usage
- Added additional context to incident description
- Normalized incident export to be consistent with other policies
- Added human-readable recommendation to incident export
- Policy no longer raises new escalations if statistics or savings data changed but nothing else has
- Streamlined code for better readability and faster execution

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=64b1457a12688300016785e1

(Note: Savings will show 0 for the above example due to the test environment. I've confirmed independently that the savings field works as expected in a normal environment)

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
