### PR TITLE
POL-905 Fix permissions of the GitHub workflow

### DIFF
--- a/.github/workflows/upload-files.yaml
+++ b/.github/workflows/upload-files.yaml
@@ -2,6 +2,11 @@ name: Upload files to GitHub
 # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#workflow_run
 # https://stackoverflow.com/questions/58457140/dependencies-between-workflows-on-github-actions
 on:
+
+  push:
+    branches:
+      - POL-905_update_policy_sync_to_use_github_03
+
   workflow_run:
     workflows: ["Test Policies"]
     branches: [master]

--- a/.github/workflows/upload-files.yaml
+++ b/.github/workflows/upload-files.yaml
@@ -8,8 +8,10 @@ on:
     types:
       - completed
 permissions:
-      id-token: write
-      contents: read
+  id-token: write
+  contents: write
+  pull-requests: write
+
 jobs:
   policy_list:
     name: "Policy List"


### PR DESCRIPTION
### Description

I updated the repository to use Github instead of S3 to publish the policy templates. I fixed permissions of the Github workflow.

### Issues Resolved

- https://flexera.atlassian.net/browse/POL-905

### Link to Example Applied Policy

N/A

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD