### PR TITLE
FOPTS-1441 Google Cloud SQL Idle Instance Recommender: fix the method to match the recommendations with the SQL instances at the 

### DIFF
--- a/cost/google/cloud_sql_idle_instance_recommendations/CHANGELOG.md
+++ b/cost/google/cloud_sql_idle_instance_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.11
+
+- Fixed the method used to match recommendations with the SQL instances introduced at v2.6
+
 ## v2.10
 
 - Updated policy README file with a deeper explanation of how the GCP recommender works and the roles required to use it.

--- a/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations.pt
+++ b/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.10",
+  version: "2.11",
   provider:"Google",
   service: "SQL",
   policy_set: "Unused Database Services",
@@ -345,13 +345,14 @@ script "js_sql_instances_cost_mapping", type:"javascript" do
     var cur = ""
 
     _.each(databases, function(database) {
-        var resource_link = database.selfLink.replace("https://www.googleapis.com/compute/v1/", "")
+        var resource_link = database.selfLink.replace("https://sqladmin.googleapis.com/v1/", "")
         database["resourceLink"] = resource_link
     })
 
     _.each(recommendations, function (recommendation) {
         count ++
-        var rec_resource_link = recommendation.resourceLink.replace("//compute.googleapis.com/", "")
+        var rec_resource_link = recommendation.resourceLink.replace("//sqladmin.googleapis.com/v1/", "")
+        rec_resource_link = rec_resource_link.slice(0, rec_resource_link.indexOf("/locations")) + rec_resource_link.slice(rec_resource_link.indexOf("/instances"))
         var database = _.find(databases, function(db) {
             return db.resourceLink == rec_resource_link
         })


### PR DESCRIPTION
### Description

The method used to match recommendations with SQL instances was copied from other recommender policies, this was making this policy not show any recommendation.

### Issues Resolved

- https://flexera.atlassian.net/browse/FOPTS-1441
- https://flexera.atlassian.net/browse/SQ-3178

### Link to Example Applied Policy

Currently I don't have any account where I could test this, but I tested with the following code:

https://flexera.atlassian.net/browse/FOPTS-1441?focusedCommentId=2133467

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
