### PR TITLE
fix: fpt install from source

### DIFF
--- a/.github/workflows/test-policies.yaml
+++ b/.github/workflows/test-policies.yaml
@@ -13,11 +13,16 @@ jobs:
     name: "Policy Test"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 100 # https://github.com/danger/danger/issues/913
+      - uses: actions/setup-go@v4
       - run: |
-          mkdir -p tmp && wget --no-check-certificate https://binaries.rightscale.com/rsbin/fpt/v1/fpt-linux-amd64.tgz && tar zxvf fpt-linux-amd64.tgz -C tmp;mv tmp/fpt/fpt .
+          mkdir -p tmp
+          git clone https://github.com/flexera-public/policy_sdk tmp/policy_sdk
+          cd tmp/policy_sdk/cmd/fpt
+          go build -o ../../../../fpt
+          rm -rf tmp
       - uses: ruby/setup-ruby@v1
         with:
           # ruby-version: 2.4.1 # Not needed with a .ruby-version file


### PR DESCRIPTION
### Description

Fixes issue seen here related to fpt binary not being available.  Given the rightscale.com URL, I suspect this is a deprecation and so this proposed fix replaces that step with steps that build fpt binary from source and put it in the same location toplevel of the repo

### Issues Resolved

https://github.com/flexera-public/policy_templates/actions/runs/5942493295/job/16115579747#step:3:8
