### PR TITLE
POL-861 Google Cost Policy README Permissions Updates

### DIFF
--- a/cost/google/cloud_sql_idle_instance_recommendations/README.md
+++ b/cost/google/cloud_sql_idle_instance_recommendations/README.md
@@ -47,10 +47,21 @@ For administrators [creating and managing credentials](https://docs.flexera.com/
 
 Provider tag value to match this policy: `gce`
 
+Required APIs to have enabled in the provider:
+
+- Resource Manager API
+- Cloud SQL Admin API
+- Recommender API
+
 Required permissions in the provider:
 
-- The `resourcemanager.projects.get` permission
-- The `roles/recommender.cloudsqlAdmin` role
+- resourcemanager.projects.get
+- cloudsql.instances.list
+- recommender.cloudsqlIdleInstanceRecommendations.list
+
+Required roles in the provider:
+
+- Cloud SQL Recommender Viewer
 
 ## Supported Clouds
 

--- a/cost/google/cud_recommendations/README.md
+++ b/cost/google/cud_recommendations/README.md
@@ -32,11 +32,22 @@ For administrators [creating and managing credentials](https://docs.flexera.com/
 
 Provider tag value to match this policy: `gce`
 
+Required APIs to have enabled in the provider:
+
+- Resource Manager API
+- Recommender API
+
 Required permissions in the provider:
 
-- The `resourcemanager.projects.get` permission
-- The `roles/recommender.billingAccountCudViewer` role
-- The `roles/recommender.projectCudViewer` role
+- resourcemanager.projects.get
+- billing.resourceCosts.get*
+- billing.accounts.getSpendingInformation*
+
+Required roles in the provider:
+
+- Project Usage Commitment Recommender Viewer
+
+\* Needed for recommendations to reflect custom contract pricing. Otherwise, recommendations will use list pricing.
 
 ## Supported Clouds
 

--- a/cost/google/idle_ip_address_recommendations/README.md
+++ b/cost/google/idle_ip_address_recommendations/README.md
@@ -33,6 +33,7 @@ This policy has the following input parameters required when launching the polic
 The following policy actions are taken on any resources found to be out of compliance.
 
 - Send an email report
+- Delete idle IP address after an approval
 
 ## Prerequisites
 
@@ -46,10 +47,23 @@ For administrators [creating and managing credentials](https://docs.flexera.com/
 
 Provider tag value to match this policy: `gce`
 
+Required APIs to have enabled in the provider:
+
+- Resource Manager API
+- Compute Engine API
+- Recommender API
+
 Required permissions in the provider:
 
-- The `resourcemanager.projects.get` permission
-- The `roles/recommender.computeAdmin` role
+- resourcemanager.projects.get
+- compute.addresses.list
+
+Required roles in the provider:
+
+- Compute Recommender Viewer
+- Compute Recommender Admin*
+
+\* Only required for taking action (deletion); the policy will still function in a read-only capacity without these permissions.
 
 ## Supported Clouds
 

--- a/cost/google/idle_persistent_disk_recommendations/README.md
+++ b/cost/google/idle_persistent_disk_recommendations/README.md
@@ -34,6 +34,7 @@ This policy has the following input parameters required when launching the polic
 The following policy actions are taken on any resources found to be out of compliance.
 
 - Send an email report
+- Delete volume after an approval
 
 ## Prerequisites
 
@@ -47,10 +48,23 @@ For administrators [creating and managing credentials](https://docs.flexera.com/
 
 Provider tag value to match this policy: `gce`
 
+Required APIs to have enabled in the provider:
+
+- Resource Manager API
+- Compute Engine API
+- Recommender API
+
 Required permissions in the provider:
 
-- The `resourcemanager.projects.get` permission
-- The `roles/recommender.computeAdmin` role
+- resourcemanager.projects.get
+- compute.disks.list
+
+Required roles in the provider:
+
+- Compute Recommender Viewer
+- Compute Recommender Admin*
+
+\* Only required for taking action (deletion); the policy will still function in a read-only capacity without these permissions.
 
 ## Supported Clouds
 

--- a/cost/google/idle_vm_recommendations/README.md
+++ b/cost/google/idle_vm_recommendations/README.md
@@ -35,6 +35,7 @@ This policy has the following input parameters required when launching the polic
 The following policy actions are taken on any resources found to be out of compliance.
 
 - Send an email report
+- Terminate idle VM after an approval
 
 ## Prerequisites
 
@@ -48,10 +49,24 @@ For administrators [creating and managing credentials](https://docs.flexera.com/
 
 Provider tag value to match this policy: `gce`
 
+Required APIs to have enabled in the provider:
+
+- Resource Manager API
+- Compute Engine API
+- Recommender API
+
 Required permissions in the provider:
 
-- The `resourcemanager.projects.get` permission
-- The `roles/recommender.computeAdmin` role
+- resourcemanager.projects.get
+- monitoring.timeSeries.list
+- compute.instances.list
+
+Required roles in the provider:
+
+- Compute Recommender Viewer
+- Compute Recommender Admin*
+
+\* Only required for taking action (termination); the policy will still function in a read-only capacity without these permissions.
 
 ## Supported Clouds
 


### PR DESCRIPTION
### Description

This updates the README files for several of our cost policies for GCP to more accurately reflect the permissions needed.

No changes are made to the policies themselves, so no testing or version changes are needed.

- [X] New functionality has been documented in the README if applicable
