### PR TITLE
FOPTS-1578 Allow Retrieving Recommendations "per cluster"

### DIFF
--- a/cost/kubecost/sizing/CHANGELOG.md
+++ b/cost/kubecost/sizing/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3
 
-- A new parameter for requesting recommendations "per cluster" or "overall" was added, if per cluster mode is configured, policy will discover clusters, iterate the clusters and request recommendations for each one. Previously, policy requested these recommendations in overall mode.
+- A new parameter for requesting recommendations "per cluster" or "overall" was added, if "per cluster" mode is configured, policy will discover clusters, iterate the clusters and request recommendations for each one. Previously, policy requested these recommendations in "overall" mode.
 
 ## v0.2
 

--- a/cost/kubecost/sizing/CHANGELOG.md
+++ b/cost/kubecost/sizing/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3
+
+- A new parameter for requesting recommendations "per cluster" or "overall" was added, if per cluster mode is configured, policy will discover clusters, iterate the clusters and request recommendations for each one. Previously, policy requested these recommendations in overall mode.
+
 ## v0.2
 
 - The CPU quantile and Memory quantile parameters are now percentiles.

--- a/cost/kubecost/sizing/CHANGELOG.md
+++ b/cost/kubecost/sizing/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3
 
-- A new parameter for requesting recommendations "per cluster" or "overall" was added, if "per cluster" mode is configured, policy will discover clusters, iterate the clusters and request recommendations for each one. Previously, policy requested these recommendations in "overall" mode.
+- Added `Scope` parameter to allow user to gather recommendations per cluster or across the entire account. Previously, the recommendations were always requested overall the account.
 
 ## v0.2
 

--- a/cost/kubecost/sizing/README.md
+++ b/cost/kubecost/sizing/README.md
@@ -13,7 +13,7 @@ Kubecost request sizing recommendations policy provides Kubecost recommendations
 
 - *Email addresses of the recipients you wish to notify* - A list of email addresses to notify
 - *Kubecost Host or IP address* - The host or IP Address where your Kubecost runs
-- *Recommendations request method* - The method used to request savings recommendations: "overall" or per "cluster"
+- *Scope* - The scope used to request savings recommendations: "overall" or "per cluster"
 - *Monthly Savings Threshold* - Specify the minimum estimated monthly savings that should result in a recommendation
   - Default: 5
   - Minimum value: 1

--- a/cost/kubecost/sizing/README.md
+++ b/cost/kubecost/sizing/README.md
@@ -45,3 +45,4 @@ Kubecost request sizing recommendations policy provides Kubecost recommendations
 ## Cost
 
 This Policy Template does not launch any instances, and so does not incur any cloud costs.
+

--- a/cost/kubecost/sizing/README.md
+++ b/cost/kubecost/sizing/README.md
@@ -45,4 +45,3 @@ Kubecost request sizing recommendations policy provides Kubecost recommendations
 ## Cost
 
 This Policy Template does not launch any instances, and so does not incur any cloud costs.
-

--- a/cost/kubecost/sizing/README.md
+++ b/cost/kubecost/sizing/README.md
@@ -13,6 +13,7 @@ Kubecost request sizing recommendations policy provides Kubecost recommendations
 
 - *Email addresses of the recipients you wish to notify* - A list of email addresses to notify
 - *Kubecost Host or IP address* - The host or IP Address where your Kubecost runs
+- *Recommendations request method* - The method used to request savings recommendations: overall or per cluster
 - *Monthly Savings Threshold* - Specify the minimum estimated monthly savings that should result in a recommendation
   - Default: 5
   - Minimum value: 1

--- a/cost/kubecost/sizing/README.md
+++ b/cost/kubecost/sizing/README.md
@@ -13,7 +13,7 @@ Kubecost request sizing recommendations policy provides Kubecost recommendations
 
 - *Email addresses of the recipients you wish to notify* - A list of email addresses to notify
 - *Kubecost Host or IP address* - The host or IP Address where your Kubecost runs
-- *Recommendations request method* - The method used to request savings recommendations: overall or per cluster
+- *Recommendations request method* - The method used to request savings recommendations: "overall" or per "cluster"
 - *Monthly Savings Threshold* - Specify the minimum estimated monthly savings that should result in a recommendation
   - Default: 5
   - Minimum value: 1

--- a/cost/kubecost/sizing/kubecost_resizing_recommendation.pt
+++ b/cost/kubecost/sizing/kubecost_resizing_recommendation.pt
@@ -25,18 +25,18 @@ parameter "param_email" do
   type "list"
 end
 
+parameter "param_kubecost_host" do
+  type "string"
+  label "Kubecost Host or IP address"
+  description "IP Address of Kubecost LB"
+end
+
 parameter "param_recommendations_request_method" do
   type "string"
   label "Recommendations request method"
   description "Choose between requesting the recommendations per cluster or overall"
   allowed_values "overall", "per cluster"
   default "overall"
