### PR TITLE
POL-903 Fixed Cost Data Issue with New Azure APIs

### DIFF
--- a/cost/azure/idle_compute_instances/CHANGELOG.md
+++ b/cost/azure/idle_compute_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.1
+
+- Corrected issue with policy not retrieving cost data on orgs using newer Azure bill connections
+
 ## v5.0
 
 - Renamed Subscription List parameter for consistency and accuracy

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "5.0",
+  version: "5.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Idle Compute Instances",
@@ -342,19 +342,29 @@ script "js_get_costs", type:"javascript" do
         "billing_center_ids": _.compact(_.map(billing_centers, function(value){ return value.id})),
         "limit": 100000,
         "filter": {
+          "type": "and",
           "expressions": [
             {
-              "dimension": "service",
-              "type": "equal",
-              "value": "Microsoft.Compute"
+              "type": "or",
+              "expressions": [
+                {
+                  "dimension": "service",
+                  "type": "equal",
+                  "value": "Microsoft.Compute"
+                },
+                {
+                  "dimension": "service",
+                  "type": "equal",
+                  "value": "microsoft.compute"
+                }
+              ]
             },
             {
               "dimension": "vendor_account",
               "type": "equal",
               "value": account_id
             }
-          ],
-          "type": "and"
+          ]
         }
       },
       headers: {

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 

--- a/cost/azure/old_snapshots/CHANGELOG.md
+++ b/cost/azure/old_snapshots/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.1
+
+- Corrected issue with policy not retrieving cost data on orgs using newer Azure bill connections
+
 ## v5.0
 
 - Renamed Subscription List parameter for consistency and accuracy

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "5.0",
+  version: "5.1",
   provider: "Azure",
   service: "Storage",
   policy_set: "Old Snapshots",
@@ -291,19 +291,29 @@ script "js_get_costs", type:"javascript" do
         "billing_center_ids": _.compact(_.map(billing_centers, function(value){ return value.id})),
         "limit": 100000,
         "filter": {
+          "type": "and"
           "expressions": [
             {
-              "dimension": "service",
-              "type": "equal",
-              "value": "Microsoft.Compute"
+              "type": "or",
+              "expressions": [
+                {
+                  "dimension": "service",
+                  "type": "equal",
+                  "value": "Microsoft.Compute"
+                },
+                {
+                  "dimension": "service",
+                  "type": "equal",
+                  "value": "microsoft.compute"
+                }
+              ]
             },
             {
               "dimension": "vendor_account",
               "type": "equal",
               "value": account_id
             }
-          ],
-          "type": "and"
+          ]
         }
       },
       headers: {

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 

--- a/cost/azure/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2
+
+- Corrected issue with policy not retrieving cost data on orgs using newer Azure bill connections
+
 ## v3.1
 
 - Added support for meta policies

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "3.1",
+  version: "3.2",
   provider: "Azure",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -674,9 +674,19 @@ script "js_instance_costs", type: "javascript" do
         "type": "and",
         "expressions": [
           {
-            "dimension": "service",
-            "type": "equal",
-            "value": "Microsoft.Compute"
+            "type": "or",
+            "expressions": [
+              {
+                "dimension": "service",
+                "type": "equal",
+                "value": "Microsoft.Compute"
+              },
+              {
+                "dimension": "service",
+                "type": "equal",
+                "value": "microsoft.compute"
+              }
+            ]
           },
           {
             "dimension": "vendor_account",

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "3.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 

--- a/cost/azure/savings_realized/CHANGELOG.md
+++ b/cost/azure/savings_realized/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.3
+
+- Corrected issue with policy not retrieving cost data on orgs using newer Azure bill connections
+
 ## v3.2
 
 - Updated indentation for chart url so it renders corrrectly in the policy incident email

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -215,7 +215,21 @@ script "js_get_base_aggregated_costs", type: "javascript" do
     "filter": {
       "type": "and",
       "expressions": [
-        { "dimension": "vendor", "type": "equal", "value": "Azure" },
+        {
+          "type": "or",
+          "expressions": [
+            {
+              "dimension": "vendor",
+              "type": "equal",
+              "value": "Azure"
+            },
+            {
+              "dimension": "vendor",
+              "type": "equal",
+              "value": "azure"
+            }
+          ]
+        },
         {
           "type": "or",
           "expressions": [
@@ -237,7 +251,21 @@ script "js_get_base_aggregated_costs", type: "javascript" do
         },
         {
           "type": "not",
-          "expression": { "dimension": "resource_type", "type": "equal", "value": "Virtual Machines-Reservation-Base VM" }
+          "expression": {
+            "type": "or",
+            "expressions": [
+              {
+                "dimension": "resource_type",
+                "type": "equal",
+                "value": "Virtual Machines-Reservation-Base VM"
+              },
+              {
+                "dimension": "resource_type",
+                "type": "equal",
+                "value": "virtual machines-reservation-base vm"
+              }
+            ]
+          }
         }
       ]
     },

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -7,7 +7,7 @@ default_frequency "monthly"
 severity "low"
 category "Cost"
 info(
-  version: "3.1",
+  version: "3.3",
   provider: "Flexera",
   service: "All",
   policy_set: "N/A"
@@ -128,7 +128,21 @@ script "js_get_ri_aggregated_costs", type: "javascript" do
       "type": "and",
       "expressions": [
         { "dimension": "vendor", "type": "equal", "value": "Azure" },
-        { "dimension": "service", "type": "equal", "value": "Microsoft.Compute" },
+        {
+          "type": "or",
+          "expressions": [
+            {
+              "dimension": "service",
+              "type": "equal",
+              "value": "Microsoft.Compute"
+            },
+            {
+              "dimension": "service",
+              "type": "equal",
+              "value": "microsoft.compute"
+            }
+          ]
+        },
         { "dimension": "resource_type", "type": "equal", "value": "Virtual Machines-Reservation-Base VM" },
         {
           "type": "not",
@@ -202,7 +216,21 @@ script "js_get_base_aggregated_costs", type: "javascript" do
       "type": "and",
       "expressions": [
         { "dimension": "vendor", "type": "equal", "value": "Azure" },
-        { "dimension": "service", "type": "equal", "value": "Microsoft.Compute" },
+        {
+          "type": "or",
+          "expressions": [
+            {
+              "dimension": "service",
+              "type": "equal",
+              "value": "Microsoft.Compute"
+            },
+            {
+              "dimension": "service",
+              "type": "equal",
+              "value": "microsoft.compute"
+            }
+          ]
+        },
         {
           "type": "not",
           "expression": { "dimension": "instance_type", "type": "equal", "value": "None" }

--- a/cost/azure/unused_ip_addresses/CHANGELOG.md
+++ b/cost/azure/unused_ip_addresses/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.1
+
+- Corrected issue with policy not retrieving cost data on orgs using newer Azure bill connections
+
 ## v6.0
 
 - Several parameters altered to be more descriptive and human-readable

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "6.0",
+  version: "6.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Unused IP Addresses",
@@ -532,14 +532,44 @@ script "js_ip_costs", type:"javascript" do
         "type": "and",
         "expressions": [
           {
-            "dimension": "service",
-            "type": "equal",
-            "value": "Microsoft.Network"
+            "type": "or",
+            "expressions": [
+              {
+                "dimension": "service",
+                "type": "equal",
+                "value": "Microsoft.Network"
+              },
+              {
+                "dimension": "service",
+                "type": "equal",
+                "value": "microsoft.network"
+              }
+            ]
           },
           {
-            "dimension": "resource_type",
-            "type": "equal",
-            "value": "Virtual Network-IP Addresses"
+            "type": "or",
+            "expressions": [
+              {
+                "dimension": "service",
+                "type": "equal",
+                "value": "Virtual Network-IP Addresses"
+              },
+              {
+                "dimension": "service",
+                "type": "equal",
+                "value": "virtual network-ip addresses"
+              },
+              {
+                "dimension": "service",
+                "type": "equal",
+                "value": "Virtual Network"
+              },
+              {
+                "dimension": "service",
+                "type": "equal",
+                "value": "virtual network"
+              }
+            ]
           },
           {
             "dimension": "vendor_account",

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses.pt
@@ -550,24 +550,14 @@ script "js_ip_costs", type:"javascript" do
             "type": "or",
             "expressions": [
               {
-                "dimension": "service",
+                "dimension": "resource_type",
                 "type": "equal",
                 "value": "Virtual Network-IP Addresses"
               },
               {
-                "dimension": "service",
+                "dimension": "resource_type",
                 "type": "equal",
                 "value": "virtual network-ip addresses"
-              },
-              {
-                "dimension": "service",
-                "type": "equal",
-                "value": "Virtual Network"
-              },
-              {
-                "dimension": "service",
-                "type": "equal",
-                "value": "virtual network"
               }
             ]
           },

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "6.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 

--- a/cost/azure/unused_sql_databases/CHANGELOG.md
+++ b/cost/azure/unused_sql_databases/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.1
+
+- Corrected issue with policy not retrieving cost data on orgs using newer Azure bill connections
+
 ## v5.0
 
 - Renamed Subscription List parameter for consistency and accuracy

--- a/cost/azure/unused_sql_databases/azure_unused_sql_databases.pt
+++ b/cost/azure/unused_sql_databases/azure_unused_sql_databases.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "5.0",
+  version: "5.1",
   provider: "Azure",
   service: "SQL",
   policy_set: "Unused Database Services",
@@ -420,19 +420,29 @@ script "js_get_costs", type:"javascript" do
         "billing_center_ids": _.compact(_.map(billing_centers, function(value){ return value.id})),
         "limit": 100000,
         "filter": {
+          "type": "and",
           "expressions": [
             {
-              "dimension": "service",
-              "type": "equal",
-              "value": "Microsoft.Sql"
+              "type": "or",
+              "expressions": [
+                {
+                  "dimension": "service",
+                  "type": "equal",
+                  "value": "Microsoft.Sql"
+                },
+                {
+                  "dimension": "service",
+                  "type": "equal",
+                  "value": "microsoft.sql"
+                }
+              ]
             },
             {
               "dimension": "vendor_account",
               "type": "equal",
               "value": account_id
             }
-          ],
-          "type": "and"
+          ]
         }
       },
       headers: {

--- a/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
+++ b/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 

--- a/cost/azure/unused_volumes/CHANGELOG.md
+++ b/cost/azure/unused_volumes/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v6.0
+
+- Several parameters altered to be more descriptive and human-readable
+- Removed deprecated "Log to CM Audit Entries" parameter
+- Added ability to only report recommendations that meet a minimum savings threshold
+- Added ability to include attached volumes in the incident and to action on them
+- Added ability to filter resources by multiple tag key:value pairs
+- Added additional context to incident description
+- Normalized incident export to be consistent with other policies
+- Added human-readable recommendation to incident export
+- Added additional fields to incident export to facilitate scraping for dashboards
+- Policy no longer raises new escalations if savings data changed but nothing else has
+- Streamlined code for better readability and faster execution
+
 ## v5.0
 
 - Renamed Subscription List parameter for consistency and accuracy

--- a/cost/azure/unused_volumes/CHANGELOG.md
+++ b/cost/azure/unused_volumes/CHANGELOG.md
@@ -1,18 +1,8 @@
 # Changelog
 
-## v6.0
+## v5.1
 
-- Several parameters altered to be more descriptive and human-readable
-- Removed deprecated "Log to CM Audit Entries" parameter
-- Added ability to only report recommendations that meet a minimum savings threshold
-- Added ability to include attached volumes in the incident and to action on them
-- Added ability to filter resources by multiple tag key:value pairs
-- Added additional context to incident description
-- Normalized incident export to be consistent with other policies
-- Added human-readable recommendation to incident export
-- Added additional fields to incident export to facilitate scraping for dashboards
-- Policy no longer raises new escalations if savings data changed but nothing else has
-- Streamlined code for better readability and faster execution
+- Corrected issue with policy not retrieving cost data on orgs using newer Azure bill connections
 
 ## v5.0
 

--- a/cost/azure/unused_volumes/azure_unused_volumes.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "5.0",
+  version: "5.1",
   provider: "Azure",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -382,9 +382,19 @@ script "js_volume_costs", type:"javascript" do
         "type": "and",
         "expressions": [
           {
-            "dimension": "service",
-            "type": "equal",
-            "value": "Microsoft.Compute"
+            "type": "or",
+            "expressions": [
+              {
+                "dimension": "service",
+                "type": "equal",
+                "value": "Microsoft.Compute"
+              },
+              {
+                "dimension": "service",
+                "type": "equal",
+                "value": "microsoft.compute"
+              }
+            ]
           },
           {
             "dimension": "vendor_account",

--- a/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 


### PR DESCRIPTION
### Description

The casing and naming conventions of some dimensions, such as the Service field, are different between the old method of ingesting Azure bills and the new method. For example, “Microsoft.Compute” is now “microsoft.compute”. This update enables our cost optimization policies to pull this data regardless of casing.

https://flexera.atlassian.net/browse/POL-903

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=64e35fc94b956f0001f2864f
https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=64e3694f2d830e000134c702

(Note: Since this is a test environment, the savings in the incident will be $0. This is just to demonstrate that the updated Optima API call itself works and does not result in any errors. I have also confirmed that this change works as expected in a client org that I was developing for, which is where I discovered the issue to begin with.)

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in CHANGELOG.MD
- (No README changes since this is just a bug fix. The policy still works the same from a user POV)