### PR TITLE
FOPTS-172 Add: Azure MCA RI Utilization PT

### DIFF
--- a/cost/azure/reserved_instances/utilization_mca/CHANGELOG.md
+++ b/cost/azure/reserved_instances/utilization_mca/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## v1.0
 
 - Initial release

--- a/cost/azure/reserved_instances/utilization_mca/CHANGELOG.md
+++ b/cost/azure/reserved_instances/utilization_mca/CHANGELOG.md
@@ -1,0 +1,3 @@
+## v1.0
+
+- Initial release

--- a/cost/azure/reserved_instances/utilization_mca/README.md
+++ b/cost/azure/reserved_instances/utilization_mca/README.md
@@ -1,0 +1,43 @@
+# Azure Reserved Instances Utilization MCA
+
+## What it does
+
+This Policy Template leverages the [Azure API for Reserved Instance Utilization and Details](https://learn.microsoft.com/en-us/rest/api/reserved-vm-instances/reservation/list-all). It will notify only if utilization of a RI falls below the value specified in the `Show Reservations with utilization below this value (%)` field. It examines the RI utilization for the prior 7 days or 30 days.
+
+## Input Parameters
+
+This policy has the following input parameters required when launching the policy.
+
+- *Azure Endpoint* - Azure Endpoint to access resources
+- *Look Back Period* - The number of days of past Azure Reservation Utilization data to analyze
+- *Show Reservations with utilization below this value (%)* - Number between 1 and 100
+- *Email addresses of the recipients you wish to notify* - A list of email addresses to notify
+
+## Policy Actions
+
+The following policy actions are taken on any resources found to be out of compliance.
+
+- Send an email report
+
+## Prerequisites
+
+This policy uses [credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for connecting to the cloud -- in order to apply this policy you must have a credential registered in the system that is compatible with this policy. If there are no credentials listed when you apply the policy, please contact your cloud admin and ask them to register a credential that is compatible with this policy. The information below should be consulted when creating the credential.
+
+### Credential configuration
+
+For administrators [creating and managing credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) to use with this policy, the following information is needed:
+
+Provider tag value to match this policy: `azure_rm`
+
+Required permissions in the provider:
+
+- Microsoft.Capacity/reservationorders/read
+
+## Supported Clouds
+
+- Azure
+
+## Cost
+
+This Policy Template does not launch any instances, and so does not incur any cloud costs.
+

--- a/cost/azure/reserved_instances/utilization_mca/azure_reserved_instance_utilization_mca.pt
+++ b/cost/azure/reserved_instances/utilization_mca/azure_reserved_instance_utilization_mca.pt
@@ -88,7 +88,7 @@ datasource "ds_revervation_all" do
     collect jq(response, '.value[]?') do
       field "id", jq(col_item, ".id")
       field "reservationId", jq(col_item, ".name")
-      field "location", jq(col_item, ".location")
+      field "region", jq(col_item, ".location")
       field "sku", jq(col_item, ".sku.name")
       field "reservedResourceType", jq(col_item, ".properties.reservedResourceType")
       field "term", jq(col_item, ".properties.term")
@@ -125,7 +125,7 @@ script "js_get_reservations_below_utilization", type: "javascript" do
     
         if (utilizationValue < param_utilization) {
             reservation.reservationOrderId = reservation.id.replace("/providers/microsoft.capacity/reservationOrders/", "").replace("/reservations/" + reservation.reservationId, "");
-            reservation.lookBackPeriod = grain + " days";
+            reservation.lookbackPeriod = grain + " days";
             reservation.utilizationPercentage = utilizationValue;
     
             result.push(reservation);
@@ -142,7 +142,7 @@ policy "pol_azure_active_reserved_instances" do
   validate $ds_reservations_below_utilization do
     summary_template "{{ len data }} Azure Reserved Instances below {{ parameters.param_utilization }}% of utilization - {{ parameters.param_lookback_period }}"
     escalate $esc_email
-    check false
+    check eq(size(data), 0)
     export do
       field "displayName" do
         label "Display name"
@@ -165,7 +165,7 @@ policy "pol_azure_active_reserved_instances" do
       field "reservationOrderId" do
         label "Reservation order ID"
       end
-      field "location" do
+      field "region" do
         label "Region"
       end
       field "sku" do
@@ -183,8 +183,8 @@ policy "pol_azure_active_reserved_instances" do
       field "billingPlan" do
         label "Reservation billing plan"
       end
-      field "lookBackPeriod" do
-        label "Look Back Period"
+      field "lookbackPeriod" do
+        label "Lookback Period"
       end
       field "utilizationPercentage" do
         label "Utilization percentage"

--- a/cost/azure/reserved_instances/utilization_mca/azure_reserved_instance_utilization_mca.pt
+++ b/cost/azure/reserved_instances/utilization_mca/azure_reserved_instance_utilization_mca.pt
@@ -76,39 +76,6 @@ end
 # Datasources & Scripts
 ###############################################################################
 
-datasource "ds_billing_accounts" do
-  request do
-    auth $auth_azure
-    verb "GET"
-    host $param_azure_endpoint
-    path "/providers/Microsoft.Billing/billingAccounts"
-    query "api-version", "2019-10-01-preview"
-  end
-  result do
-    collect jq(response, '.value[]?') do
-      field "name", jq(col_item, ".name")
-    end
-  end
-end
-
-datasource "ds_billing_profiles" do
-  iterate $ds_billing_accounts
-  request do
-    auth $auth_azure
-    verb "GET"
-    host $param_azure_endpoint
-    path join(["/providers/Microsoft.Billing/billingAccounts/", val(iter_item, "name") , "/billingProfiles"])
-    query "api-version", "2019-10-01-preview"
-  end
-  result do
-    collect jq(response, '.value[]?') do
-      field "id", jq(col_item, ".id")
-      field "name", jq(col_item, ".name")
-      field "properties", jq(col_item, ".properties")
-    end
-  end
-end
-
 datasource "ds_revervation_all" do
   request do
     auth $auth_azure
@@ -158,7 +125,7 @@ script "js_get_reservations_below_utilization", type: "javascript" do
     
         if (utilizationValue < param_utilization) {
             reservation.reservationOrderId = reservation.id.replace("/providers/microsoft.capacity/reservationOrders/", "").replace("/reservations/" + reservation.reservationId, "");
-            reservation.utilizationDays = grain + " days";
+            reservation.lookBackPeriod = grain + " days";
             reservation.utilizationPercentage = utilizationValue;
     
             result.push(reservation);
@@ -173,7 +140,7 @@ end
 
 policy "pol_azure_active_reserved_instances" do
   validate $ds_reservations_below_utilization do
-    summary_template "Example of MCA"
+    summary_template "{{ len data }} Azure Reserved Instances below {{ parameters.param_utilization }}% of utilization - {{ parameters.param_lookback_period }}"
     escalate $esc_email
     check false
     export do
@@ -216,8 +183,8 @@ policy "pol_azure_active_reserved_instances" do
       field "billingPlan" do
         label "Reservation billing plan"
       end
-      field "utilizationDays" do
-        label "Utilization days"
+      field "lookBackPeriod" do
+        label "Look Back Period"
       end
       field "utilizationPercentage" do
         label "Utilization percentage"

--- a/cost/azure/reserved_instances/utilization_mca/azure_reserved_instance_utilization_mca.pt
+++ b/cost/azure/reserved_instances/utilization_mca/azure_reserved_instance_utilization_mca.pt
@@ -1,0 +1,238 @@
+name "Azure Reserved Instances Utilization MCA"
+rs_pt_ver 20180301
+type "policy"
+short_description "A policy that sends email notifications when utilization falls below a threshold. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/reserved_instances/utilization_mca) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+long_description ""
+severity "medium"
+category "Cost"
+default_frequency "weekly"
+info(
+  version: "1.0",
+  provider: "Azure",
+  service: "Compute",
+  policy_set: ""
+)
+
+###############################################################################
+# Parameters
+###############################################################################
+
+parameter "param_utilization" do
+  category "RI"
+  label "Show Reservations with utilization below this value (%)"
+  type "number"
+  min_value 1
+  max_value 100
+  default 100
+end
+
+parameter "param_azure_endpoint" do
+  type "string"
+  label "Azure Endpoint"
+  description "Azure Endpoint to access resources"
+  allowed_values "management.azure.com", "management.chinacloudapi.cn"
+  default "management.azure.com"
+end
+
+parameter "param_lookback_period" do
+  category "Savings Plan"
+  label "Look Back Period"
+  default "Last 7 days"
+  description "The number of days of past Azure Reservation Utilization data to analyze"
+  allowed_values "Last 7 days", "Last 30 days"
+  type "string"
+end
+
+parameter "param_email" do
+  type "list"
+  label "Email addresses of the recipients you wish to notify"
+end
+
+###############################################################################
+# Authentication
+###############################################################################
+
+credentials "auth_azure" do
+  schemes "oauth2"
+  label "Azure"
+  description "Select the Azure Resource Manager Credential from the list."
+  tags "provider=azure_rm"
+end
+
+###############################################################################
+# Pagination
+###############################################################################
+
+pagination "pagination_azure" do
+  get_page_marker do
+    body_path "nextLink"
+  end
+  set_page_marker do
+    uri true
+  end
+end
+
+###############################################################################
+# Datasources & Scripts
+###############################################################################
+
+datasource "ds_billing_accounts" do
+  request do
+    auth $auth_azure
+    verb "GET"
+    host $param_azure_endpoint
+    path "/providers/Microsoft.Billing/billingAccounts"
+    query "api-version", "2019-10-01-preview"
+  end
+  result do
+    collect jq(response, '.value[]?') do
+      field "name", jq(col_item, ".name")
+    end
+  end
+end
+
+datasource "ds_billing_profiles" do
+  iterate $ds_billing_accounts
+  request do
+    auth $auth_azure
+    verb "GET"
+    host $param_azure_endpoint
+    path join(["/providers/Microsoft.Billing/billingAccounts/", val(iter_item, "name") , "/billingProfiles"])
+    query "api-version", "2019-10-01-preview"
+  end
+  result do
+    collect jq(response, '.value[]?') do
+      field "id", jq(col_item, ".id")
+      field "name", jq(col_item, ".name")
+      field "properties", jq(col_item, ".properties")
+    end
+  end
+end
+
+datasource "ds_revervation_all" do
+  request do
+    auth $auth_azure
+    verb "GET"
+    host $param_azure_endpoint
+    path "/providers/Microsoft.Capacity/reservations"
+    query "api-version", "2022-11-01"
+  end
+  result do
+    collect jq(response, '.value[]?') do
+      field "id", jq(col_item, ".id")
+      field "reservationId", jq(col_item, ".name")
+      field "location", jq(col_item, ".location")
+      field "sku", jq(col_item, ".sku.name")
+      field "reservedResourceType", jq(col_item, ".properties.reservedResourceType")
+      field "term", jq(col_item, ".properties.term")
+      field "instanceFlexibility", jq(col_item, ".properties.instanceFlexibility")
+      field "displayName", jq(col_item, ".properties.displayName")
+      field "billingScopeId", jq(col_item, ".properties.billingScopeId")
+      field "billingPlan", jq(col_item, ".properties.billingPlan")
+      field "utilizationAggregates", jq(col_item, ".properties.utilization.aggregates")
+      field "quantity", jq(col_item, ".properties.quantity")
+      field "expiryDate", jq(col_item, ".properties.expiryDateTime")
+      field "appliedScopeType", jq(col_item, ".properties.appliedScopeType")
+    end
+  end
+end
+
+datasource "ds_reservations_below_utilization" do
+  run_script $js_get_reservations_below_utilization, $ds_revervation_all, $param_lookback_period, $param_utilization
+end
+
+script "js_get_reservations_below_utilization", type: "javascript" do
+  parameters "ds_reservation_all", "param_lookback_period", "param_utilization"
+  result "result"
+  code <<-EOS
+    var result = [];
+
+    var grain = 30;
+    
+    if (param_lookback_period == "Last 7 days") {
+        grain = 7;
+    }
+    
+    _.each(ds_reservation_all, function (reservation) {
+        var utilizationValue = _.findWhere(reservation.utilizationAggregates, { grain: grain }).value;
+    
+        if (utilizationValue < param_utilization) {
+            reservation.reservationOrderId = reservation.id.replace("/providers/microsoft.capacity/reservationOrders/", "").replace("/reservations/" + reservation.reservationId, "");
+            reservation.utilizationDays = grain + " days";
+            reservation.utilizationPercentage = utilizationValue;
+    
+            result.push(reservation);
+        }
+    });
+  EOS
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "pol_azure_active_reserved_instances" do
+  validate $ds_reservations_below_utilization do
+    summary_template "Example of MCA"
+    escalate $esc_email
+    check false
+    export do
+      field "displayName" do
+        label "Display name"
+      end
+      field "appliedScopeType" do
+        label "Applied scope type"
+      end
+      field "expiryDate" do
+        label "Expiry date"
+      end
+      field "quantity" do
+        label "Quantity"
+      end
+      field "reservedResourceType" do
+        label "Reserved resource type"
+      end
+      field "reservationId" do
+        label "Reservation ID"
+      end
+      field "reservationOrderId" do
+        label "Reservation order ID"
+      end
+      field "location" do
+        label "Region"
+      end
+      field "sku" do
+        label "Instance type"
+      end
+      field "term" do
+        label "Term"
+      end
+      field "instanceFlexibility" do
+        label "Instance flexibility"
+      end
+      field "billingScopeId" do
+        label "Purchasing subscription"
+      end
+      field "billingPlan" do
+        label "Reservation billing plan"
+      end
+      field "utilizationDays" do
+        label "Utilization days"
+      end
+      field "utilizationPercentage" do
+        label "Utilization percentage"
+      end
+    end
+  end
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Sends incident email"
+  email $param_email
+end

--- a/cost/azure/reserved_instances/utilization_mca/azure_reserved_instance_utilization_mca.pt
+++ b/cost/azure/reserved_instances/utilization_mca/azure_reserved_instance_utilization_mca.pt
@@ -17,15 +17,6 @@ info(
 # Parameters
 ###############################################################################
 
-parameter "param_utilization" do
-  category "RI"
-  label "Show Reservations with utilization below this value (%)"
-  type "number"
-  min_value 1
-  max_value 100
-  default 100
-end
-
 parameter "param_azure_endpoint" do
   type "string"
   label "Azure Endpoint"
@@ -41,6 +32,15 @@ parameter "param_lookback_period" do
   description "The number of days of past Azure Reservation Utilization data to analyze"
   allowed_values "Last 7 days", "Last 30 days"
   type "string"
+end
+
+parameter "param_utilization" do
+  category "RI"
+  label "Show Reservations with utilization below this value (%)"
+  type "number"
+  min_value 1
+  max_value 100
+  default 100
 end
 
 parameter "param_email" do


### PR DESCRIPTION
### Description

The Azure RI Utilization policy currently only supports Azure EA.  We should create a new version modeled after the Azure EA policy that supports the Azure MCA API.  

EA version: https://github.com/flexera-public/policy_templates/tree/master/cost/azure/reserved_instances/utilization

More details: [here](https://flexera.atlassian.net/browse/FOPTS-172).

### Issues Resolved

Add support for MCA accounts to get a list of reserved instances with an utilization below a value using a full new policy template.

### Link to Example Applied Policy

https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/104308?policyId=64ca8480cd41360001891bed

### Contribution Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