-end
-
-parameter "param_kubecost_host" do
-  type "string"
-  label "Kubecost Host or IP address"
-  description "IP Address of Kubecost LB"
 end
 
 parameter "param_minimum_savings_threshold" do

--- a/cost/kubecost/sizing/kubecost_resizing_recommendation.pt
+++ b/cost/kubecost/sizing/kubecost_resizing_recommendation.pt
@@ -133,6 +133,14 @@ datasource "ds_request_sizing" do
   end
 end
 
+script "js_get_request_from_iter_item", type: "javascript" do
+  parameters "item"
+  result "request"
+  code <<-EOS
+  request = item
+  EOS
+end
+
 datasource "ds_get_currency" do
   request do
     verb "GET"
@@ -163,14 +171,6 @@ end
 
 datasource "ds_sizing_recommendation_request_list" do
   run_script $js_sizing_recommendation_request_list, $param_kubecost_host, $param_recommendations_request_method, $ds_get_clusters, $param_cpu_algo, $param_cpu_q, $param_mem_algo, $param_mem_q, $param_window, $param_cpu_util, $param_mem_util
-end
-
-script "js_get_request_from_iter_item", type: "javascript" do
-  parameters "item"
-  result "request"
-  code <<-EOS
-  var request = item
-  EOS
 end
 
 script "js_sizing_recommendation_request_list", type: "javascript" do

--- a/cost/kubecost/sizing/kubecost_resizing_recommendation.pt
+++ b/cost/kubecost/sizing/kubecost_resizing_recommendation.pt
@@ -8,7 +8,7 @@ category "Cost"
 default_frequency "daily"
 tenancy "single"
 info(
-  version: "0.2",
+  version: "0.3",
   provider: "Kubecost",
   service: "Kubernetes",
   policy_set: "Rightsize Containers",
@@ -23,6 +23,14 @@ parameter "param_email" do
   label "Email addresses"
   description "Email addresses of the recipients you wish to notify"
   type "list"
+end
+
+parameter "param_recommendations_request_method" do
+  type "string"
+  label "Recommendations request method"
+  description "Choose between requesting the recommendations per cluster or overall"
+  allowed_values "overall", "per cluster"
+  default "overall"
 end
 
 parameter "param_kubecost_host" do
@@ -103,8 +111,9 @@ end
 ###############################################################################
 
 datasource "ds_request_sizing" do
+  iterate $ds_sizing_recommendation_request_list
   request do
-    run_script $js_request_sizing, $param_kubecost_host, $param_cpu_algo, $param_cpu_q, $param_mem_algo, $param_mem_q, $param_window, $param_cpu_util, $param_mem_util
+    run_script $js_get_request_from_iter_item, iter_item
   end
   result do
     encoding "json"
@@ -137,31 +146,83 @@ datasource "ds_get_currency" do
   end
 end
 
-script "js_request_sizing", type: "javascript" do
-  parameters "kubecost_host", "param_cpu_algo", "param_cpu_q", "param_mem_algo", "param_mem_q", "param_window", "param_cpu_util", "param_mem_util"
+datasource "ds_get_clusters" do
+  request do
+    verb "GET"
+    scheme "http"
+    host $param_kubecost_host
+    path "/model/clusterInfoMap"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "data | values(@)") do
+      field "clusterId", jmes_path(col_item, "id")
+    end
+  end
+end
+
+datasource "ds_sizing_recommendation_request_list" do
+  run_script $js_sizing_recommendation_request_list, $param_kubecost_host, $param_recommendations_request_method, $ds_get_clusters, $param_cpu_algo, $param_cpu_q, $param_mem_algo, $param_mem_q, $param_window, $param_cpu_util, $param_mem_util
+end
+
+script "js_get_request_from_iter_item", type: "javascript" do
+  parameters "item"
   result "request"
   code <<-EOS
+  var request = item
+  EOS
+end
 
+script "js_sizing_recommendation_request_list", type: "javascript" do
+  parameters "kubecost_host", "param_recommendations_request_method", "ds_get_clusters", "param_cpu_algo", "param_cpu_q", "param_mem_algo", "param_mem_q", "param_window", "param_cpu_util", "param_mem_util"
+  result "request_list"
+  code <<-EOS
   param_cpu_q = param_cpu_q.toString()
   param_mem_q = param_mem_q.toString()
   param_cpu_util = (param_cpu_util/100).toString()
   param_mem_util = (param_mem_util/100).toString()
 
