### PR TITLE
FOPTS-1325 Turbonomic Unattached Volumes (GCP) 

### DIFF
--- a/cost/turbonomics/delete_unattached_volumes/gcp/CHANGELOG.md
+++ b/cost/turbonomics/delete_unattached_volumes/gcp/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.5
+
+- Added `Provisioned IOPs` incident field.
+- Added `Last VM` incident field.
+- Added `Action State` incident field.
+- Added `Disruptiveness` incident field.
+- Added `Reversibility` incident field.
+- Added `System Details URL` incident field.
+- Renamed `Attachment State` incident field to `State`.
+- Renamed `Created Time` incident field to `Action Created Time`.
+- Renamed `Unused Days` parameter to `Days Unattached`.
+- Changed internal names of several incident fields to ensure that they are properly scraped for dashboards.
+- Removed hardcoded host on business units path.
+
 ## v0.4
 
 - Updates provider from GCP to Google

--- a/cost/turbonomics/delete_unattached_volumes/gcp/CHANGELOG.md
+++ b/cost/turbonomics/delete_unattached_volumes/gcp/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Renamed `Created Time` incident field to `Action Created Time`.
 - Renamed `Unused Days` parameter to `Days Unattached`.
 - Changed internal names of several incident fields to ensure that they are properly scraped for dashboards.
-- Removed hardcoded host on business units path.
+- Turbonomic business units are now retrieved from `Turbonomic API Host endpoint` parameter instead of `sales1.demo.turbonomic.com` host.
 
 ## v0.4
 

--- a/cost/turbonomics/delete_unattached_volumes/gcp/turbonomics_delete_virtual_volumes.pt
+++ b/cost/turbonomics/delete_unattached_volumes/gcp/turbonomics_delete_virtual_volumes.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.4",
+  version: "0.5",
   provider: "Google",
   source: "Turbonomic",
   service: "Storage",
@@ -38,7 +38,7 @@ end
 
 parameter "param_days_unattached" do
   type "number"
-  label "Unused days"
+  label "Days Unattached"
   description "The number of days a volume has been unused. The days should be greater than zero"
   default 30
   min_value 1
@@ -94,9 +94,14 @@ datasource "ds_get_turbonomics_recommendations" do
       field "createdTime", jmes_path(col_item, "createTime")
       field "attachmentState", jmes_path(col_item, "target.aspects.virtualDisksAspect.virtualDisks[0].attachmentState")
       field "daysUnattached", jmes_path(col_item, "target.aspects.virtualDisksAspect.virtualDisks[0].numDaysUnattached")
-      field "size", jmes_path(col_item, "target.aspects.virtualDisksAspect.virtualDisks[0].stats")
+      field "stats", jmes_path(col_item, "target.aspects.virtualDisksAspect.virtualDisks[0].stats")
       field "savings", jmes_path(col_item, "stats[0].value")
       field "savingsCurrency", jmes_path(col_item, "stats[0].units")
+      field "actionState", jmes_path(col_item, "actionState")
+      field "disruptiveness", jmes_path(col_item, "executionCharacteristics.disruptiveness")
+      field "reversibility", jmes_path(col_item, "executionCharacteristics.reversibility")
+      field "lastVm", jmes_path(col_item, "target.aspects.virtualDisksAspect.virtualDisks[0].lastAttachedVm")
+      field "uuid", jmes_path(col_item, "uuid")
     end
   end
 end
@@ -104,7 +109,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, $auth_cookie, $param_provider
+    run_script $js_get_business_units, $auth_cookie, $param_provider, $param_turbonomic_host
   end
   result do
     encoding "json"
@@ -117,7 +122,7 @@ datasource "ds_get_business_units" do
 end
 
 datasource "ds_filtered_turbonomics_recommendations" do
-  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $param_days_unattached, $ds_get_business_units, $param_provider
+  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $param_days_unattached, $ds_get_business_units, $param_provider, $param_turbonomic_host
 end
 
 ###############################################################################
@@ -157,7 +162,7 @@ end
 ## verified that discovered is the only one we need
 script "js_get_business_units", type: "javascript" do
   result "request"
-  parameters "auth_cookie", "param_provider"
+  parameters "auth_cookie", "param_provider", "param_turbonomic_host"
   code <<-EOS
   //replace cookie every day this is run
     var providers = {
@@ -167,7 +172,7 @@ script "js_get_business_units", type: "javascript" do
     }
     var request = {
       verb: "GET",
-      host: "sales1.demo.turbonomic.com",
+      host: param_turbonomic_host,
       path: "/api/v3/businessunits",
       query_params: {
         "cloud_type": providers[param_provider],
@@ -183,7 +188,7 @@ end
 
 script "js_filtered_turbonomics_recommendations", type: "javascript" do
   result "result"
-  parameters "ds_get_turbonomics_recommendations", "param_days_unattached", "ds_get_business_units", "param_provider"
+  parameters "ds_get_turbonomics_recommendations", "param_days_unattached", "ds_get_business_units", "param_provider", "param_turbonomic_host"
   code <<-EOS
     instances = []
     monthlySavings = 0.0
@@ -226,10 +231,12 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
         } else {
           volume.savingsCurrency = "$"
         }
-        _.each(volume.size, function(stat){
+        _.each(volume.stats, function(stat){
           if (stat.name === "StorageAmount") {
-            volume.size = stat.capacity.total + " " + stat.units
-            return
+            volume.size = stat.capacity.total
+          }
+          if(stat.name === "StorageAccess") {
+            volume.iops = stat.capacity.total
           }
         })
         tags = []
@@ -252,6 +259,7 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
         }
         volume.savings = (Math.round(volume.savings * 730 * 1000) / 1000)
         monthlySavings = monthlySavings + volume.savings
+        volume.url = param_turbonomic_host + "/app/index.html#/view/main/action/" + volume.uuid
         instances.push(volume)
       }
     })
@@ -319,21 +327,41 @@ EOS
       field "tags" do
         label "Tags"
       end
-      field "createdTime" do
-        label "Created Time"
+      field "actionCreatedTime" do
+        label "Action Created Time"
+        path "createdTime"
       end
-      field "attachmentState" do
-        label "Attachment State"
+      field "state" do
+        label "State"
+        path "attachmentState"
       end
       field "daysUnattached" do
         label "Days Unattached"
       end
-      field "size" do
-        label "Size"
-      end
       field "id" do
         label "Resource ID"
         path "resourceID"
+      end
+      field "iops" do
+        label "Provisioned IOPs"
+      end
+      field "size" do
+        label "Size (GB)"
+      end
+      field "lastVm" do
+        label "Last VM"
+      end
+      field "actionState" do
+        label "Action State"
+      end
+      field "disruptiveness" do
+        label "Disruptiveness"
+      end
+      field "reversibility" do
+        label "Reversibility"
+      end
+      field "url" do
+        label "System Details URL"
       end
     end
     escalate $esc_email


### PR DESCRIPTION
### Description

GCP Unattached Volumes policy needs to show the following information: storage access IOPs, storage amount, last VM volumes was attached to, action nature: disruptive or not, reversible or not, system details URL.

### Issues Resolved

Added all requested fields and normalized incident fields.

### Link to Example Applied Policy

- GCP delete unattached volumes: https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/60073?policyId=64c31164cd41360001891b57

### Contribution Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD