### PR TITLE
FOPTS-1323 Turbonomic Unattached Volumes (AWS)

### DIFF
--- a/cost/turbonomics/delete_unattached_volumes/aws/CHANGELOG.md
+++ b/cost/turbonomics/delete_unattached_volumes/aws/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.4
+
+- Added `Storage Access` incident field.
+- Added `Last Attached VM` incident field.
+- Added `Action State` incident field.
+- Added `Disruptiveness` incident field.
+- Added `Reversibility` incident field.
+- Added `System Details URL` incident field.
+- Renamed `Size` incident field to `Storage Amount`.
+- Changed internal names of several incident fields to ensure that they are properly scraped for dashboards.
+
 ## v0.3
 
 - Fixed readme Link in the policy.

--- a/cost/turbonomics/delete_unattached_volumes/aws/turbonomics_delete_virtual_volumes.pt
+++ b/cost/turbonomics/delete_unattached_volumes/aws/turbonomics_delete_virtual_volumes.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.3",
+  version: "0.4",
   provider: "AWS",
   source: "Turbonomic",
   service: "Storage",
@@ -93,9 +93,14 @@ datasource "ds_get_turbonomics_recommendations" do
       field "createdTime", jmes_path(col_item, "createTime")
       field "attachmentState", jmes_path(col_item, "target.aspects.virtualDisksAspect.virtualDisks[0].attachmentState")
       field "daysUnattached", jmes_path(col_item, "target.aspects.virtualDisksAspect.virtualDisks[0].numDaysUnattached")
-      field "size", jmes_path(col_item, "target.aspects.virtualDisksAspect.virtualDisks[0].stats")
+      field "stats", jmes_path(col_item, "target.aspects.virtualDisksAspect.virtualDisks[0].stats")
       field "savings", jmes_path(col_item, "stats[0].value")
       field "savingsCurrency", jmes_path(col_item, "stats[0].units")
+      field "actionState", jmes_path(col_item, "actionState")
+      field "disruptiveness", jmes_path(col_item, "executionCharacteristics.disruptiveness")
+      field "reversibility", jmes_path(col_item, "executionCharacteristics.reversibility")
+      field "lastAttachedVm", jmes_path(col_item, "target.aspects.virtualDisksAspect.virtualDisks[0].lastAttachedVm")
+      field "uuid", jmes_path(col_item, "uuid")
     end
   end
 end
@@ -116,7 +121,7 @@ datasource "ds_get_business_units" do
 end
 
 datasource "ds_filtered_turbonomics_recommendations" do
-  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $param_days_unattached, $ds_get_business_units, $param_provider
+  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $param_days_unattached, $ds_get_business_units, $param_provider, $param_turbonomic_host
 end
 
 ###############################################################################
@@ -182,7 +187,7 @@ end
 
 script "js_filtered_turbonomics_recommendations", type: "javascript" do
   result "result"
-  parameters "ds_get_turbonomics_recommendations", "param_days_unattached", "ds_get_business_units", "param_provider"
+  parameters "ds_get_turbonomics_recommendations", "param_days_unattached", "ds_get_business_units", "param_provider", "param_turbonomic_host"
   code <<-EOS
     instances = []
     monthlySavings = 0.0
@@ -225,10 +230,12 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
         } else {
           volume.savingsCurrency = "$"
         }
-        _.each(volume.size, function(stat){
+        _.each(volume.stats, function(stat){
           if (stat.name === "StorageAmount") {
             volume.size = stat.capacity.total + " " + stat.units
-            return
+          }
+          if(stat.name === "StorageAccess") {
+            volume.iops = stat.capacity.total + " " + stat.units
           }
         })
         tags = []
@@ -251,6 +258,7 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
         }
         volume.savings = (Math.round(volume.savings * 730 * 1000) / 1000)
         monthlySavings = monthlySavings + volume.savings
+        volume.url = param_turbonomic_host + "/app/index.html#/view/main/action/" + volume.uuid
         instances.push(volume)
       }
     })
@@ -321,18 +329,38 @@ EOS
       field "createdTime" do
         label "Created Time"
       end
-      field "attachmentState" do
+      field "state" do
         label "Attachment State"
+        path "attachmentState"
       end
-      field "daysUnattached" do
+      field "lookbackPeriod" do
         label "Days Unattached"
-      end
-      field "size" do
-        label "Size"
+        path "daysUnattached"
       end
       field "id" do
         label "Resource ID"
         path "resourceID"
+      end
+      field "iops" do
+        label "Storage Access"
+      end
+      field "size" do
+        label "Storage Amount"
+      end
+      field "lastAttachedVm" do
+        label "Last Attached VM"
+      end
+      field "actionState" do
+        label "Action State"
+      end
+      field "disruptiveness" do
+        label "Disruptiveness"
+      end
+      field "reversibility" do
+        label "Reversibility"
+      end
+      field "url" do
+        label "System Details URL"
       end
     end
     escalate $esc_email


### PR DESCRIPTION
### Description

AWS Unattached Volumes policy needs to show the following information: storage access IOPs, storage amount, last VM volumes was attached to, action nature: disruptive or not, reversible or not, system details URL.

### Issues Resolved

Added all requested fields and normalized incident fields.

### Link to Example Applied Policy

- Policy with Mock Data: https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/60073?policyId=64b19456717332000128f016
- Policy: https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/60073?policyId=64b196a8717332000128f017

### Contribution Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
