### PR TITLE
FOPTS-1333 Turbonomic Rightsize DBs (AWS) - Bring recommendation supporting information

### DIFF
--- a/cost/turbonomics/rightsize_databases_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_databases_recommendations/aws/CHANGELOG.md
@@ -5,31 +5,31 @@
 - Added `VM Age` incident field.
 - Added `Pricing Model` incident field.
 - Added `System Details URL` incident field.
-- Added `Current GB Size` incident field.
-- Added `Current GB Size % Utilization` incident field.
-- Added `After GB Size` incident field.
-- Added `After GB Size % Utilization` incident field.
-- Added `Current DTU` incident field.
-- Added `Current DTU % Utilization` incident field.
+- Added `Size (GB)` incident field.
+- Added `Size % Utilization` incident field.
+- Added `After Size (GB)` incident field.
+- Added `After Size % Utilization` incident field.
+- Added `DTU` incident field.
+- Added `DTU % Utilization` incident field.
 - Added `After DTU` incident field.
 - Added `After DTU % Utilization` incident field.
-- Added `Current IOPs` incident field.
-- Added `Current IOPs % Utilization` incident field.
+- Added `IOPs` incident field.
+- Added `IOPs % Utilization` incident field.
 - Added `After IOPs` incident field.
 - Added `After IOPs % Utilization` incident field.
-- Added `Current GB Virtual Memory` incident field.
-- Added `Current GB Virtual Memory % Utilization` incident field.
-- Added `After GB Virtual Memory` incident field.
-- Added `After GB Virtual Memory % Utilization` incident field.
-- Added `Current GHz Virtual CPU` incident field.
-- Added `Current GHz Virtual CPU % Utilization` incident field.
-- Added `After GHz Virtual CPU` incident field.
-- Added `After GHz Virtual CPU % Utilization` incident field.
-- Added `Current MB/s IOThroughput` incident field.
-- Added `Current MB/s IOThroughput % Utilization` incident field.
-- Added `After MB/s IOThroughput` incident field.
-- Added `After MB/s IOThroughput % Utilization` incident field.
-- Added `Current Connections` incident field.
+- Added `Virtual Memory (GB)` incident field.
+- Added `Virtual Memory % Utilization` incident field.
+- Added `After Virtual Memory (GB)` incident field.
+- Added `After Virtual Memory % Utilization` incident field.
+- Added `Virtual CPU (GHz)` incident field.
+- Added `Virtual CPU % Utilization` incident field.
+- Added `After Virtual CPU (GHz)` incident field.
+- Added `After Virtual CPU % Utilization` incident field.
+- Added `IOThroughput (MB/s)` incident field.
+- Added `IOThroughput % Utilization` incident field.
+- Added `After IOThroughput (MB/s)` incident field.
+- Added `After IOThroughput % Utilization` incident field.
+- Added `Connections` incident field.
 - Added `After Connections` incident field.
 
 ## v0.2

--- a/cost/turbonomics/rightsize_databases_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_databases_recommendations/aws/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## v0.3
+
+- Added `VM Age` incident field.
+- Added `Pricing Model` incident field.
+- Added `URL` incident field.
+- Added `Actual Storage Amount` incident field.
+- Added `Actual Storage Amount % Utilization` incident field.
+- Added `New Storage Amount` incident field.
+- Added `New Storage Amount % Utilization` incident field.
+- Added `Actual DTU` incident field.
+- Added `Actual DTU % Utilization` incident field.
+- Added `New DTU` incident field.
+- Added `New DTU % Utilization` incident field.
+- Added `Actual IOPs` incident field.
+- Added `Actual IOPs % Utilization` incident field.
+- Added `New IOPs` incident field.
+- Added `New IOPs % Utilization` incident field.
+- Added `Actual Virtual Memory` incident field.
+- Added `Actual Virtual Memory % Utilization` incident field.
+- Added `New Virtual Memory` incident field.
+- Added `New Virtual Memory % Utilization` incident field.
+- Added `Actual Virtual CPU` incident field.
+- Added `Actual Virtual CPU % Utilization` incident field.
+- Added `New Virtual CPU` incident field.
+- Added `New Virtual CPU % Utilization` incident field.
+- Added `Actual IOThroughput` incident field.
+- Added `Actual IOThroughput  % Utilization` incident field.
+- Added `New IOThroughput` incident field.
+- Added `New IOThroughput  % Utilization` incident field.
+
 ## v0.2
 
 - Links to documentation were added to the short description of the policy.

--- a/cost/turbonomics/rightsize_databases_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_databases_recommendations/aws/CHANGELOG.md
@@ -4,31 +4,31 @@
 
 - Added `VM Age` incident field.
 - Added `Pricing Model` incident field.
-- Added `URL` incident field.
-- Added `Actual Storage Amount` incident field.
-- Added `Actual Storage Amount % Utilization` incident field.
-- Added `New Storage Amount` incident field.
-- Added `New Storage Amount % Utilization` incident field.
-- Added `Actual DTU` incident field.
-- Added `Actual DTU % Utilization` incident field.
-- Added `New DTU` incident field.
-- Added `New DTU % Utilization` incident field.
-- Added `Actual IOPs` incident field.
-- Added `Actual IOPs % Utilization` incident field.
-- Added `New IOPs` incident field.
-- Added `New IOPs % Utilization` incident field.
-- Added `Actual Virtual Memory` incident field.
-- Added `Actual Virtual Memory % Utilization` incident field.
-- Added `New Virtual Memory` incident field.
-- Added `New Virtual Memory % Utilization` incident field.
-- Added `Actual Virtual CPU` incident field.
-- Added `Actual Virtual CPU % Utilization` incident field.
-- Added `New Virtual CPU` incident field.
-- Added `New Virtual CPU % Utilization` incident field.
-- Added `Actual IOThroughput` incident field.
-- Added `Actual IOThroughput  % Utilization` incident field.
-- Added `New IOThroughput` incident field.
-- Added `New IOThroughput  % Utilization` incident field.
+- Added `System Details URL` incident field.
+- Added `Current Size` incident field.
+- Added `Current Size % Utilization` incident field.
+- Added `After Size` incident field.
+- Added `After Size % Utilization` incident field.
+- Added `Current DTU` incident field.
+- Added `Current DTU % Utilization` incident field.
+- Added `After DTU` incident field.
+- Added `After DTU % Utilization` incident field.
+- Added `Current IOPs` incident field.
+- Added `Current IOPs % Utilization` incident field.
+- Added `After IOPs` incident field.
+- Added `After IOPs % Utilization` incident field.
+- Added `Current Virtual Memory` incident field.
+- Added `Current Virtual Memory % Utilization` incident field.
+- Added `After Virtual Memory` incident field.
+- Added `After Virtual Memory % Utilization` incident field.
+- Added `Current Virtual CPU` incident field.
+- Added `Current Virtual CPU % Utilization` incident field.
+- Added `After Virtual CPU` incident field.
+- Added `After Virtual CPU % Utilization` incident field.
+- Added `Current IOThroughput` incident field.
+- Added `Current IOThroughput  % Utilization` incident field.
+- Added `After IOThroughput` incident field.
+- Added `After IOThroughput  % Utilization` incident field.
 
 ## v0.2
 

--- a/cost/turbonomics/rightsize_databases_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_databases_recommendations/aws/CHANGELOG.md
@@ -5,29 +5,29 @@
 - Added `Recommendation Created Time` incident field.
 - Added `System Details URL` incident field.
 - Added `Storage (GB)` incident field.
-- Added `Storage % Utilization` incident field.
+- Added `Storage Utilization (%)` incident field.
 - Added `New Storage (GB)` incident field.
-- Added `New Storage % Utilization` incident field.
+- Added `New Storage Utilization (%)` incident field.
 - Added `DTU Capacity` incident field.
-- Added `DTU % Utilization` incident field.
+- Added `DTU Utilization (%)` incident field.
 - Added `New DTU Capacity` incident field.
-- Added `New DTU % Utilization` incident field.
+- Added `New DTU Utilization (%)` incident field.
 - Added `IOPs Capacity` incident field.
-- Added `IOPs % Utilization` incident field.
+- Added `IOPs Utilization (%)` incident field.
 - Added `New IOPs Capacity` incident field.
-- Added `New IOPs % Utilization` incident field.
+- Added `New IOPs Utilization (%)` incident field.
 - Added `Memory (GB)` incident field.
-- Added `Memory % Utilization` incident field.
+- Added `Memory Utilization (%)` incident field.
 - Added `New Memory (GB)` incident field.
-- Added `New Memory % Utilization` incident field.
+- Added `New Memory Utilization (%)` incident field.
 - Added `CPU (GHz)` incident field.
-- Added `CPU % Utilization` incident field.
+- Added `CPU Utilization (%)` incident field.
 - Added `New CPU (GHz)` incident field.
-- Added `new CPU % Utilization` incident field.
+- Added `new CPU Utilization (%)` incident field.
 - Added `Throughput (MB/s)` incident field.
-- Added `Throughput % Utilization` incident field.
+- Added `Throughput Utilization (%)` incident field.
 - Added `New Throughput (MB/s)` incident field.
-- Added `New Throughput % Utilization` incident field.
+- Added `New Throughput Utilization (%)` incident field.
 - Added `Connections` incident field.
 - Added `New Connections` incident field.
 

--- a/cost/turbonomics/rightsize_databases_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_databases_recommendations/aws/CHANGELOG.md
@@ -2,35 +2,34 @@
 
 ## v0.3
 
-- Added `VM Age` incident field.
-- Added `Pricing Model` incident field.
+- Added `Recommendation Created Time` incident field.
 - Added `System Details URL` incident field.
-- Added `Size (GB)` incident field.
-- Added `Size % Utilization` incident field.
-- Added `After Size (GB)` incident field.
-- Added `After Size % Utilization` incident field.
-- Added `DTU` incident field.
+- Added `Storage (GB)` incident field.
+- Added `Storage % Utilization` incident field.
+- Added `New Storage (GB)` incident field.
+- Added `New Storage % Utilization` incident field.
+- Added `DTU Capacity` incident field.
 - Added `DTU % Utilization` incident field.
-- Added `After DTU` incident field.
-- Added `After DTU % Utilization` incident field.
-- Added `IOPs` incident field.
+- Added `New DTU Capacity` incident field.
+- Added `New DTU % Utilization` incident field.
+- Added `IOPs Capacity` incident field.
 - Added `IOPs % Utilization` incident field.
-- Added `After IOPs` incident field.
-- Added `After IOPs % Utilization` incident field.
-- Added `Virtual Memory (GB)` incident field.
-- Added `Virtual Memory % Utilization` incident field.
-- Added `After Virtual Memory (GB)` incident field.
-- Added `After Virtual Memory % Utilization` incident field.
-- Added `Virtual CPU (GHz)` incident field.
-- Added `Virtual CPU % Utilization` incident field.
-- Added `After Virtual CPU (GHz)` incident field.
-- Added `After Virtual CPU % Utilization` incident field.
-- Added `IOThroughput (MB/s)` incident field.
-- Added `IOThroughput % Utilization` incident field.
-- Added `After IOThroughput (MB/s)` incident field.
-- Added `After IOThroughput % Utilization` incident field.
+- Added `New IOPs Capacity` incident field.
+- Added `New IOPs % Utilization` incident field.
+- Added `Memory (GB)` incident field.
+- Added `Memory % Utilization` incident field.
+- Added `New Memory (GB)` incident field.
+- Added `New Memory % Utilization` incident field.
+- Added `CPU (GHz)` incident field.
+- Added `CPU % Utilization` incident field.
+- Added `New CPU (GHz)` incident field.
+- Added `new CPU % Utilization` incident field.
+- Added `Throughput (MB/s)` incident field.
+- Added `Throughput % Utilization` incident field.
+- Added `New Throughput (MB/s)` incident field.
+- Added `New Throughput % Utilization` incident field.
 - Added `Connections` incident field.
-- Added `After Connections` incident field.
+- Added `New Connections` incident field.
 
 ## v0.2
 

--- a/cost/turbonomics/rightsize_databases_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_databases_recommendations/aws/CHANGELOG.md
@@ -5,10 +5,10 @@
 - Added `VM Age` incident field.
 - Added `Pricing Model` incident field.
 - Added `System Details URL` incident field.
-- Added `Current Size` incident field.
-- Added `Current Size % Utilization` incident field.
-- Added `After Size` incident field.
-- Added `After Size % Utilization` incident field.
+- Added `Current GB Size` incident field.
+- Added `Current GB Size % Utilization` incident field.
+- Added `After GB Size` incident field.
+- Added `After GB Size % Utilization` incident field.
 - Added `Current DTU` incident field.
 - Added `Current DTU % Utilization` incident field.
 - Added `After DTU` incident field.
@@ -17,18 +17,20 @@
 - Added `Current IOPs % Utilization` incident field.
 - Added `After IOPs` incident field.
 - Added `After IOPs % Utilization` incident field.
-- Added `Current Virtual Memory` incident field.
-- Added `Current Virtual Memory % Utilization` incident field.
-- Added `After Virtual Memory` incident field.
-- Added `After Virtual Memory % Utilization` incident field.
-- Added `Current Virtual CPU` incident field.
-- Added `Current Virtual CPU % Utilization` incident field.
-- Added `After Virtual CPU` incident field.
-- Added `After Virtual CPU % Utilization` incident field.
-- Added `Current IOThroughput` incident field.
-- Added `Current IOThroughput  % Utilization` incident field.
-- Added `After IOThroughput` incident field.
-- Added `After IOThroughput  % Utilization` incident field.
+- Added `Current GB Virtual Memory` incident field.
+- Added `Current GB Virtual Memory % Utilization` incident field.
+- Added `After GB Virtual Memory` incident field.
+- Added `After GB Virtual Memory % Utilization` incident field.
+- Added `Current GHz Virtual CPU` incident field.
+- Added `Current GHz Virtual CPU % Utilization` incident field.
+- Added `After GHz Virtual CPU` incident field.
+- Added `After GHz Virtual CPU % Utilization` incident field.
+- Added `Current MB/s IOThroughput` incident field.
+- Added `Current MB/s IOThroughput % Utilization` incident field.
+- Added `After MB/s IOThroughput` incident field.
+- Added `After MB/s IOThroughput % Utilization` incident field.
+- Added `Current Connections` incident field.
+- Added `After Connections` incident field.
 
 ## v0.2
 

--- a/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
+++ b/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
@@ -327,7 +327,7 @@ script "js_get_projected_statistics", type: "javascript" do
     }
     //Payload for DatabaseServer : ['VCPU', 'StorageAccess', '']
     if (instance.className = "DatabaseServer"){
-      body_fields = {"statistics":[{"name":"VCPU","groupBy":["key","percentile"]},{"name":"VMem","groupBy":["key","percentile"]},{"name":"IOThroughput","groupBy":["key","percentile"]},{"name":"DBCacheHitRate","groupBy":["key","percentile"]},{"name":"VStorage","groupBy":["key", "percentile"]},{"name":"StorageAccess","groupBy":["key","percentile"]},{"name":"StorageAmount","groupBy":["key"]},{"name":"Connection","groupBy":["key"]}],"startDate":nowDay.getTime(),"endDate":pastDay.getTime()}
+      body_fields = {"statistics":[{"name":"VCPU","groupBy":["key","percentile"]},{"name":"VMem","groupBy":["key","percentile"]},{"name":"IOThroughput","groupBy":["key","percentile"]},{"name":"DBCacheHitRate","groupBy":["key","percentile"]},{"name":"VStorage","groupBy":["key"]},{"name":"StorageAccess","groupBy":["key","percentile"]},{"name":"StorageAmount","groupBy":["key"]},{"name":"Connection","groupBy":["key"]}],"startDate":nowDay.getTime(),"endDate":pastDay.getTime()}
     }
 
     request = {
@@ -351,7 +351,7 @@ script "js_combined_data", type: "javascript" do
   result "result"
   parameters "ds_get_turbonomic_recommendations", "ds_get_projected_statistics", "ds_get_current_statistics"
   code <<-EOS
-    _.each(ds_get_projected_statistics, function (projectedStatistic) {
+    _.each(ds_get_projected_statistics, function (projectedStatistic, ii) {
       _.each(ds_get_turbonomic_recommendations.instances, function (db, index) {
           if (db.uuid === projectedStatistic.uuid) {
             db.newSize = (projectedStatistic.size[0]/1024)
@@ -383,8 +383,13 @@ script "js_combined_data", type: "javascript" do
               db.throughputP95 = ((ds_get_current_statistics[index].iOThroughput[1]*100)/ds_get_current_statistics[index].iOThroughput[0]).toFixed(2)
             }
             if (db.className == "DatabaseServer") {
-              db.connections = projectedStatistic.connection[0]
-              db.newConnections = ds_get_current_statistics[index].connection[0]
+              if (projectedStatistic.connection == null) {
+                db.connections = ""
+                db.newConnections = ""
+              }else{
+                db.connections = projectedStatistic.connection[0]
+                db.newConnections = ds_get_current_statistics[index].connection[0]
+              }
               db.newIops = projectedStatistic.iops[0]
               db.newIopsP95 = ((projectedStatistic.iops[1]*100)/projectedStatistic.iops[0]).toFixed(2)
               db.newMem = (projectedStatistic.vmem[0]/1048576).toFixed(2)
@@ -469,14 +474,16 @@ policy "pol_turbonomic_rightsize_databases" do
       field "size" do
         label "Storage (GB)"
       end
-      field "sizeUtil" do
+      field "capacityUtil" do
         label "Storage Utilization (%)"
+        path "sizeUtil"
       end
       field "newSize" do
         label "New Storage (GB)"
       end
-      field "newSizeUtil" do
+      field "newCapacityUtil" do
         label "New Storage Utilization (%)"
+        path "newSizeUtil"
       end
       field "dtu" do
         label "DTU Capacity"

--- a/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
+++ b/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
@@ -355,65 +355,59 @@ script "js_combined_data", type: "javascript" do
     _.each(ds_get_projected_statistics, function (projectedStatistic) {
       _.each(ds_get_turbonomic_recommendations.instances, function (db, index) {
           if (db.uuid === projectedStatistic.uuid) {
-            db.size = (projectedStatistic.size[0]/1024)
-            db.diskUtilization = ((projectedStatistic.size[1]*100)/projectedStatistic.size[0]).toFixed(2)
-            db.sizenow = (ds_get_current_statistics[index].size[0]/1024)
-            db.sizeutil = ((ds_get_current_statistics[index].size[1]*100)/ds_get_current_statistics[index].size[0]).toFixed(2)
-
+            db.afterSize = (projectedStatistic.size[0]/1024)
+            db.afterSizeUtil = ((projectedStatistic.size[1]*100)/projectedStatistic.size[0]).toFixed(2)
+            db.size = (ds_get_current_statistics[index].size[0]/1024)
+            db.sizeUtil = ((ds_get_current_statistics[index].size[1]*100)/ds_get_current_statistics[index].size[0]).toFixed(2)
             if (_.contains(db.pricingModel, "DTU")){
-              db.dtu = projectedStatistic.dtu[0]
-              db.dtuafter = ((projectedStatistic.dtu[1]*100)/projectedStatistic.dtu[0]).toFixed(2)
-              db.dtunow = ds_get_current_statistics[index].dtu[0]
-              db.dtuutilnow = ((ds_get_current_statistics[index].dtu[1]*100)/ds_get_current_statistics[index].dtu[0]).toFixed(2)
+              db.afterDtu = projectedStatistic.dtu[0]
+              db.afterDtuUtil = ((projectedStatistic.dtu[1]*100)/projectedStatistic.dtu[0]).toFixed(2)
+              db.dtu = ds_get_current_statistics[index].dtu[0]
+              db.dtuutil = ((ds_get_current_statistics[index].dtu[1]*100)/ds_get_current_statistics[index].dtu[0]).toFixed(2)
             }
-
             if (_.contains(db.pricingModel, "StorageAmount")){
-              db.iops = projectedStatistic.iops[0]
-              db.iopsutil = ((projectedStatistic.iops[1]*100)/projectedStatistic.iops[0]).toFixed(2)
-              db.vmem = (projectedStatistic.vmem[0]/1048576).toFixed(2)
-              db.vmemutil = ((projectedStatistic.vmem[1]*100)/projectedStatistic.vmem[0]).toFixed(2)
-              db.vcpu = (projectedStatistic.vcpu[0]/1000).toFixed(2)
-              db.vcpuutil = ((projectedStatistic.vcpu[1]*100)/projectedStatistic.vcpu[0]).toFixed(2)
-              db.iOThroughput = (projectedStatistic.iOThroughput[0]*0.000125).toFixed(2)
-              db.iOThroughpututil = ((projectedStatistic.iOThroughput[1]*100)/projectedStatistic.iOThroughput[0]).toFixed(2)
-              db.iopsnow = ds_get_current_statistics[index].iops[0]
-              db.iopsutilnow = ((ds_get_current_statistics[index].iops[1]*100)/ds_get_current_statistics[index].iops[0]).toFixed(2)
-              db.vmemnow = (ds_get_current_statistics[index].vmem[0]/1048576).toFixed(2)
-              db.vmemutilnow = ((ds_get_current_statistics[index].vmem[1]*100)/ds_get_current_statistics[index].vmem[0]).toFixed(2)
-              db.vcpunow = (ds_get_current_statistics[index].vcpu[0]/1000).toFixed(2)
-              db.vcpuutilnow = ((ds_get_current_statistics[index].vcpu[1]*100)/ds_get_current_statistics[index].vcpu[0]).toFixed(2)
-              db.iOThroughputnow = (ds_get_current_statistics[index].iOThroughput[0]*0.000125).toFixed(2)
-              db.iOThroughpututilnow = ((ds_get_current_statistics[index].iOThroughput[1]*100)/ds_get_current_statistics[index].iOThroughput[0]).toFixed(2)
+              db.afterIops = projectedStatistic.iops[0]
+              db.afterIopsUtil = ((projectedStatistic.iops[1]*100)/projectedStatistic.iops[0]).toFixed(2)
+              db.afterVmem = (projectedStatistic.vmem[0]/1048576).toFixed(2)
+              db.afterVmemUtil = ((projectedStatistic.vmem[1]*100)/projectedStatistic.vmem[0]).toFixed(2)
+              db.afterVcpu = (projectedStatistic.vcpu[0]/1000).toFixed(2)
+              db.afterVcpuUtil = ((projectedStatistic.vcpu[1]*100)/projectedStatistic.vcpu[0]).toFixed(2)
+              db.afterIOThroughput = (projectedStatistic.iOThroughput[0]*0.000125).toFixed(2)
+              db.afterIOThroughpututil = ((projectedStatistic.iOThroughput[1]*100)/projectedStatistic.iOThroughput[0]).toFixed(2)
+              db.iops = ds_get_current_statistics[index].iops[0]
+              db.iopsUtil = ((ds_get_current_statistics[index].iops[1]*100)/ds_get_current_statistics[index].iops[0]).toFixed(2)
+              db.vmem = (ds_get_current_statistics[index].vmem[0]/1048576).toFixed(2)
+              db.vmemUtil = ((ds_get_current_statistics[index].vmem[1]*100)/ds_get_current_statistics[index].vmem[0]).toFixed(2)
+              db.vcpu = (ds_get_current_statistics[index].vcpu[0]/1000).toFixed(2)
+              db.vcpuUtil = ((ds_get_current_statistics[index].vcpu[1]*100)/ds_get_current_statistics[index].vcpu[0]).toFixed(2)
+              db.iOThroughput = (ds_get_current_statistics[index].iOThroughput[0]*0.000125).toFixed(2)
+              db.iOThroughpututil = ((ds_get_current_statistics[index].iOThroughput[1]*100)/ds_get_current_statistics[index].iOThroughput[0]).toFixed(2)
             }
-
             if (db.className == "DatabaseServer") {
-              db.connectionNow = projectedStatistic.connection[0]
-              db.connectionAfter = ds_get_current_statistics[index].connection[0]
-              db.iops = projectedStatistic.iops[0]
-              db.iopsutil = ((projectedStatistic.iops[1]*100)/projectedStatistic.iops[0]).toFixed(2)
-              db.vmem = (projectedStatistic.vmem[0]/1048576).toFixed(2)
-              db.vmemutil = ((projectedStatistic.vmem[1]*100)/projectedStatistic.vmem[0]).toFixed(2)
-              db.vcpu = (projectedStatistic.vcpu[0]/1000).toFixed(2)
-              db.vcpuutil = ((projectedStatistic.vcpu[1]*100)/projectedStatistic.vcpu[0]).toFixed(2)
-              db.iopsnow = ds_get_current_statistics[index].iops[0]
-              db.iopsutilnow = ((ds_get_current_statistics[index].iops[1]*100)/ds_get_current_statistics[index].iops[0]).toFixed(2)
-              db.vmemnow = (ds_get_current_statistics[index].vmem[0]/1048576).toFixed(2)
-              db.vmemutilnow = ((ds_get_current_statistics[index].vmem[1]*100)/ds_get_current_statistics[index].vmem[0]).toFixed(2)
-              db.vcpunow = (ds_get_current_statistics[index].vcpu[0]/1000).toFixed(2)
-              db.vcpuutilnow = ((ds_get_current_statistics[index].vcpu[1]*100)/ds_get_current_statistics[index].vcpu[0]).toFixed(2)
+              db.connections = projectedStatistic.connection[0]
+              db.afterConnections = ds_get_current_statistics[index].connection[0]
+              db.afterIops = projectedStatistic.iops[0]
+              db.afterIopsUtil = ((projectedStatistic.iops[1]*100)/projectedStatistic.iops[0]).toFixed(2)
+              db.afterVmem = (projectedStatistic.vmem[0]/1048576).toFixed(2)
+              db.afterVmemUtil = ((projectedStatistic.vmem[1]*100)/projectedStatistic.vmem[0]).toFixed(2)
+              db.afterVcpu = (projectedStatistic.vcpu[0]/1000).toFixed(2)
+              db.afterVcpuUtil = ((projectedStatistic.vcpu[1]*100)/projectedStatistic.vcpu[0]).toFixed(2)
+              db.iops = ds_get_current_statistics[index].iops[0]
+              db.iopsUtil = ((ds_get_current_statistics[index].iops[1]*100)/ds_get_current_statistics[index].iops[0]).toFixed(2)
+              db.vmem = (ds_get_current_statistics[index].vmem[0]/1048576).toFixed(2)
+              db.vmemUtil = ((ds_get_current_statistics[index].vmem[1]*100)/ds_get_current_statistics[index].vmem[0]).toFixed(2)
+              db.vcpu = (ds_get_current_statistics[index].vcpu[0]/1000).toFixed(2)
+              db.vcpuUtil = ((ds_get_current_statistics[index].vcpu[1]*100)/ds_get_current_statistics[index].vcpu[0]).toFixed(2)
             }
           }
       })
     })
-
     result = {
       'instances': ds_get_turbonomic_recommendations.instances,
       'message': ds_get_turbonomic_recommendations.message
     }
-
   EOS
 end
-
 ###############################################################################
 # Policy
 ###############################################################################
@@ -479,82 +473,82 @@ policy "pol_turbonomic_rightsize_databases" do
       field "url" do
         label "System Details URL"
       end
-      field "sizenow" do
-        label "Current GB Size"
-      end
-      field "sizeutil" do
-        label "Current GB Size % Utilization"
-      end
       field "size" do
-        label "After GB Size"
+        label "Size (GB)"
       end
-      field "diskUtilization" do
-        label "After GB Size % Utilization"
+      field "sizeUtil" do
+        label "Size % Utilization"
       end
-      field "dtunow" do
-        label "Current DTU"
+      field "afterSize" do
+        label "After Size (GB)"
       end
-      field "dtuutilnow" do
-        label "Current DTU % Utilization"
+      field "afterSizeUtil" do
+        label "After Size % Utilization"
       end
       field "dtu" do
+        label "DTU"
+      end
+      field "dtuutil" do
+        label "DTU % Utilization"
+      end
+      field "afterDtu" do
         label "After DTU"
       end
-      field "dtuafter" do
+      field "afterDtuUtil" do
         label "After DTU % Utilization"
       end
-      field "iopsnow" do
-        label "Current IOPs"
-      end
-      field "iopsutilnow" do
-        label "Current IOPs % Utilization"
-      end
       field "iops" do
+        label "IOPs"
+      end
+      field "iopsUtil" do
+        label "IOPs % Utilization"
+      end
+      field "afterIops" do
         label "After IOPs"
       end
-      field "iopsutil" do
+      field "afterIopsUtil" do
         label "After IOPs % Utilization"
       end
-      field "vmemnow" do
-        label "Current GB Virtual Memory"
-      end
-      field "vmemutilnow" do
-        label "Current GB Virtual Memory % Utilization"
-      end
       field "vmem" do
-        label "After GB Virtual Memory"
+        label "Virtual Memory (GB)"
       end
-      field "vmemutil" do
-        label "After GB Virtual Memory % Utilization"
+      field "vmemUtil" do
+        label "Virtual Memory % Utilization"
       end
-      field "vcpunow" do
-        label "Current GHz Virtual CPU"
+      field "afterVmem" do
+        label "After Virtual Memory (GB)"
       end
-      field "vcpuutilnow" do
-        label "Current GHz Virtual CPU % Utilization"
+      field "afterVmemUtil" do
+        label "After Virtual Memory % Utilization"
       end
       field "vcpu" do
-        label "After GHz Virtual CPU"
+        label "Virtual CPU (GHz)"
       end
-      field "vcpuutil" do
-        label "After GHz Virtual CPU % Utilization"
+      field "vcpuUtil" do
+        label "Virtual CPU % Utilization"
       end
-      field "iOThroughputnow" do
-        label "Current MB/s IOThroughput"
+      field "afterVcpu" do
+        label "After Virtual CPU (GHz)"
       end
-      field "iOThroughpututilnow" do
-        label "Current MB/s IOThroughput % Utilization"
+      field "afterVcpuUtil" do
+        label "After Virtual CPU % Utilization"
       end
       field "iOThroughput" do
-        label "After MB/s IOThroughput"
+        label "IOThroughput (MB/s)"
       end
       field "iOThroughpututil" do
-        label "After MB/s IOThroughput % Utilization"
+        label "IOThroughput % Utilization"
       end
-      field "connectionNow" do
-        label "Current Connections"
+      field "afterIOThroughput" do
+        label "After IOThroughput (MB/s)"
       end
-      field "connectionAfter" do
+      field "afterIOThroughpututil" do
+        label "AfterIOThroughput % Utilization"
+      end
+      field "connections" do
+        label "Connections"
+      end
+      field "afterConnections" do
         label "After Connections"
       end
     end

--- a/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
+++ b/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
@@ -366,7 +366,7 @@ script "js_combined_data", type: "javascript" do
             }
             if (_.contains(db.pricingModel, "StorageAmount")){
               db.newIops = projectedStatistic.iops[0]
-              db.newIopsUtil = ((projectedStatistic.iops[1]*100)/projectedStatistic.iops[0]).toFixed(2)
+              db.newIopsP95 = ((projectedStatistic.iops[1]*100)/projectedStatistic.iops[0]).toFixed(2)
               db.newMem = (projectedStatistic.vmem[0]/1048576).toFixed(2)
               db.newMemP95 = ((projectedStatistic.vmem[1]*100)/projectedStatistic.vmem[0]).toFixed(2)
               db.newCpu = (projectedStatistic.vcpu[0]/1000).toFixed(2)
@@ -374,7 +374,7 @@ script "js_combined_data", type: "javascript" do
               db.newThroughput = (projectedStatistic.iOThroughput[0]*0.000125).toFixed(2)
               db.newThroughputP95 = ((projectedStatistic.iOThroughput[1]*100)/projectedStatistic.iOThroughput[0]).toFixed(2)
               db.iops = ds_get_current_statistics[index].iops[0]
-              db.iopsUtil = ((ds_get_current_statistics[index].iops[1]*100)/ds_get_current_statistics[index].iops[0]).toFixed(2)
+              db.iopsP95 = ((ds_get_current_statistics[index].iops[1]*100)/ds_get_current_statistics[index].iops[0]).toFixed(2)
               db.mem = (ds_get_current_statistics[index].vmem[0]/1048576).toFixed(2)
               db.memP95 = ((ds_get_current_statistics[index].vmem[1]*100)/ds_get_current_statistics[index].vmem[0]).toFixed(2)
               db.cpu = (ds_get_current_statistics[index].vcpu[0]/1000).toFixed(2)
@@ -386,13 +386,13 @@ script "js_combined_data", type: "javascript" do
               db.connections = projectedStatistic.connection[0]
               db.newConnections = ds_get_current_statistics[index].connection[0]
               db.newIops = projectedStatistic.iops[0]
-              db.newIopsUtil = ((projectedStatistic.iops[1]*100)/projectedStatistic.iops[0]).toFixed(2)
+              db.newIopsP95 = ((projectedStatistic.iops[1]*100)/projectedStatistic.iops[0]).toFixed(2)
               db.newMem = (projectedStatistic.vmem[0]/1048576).toFixed(2)
               db.newMemP95 = ((projectedStatistic.vmem[1]*100)/projectedStatistic.vmem[0]).toFixed(2)
               db.newCpu = (projectedStatistic.vcpu[0]/1000).toFixed(2)
               db.newCpuP95 = ((projectedStatistic.vcpu[1]*100)/projectedStatistic.vcpu[0]).toFixed(2)
               db.iops = ds_get_current_statistics[index].iops[0]
-              db.iopsUtil = ((ds_get_current_statistics[index].iops[1]*100)/ds_get_current_statistics[index].iops[0]).toFixed(2)
+              db.iopsP95 = ((ds_get_current_statistics[index].iops[1]*100)/ds_get_current_statistics[index].iops[0]).toFixed(2)
               db.mem = (ds_get_current_statistics[index].vmem[0]/1048576).toFixed(2)
               db.memP95 = ((ds_get_current_statistics[index].vmem[1]*100)/ds_get_current_statistics[index].vmem[0]).toFixed(2)
               db.cpu = (ds_get_current_statistics[index].vcpu[0]/1000).toFixed(2)
@@ -470,73 +470,73 @@ policy "pol_turbonomic_rightsize_databases" do
         label "Storage (GB)"
       end
       field "sizeUtil" do
-        label "Storage % Utilization"
+        label "Storage Utilization (%)"
       end
       field "newSize" do
         label "New Storage (GB)"
       end
       field "newSizeUtil" do
-        label "New Storage % Utilization"
+        label "New Storage Utilization (%)"
       end
       field "dtu" do
         label "DTU Capacity"
       end
       field "dtuUtil" do
-        label "DTU % Utilization"
+        label "DTU Utilization (%)"
       end
       field "newDtu" do
         label "New DTU Capacity"
       end
       field "newDtuUtil" do
-        label "New DTU % Utilization"
+        label "New DTU Utilization (%)"
       end
       field "iops" do
         label "IOPs Capacity"
       end
-      field "iopsUtil" do
-        label "IOPs % Utilization"
+      field "iopsP95" do
+        label "IOPs Utilization (%)"
       end
       field "newIops" do
         label "New IOPs Capacity"
       end
-      field "newIopsUtil" do
-        label "New IOPs % Utilization"
+      field "newIopsP95" do
+        label "New IOPs Utilization (%)"
       end
       field "mem" do
         label "Memory (GB)"
       end
       field "memP95" do
-        label "Memory % Utilization"
+        label "Memory Utilization (%)"
       end
       field "newMem" do
         label "New Memory (GB)"
       end
       field "newMemP95" do
-        label "New Memory % Utilization"
+        label "New Memory Utilization (%)"
       end
       field "cpu" do
         label "CPU (GHz)"
       end
       field "cpuP95" do
-        label "CPU % Utilization"
+        label "CPU Utilization (%)"
       end
       field "newCpu" do
         label "New CPU (GHz)"
       end
       field "newCpuP95" do
-        label "new CPU % Utilization"
+        label "new CPU Utilization (%)"
       end
       field "throughput" do
         label "Throughput (MB/s)"
       end
       field "throughputP95" do
-        label "Throughput % Utilization"
+        label "Throughput Utilization (%)"
       end
       field "newThroughput" do
         label "New Throughput (MB/s)"
       end
       field "newThroughputP95" do
-        label "New Throughput % Utilization"
+        label "New Throughput Utilization (%)"
       end
       field "connections" do
         label "Connections"

--- a/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
+++ b/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
@@ -318,15 +318,16 @@ script "js_get_projected_statistics", type: "javascript" do
     nowDay = new Date(Date.now())
     pastDay = new Date(Date.now() + nineHours)
     body_fields = {}
-
-    if (instance.className = "DatabaseServer"){
-      body_fields = {"statistics":[{"name":"VCPU","groupBy":["key","percentile"]},{"name":"VMem","groupBy":["key","percentile"]},{"name":"IOThroughput","groupBy":["key","percentile"]},{"name":"DBCacheHitRate","groupBy":["key","percentile"]},{"name":"VStorage","groupBy":["key", "percentile"]},{"name":"StorageAccess","groupBy":["key","percentile"]},{"name":"StorageAmount","groupBy":["key"]},{"name":"Connection","groupBy":["key"]}],"startDate":nowDay.getTime(),"endDate":pastDay.getTime()}
-    }
+    //Different Payloads are used for Database : ['DTU'], ['StorageAmount']
     if (_.contains("DTU", instance.pricingModel)){
       body_fields = {"statistics":[{"name":"DTU","groupBy":["key","percentile"]},{"name":"StorageAmount","groupBy":["key"]}],"startDate":nowDay.getTime(),"endDate":pastDay.getTime()}
     }
     if (_.contains("StorageAmount", instance.pricingModel)){
       body_fields = {"statistics":[{"name":"VCPU","groupBy":["key","percentile"]},{"name":"VMem","groupBy":["key","percentile"]},{"name":"StorageAccess","groupBy":["key","percentile"]},{"name":"IOThroughput","groupBy":["key","percentile"]},{"name":"StorageAmount","groupBy":["key"]}],"startDate":nowDay.getTime(),"endDate":pastDay.getTime()}
+    }
+    //Payload for DatabaseServer : ['VCPU', 'StorageAccess', '']
+    if (instance.className = "DatabaseServer"){
+      body_fields = {"statistics":[{"name":"VCPU","groupBy":["key","percentile"]},{"name":"VMem","groupBy":["key","percentile"]},{"name":"IOThroughput","groupBy":["key","percentile"]},{"name":"DBCacheHitRate","groupBy":["key","percentile"]},{"name":"VStorage","groupBy":["key", "percentile"]},{"name":"StorageAccess","groupBy":["key","percentile"]},{"name":"StorageAmount","groupBy":["key"]},{"name":"Connection","groupBy":["key"]}],"startDate":nowDay.getTime(),"endDate":pastDay.getTime()}
     }
 
     request = {
@@ -412,9 +413,9 @@ end
 
 policy "pol_turbonomic_rightsize_databases" do
   validate $ds_combined_data do
-    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data.instances }} Turbonomic Databases to Rightsize found"
+    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data.instances }} Turbonomic Databases & Database Servers to Rightsize found"
     detail_template <<-EOS
-      ## Turbonomic Rightsize Databases Recommendations
+      ## Turbonomic Rightsize Databases & Database Servers Recommendations
       {{data.message}}
     EOS
     check eq(size(val(data, "instances")), 0)

--- a/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
+++ b/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
@@ -84,6 +84,7 @@ datasource "ds_get_turbonomic_recommendations" do
       field "savingsCurrency", jmes_path(col_item, "stats[0].units")
       field "pricingModel", jmes_path(col_item, "risk.reasonCommodities[0]")
       field "uuid", jmes_path(col_item, "target.uuid")
+      field "actionID", jmes_path(col_item, "actionID")
     end
   end
 end
@@ -162,12 +163,12 @@ script "js_get_business_units", type: "javascript" do
 end
 
 datasource "ds_filtered_turbonomic_recommendations" do
-  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $param_provider
+  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $param_provider, $param_turbonomic_endpoint
 end
 
 script "js_filtered_turbonomic_recommendations", type: "javascript" do
   result "result"
-  parameters "ds_get_turbonomic_recommendations", "ds_get_business_units", "param_provider"
+  parameters "ds_get_turbonomic_recommendations", "ds_get_business_units", "param_provider", "turbonomic_endpoint"
   code <<-EOS
     instances = []
     monthlySavings = 0.0
@@ -240,7 +241,7 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
             monthlySavings = monthlySavings + db.savings
             instanceCreatedDate = new Date(db.createdTime)
             db.vmAge = (Math.round(nowDay.getTime() - instanceCreatedDate.getTime()) / (oneDay)).toFixed(0) + " Day(s)"
-            db.url = "https://"
+            db.url = "https://"+ turbonomic_endpoint + "/app/index.html#/view/main/action/" + db.actionID
             instances.push(db)
         }
     })
@@ -453,79 +454,79 @@ policy "pol_turbonomic_rightsize_databases" do
         label "Pricing Model"
       end
       field "url" do
-        label "URL"
+        label "System Details URL"
       end
       field "sizenow" do
-        label "Actual Storage Amount"
+        label "Current Size"
       end
       field "sizeutil" do
-        label "Actual Storage Amount % Utilization"
+        label "Current Size % Utilization"
       end
       field "size" do
-        label "New Storage Amount"
+        label "After Size"
       end
       field "diskUtilization" do
-        label "New Storage Amount % Utilization"
+        label "After Size % Utilization"
       end
       field "dtunow" do
-        label "Actual DTU"
+        label "Current DTU"
       end
       field "dtuutilnow" do
-        label "Actual DTU % Utilization"
+        label "Current DTU % Utilization"
       end
       field "dtu" do
-        label "New DTU"
+        label "After DTU"
       end
       field "dtuafter" do
-        label "New DTU % Utilization"
+        label "After DTU % Utilization"
       end
       field "iopsnow" do
-        label "Actual IOPs"
+        label "Current IOPs"
       end
       field "iopsutilnow" do
-        label "Actual IOPs % Utilization"
+        label "Current IOPs % Utilization"
       end
       field "iops" do
-        label "New IOPs"
+        label "After IOPs"
       end
       field "iopsutil" do
-        label "New IOPs % Utilization"
+        label "After IOPs % Utilization"
       end
       field "vmemnow" do
-        label "Actual Virtual Memory"
+        label "Current Virtual Memory"
       end
       field "vmemutilnow" do
-        label "Actual Virtual Memory % Utilization"
+        label "Current Virtual Memory % Utilization"
       end
       field "vmem" do
-        label "New Virtual Memory"
+        label "After Virtual Memory"
       end
       field "vmemutil" do
-        label "New Virtual Memory % Utilization"
+        label "After Virtual Memory % Utilization"
       end
       field "vcpunow" do
-        label "Actual Virtual CPU"
+        label "Current Virtual CPU"
       end
       field "vcpuutilnow" do
-        label "Actual Virtual CPU % Utilization"
+        label "Current Virtual CPU % Utilization"
       end
       field "vcpu" do
-        label "New Virtual CPU"
+        label "After Virtual CPU"
       end
       field "vcpuutil" do
-        label "New Virtual CPU % Utilization"
+        label "After Virtual CPU % Utilization"
       end
       field "iOThroughputnow" do
-        label "Actual IOThroughput"
+        label "Current IOThroughput"
       end
       field "iOThroughpututilnow" do
-        label "Actual IOThroughput  % Utilization"
+        label "Current IOThroughput  % Utilization"
       end
       field "iOThroughput" do
-        label "New IOThroughput"
+        label "After IOThroughput"
       end
       field "iOThroughpututil" do
-        label "New IOThroughput  % Utilization"
+        label "After IOThroughput  % Utilization"
       end
     end
     escalate $esc_email

--- a/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
+++ b/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
@@ -240,8 +240,6 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
 
             db.savings = (Math.round(db.savings * 730 * 1000) / 1000)
             monthlySavings = monthlySavings + db.savings
-            instanceCreatedDate = new Date(db.createdTime)
-            db.vmAge = (Math.round(nowDay.getTime() - instanceCreatedDate.getTime()) / (oneDay)).toFixed(0) + " Day(s)"
             db.url = "https://"+ turbonomic_endpoint + "/app/index.html#/view/main/action/" + db.actionID
             instances.push(db)
         }
@@ -355,49 +353,49 @@ script "js_combined_data", type: "javascript" do
     _.each(ds_get_projected_statistics, function (projectedStatistic) {
       _.each(ds_get_turbonomic_recommendations.instances, function (db, index) {
           if (db.uuid === projectedStatistic.uuid) {
-            db.afterSize = (projectedStatistic.size[0]/1024)
-            db.afterSizeUtil = ((projectedStatistic.size[1]*100)/projectedStatistic.size[0]).toFixed(2)
+            db.newSize = (projectedStatistic.size[0]/1024)
+            db.newSizeUtil = ((projectedStatistic.size[1]*100)/projectedStatistic.size[0]).toFixed(2)
             db.size = (ds_get_current_statistics[index].size[0]/1024)
             db.sizeUtil = ((ds_get_current_statistics[index].size[1]*100)/ds_get_current_statistics[index].size[0]).toFixed(2)
             if (_.contains(db.pricingModel, "DTU")){
-              db.afterDtu = projectedStatistic.dtu[0]
-              db.afterDtuUtil = ((projectedStatistic.dtu[1]*100)/projectedStatistic.dtu[0]).toFixed(2)
+              db.newDtu = projectedStatistic.dtu[0]
+              db.newDtuUtil = ((projectedStatistic.dtu[1]*100)/projectedStatistic.dtu[0]).toFixed(2)
               db.dtu = ds_get_current_statistics[index].dtu[0]
               db.dtuUtil = ((ds_get_current_statistics[index].dtu[1]*100)/ds_get_current_statistics[index].dtu[0]).toFixed(2)
             }
             if (_.contains(db.pricingModel, "StorageAmount")){
-              db.afterIops = projectedStatistic.iops[0]
-              db.afterIopsUtil = ((projectedStatistic.iops[1]*100)/projectedStatistic.iops[0]).toFixed(2)
-              db.afterVmem = (projectedStatistic.vmem[0]/1048576).toFixed(2)
-              db.afterVmemUtil = ((projectedStatistic.vmem[1]*100)/projectedStatistic.vmem[0]).toFixed(2)
-              db.afterVcpu = (projectedStatistic.vcpu[0]/1000).toFixed(2)
-              db.afterVcpuUtil = ((projectedStatistic.vcpu[1]*100)/projectedStatistic.vcpu[0]).toFixed(2)
-              db.afterIOThroughput = (projectedStatistic.iOThroughput[0]*0.000125).toFixed(2)
-              db.afterIOThroughpututil = ((projectedStatistic.iOThroughput[1]*100)/projectedStatistic.iOThroughput[0]).toFixed(2)
+              db.newIops = projectedStatistic.iops[0]
+              db.newIopsUtil = ((projectedStatistic.iops[1]*100)/projectedStatistic.iops[0]).toFixed(2)
+              db.newMem = (projectedStatistic.vmem[0]/1048576).toFixed(2)
+              db.newMemP95 = ((projectedStatistic.vmem[1]*100)/projectedStatistic.vmem[0]).toFixed(2)
+              db.newCpu = (projectedStatistic.vcpu[0]/1000).toFixed(2)
+              db.newCpuP95 = ((projectedStatistic.vcpu[1]*100)/projectedStatistic.vcpu[0]).toFixed(2)
+              db.newThroughput = (projectedStatistic.iOThroughput[0]*0.000125).toFixed(2)
+              db.newThroughputP95 = ((projectedStatistic.iOThroughput[1]*100)/projectedStatistic.iOThroughput[0]).toFixed(2)
               db.iops = ds_get_current_statistics[index].iops[0]
               db.iopsUtil = ((ds_get_current_statistics[index].iops[1]*100)/ds_get_current_statistics[index].iops[0]).toFixed(2)
-              db.vmem = (ds_get_current_statistics[index].vmem[0]/1048576).toFixed(2)
-              db.vmemUtil = ((ds_get_current_statistics[index].vmem[1]*100)/ds_get_current_statistics[index].vmem[0]).toFixed(2)
-              db.vcpu = (ds_get_current_statistics[index].vcpu[0]/1000).toFixed(2)
-              db.vcpuUtil = ((ds_get_current_statistics[index].vcpu[1]*100)/ds_get_current_statistics[index].vcpu[0]).toFixed(2)
-              db.iOThroughput = (ds_get_current_statistics[index].iOThroughput[0]*0.000125).toFixed(2)
-              db.iOThroughpututil = ((ds_get_current_statistics[index].iOThroughput[1]*100)/ds_get_current_statistics[index].iOThroughput[0]).toFixed(2)
+              db.mem = (ds_get_current_statistics[index].vmem[0]/1048576).toFixed(2)
+              db.memP95 = ((ds_get_current_statistics[index].vmem[1]*100)/ds_get_current_statistics[index].vmem[0]).toFixed(2)
+              db.cpu = (ds_get_current_statistics[index].vcpu[0]/1000).toFixed(2)
+              db.cpuP95 = ((ds_get_current_statistics[index].vcpu[1]*100)/ds_get_current_statistics[index].vcpu[0]).toFixed(2)
+              db.throughput = (ds_get_current_statistics[index].iOThroughput[0]*0.000125).toFixed(2)
+              db.throughputP95 = ((ds_get_current_statistics[index].iOThroughput[1]*100)/ds_get_current_statistics[index].iOThroughput[0]).toFixed(2)
             }
             if (db.className == "DatabaseServer") {
               db.connections = projectedStatistic.connection[0]
-              db.afterConnections = ds_get_current_statistics[index].connection[0]
-              db.afterIops = projectedStatistic.iops[0]
-              db.afterIopsUtil = ((projectedStatistic.iops[1]*100)/projectedStatistic.iops[0]).toFixed(2)
-              db.afterVmem = (projectedStatistic.vmem[0]/1048576).toFixed(2)
-              db.afterVmemUtil = ((projectedStatistic.vmem[1]*100)/projectedStatistic.vmem[0]).toFixed(2)
-              db.afterVcpu = (projectedStatistic.vcpu[0]/1000).toFixed(2)
-              db.afterVcpuUtil = ((projectedStatistic.vcpu[1]*100)/projectedStatistic.vcpu[0]).toFixed(2)
+              db.newConnections = ds_get_current_statistics[index].connection[0]
+              db.newIops = projectedStatistic.iops[0]
+              db.newIopsUtil = ((projectedStatistic.iops[1]*100)/projectedStatistic.iops[0]).toFixed(2)
+              db.newMem = (projectedStatistic.vmem[0]/1048576).toFixed(2)
+              db.newMemP95 = ((projectedStatistic.vmem[1]*100)/projectedStatistic.vmem[0]).toFixed(2)
+              db.newCpu = (projectedStatistic.vcpu[0]/1000).toFixed(2)
+              db.newCpuP95 = ((projectedStatistic.vcpu[1]*100)/projectedStatistic.vcpu[0]).toFixed(2)
               db.iops = ds_get_current_statistics[index].iops[0]
               db.iopsUtil = ((ds_get_current_statistics[index].iops[1]*100)/ds_get_current_statistics[index].iops[0]).toFixed(2)
-              db.vmem = (ds_get_current_statistics[index].vmem[0]/1048576).toFixed(2)
-              db.vmemUtil = ((ds_get_current_statistics[index].vmem[1]*100)/ds_get_current_statistics[index].vmem[0]).toFixed(2)
-              db.vcpu = (ds_get_current_statistics[index].vcpu[0]/1000).toFixed(2)
-              db.vcpuUtil = ((ds_get_current_statistics[index].vcpu[1]*100)/ds_get_current_statistics[index].vcpu[0]).toFixed(2)
+              db.mem = (ds_get_current_statistics[index].vmem[0]/1048576).toFixed(2)
+              db.memP95 = ((ds_get_current_statistics[index].vmem[1]*100)/ds_get_current_statistics[index].vmem[0]).toFixed(2)
+              db.cpu = (ds_get_current_statistics[index].vcpu[0]/1000).toFixed(2)
+              db.cpuP95 = ((ds_get_current_statistics[index].vcpu[1]*100)/ds_get_current_statistics[index].vcpu[0]).toFixed(2)
             }
           }
       })
@@ -462,94 +460,88 @@ policy "pol_turbonomic_rightsize_databases" do
         label "Cloud Provider"
       end
       field "createdTime" do
-        label "Created Time"
-      end
-      field "vmAge" do
-        label "VM Age"
-      end
-      field "pricingModel" do
-        label "Pricing Model"
+        label "Recommendation Created Time"
       end
       field "url" do
         label "System Details URL"
       end
       field "size" do
-        label "Size (GB)"
+        label "Storage (GB)"
       end
       field "sizeUtil" do
-        label "Size % Utilization"
+        label "Storage % Utilization"
       end
-      field "afterSize" do
-        label "After Size (GB)"
+      field "newSize" do
+        label "New Storage (GB)"
       end
-      field "afterSizeUtil" do
-        label "After Size % Utilization"
+      field "newSizeUtil" do
+        label "New Storage % Utilization"
       end
       field "dtu" do
-        label "DTU"
+        label "DTU Capacity"
       end
       field "dtuUtil" do
         label "DTU % Utilization"
       end
-      field "afterDtu" do
-        label "After DTU"
+      field "newDtu" do
+        label "New DTU Capacity"
       end
-      field "afterDtuUtil" do
-        label "After DTU % Utilization"
+      field "newDtuUtil" do
+        label "New DTU % Utilization"
       end
       field "iops" do
-        label "IOPs"
+        label "IOPs Capacity"
       end
       field "iopsUtil" do
         label "IOPs % Utilization"
       end
-      field "afterIops" do
-        label "After IOPs"
+      field "newIops" do
+        label "New IOPs Capacity"
       end
-      field "afterIopsUtil" do
-        label "After IOPs % Utilization"
+      field "newIopsUtil" do
+        label "New IOPs % Utilization"
       end
-      field "vmem" do
-        label "Virtual Memory (GB)"
+      field "mem" do
+        label "Memory (GB)"
       end
-      field "vmemUtil" do
-        label "Virtual Memory % Utilization"
+      field "memP95" do
+        label "Memory % Utilization"
       end
-      field "afterVmem" do
-        label "After Virtual Memory (GB)"
+      field "newMem" do
+        label "New Memory (GB)"
       end
-      field "afterVmemUtil" do
-        label "After Virtual Memory % Utilization"
+      field "newMemP95" do
+        label "New Memory % Utilization"
       end
-      field "vcpu" do
-        label "Virtual CPU (GHz)"
+      field "cpu" do
+        label "CPU (GHz)"
       end
-      field "vcpuUtil" do
-        label "Virtual CPU % Utilization"
+      field "cpuP95" do
+        label "CPU % Utilization"
       end
-      field "afterVcpu" do
-        label "After Virtual CPU (GHz)"
+      field "newCpu" do
+        label "New CPU (GHz)"
       end
-      field "afterVcpuUtil" do
-        label "After Virtual CPU % Utilization"
+      field "newCpuP95" do
+        label "new CPU % Utilization"
       end
-      field "iOThroughput" do
-        label "IOThroughput (MB/s)"
+      field "throughput" do
+        label "Throughput (MB/s)"
       end
-      field "iOThroughpututil" do
-        label "IOThroughput % Utilization"
+      field "throughputP95" do
+        label "Throughput % Utilization"
       end
-      field "afterIOThroughput" do
-        label "After IOThroughput (MB/s)"
+      field "newThroughput" do
+        label "New Throughput (MB/s)"
       end
-      field "afterIOThroughpututil" do
-        label "After IOThroughput % Utilization"
+      field "newThroughputP95" do
+        label "New Throughput % Utilization"
       end
       field "connections" do
         label "Connections"
       end
-      field "afterConnections" do
-        label "After Connections"
+      field "newConnections" do
+        label "New Connections"
       end
     end
     escalate $esc_email

--- a/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
+++ b/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
@@ -363,7 +363,7 @@ script "js_combined_data", type: "javascript" do
               db.afterDtu = projectedStatistic.dtu[0]
               db.afterDtuUtil = ((projectedStatistic.dtu[1]*100)/projectedStatistic.dtu[0]).toFixed(2)
               db.dtu = ds_get_current_statistics[index].dtu[0]
-              db.dtuutil = ((ds_get_current_statistics[index].dtu[1]*100)/ds_get_current_statistics[index].dtu[0]).toFixed(2)
+              db.dtuUtil = ((ds_get_current_statistics[index].dtu[1]*100)/ds_get_current_statistics[index].dtu[0]).toFixed(2)
             }
             if (_.contains(db.pricingModel, "StorageAmount")){
               db.afterIops = projectedStatistic.iops[0]
@@ -488,7 +488,7 @@ policy "pol_turbonomic_rightsize_databases" do
       field "dtu" do
         label "DTU"
       end
-      field "dtuutil" do
+      field "dtuUtil" do
         label "DTU % Utilization"
       end
       field "afterDtu" do
@@ -543,7 +543,7 @@ policy "pol_turbonomic_rightsize_databases" do
         label "After IOThroughput (MB/s)"
       end
       field "afterIOThroughpututil" do
-        label "AfterIOThroughput % Utilization"
+        label "After IOThroughput % Utilization"
       end
       field "connections" do
         label "Connections"

--- a/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
+++ b/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
@@ -82,9 +82,10 @@ datasource "ds_get_turbonomic_recommendations" do
       field "createdTime", jmes_path(col_item, "createTime")
       field "savings", jmes_path(col_item, "stats[0].value")
       field "savingsCurrency", jmes_path(col_item, "stats[0].units")
-      field "pricingModel", jmes_path(col_item, "risk.reasonCommodities[0]")
+      field "pricingModel", jmes_path(col_item, "risk.reasonCommodities")
       field "uuid", jmes_path(col_item, "target.uuid")
       field "actionID", jmes_path(col_item, "actionID")
+      field "className", jmes_path(col_item, "target.className")
     end
   end
 end
@@ -281,11 +282,12 @@ datasource "ds_get_projected_statistics" do
     collect jmes_path(response,"[-1]") do
       field "uuid", val(iter_item, "uuid")
       field "size", jmes_path(col_item, "statistics[?name == 'StorageAmount'].[ capacity.total, value][0]")
-      field "iops", jmes_path(col_item, "statistics[?name == 'StorageAccess'].[ capacity.total, value][0]")
-      field "vmem", jmes_path(col_item, "statistics[?name == 'VMem'].[ capacity.total, value][0]")
-      field "vcpu", jmes_path(col_item, "statistics[?name == 'VCPU'].[ capacity.total, value][0]")
-      field "iOThroughput", jmes_path(col_item, "statistics[?name == 'IOThroughput'].[ capacity.total, value][0]")
-      field "dtu", jmes_path(col_item, "statistics[?name == 'DTU'].[ capacity.total, value][0]")
+      field "iops", jmes_path(col_item, "statistics[?name == 'StorageAccess'].[histUtilizations[?type == 'percentile'].[capacity,usage][]][][]")
+      field "vmem", jmes_path(col_item, "statistics[?name == 'VMem'].[histUtilizations[?type == 'percentile'].[capacity,usage][]][][]")
+      field "vcpu", jmes_path(col_item, "statistics[?name == 'VCPU'].[histUtilizations[?type == 'percentile'].[capacity,usage][]][][]")
+      field "iOThroughput", jmes_path(col_item, "statistics[?name == 'IOThroughput'].[histUtilizations[?type == 'percentile'].[capacity,usage][]][][]")
+      field "connection", jmes_path(col_item, "statistics[?name == 'Connection'].[ capacity.total][0]")
+      field "dtu", jmes_path(col_item, "statistics[?name == 'DTU'].[histUtilizations[?type == 'percentile'].[capacity,usage][]][][]")
     end
   end
 end
@@ -300,11 +302,12 @@ datasource "ds_get_current_statistics" do
     collect jmes_path(response,"[-2]") do
       field "uuid", val(iter_item, "uuid")
       field "size", jmes_path(col_item, "statistics[?name == 'StorageAmount'].[ capacity.total, value][-1]")
-      field "iops", jmes_path(col_item, "statistics[?name == 'StorageAccess'].[ capacity.total, value][-1]")
-      field "vmem", jmes_path(col_item, "statistics[?name == 'VMem'].[ capacity.total, value][-1]")
-      field "vcpu", jmes_path(col_item, "statistics[?name == 'VCPU'].[ capacity.total, value][-1]")
-      field "iOThroughput", jmes_path(col_item, "statistics[?name == 'IOThroughput'].[ capacity.total, value][-1]")
-      field "dtu", jmes_path(col_item, "statistics[?name == 'DTU'].[ capacity.total, value][-1]")
+      field "iops", jmes_path(col_item, "statistics[?name == 'StorageAccess'].[histUtilizations[?type == 'percentile'].[capacity,usage][]][][]")
+      field "vmem", jmes_path(col_item, "statistics[?name == 'VMem'].[histUtilizations[?type == 'percentile'].[capacity,usage][]][][]")
+      field "vcpu", jmes_path(col_item, "statistics[?name == 'VCPU'].[histUtilizations[?type == 'percentile'].[capacity,usage][]][][]")
+      field "iOThroughput", jmes_path(col_item, "statistics[?name == 'IOThroughput'].[histUtilizations[?type == 'percentile'].[capacity,usage][]][][]")
+      field "connection", jmes_path(col_item, "statistics[?name == 'Connection'].[ capacity.total][0]")
+      field "dtu", jmes_path(col_item, "statistics[?name == 'DTU'].[histUtilizations[?type == 'percentile'].[capacity,usage][]][][]")
     end
   end
 end
@@ -318,11 +321,13 @@ script "js_get_projected_statistics", type: "javascript" do
     pastDay = new Date(Date.now() + nineHours)
     body_fields = {}
 
-    if (instance.pricingModel == "DTU"){
+    if (instance.className = "DatabaseServer"){
+      body_fields = {"statistics":[{"name":"VCPU","groupBy":["key","percentile"]},{"name":"VMem","groupBy":["key","percentile"]},{"name":"IOThroughput","groupBy":["key","percentile"]},{"name":"DBCacheHitRate","groupBy":["key","percentile"]},{"name":"VStorage","groupBy":["key", "percentile"]},{"name":"StorageAccess","groupBy":["key","percentile"]},{"name":"StorageAmount","groupBy":["key"]},{"name":"Connection","groupBy":["key"]}],"startDate":nowDay.getTime(),"endDate":pastDay.getTime()}
+    }
+    if (_.contains("DTU", instance.pricingModel)){
       body_fields = {"statistics":[{"name":"DTU","groupBy":["key","percentile"]},{"name":"StorageAmount","groupBy":["key"]}],"startDate":nowDay.getTime(),"endDate":pastDay.getTime()}
     }
-
-    if (instance.pricingModel == "StorageAmount"){
+    if (_.contains("StorageAmount", instance.pricingModel)){
       body_fields = {"statistics":[{"name":"VCPU","groupBy":["key","percentile"]},{"name":"VMem","groupBy":["key","percentile"]},{"name":"StorageAccess","groupBy":["key","percentile"]},{"name":"IOThroughput","groupBy":["key","percentile"]},{"name":"StorageAmount","groupBy":["key"]}],"startDate":nowDay.getTime(),"endDate":pastDay.getTime()}
     }
 
@@ -350,34 +355,52 @@ script "js_combined_data", type: "javascript" do
     _.each(ds_get_projected_statistics, function (projectedStatistic) {
       _.each(ds_get_turbonomic_recommendations.instances, function (db, index) {
           if (db.uuid === projectedStatistic.uuid) {
-            db.size = (projectedStatistic.size[0]/1024) + " GB"
-            db.diskUtilization = ((projectedStatistic.size[1]*100)/projectedStatistic.size[0]).toFixed(2) + " %"
-            db.sizenow = (ds_get_current_statistics[index].size[0]/1024) + " GB"
-            db.sizeutil = ((ds_get_current_statistics[index].size[1]*100)/ds_get_current_statistics[index].size[0]).toFixed(2) + " %"
-            if (db.pricingModel == "DTU"){
-              db.dtu = projectedStatistic.dtu[0]
-              db.dtuafter = ((projectedStatistic.dtu[1]*100)/projectedStatistic.dtu[0]).toFixed(2) + " %"
-              db.dtunow = ds_get_current_statistics[index].dtu[0]
-              db.dtuutilnow = ((ds_get_current_statistics[index].dtu[1]*100)/ds_get_current_statistics[index].dtu[0]).toFixed(2) + " %"
-            }
-            if (db.pricingModel == "StorageAmount"){
-              db.iops = projectedStatistic.iops[0] + " IOPS"
-              db.iopsutil = ((projectedStatistic.iops[1]*100)/projectedStatistic.iops[0]).toFixed(2) + " %"
-              db.vmem = (projectedStatistic.vmem[0]/1048576).toFixed(2) + " GB"
-              db.vmemutil = ((projectedStatistic.vmem[1]*100)/projectedStatistic.vmem[0]).toFixed(2) + " %"
-              db.vcpu = (projectedStatistic.vcpu[0]/1000).toFixed(2) + " GHz"
-              db.vcpuutil = ((projectedStatistic.vcpu[1]*100)/projectedStatistic.vcpu[0]).toFixed(2) + " %"
-              db.iOThroughput = (projectedStatistic.iOThroughput[0]*0.000125).toFixed(2) + " MB/s"
-              db.iOThroughpututil = ((projectedStatistic.iOThroughput[1]*100)/projectedStatistic.iOThroughput[0]).toFixed(2) + " %"
+            db.size = (projectedStatistic.size[0]/1024)
+            db.diskUtilization = ((projectedStatistic.size[1]*100)/projectedStatistic.size[0]).toFixed(2)
+            db.sizenow = (ds_get_current_statistics[index].size[0]/1024)
+            db.sizeutil = ((ds_get_current_statistics[index].size[1]*100)/ds_get_current_statistics[index].size[0]).toFixed(2)
 
-              db.iopsnow = ds_get_current_statistics[index].iops[0] + " IOPS"
-              db.iopsutilnow = ((ds_get_current_statistics[index].iops[1]*100)/ds_get_current_statistics[index].iops[0]).toFixed(2) + " %"
-              db.vmemnow = (ds_get_current_statistics[index].vmem[0]/1048576).toFixed(2) + " GB"
-              db.vmemutilnow = ((ds_get_current_statistics[index].vmem[1]*100)/ds_get_current_statistics[index].vmem[0]).toFixed(2) + " %"
-              db.vcpunow = (ds_get_current_statistics[index].vcpu[0]/1000).toFixed(2) + " GHz"
-              db.vcpuutilnow = ((ds_get_current_statistics[index].vcpu[1]*100)/ds_get_current_statistics[index].vcpu[0]).toFixed(2) + " %"
-              db.iOThroughputnow = (ds_get_current_statistics[index].iOThroughput[0]*0.000125).toFixed(2) + " MB/s"
-              db.iOThroughpututilnow = ((ds_get_current_statistics[index].iOThroughput[1]*100)/ds_get_current_statistics[index].iOThroughput[0]).toFixed(2) + " %"
+            if (_.contains(db.pricingModel, "DTU")){
+              db.dtu = projectedStatistic.dtu[0]
+              db.dtuafter = ((projectedStatistic.dtu[1]*100)/projectedStatistic.dtu[0]).toFixed(2)
+              db.dtunow = ds_get_current_statistics[index].dtu[0]
+              db.dtuutilnow = ((ds_get_current_statistics[index].dtu[1]*100)/ds_get_current_statistics[index].dtu[0]).toFixed(2)
+            }
+
+            if (_.contains(db.pricingModel, "StorageAmount")){
+              db.iops = projectedStatistic.iops[0]
+              db.iopsutil = ((projectedStatistic.iops[1]*100)/projectedStatistic.iops[0]).toFixed(2)
+              db.vmem = (projectedStatistic.vmem[0]/1048576).toFixed(2)
+              db.vmemutil = ((projectedStatistic.vmem[1]*100)/projectedStatistic.vmem[0]).toFixed(2)
+              db.vcpu = (projectedStatistic.vcpu[0]/1000).toFixed(2)
+              db.vcpuutil = ((projectedStatistic.vcpu[1]*100)/projectedStatistic.vcpu[0]).toFixed(2)
+              db.iOThroughput = (projectedStatistic.iOThroughput[0]*0.000125).toFixed(2)
+              db.iOThroughpututil = ((projectedStatistic.iOThroughput[1]*100)/projectedStatistic.iOThroughput[0]).toFixed(2)
+              db.iopsnow = ds_get_current_statistics[index].iops[0]
+              db.iopsutilnow = ((ds_get_current_statistics[index].iops[1]*100)/ds_get_current_statistics[index].iops[0]).toFixed(2)
+              db.vmemnow = (ds_get_current_statistics[index].vmem[0]/1048576).toFixed(2)
+              db.vmemutilnow = ((ds_get_current_statistics[index].vmem[1]*100)/ds_get_current_statistics[index].vmem[0]).toFixed(2)
+              db.vcpunow = (ds_get_current_statistics[index].vcpu[0]/1000).toFixed(2)
+              db.vcpuutilnow = ((ds_get_current_statistics[index].vcpu[1]*100)/ds_get_current_statistics[index].vcpu[0]).toFixed(2)
+              db.iOThroughputnow = (ds_get_current_statistics[index].iOThroughput[0]*0.000125).toFixed(2)
+              db.iOThroughpututilnow = ((ds_get_current_statistics[index].iOThroughput[1]*100)/ds_get_current_statistics[index].iOThroughput[0]).toFixed(2)
+            }
+
+            if (db.className == "DatabaseServer") {
+              db.connectionNow = projectedStatistic.connection[0]
+              db.connectionAfter = ds_get_current_statistics[index].connection[0]
+              db.iops = projectedStatistic.iops[0]
+              db.iopsutil = ((projectedStatistic.iops[1]*100)/projectedStatistic.iops[0]).toFixed(2)
+              db.vmem = (projectedStatistic.vmem[0]/1048576).toFixed(2)
+              db.vmemutil = ((projectedStatistic.vmem[1]*100)/projectedStatistic.vmem[0]).toFixed(2)
+              db.vcpu = (projectedStatistic.vcpu[0]/1000).toFixed(2)
+              db.vcpuutil = ((projectedStatistic.vcpu[1]*100)/projectedStatistic.vcpu[0]).toFixed(2)
+              db.iopsnow = ds_get_current_statistics[index].iops[0]
+              db.iopsutilnow = ((ds_get_current_statistics[index].iops[1]*100)/ds_get_current_statistics[index].iops[0]).toFixed(2)
+              db.vmemnow = (ds_get_current_statistics[index].vmem[0]/1048576).toFixed(2)
+              db.vmemutilnow = ((ds_get_current_statistics[index].vmem[1]*100)/ds_get_current_statistics[index].vmem[0]).toFixed(2)
+              db.vcpunow = (ds_get_current_statistics[index].vcpu[0]/1000).toFixed(2)
+              db.vcpuutilnow = ((ds_get_current_statistics[index].vcpu[1]*100)/ds_get_current_statistics[index].vcpu[0]).toFixed(2)
             }
           }
       })
@@ -457,16 +480,16 @@ policy "pol_turbonomic_rightsize_databases" do
         label "System Details URL"
       end
       field "sizenow" do
-        label "Current Size"
+        label "Current GB Size"
       end
       field "sizeutil" do
-        label "Current Size % Utilization"
+        label "Current GB Size % Utilization"
       end
       field "size" do
-        label "After Size"
+        label "After GB Size"
       end
       field "diskUtilization" do
-        label "After Size % Utilization"
+        label "After GB Size % Utilization"
       end
       field "dtunow" do
         label "Current DTU"
@@ -493,40 +516,46 @@ policy "pol_turbonomic_rightsize_databases" do
         label "After IOPs % Utilization"
       end
       field "vmemnow" do
-        label "Current Virtual Memory"
+        label "Current GB Virtual Memory"
       end
       field "vmemutilnow" do
-        label "Current Virtual Memory % Utilization"
+        label "Current GB Virtual Memory % Utilization"
       end
       field "vmem" do
-        label "After Virtual Memory"
+        label "After GB Virtual Memory"
       end
       field "vmemutil" do
-        label "After Virtual Memory % Utilization"
+        label "After GB Virtual Memory % Utilization"
       end
       field "vcpunow" do
-        label "Current Virtual CPU"
+        label "Current GHz Virtual CPU"
       end
       field "vcpuutilnow" do
-        label "Current Virtual CPU % Utilization"
+        label "Current GHz Virtual CPU % Utilization"
       end
       field "vcpu" do
-        label "After Virtual CPU"
+        label "After GHz Virtual CPU"
       end
       field "vcpuutil" do
-        label "After Virtual CPU % Utilization"
+        label "After GHz Virtual CPU % Utilization"
       end
       field "iOThroughputnow" do
-        label "Current IOThroughput"
+        label "Current MB/s IOThroughput"
       end
       field "iOThroughpututilnow" do
-        label "Current IOThroughput  % Utilization"
+        label "Current MB/s IOThroughput % Utilization"
       end
       field "iOThroughput" do
-        label "After IOThroughput"
+        label "After MB/s IOThroughput"
       end
       field "iOThroughpututil" do
-        label "After IOThroughput  % Utilization"
+        label "After MB/s IOThroughput % Utilization"
+      end
+      field "connectionNow" do
+        label "Current Connections"
+      end
+      field "connectionAfter" do
+        label "After Connections"
       end
     end
     escalate $esc_email

--- a/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
+++ b/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.2",
+  version: "0.3",
   source: "Turbonomic",
   service: "Usage Discount",
   provider: "AWS",
@@ -60,7 +60,7 @@ pagination "turbonomic_databases_pagination_header" do
 end
 
 ###############################################################################
-# Datasources
+# Datasources & Scripts
 ###############################################################################
 
 datasource "ds_get_turbonomic_recommendations" do
@@ -82,31 +82,11 @@ datasource "ds_get_turbonomic_recommendations" do
       field "createdTime", jmes_path(col_item, "createTime")
       field "savings", jmes_path(col_item, "stats[0].value")
       field "savingsCurrency", jmes_path(col_item, "stats[0].units")
+      field "pricingModel", jmes_path(col_item, "risk.reasonCommodities[0]")
+      field "uuid", jmes_path(col_item, "target.uuid")
     end
   end
 end
-
-datasource "ds_get_business_units" do
-  request do
-    run_script $js_get_business_units, $param_turbonomic_endpoint, $param_auth_cookie, $param_provider
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "[*]") do
-      field "uuid", jmes_path(col_item, "uuid")
-      field "accountID", jmes_path(col_item, "accountId")
-      field "displayName", jmes_path(col_item, "displayName")
-    end
-  end
-end
-
-datasource "ds_filtered_turbonomic_recommendations" do
-  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $param_provider
-end
-
-###############################################################################
-# Scripts
-###############################################################################
 
 script "js_get_turbonomic_recommendations", type: "javascript" do
   result "request"
@@ -134,6 +114,20 @@ script "js_get_turbonomic_recommendations", type: "javascript" do
       }
     }
   EOS
+end
+
+datasource "ds_get_business_units" do
+  request do
+    run_script $js_get_business_units, $param_turbonomic_endpoint, $param_auth_cookie, $param_provider
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "uuid", jmes_path(col_item, "uuid")
+      field "accountID", jmes_path(col_item, "accountId")
+      field "displayName", jmes_path(col_item, "displayName")
+    end
+  end
 end
 
 script "js_get_business_units", type: "javascript" do
@@ -167,13 +161,19 @@ script "js_get_business_units", type: "javascript" do
   EOS
 end
 
+datasource "ds_filtered_turbonomic_recommendations" do
+  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $param_provider
+end
+
 script "js_filtered_turbonomic_recommendations", type: "javascript" do
   result "result"
   parameters "ds_get_turbonomic_recommendations", "ds_get_business_units", "param_provider"
   code <<-EOS
     instances = []
     monthlySavings = 0.0
-    
+    oneDay = 1000 * 60 * 60 * 24
+    nowDay = new Date(Date.now())
+
     function formatNumber(number, separator) {
         numString = number.toString()
         values = numString.split(".")
@@ -191,7 +191,7 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
         }
         return result + "." + values[1]
     }
-    
+
     _.each(ds_get_business_units, function (businessUnit) {
         _.each(ds_get_turbonomic_recommendations, function (db, index) {
             if (db.businessUUID === businessUnit.uuid) {
@@ -200,13 +200,13 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
             }
         })
     })
-    
+
     provider_service = {
         "AWS": "RDS",
         "Azure Subscription": "Azure SQL Database",
         "GCP Project": "Cloud SQL"
     }
-    
+
     _.each(ds_get_turbonomic_recommendations, function (db) {
         if (db.provider === param_provider || param_provider === "All") {
             if (typeof db.savingsCurrency != "undefined" && db.savingsCurrency != null) {
@@ -216,7 +216,7 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
             } else {
                 db.savingsCurrency = "$"
             }
-    
+
             tags = []
             if (typeof db.tags === "undefined" || db.tags === null) {
                 db.tags = tags
@@ -235,15 +235,18 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
             if (typeof db.savings === "undefined" || db.savings === null || db.savings === "" || isNaN(db.savings)) {
                 db.savings = 0.0
             }
-    
+
             db.savings = (Math.round(db.savings * 730 * 1000) / 1000)
             monthlySavings = monthlySavings + db.savings
+            instanceCreatedDate = new Date(db.createdTime)
+            db.vmAge = (Math.round(nowDay.getTime() - instanceCreatedDate.getTime()) / (oneDay)).toFixed(0) + " Day(s)"
+            db.url = "https://"
             instances.push(db)
         }
     })
-    
+
     message = ""
-    
+
     if (instances.length != 0) {
         pretty_savings = instances[0].savingsCurrency + ' ' + formatNumber(monthlySavings.toFixed(2), ",")
         message = "The total estimated monthly savings are " + pretty_savings + '.'
@@ -255,12 +258,144 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
   EOS
 end
 
+datasource "ds_filtered_recommendations" do
+  run_script $js_only_recommendations, $ds_filtered_turbonomic_recommendations
+end
+
+script "js_only_recommendations", type: "javascript" do
+  parameters "arg"
+  result "results"
+  code <<-EOS
+    results = arg.instances
+  EOS
+end
+
+datasource "ds_get_projected_statistics" do
+  iterate $ds_filtered_recommendations
+  request do
+    run_script $js_get_projected_statistics, iter_item, $param_turbonomic_endpoint, $param_auth_cookie
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response,"[-1]") do
+      field "uuid", val(iter_item, "uuid")
+      field "size", jmes_path(col_item, "statistics[?name == 'StorageAmount'].[ capacity.total, value][0]")
+      field "iops", jmes_path(col_item, "statistics[?name == 'StorageAccess'].[ capacity.total, value][0]")
+      field "vmem", jmes_path(col_item, "statistics[?name == 'VMem'].[ capacity.total, value][0]")
+      field "vcpu", jmes_path(col_item, "statistics[?name == 'VCPU'].[ capacity.total, value][0]")
+      field "iOThroughput", jmes_path(col_item, "statistics[?name == 'IOThroughput'].[ capacity.total, value][0]")
+      field "dtu", jmes_path(col_item, "statistics[?name == 'DTU'].[ capacity.total, value][0]")
+    end
+  end
+end
+
+datasource "ds_get_current_statistics" do
+  iterate $ds_filtered_recommendations
+  request do
+    run_script $js_get_projected_statistics, iter_item, $param_turbonomic_endpoint, $param_auth_cookie
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response,"[-2]") do
+      field "uuid", val(iter_item, "uuid")
+      field "size", jmes_path(col_item, "statistics[?name == 'StorageAmount'].[ capacity.total, value][-1]")
+      field "iops", jmes_path(col_item, "statistics[?name == 'StorageAccess'].[ capacity.total, value][-1]")
+      field "vmem", jmes_path(col_item, "statistics[?name == 'VMem'].[ capacity.total, value][-1]")
+      field "vcpu", jmes_path(col_item, "statistics[?name == 'VCPU'].[ capacity.total, value][-1]")
+      field "iOThroughput", jmes_path(col_item, "statistics[?name == 'IOThroughput'].[ capacity.total, value][-1]")
+      field "dtu", jmes_path(col_item, "statistics[?name == 'DTU'].[ capacity.total, value][-1]")
+    end
+  end
+end
+
+script "js_get_projected_statistics", type: "javascript" do
+  parameters "instance", "turbonomic_endpoint", "auth_cookie"
+  result "request"
+  code <<-EOS
+    nineHours = 1000 * 60 * 60 * 9
+    nowDay = new Date(Date.now())
+    pastDay = new Date(Date.now() + nineHours)
+    body_fields = {}
+
+    if (instance.pricingModel == "DTU"){
+      body_fields = {"statistics":[{"name":"DTU","groupBy":["key","percentile"]},{"name":"StorageAmount","groupBy":["key"]}],"startDate":nowDay.getTime(),"endDate":pastDay.getTime()}
+    }
+
+    if (instance.pricingModel == "StorageAmount"){
+      body_fields = {"statistics":[{"name":"VCPU","groupBy":["key","percentile"]},{"name":"VMem","groupBy":["key","percentile"]},{"name":"StorageAccess","groupBy":["key","percentile"]},{"name":"IOThroughput","groupBy":["key","percentile"]},{"name":"StorageAmount","groupBy":["key"]}],"startDate":nowDay.getTime(),"endDate":pastDay.getTime()}
+    }
+
+    request = {
+      verb: "POST",
+      host: turbonomic_endpoint,
+      path: "/api/v3/stats/" + instance.uuid,
+      body_fields: body_fields
+      headers: {
+        "Content-Type": "application/json"
+        "Cookie": auth_cookie
+      }
+    }
+  EOS
+end
+
+datasource "ds_combined_data" do
+  run_script $js_combined_data, $ds_filtered_turbonomic_recommendations, $ds_get_projected_statistics, $ds_get_current_statistics
+end
+
+script "js_combined_data", type: "javascript" do
+  result "result"
+  parameters "ds_get_turbonomic_recommendations", "ds_get_projected_statistics", "ds_get_current_statistics"
+  code <<-EOS
+    _.each(ds_get_projected_statistics, function (projectedStatistic) {
+      _.each(ds_get_turbonomic_recommendations.instances, function (db, index) {
+          if (db.uuid === projectedStatistic.uuid) {
+            db.size = (projectedStatistic.size[0]/1024) + " GB"
+            db.diskUtilization = ((projectedStatistic.size[1]*100)/projectedStatistic.size[0]).toFixed(2) + " %"
+            db.sizenow = (ds_get_current_statistics[index].size[0]/1024) + " GB"
+            db.sizeutil = ((ds_get_current_statistics[index].size[1]*100)/ds_get_current_statistics[index].size[0]).toFixed(2) + " %"
+            if (db.pricingModel == "DTU"){
+              db.dtu = projectedStatistic.dtu[0]
+              db.dtuafter = ((projectedStatistic.dtu[1]*100)/projectedStatistic.dtu[0]).toFixed(2) + " %"
+              db.dtunow = ds_get_current_statistics[index].dtu[0]
+              db.dtuutilnow = ((ds_get_current_statistics[index].dtu[1]*100)/ds_get_current_statistics[index].dtu[0]).toFixed(2) + " %"
+            }
+            if (db.pricingModel == "StorageAmount"){
+              db.iops = projectedStatistic.iops[0] + " IOPS"
+              db.iopsutil = ((projectedStatistic.iops[1]*100)/projectedStatistic.iops[0]).toFixed(2) + " %"
+              db.vmem = (projectedStatistic.vmem[0]/1048576).toFixed(2) + " GB"
+              db.vmemutil = ((projectedStatistic.vmem[1]*100)/projectedStatistic.vmem[0]).toFixed(2) + " %"
+              db.vcpu = (projectedStatistic.vcpu[0]/1000).toFixed(2) + " GHz"
+              db.vcpuutil = ((projectedStatistic.vcpu[1]*100)/projectedStatistic.vcpu[0]).toFixed(2) + " %"
+              db.iOThroughput = (projectedStatistic.iOThroughput[0]*0.000125).toFixed(2) + " MB/s"
+              db.iOThroughpututil = ((projectedStatistic.iOThroughput[1]*100)/projectedStatistic.iOThroughput[0]).toFixed(2) + " %"
+
+              db.iopsnow = ds_get_current_statistics[index].iops[0] + " IOPS"
+              db.iopsutilnow = ((ds_get_current_statistics[index].iops[1]*100)/ds_get_current_statistics[index].iops[0]).toFixed(2) + " %"
+              db.vmemnow = (ds_get_current_statistics[index].vmem[0]/1048576).toFixed(2) + " GB"
+              db.vmemutilnow = ((ds_get_current_statistics[index].vmem[1]*100)/ds_get_current_statistics[index].vmem[0]).toFixed(2) + " %"
+              db.vcpunow = (ds_get_current_statistics[index].vcpu[0]/1000).toFixed(2) + " GHz"
+              db.vcpuutilnow = ((ds_get_current_statistics[index].vcpu[1]*100)/ds_get_current_statistics[index].vcpu[0]).toFixed(2) + " %"
+              db.iOThroughputnow = (ds_get_current_statistics[index].iOThroughput[0]*0.000125).toFixed(2) + " MB/s"
+              db.iOThroughpututilnow = ((ds_get_current_statistics[index].iOThroughput[1]*100)/ds_get_current_statistics[index].iOThroughput[0]).toFixed(2) + " %"
+            }
+          }
+      })
+    })
+
+    result = {
+      'instances': ds_get_turbonomic_recommendations.instances,
+      'message': ds_get_turbonomic_recommendations.message
+    }
+
+  EOS
+end
+
 ###############################################################################
 # Policy
 ###############################################################################
 
 policy "pol_turbonomic_rightsize_databases" do
-  validate $ds_filtered_turbonomic_recommendations do
+  validate $ds_combined_data do
     summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data.instances }} Turbonomic Databases to Rightsize found"
     detail_template <<-EOS
       ## Turbonomic Rightsize Databases Recommendations
@@ -311,6 +446,87 @@ policy "pol_turbonomic_rightsize_databases" do
       field "createdTime" do
         label "Created Time"
       end
+      field "vmAge" do
+        label "VM Age"
+      end
+      field "pricingModel" do
+        label "Pricing Model"
+      end
+      field "url" do
+        label "URL"
+      end
+      field "sizenow" do
+        label "Actual Storage Amount"
+      end
+      field "sizeutil" do
+        label "Actual Storage Amount % Utilization"
+      end
+      field "size" do
+        label "New Storage Amount"
+      end
+      field "diskUtilization" do
+        label "New Storage Amount % Utilization"
+      end
+      field "dtunow" do
+        label "Actual DTU"
+      end
+      field "dtuutilnow" do
+        label "Actual DTU % Utilization"
+      end
+      field "dtu" do
+        label "New DTU"
+      end
+      field "dtuafter" do
+        label "New DTU % Utilization"
+      end
+      field "iopsnow" do
+        label "Actual IOPs"
+      end
+      field "iopsutilnow" do
+        label "Actual IOPs % Utilization"
+      end
+      field "iops" do
+        label "New IOPs"
+      end
+      field "iopsutil" do
+        label "New IOPs % Utilization"
+      end
+      field "vmemnow" do
+        label "Actual Virtual Memory"
+      end
+      field "vmemutilnow" do
+        label "Actual Virtual Memory % Utilization"
+      end
+      field "vmem" do
+        label "New Virtual Memory"
+      end
+      field "vmemutil" do
+        label "New Virtual Memory % Utilization"
+      end
+      field "vcpunow" do
+        label "Actual Virtual CPU"
+      end
+      field "vcpuutilnow" do
+        label "Actual Virtual CPU % Utilization"
+      end
+      field "vcpu" do
+        label "New Virtual CPU"
+      end
+      field "vcpuutil" do
+        label "New Virtual CPU % Utilization"
+      end
+      field "iOThroughputnow" do
+        label "Actual IOThroughput"
+      end
+      field "iOThroughpututilnow" do
+        label "Actual IOThroughput  % Utilization"
+      end
+      field "iOThroughput" do
+        label "New IOThroughput"
+      end
+      field "iOThroughpututil" do
+        label "New IOThroughput  % Utilization"
+      end
     end
     escalate $esc_email
   end
@@ -326,4 +542,3 @@ escalation "esc_email" do
   description "Send incident email"
   email $param_email
 end
-


### PR DESCRIPTION
### Description

AWS Rightsize DBs policy needs to show the following information: VM age, uptime, vCPU capacity before/after, vCPU utilization before/after, Memory capacity before/after, memory utilization before/after, IOPs capacity and utilization before/after, disk capacity and utilization before/after, connection capacity and utilization before/after, system details URL.

### Issues Resolved

[FOPTS-1333](https://flexera.atlassian.net/browse/FOPTS-1333)

### Link to Example Applied Policy
[Turbonomic Rightsize Databases Recommendations AWS Policy Template Applied ](https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/107982?policyId=64d1884d85ab670001ff6d64)


### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
