### PR TITLE
FOPTS-682 Google recommender policies update readme

### DIFF
--- a/cost/google/cloud_sql_idle_instance_recommendations/CHANGELOG.md
+++ b/cost/google/cloud_sql_idle_instance_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.10
+
+- Updated policy README file with a deeper explanation of how the GCP recommender works and the roles required to use it.
+
 ## v2.9
 
 - Added `Lookback Period In Days` incident field.

--- a/cost/google/cloud_sql_idle_instance_recommendations/README.md
+++ b/cost/google/cloud_sql_idle_instance_recommendations/README.md
@@ -4,6 +4,23 @@
 
 This Policy finds Idle Cloud SQL Instance Recommendations and reports when it finds them. You can then delete the idle volumes
 
+### How it works
+
+This policy uses the GCP recommender `google.cloudsql.instance.IdleRecommender`, which analyzes the usage metrics of primary instances that are **older than 30 days**. For each instance, the recommender considers the values of certain [metrics](https://cloud.google.com/monitoring/api/metrics_gcp#gcp-cloudsql) within an observation period spanning the last 30 days. The recommender **does not** analyze read replicas.
+
+If the activity level within the observation period is below a certain threshold, the recommender estimates that the instance is idle. Recommendations are generated every 24 hours for shutting down such instances.
+
+It is important that the policy GCP credentials have at least one of the following roles:
+
+- `recommender.cloudsqlViewer`
+- `cloudsql.viewer`
+
+You also need to [enable the Recommender API](https://console.cloud.google.com/flows/enableapi?apiid=recommender.googleapis.com)
+
+Check the following official GCP docs for more:
+
+- [Identify idle Cloud SQL instances](https://cloud.google.com/sql/docs/sqlserver/recommender-sql-idle)
+
 ## Input Parameters
 
 This policy has the following input parameters required when launching the policy.

--- a/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations.pt
+++ b/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.9",
+  version: "2.10",
   provider:"Google",
   service: "SQL",
   policy_set: "Unused Database Services",

--- a/cost/google/idle_ip_address_recommendations/CHANGELOG.md
+++ b/cost/google/idle_ip_address_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.11
+
+- Updated policy README file with a deeper explanation of how the GCP recommender works and the roles required to use it.
+
 ## v2.10
 
 - Modified the number of GCP recommender API calls that can be done before waiting to prevent a quota limit error: 100 request per minute.

--- a/cost/google/idle_ip_address_recommendations/README.md
+++ b/cost/google/idle_ip_address_recommendations/README.md
@@ -4,6 +4,22 @@
 
 This Policy finds Idle IP Address Recommendations and reports when it finds them. You can then delete the idle addresses
 
+### How it works
+
+This policy uses the GCP recommender `google.compute.address.IdleResourceRecommender`, which checks if a resource has not been attached to a VM or other resource for 15 days, the recommender classifies that resource as idle.
+
+Idle resource recommendations begin 15 days after resource creation, and they are updated once every 24 hours.
+
+It is important that the policy GCP credentials have at least one of the following roles:
+
+- `recommender.computeAddressIdleResourceRecommendations.list`
+
+You also need to [enable the Recommender API](https://console.cloud.google.com/flows/enableapi?apiid=recommender.googleapis.com)
+
+Check the following official GCP docs for more:
+
+- [Viewing and applying idle resources recommendations](https://cloud.google.com/compute/docs/viewing-and-applying-idle-resources-recommendations)
+
 ## Input Parameters
 
 This policy has the following input parameters required when launching the policy.

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.10",
+  version: "2.11",
   provider: "Google",
   service: "Compute",
   policy_set: "Unused IP Addresses",

--- a/cost/google/idle_persistent_disk_recommendations/CHANGELOG.md
+++ b/cost/google/idle_persistent_disk_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.10
+
+- Updated policy README file with a deeper explanation of how the GCP recommender works and the roles required to use it.
+
 ## v2.9
 
 - Modified the number of GCP recommender API calls that can be done before waiting to prevent a quota limit error: 100 request per minute.

--- a/cost/google/idle_persistent_disk_recommendations/README.md
+++ b/cost/google/idle_persistent_disk_recommendations/README.md
@@ -4,6 +4,21 @@
 
 This Policy finds Idle Persistent Disk Recommendations and reports when it finds them. You can then delete the idle volumes
 
+### How it works
+
+This policy uses the GCP recommender `google.compute.disk.IdleResourceRecommender`, which 
+
+It is important that the policy GCP credentials have at least one of the following roles:
+
+-
+-
+
+You also need to [enable the Recommender API](https://console.cloud.google.com/flows/enableapi?apiid=recommender.googleapis.com)
+
+Check the following official GCP docs for more:
+
+- 
+
 ## Input Parameters
 
 This policy has the following input parameters required when launching the policy.

--- a/cost/google/idle_persistent_disk_recommendations/README.md
+++ b/cost/google/idle_persistent_disk_recommendations/README.md
@@ -6,18 +6,19 @@ This Policy finds Idle Persistent Disk Recommendations and reports when it finds
 
 ### How it works
 
-This policy uses the GCP recommender `google.compute.disk.IdleResourceRecommender`, which 
+This policy uses the GCP recommender `google.compute.disk.IdleResourceRecommender`, which checks if a resource has not been attached to a VM or other resource for 15 days, the recommender classifies that resource as idle.
+
+Idle resource recommendations begin 15 days after resource creation, and they are updated once every 24 hours.
 
 It is important that the policy GCP credentials have at least one of the following roles:
 
--
--
+- `recommender.computeAddressIdleResourceRecommendations.list`
 
 You also need to [enable the Recommender API](https://console.cloud.google.com/flows/enableapi?apiid=recommender.googleapis.com)
 
 Check the following official GCP docs for more:
 
-- 
+- [Viewing and applying idle resources recommendations](https://cloud.google.com/compute/docs/viewing-and-applying-idle-resources-recommendations)
 
 ## Input Parameters
 

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.9",
+  version: "2.10",
   provider:"Google",
   service: "Storage",
   policy_set: "Unused Volumes",

--- a/cost/google/idle_vm_recommendations/CHANGELOG.md
+++ b/cost/google/idle_vm_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.11
+
+- Updated policy README file with a deeper explanation of how the GCP recommender works and the roles required to use it.
+
 ## v2.10
 
 - Modified the number of GCP recommender API calls that can be done before waiting to prevent a quota limit error: 100 request per minute.

--- a/cost/google/idle_vm_recommendations/README.md
+++ b/cost/google/idle_vm_recommendations/README.md
@@ -8,6 +8,8 @@ This Policy finds Idle Virtual Machine Recommendations and reports when it finds
 
 This policy uses the GCP recommender `google.compute.instance.IdleResourceRecommender`, which identifies instances (VM) that have not been used over the previous 1 to 14 days, or, for new VMs, starting one day after VM creation: the algorithm considers the CPU and network usage in the last observation period. If CPU and network usage are below predefined thresholds, the Recommender classifies the VM as idle.
 
+After a VM is created and running for at least one day during the observation period, Compute Engine begins generating idle VM recommendations for it. New recommendations are generated once per day.
+
 It is important that the policy GCP credentials have at least one of the following permissions:
 
 - `recommender.computeInstanceIdleResourceRecommendations.list`

--- a/cost/google/idle_vm_recommendations/README.md
+++ b/cost/google/idle_vm_recommendations/README.md
@@ -4,6 +4,21 @@
 
 This Policy finds Idle Virtual Machine Recommendations and reports when it finds them. You can then delete the idle instances
 
+### How it works
+
+This policy uses the GCP recommender `google.compute.instance.IdleResourceRecommender`, which identifies instances (VM) that have not been used over the previous 1 to 14 days, or, for new VMs, starting one day after VM creation: the algorithm considers the CPU and network usage in the last observation period. If CPU and network usage are below predefined thresholds, the Recommender classifies the VM as idle.
+
+It is important that the policy GCP credentials have at least one of the following permissions:
+
+- `recommender.computeInstanceIdleResourceRecommendations.list`
+
+You also need to [enable the Recommender API](https://console.cloud.google.com/flows/enableapi?apiid=recommender.googleapis.com)
+
+Check the following official GCP docs for more:
+
+- [How detection of idle VM instances works](https://cloud.google.com/compute/docs/instances/idle-vm-recommendations-overview#how_detection_of_idle_vm_instances_works)
+- [Viewing idle VM instance recommendations](https://cloud.google.com/compute/docs/instances/viewing-and-applying-idle-vm-recommendations#viewing_idle_vm_instance_recommendations)
+
 ## Input Parameters
 
 This policy has the following input parameters required when launching the policy.

--- a/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
+++ b/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.10",
+  version: "2.11",
   provider:"Google",
   service: "Compute",
   policy_set: "Idle Compute Instances",


### PR DESCRIPTION
### Description

This change adds documentation about how the recommender API works to the GCP recommender policies:

- Google Cloud SQL Idle Instance Recommender
- Google Idle IP Address Recommender
- Google Idle Persistent Disk Recommender
- Google Idle VM Recommender

### Issues Resolved

https://flexera.atlassian.net/browse/FOPTS-682

### Link to Example Applied Policy

This change only updates the documentation of the policies.

### Contribution Check List

- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
