### PR TITLE
POL-905 Update policy_sync.pt to use Github instead of S3

### DIFF
--- a/.github/workflows/upload-files.yaml
+++ b/.github/workflows/upload-files.yaml
@@ -1,4 +1,4 @@
-name: Upload files to S3
+name: Upload files to GitHub
 # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#workflow_run
 # https://stackoverflow.com/questions/58457140/dependencies-between-workflows-on-github-actions
 on:
@@ -25,13 +25,21 @@ jobs:
         run: |
           bundle install --without documentation --path bundle
           bundle exec rake generate_policy_list
-      - name: Upload to s3
-        uses: aws-actions/configure-aws-credentials@master
+          cp dist/active_policy_list.json data/active_policy_list/active_policy_list.json
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v4
         with:
-          role-to-assume: arn:aws:iam::023366516001:role/rs-policysync-tools-github-actions
-          role-session-name: uploadactivepolicylist
-          aws-region: us-east-1
-      # Upload a file to AWS s3
-      - name:  Copy active-policy-list.json to s3
+          commit-message: "Update active policy list"
+          title: "Update Active Policy List"
+          body: "Update Active Policy List from GitHub Actions Workflow [${{ github.workflow }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+          branch: "task/update-active-policy-list"
+          delete-branch: true
+          labels: "automation"
+
+      - name: Check outputs
+        if: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
-          aws s3 cp ./dist/active-policy-list.json s3://rs-policysync-tool/active-policy-list.json --acl public-read
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/tools/policy_sync/CHANGELOG.md
+++ b/tools/policy_sync/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v1.17
+
+- Changed the source of active policy list from S3 to GitHub
+
 ## v1.16
 
 - Added additional checking if policy long description or policy version are not defined

--- a/tools/policy_sync/policy_sync.pt
+++ b/tools/policy_sync/policy_sync.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Operational"
 default_frequency "15 minutes"
 info(
-  version: "1.16",
+  version: "1.17",
   publish: "false",
   provider: "Flexera",
   service: "Policy Engine",
@@ -52,12 +52,12 @@ end
 datasource "ds_active_policy_list" do
   request do
     verb "GET"
-    host "s3.amazonaws.com"
-    path "/rs-policysync-tool/active-policy-list.json"
+    host "raw.githubusercontent.com"
+    path "/flexera-public/policy_templates/master/data/active_policy_list/active_policy_list.json"
     header "User-Agent", "RS Policies"
   end
   result do
-    collect jmes_path(response,"policies") do
+    collect jmes_path(response, "policies") do
       field "name", jmes_path(col_item, "name")
       field "file_name", jmes_path(col_item, "file_name")
       field "version", jmes_path(col_item, "version")


### PR DESCRIPTION
### Description

I updated the repository to use Github instead of S3 to publish the policy templates.

### Issues Resolved

- https://flexera.atlassian.net/browse/POL-905

### Link to Example Applied Policy

N/A

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