-  var request = {
-      "verb": "GET",
-      "scheme": "http",
-      "host": kubecost_host,
-      "path": "/model/savings/requestSizingV2",
-      "query_params": {
-        "algorithmCPU": param_cpu_algo,
-        "qCPU": param_cpu_q,
-        "algorithmRAM": param_mem_algo,
-        "qRAM": param_mem_q,
-        "window": param_window,
-        "targetCPUUtilization": param_cpu_util,
-        "targetRAMUtilization": param_mem_util
+  request_list = []
+  if (param_recommendations_request_method === "per cluster") {
+    _.forEach(ds_get_clusters, function (clusterData) {
+      request_list.push(
+        {
+          "verb": "GET",
+          "scheme": "http",
+          "host": kubecost_host,
+          "path": "/model/savings/requestSizingV2",
+          "query_params": {
+            "filter": 'cluster:"' + clusterData.clusterId + '"',
+            "algorithmCPU": param_cpu_algo,
+            "qCPU": param_cpu_q,
+            "algorithmRAM": param_mem_algo,
+            "qRAM": param_mem_q,
+            "window": param_window,
+            "targetCPUUtilization": param_cpu_util,
+            "targetRAMUtilization": param_mem_util
+          }
+        }
+      )
+    })
+  } else {  // Else means: param_recommendations_request_method === "overall"
+    request_list.push(
+      {
+        "verb": "GET",
+        "scheme": "http",
+        "host": kubecost_host,
+        "path": "/model/savings/requestSizingV2",
+        "query_params": {
+          "algorithmCPU": param_cpu_algo,
+          "qCPU": param_cpu_q,
+          "algorithmRAM": param_mem_algo,
+          "qRAM": param_mem_q,
+          "window": param_window,
+          "targetCPUUtilization": param_cpu_util,
+          "targetRAMUtilization": param_mem_util
+        }
       }
-    }
+    )
+  }
   EOS
 end
 

--- a/cost/kubecost/sizing/kubecost_resizing_recommendation.pt
+++ b/cost/kubecost/sizing/kubecost_resizing_recommendation.pt
@@ -31,9 +31,9 @@ parameter "param_kubecost_host" do
   description "IP Address of Kubecost LB"
 end
 
-parameter "param_recommendations_request_method" do
+parameter "param_scope" do
   type "string"
-  label "Recommendations request method"
+  label "Scope"
   description "Choose between requesting the recommendations per cluster or overall"
   allowed_values "overall", "per cluster"
   default "overall"
@@ -170,11 +170,11 @@ datasource "ds_get_clusters" do
 end
 
 datasource "ds_sizing_recommendation_request_list" do
-  run_script $js_sizing_recommendation_request_list, $param_kubecost_host, $param_recommendations_request_method, $ds_get_clusters, $param_cpu_algo, $param_cpu_q, $param_mem_algo, $param_mem_q, $param_window, $param_cpu_util, $param_mem_util
+  run_script $js_sizing_recommendation_request_list, $param_kubecost_host, $param_scope, $ds_get_clusters, $param_cpu_algo, $param_cpu_q, $param_mem_algo, $param_mem_q, $param_window, $param_cpu_util, $param_mem_util
 end
 
 script "js_sizing_recommendation_request_list", type: "javascript" do
-  parameters "kubecost_host", "param_recommendations_request_method", "ds_get_clusters", "param_cpu_algo", "param_cpu_q", "param_mem_algo", "param_mem_q", "param_window", "param_cpu_util", "param_mem_util"
+  parameters "kubecost_host", "param_scope", "ds_get_clusters", "param_cpu_algo", "param_cpu_q", "param_mem_algo", "param_mem_q", "param_window", "param_cpu_util", "param_mem_util"
   result "request_list"
   code <<-EOS
   param_cpu_q = param_cpu_q.toString()
@@ -183,7 +183,7 @@ script "js_sizing_recommendation_request_list", type: "javascript" do
   param_mem_util = (param_mem_util/100).toString()
 
   request_list = []
-  if (param_recommendations_request_method === "per cluster") {
+  if (param_scope === "per cluster") {
     _.forEach(ds_get_clusters, function (clusterData) {
       request_list.push(
         {
@@ -204,7 +204,7 @@ script "js_sizing_recommendation_request_list", type: "javascript" do
         }
       )
     })
-  } else {  // Else means: param_recommendations_request_method === "overall"
+  } else {  // Else means: param_scope === "overall"
     request_list.push(
       {
         "verb": "GET",


### PR DESCRIPTION
### Description

As a user I want to be able to configure Kubecost Request Rightsizing Recommendations policy to request recommendations per-cluster or overall, so that I can insure that the responses do not violate limits set up in my environment.

If per cluster mode is configured, policy will discover clusters, iterate the clusters and request recommendations for each one.

### Issues Resolved

- https://flexera.atlassian.net/browse/FOPTS-1578

### Link to Example Applied Policy

Per cluster: https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/107982?policyId=64dbaaf453379b0001babd96
Overall: https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/107982?policyId=64dbab4453379b0001babd97

### Contribution Check List

- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
