### PR TITLE
FOPTS-1324 Turbonomic Unattached Volumes (Azure)

### DIFF
--- a/cost/turbonomics/delete_unattached_volumes/aws/CHANGELOG.md
+++ b/cost/turbonomics/delete_unattached_volumes/aws/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.5
+
+- Renamed `Storage Access` incident field to `IOps`.
+- Renamed `Storage Amount` incident field to `Size`.
+- Renamed `Attachment State` incident field to `State`.
+- Renamed `Days Unattached` incident field to `Lookback Period`.
+- Removed hardcoded host on business units path.
+
 ## v0.4
 
 - Added `Storage Access` incident field.

--- a/cost/turbonomics/delete_unattached_volumes/aws/CHANGELOG.md
+++ b/cost/turbonomics/delete_unattached_volumes/aws/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## v0.5
 
-- Renamed `Storage Access` incident field to `IOps`.
+- Renamed `Storage Access` incident field to `Provisioned IOPs`.
 - Renamed `Storage Amount` incident field to `Size`.
 - Renamed `Attachment State` incident field to `State`.
-- Renamed `Days Unattached` incident field to `Lookback Period`.
+- Renamed `Created Time` incident field to `Action Created Time`.
+- Renamed `Last Attached VM` incident field to `Last VM`.
+- Renamed `Unused Days` parameter to `Days Unattached`.
 - Removed hardcoded host on business units path.
 
 ## v0.4

--- a/cost/turbonomics/delete_unattached_volumes/aws/turbonomics_delete_virtual_volumes.pt
+++ b/cost/turbonomics/delete_unattached_volumes/aws/turbonomics_delete_virtual_volumes.pt
@@ -37,7 +37,7 @@ end
 
 parameter "param_days_unattached" do
   type "number"
-  label "Unused days"
+  label "Days Unattached"
   description "The number of days a volume has been unused. The days should be greater than zero"
   default 30
   min_value 1
@@ -99,7 +99,7 @@ datasource "ds_get_turbonomics_recommendations" do
       field "actionState", jmes_path(col_item, "actionState")
       field "disruptiveness", jmes_path(col_item, "executionCharacteristics.disruptiveness")
       field "reversibility", jmes_path(col_item, "executionCharacteristics.reversibility")
-      field "lastAttachedVm", jmes_path(col_item, "target.aspects.virtualDisksAspect.virtualDisks[0].lastAttachedVm")
+      field "lastVm", jmes_path(col_item, "target.aspects.virtualDisksAspect.virtualDisks[0].lastAttachedVm")
       field "uuid", jmes_path(col_item, "uuid")
     end
   end
@@ -326,29 +326,29 @@ EOS
       field "tags" do
         label "Tags"
       end
-      field "createdTime" do
-        label "Created Time"
+      field "actionCreatedTime" do
+        label "Action Created Time"
+        path "createdTime"
       end
       field "state" do
         label "State"
         path "attachmentState"
       end
-      field "lookbackPeriod" do
-        label "Lookback Period (Days)"
-        path "daysUnattached"
+      field "daysUnattached" do
+        label "Days Unattached"
       end
       field "id" do
         label "Resource ID"
         path "resourceID"
       end
       field "iops" do
-        label "IOps"
+        label "Provisioned IOPs"
       end
       field "size" do
         label "Size (GB)"
       end
-      field "lastAttachedVm" do
-        label "Last Attached VM"
+      field "lastVm" do
+        label "Last VM"
       end
       field "actionState" do
         label "Action State"

--- a/cost/turbonomics/delete_unattached_volumes/aws/turbonomics_delete_virtual_volumes.pt
+++ b/cost/turbonomics/delete_unattached_volumes/aws/turbonomics_delete_virtual_volumes.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.4",
+  version: "0.5",
   provider: "AWS",
   source: "Turbonomic",
   service: "Storage",
@@ -108,7 +108,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, $auth_cookie, $param_provider
+    run_script $js_get_business_units, $auth_cookie, $param_provider, $param_turbonomic_host
   end
   result do
     encoding "json"
@@ -161,7 +161,7 @@ end
 ## verified that discovered is the only one we need
 script "js_get_business_units", type: "javascript" do
   result "request"
-  parameters "auth_cookie", "param_provider"
+  parameters "auth_cookie", "param_provider", "param_turbonomic_host"
   code <<-EOS
   //replace cookie every day this is run
     var providers = {
@@ -171,7 +171,7 @@ script "js_get_business_units", type: "javascript" do
     }
     var request = {
       verb: "GET",
-      host: "sales1.demo.turbonomic.com",
+      host: param_turbonomic_host,
       path: "/api/v3/businessunits",
       query_params: {
         "cloud_type": providers[param_provider],
@@ -232,10 +232,10 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
         }
         _.each(volume.stats, function(stat){
           if (stat.name === "StorageAmount") {
-            volume.size = stat.capacity.total + " " + stat.units
+            volume.size = stat.capacity.total
           }
           if(stat.name === "StorageAccess") {
-            volume.iops = stat.capacity.total + " " + stat.units
+            volume.iops = stat.capacity.total
           }
         })
         tags = []
@@ -330,11 +330,11 @@ EOS
         label "Created Time"
       end
       field "state" do
-        label "Attachment State"
+        label "State"
         path "attachmentState"
       end
       field "lookbackPeriod" do
-        label "Days Unattached"
+        label "Lookback Period (Days)"
         path "daysUnattached"
       end
       field "id" do
@@ -342,10 +342,10 @@ EOS
         path "resourceID"
       end
       field "iops" do
-        label "Storage Access"
+        label "IOps"
       end
       field "size" do
-        label "Storage Amount"
+        label "Size (GB)"
       end
       field "lastAttachedVm" do
         label "Last Attached VM"

--- a/cost/turbonomics/delete_unattached_volumes/azure/CHANGELOG.md
+++ b/cost/turbonomics/delete_unattached_volumes/azure/CHANGELOG.md
@@ -2,14 +2,15 @@
 
 ## v0.4
 
-- Added `IOps` incident field.
-- Added `Last Attached VM` incident field.
+- Added `Provisioned IOPs` incident field.
+- Added `Last VM` incident field.
 - Added `Action State` incident field.
 - Added `Disruptiveness` incident field.
 - Added `Reversibility` incident field.
 - Added `System Details URL` incident field.
-- Renamed `Days Unattached` incident field to `Lookback Period`.
 - Renamed `Attachment State` incident field to `State`.
+- Renamed `Created Time` incident field to `Action Created Time`.
+- Renamed `Unused Days` parameter to `Days Unattached`.
 - Changed internal names of several incident fields to ensure that they are properly scraped for dashboards.
 - Removed hardcoded host on business units path.
 

--- a/cost/turbonomics/delete_unattached_volumes/azure/CHANGELOG.md
+++ b/cost/turbonomics/delete_unattached_volumes/azure/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.4
+
+- Added `IOps` incident field.
+- Added `Last Attached VM` incident field.
+- Added `Action State` incident field.
+- Added `Disruptiveness` incident field.
+- Added `Reversibility` incident field.
+- Added `System Details URL` incident field.
+- Renamed `Days Unattached` incident field to `Lookback Period`.
+- Renamed `Attachment State` incident field to `State`.
+- Changed internal names of several incident fields to ensure that they are properly scraped for dashboards.
+- Removed hardcoded host on business units path.
+
 ## v0.3
 
 - Fixed readme Link in the policy.

--- a/cost/turbonomics/delete_unattached_volumes/azure/turbonomics_delete_virtual_volumes.pt
+++ b/cost/turbonomics/delete_unattached_volumes/azure/turbonomics_delete_virtual_volumes.pt
@@ -38,7 +38,7 @@ end
 
 parameter "param_days_unattached" do
   type "number"
-  label "Unused days"
+  label "Days Unattached"
   description "The number of days a volume has been unused. The days should be greater than zero"
   default 30
   min_value 1
@@ -100,7 +100,7 @@ datasource "ds_get_turbonomics_recommendations" do
       field "actionState", jmes_path(col_item, "actionState")
       field "disruptiveness", jmes_path(col_item, "executionCharacteristics.disruptiveness")
       field "reversibility", jmes_path(col_item, "executionCharacteristics.reversibility")
-      field "lastAttachedVm", jmes_path(col_item, "target.aspects.virtualDisksAspect.virtualDisks[0].lastAttachedVm")
+      field "lastVm", jmes_path(col_item, "target.aspects.virtualDisksAspect.virtualDisks[0].lastAttachedVm")
       field "uuid", jmes_path(col_item, "uuid")
     end
   end
@@ -326,29 +326,29 @@ EOS
       field "tags" do
         label "Tags"
       end
-      field "createdTime" do
-        label "Created Time"
+      field "actionCreatedTime" do
+        label "Action Created Time"
+        path "createdTime"
       end
       field "state" do
         label "State"
         path "attachmentState"
       end
-      field "lookbackPeriod" do
-        label "Lookback Period (Days)"
-        path "daysUnattached"
+      field "daysUnattached" do
+        label "Days Unattached"
       end
       field "id" do
         label "Resource ID"
         path "resourceID"
       end
       field "iops" do
-        label "IOps"
+        label "Provisioned IOPs"
       end
       field "size" do
         label "Size (GB)"
       end
-      field "lastAttachedVm" do
-        label "Last Attached VM"
+      field "lastVm" do
+        label "Last VM"
       end
       field "actionState" do
         label "Action State"
@@ -363,6 +363,7 @@ EOS
         label "System Details URL"
       end
     end
+
     escalate $esc_email
   end
 end

--- a/cost/turbonomics/delete_unattached_volumes/azure/turbonomics_delete_virtual_volumes.pt
+++ b/cost/turbonomics/delete_unattached_volumes/azure/turbonomics_delete_virtual_volumes.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.3",
+  version: "0.4",
   provider: "Azure",
   source: "Turbonomic",
   service: "Storage",
@@ -94,9 +94,14 @@ datasource "ds_get_turbonomics_recommendations" do
       field "createdTime", jmes_path(col_item, "createTime")
       field "attachmentState", jmes_path(col_item, "target.aspects.virtualDisksAspect.virtualDisks[0].attachmentState")
       field "daysUnattached", jmes_path(col_item, "target.aspects.virtualDisksAspect.virtualDisks[0].numDaysUnattached")
-      field "size", jmes_path(col_item, "target.aspects.virtualDisksAspect.virtualDisks[0].stats")
+      field "stats", jmes_path(col_item, "target.aspects.virtualDisksAspect.virtualDisks[0].stats")
       field "savings", jmes_path(col_item, "stats[0].value")
       field "savingsCurrency", jmes_path(col_item, "stats[0].units")
+      field "actionState", jmes_path(col_item, "actionState")
+      field "disruptiveness", jmes_path(col_item, "executionCharacteristics.disruptiveness")
+      field "reversibility", jmes_path(col_item, "executionCharacteristics.reversibility")
+      field "lastAttachedVm", jmes_path(col_item, "target.aspects.virtualDisksAspect.virtualDisks[0].lastAttachedVm")
+      field "uuid", jmes_path(col_item, "uuid")
     end
   end
 end
@@ -104,7 +109,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, $auth_cookie, $param_provider
+    run_script $js_get_business_units, $auth_cookie, $param_provider, $param_turbonomic_host
   end
   result do
     encoding "json"
@@ -117,7 +122,7 @@ datasource "ds_get_business_units" do
 end
 
 datasource "ds_filtered_turbonomics_recommendations" do
-  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $param_days_unattached, $ds_get_business_units, $param_provider
+  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $param_days_unattached, $ds_get_business_units, $param_provider, $param_turbonomic_host
 end
 
 ###############################################################################
@@ -156,7 +161,7 @@ end
 ## verified that discovered is the only one we need
 script "js_get_business_units", type: "javascript" do
   result "request"
-  parameters "auth_cookie", "param_provider"
+  parameters "auth_cookie", "param_provider", "param_turbonomic_host"
   code <<-EOS
   //replace cookie every day this is run
     var providers = {
@@ -166,7 +171,7 @@ script "js_get_business_units", type: "javascript" do
     }
     var request = {
       verb: "GET",
-      host: "sales1.demo.turbonomic.com",
+      host: param_turbonomic_host,
       path: "/api/v3/businessunits",
       query_params: {
         "cloud_type": providers[param_provider],
@@ -182,7 +187,7 @@ end
 
 script "js_filtered_turbonomics_recommendations", type: "javascript" do
   result "result"
-  parameters "ds_get_turbonomics_recommendations", "param_days_unattached", "ds_get_business_units", "param_provider"
+  parameters "ds_get_turbonomics_recommendations", "param_days_unattached", "ds_get_business_units", "param_provider", "param_turbonomic_host"
   code <<-EOS
     instances = []
     monthlySavings = 0.0
@@ -225,10 +230,12 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
         } else {
           volume.savingsCurrency = "$"
         }
-        _.each(volume.size, function(stat){
+        _.each(volume.stats, function(stat){
           if (stat.name === "StorageAmount") {
-            volume.size = stat.capacity.total + " " + stat.units
-            return
+            volume.size = stat.capacity.total
+          }
+          if(stat.name === "StorageAccess") {
+            volume.iops = stat.capacity.total
           }
         })
         tags = []
@@ -251,6 +258,7 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
         }
         volume.savings = (Math.round(volume.savings * 730 * 1000) / 1000)
         monthlySavings = monthlySavings + volume.savings
+        volume.url = param_turbonomic_host + "/app/index.html#/view/main/action/" + volume.uuid
         instances.push(volume)
       }
     })
@@ -321,18 +329,38 @@ EOS
       field "createdTime" do
         label "Created Time"
       end
-      field "attachmentState" do
-        label "Attachment State"
+      field "state" do
+        label "State"
+        path "attachmentState"
       end
-      field "daysUnattached" do
-        label "Days Unattached"
-      end
-      field "size" do
-        label "Size"
+      field "lookbackPeriod" do
+        label "Lookback Period (Days)"
+        path "daysUnattached"
       end
       field "id" do
         label "Resource ID"
         path "resourceID"
+      end
+      field "iops" do
+        label "IOps"
+      end
+      field "size" do
+        label "Size (GB)"
+      end
+      field "lastAttachedVm" do
+        label "Last Attached VM"
+      end
+      field "actionState" do
+        label "Action State"
+      end
+      field "disruptiveness" do
+        label "Disruptiveness"
+      end
+      field "reversibility" do
+        label "Reversibility"
+      end
+      field "url" do
+        label "System Details URL"
       end
     end
     escalate $esc_email


### PR DESCRIPTION
### Description

Azure Unattached Volumes policy needs to show the following information: storage access IOPs, storage amount, last VM volumes was attached to, action nature: disruptive or not, reversible or not, system details URL.

### Issues Resolved

Added all requested fields and normalized incident fields.

### Link to Example Applied Policy

- Azure delete unattached volumes: https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/60073?policyId=64bec383cd41360001891b08
- AWS delete unattached volumes: https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/60073?policyId=64bfff2285ab670001ff6c0f

### Contribution Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
