### PR TITLE
FOPTS-1329 Turbonomic Rightsize Volumes (GCP)

### DIFF
--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/gcp/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/gcp/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.4
 
-- Unpublished policy from catalog since Turbonomic does not support Google provider yet.
+- Unpublished policy from catalog since Turbonomic Rightsize Volumes does not support Google provider yet.
 
 ## v0.3
 

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/gcp/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/gcp/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4
+
+- Unpublished policy from catalog since Turbonomic does not support Google provider yet.
+
 ## v0.3
 
 - Updates provider from GCP to Google

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/gcp/turbonomics_rightsize_virtual_volumes_recommendations.pt
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/gcp/turbonomics_rightsize_virtual_volumes_recommendations.pt
@@ -6,12 +6,13 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.3",
+  version: "0.4",
   source: "Turbonomic",
   service: "Usage Discount",
   provider: "Google",
   policy_set: "Rightsize Volumes",
-  recommendation_type: "Usage Reduction"
+  recommendation_type: "Usage Reduction",
+  publish: "false"
 )
 
 ##################


### PR DESCRIPTION
### Description

GCP Rightsize Volumes is not supported on Turbonomic yet.

### Issues Resolved

Unpublished policy from catalog since Turbonomic Rightsize Volumes does not support Google provider yet.

### Link to Example Applied Policy

N/A

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
