### PR TITLE
POL-905 Fix the name of the active policy list file

### DIFF
--- a/.github/workflows/upload-files.yaml
+++ b/.github/workflows/upload-files.yaml
@@ -25,7 +25,7 @@ jobs:
         run: |
           bundle install --without documentation --path bundle
           bundle exec rake generate_policy_list
-          cp dist/active_policy_list.json data/active_policy_list/active_policy_list.json
+          cp dist/active-policy-list.json data/active_policy_list/active_policy_list.json
 
       - name: Create Pull Request
         id: cpr


### PR DESCRIPTION
### Description

I updated the repository to use Github instead of S3 to publish the policy templates. I fixed the name of the active policy list file.

### Issues Resolved

- https://flexera.atlassian.net/browse/POL-905

### Link to Example Applied Policy

N/A

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
