### PR TITLE
FOPTS-1331 Turbonomic Rightsize VMs (Azure) - Bring recommendation supporting information

### DIFF
--- a/cost/turbonomics/scale_virtual_machines_recommendations/azure/CHANGELOG.md
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/azure/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v0.4
+
+- Renamed `Created Time` incident field to `Recommendation Created Time`.
+- Added `System Details URL` incident field.
+- Added `IOPs Capacity` incident field.
+- Added `IOPs Utilization (%)` incident field.
+- Added `New IOPs Capacity` incident field.
+- Added `New IOPs Utilization (%)` incident field.
+- Added `Memory (GB)` incident field.
+- Added `Memory Utilization (%)` incident field.
+- Added `New Memory (GB)` incident field.
+- Added `New Memory Utilization (%)` incident field.
+- Added `CPU (GHz)` incident field.
+- Added `CPU Utilization (%)` incident field.
+- Added `New CPU (GHz)` incident field.
+- Added `New CPU Utilization (%)` incident field.
+- Added `Throughput (MB/s)` incident field.
+- Added `Throughput Utilization (%)` incident field.
+- Added `New Throughput (MB/s)` incident field.
+- Added `New Throughput Utilization (%)` incident field.
+
 ## v0.3
 
 - Fixed readme Link in the policy.

--- a/cost/turbonomics/scale_virtual_machines_recommendations/azure/turbonomics_scale_virtual_machines.pt
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/azure/turbonomics_scale_virtual_machines.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.3",
+  version: "0.4",
   provider: "Azure",
   source: "Turbonomic",
   service: "Compute",
@@ -31,7 +31,7 @@ parameter "auth_cookie" do
   type "string"
   label "Authorization Cookie"
   no_echo true
-  description "authorization cookie pulled from manual source"
+  description "Authorization cookie pulled from manual source"
 end
 
 parameter "param_email" do
@@ -71,7 +71,7 @@ pagination "turbonomics_vm_pagination_header" do
 end
 
 ###############################################################################
-# Datasources
+# Datasources & Scripts
 ###############################################################################
 
 #get turbonomic recommendation data
@@ -96,43 +96,10 @@ datasource "ds_get_turbonomics_recommendations" do
       field "createdTime", jmes_path(col_item, "createTime")
       field "savings", jmes_path(col_item, "stats[0].value")
       field "savingsCurrency", jmes_path(col_item, "stats[0].units")
+      field "tUuid", jmes_path(col_item, "target.uuid")
     end
   end
 end
-
-##this will potentially be a lot of calls. how to make this more performant
-datasource "ds_get_action_details" do
-  request do
-    run_script $js_get_action_details, $param_turbonomic_endpoint, $auth_cookie, $ds_get_turbonomics_recommendations
-  end
-  result do
-    encoding "json"
-    field "uuids", response
-  end
-end
-
-##this will potentially be a lot of calls. how to make this more performant
-datasource "ds_get_business_units" do
-  request do
-    run_script $js_get_business_units, $param_turbonomic_endpoint, $auth_cookie, $param_provider
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "[*]") do
-      field "uuid", jmes_path(col_item, "uuid")
-      field "accountID", jmes_path(col_item, "accountId")
-      field "displayName", jmes_path(col_item, "displayName")
-    end
-  end
-end
-
-datasource "ds_filtered_turbonomics_recommendations" do
-  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_action_details, $ds_get_business_units, $param_provider
-end
-
-###############################################################################
-# Scripts
-###############################################################################
 
 ##script using a manually acquired turbonomic cookie and pulls hard coded scalable vm data
 script "js_get_turbonomics_recommendations", type: "javascript" do
@@ -162,7 +129,58 @@ script "js_get_turbonomics_recommendations", type: "javascript" do
         "Cookie": auth_cookie
       }
     }
-EOS
+  EOS
+end
+
+##this will potentially be a lot of calls. how to make this more performant
+datasource "ds_get_action_details" do
+  request do
+    run_script $js_get_action_details, $param_turbonomic_endpoint, $auth_cookie, $ds_get_turbonomics_recommendations
+  end
+  result do
+    encoding "json"
+    field "uuids", response
+  end
+end
+
+##
+script "js_get_action_details", type: "javascript" do
+  result "request"
+  parameters "turbonomic_endpoint", "auth_cookie", "ds_get_turbonomics_recommendations"
+  code <<-EOS
+  //replace cookie every day this is run
+    var uuids = []
+    _.each(ds_get_turbonomics_recommendations, function(instance){
+      uuids.push(instance.uuid)
+    })
+    var request = {
+      verb: "POST",
+      host: turbonomic_endpoint,
+      path: "/api/v3/actions/details",
+      body_fields: {
+        "uuids": uuids,
+      },
+      headers: {
+        "Content-Type": "application/json"
+        "Cookie": auth_cookie
+      }
+    }
+  EOS
+end
+
+##this will potentially be a lot of calls. how to make this more performant
+datasource "ds_get_business_units" do
+  request do
+    run_script $js_get_business_units, $param_turbonomic_endpoint, $auth_cookie, $param_provider
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "uuid", jmes_path(col_item, "uuid")
+      field "accountID", jmes_path(col_item, "accountId")
+      field "displayName", jmes_path(col_item, "displayName")
+    end
+  end
 end
 
 ## verified that discovered is the only one we need
@@ -189,37 +207,16 @@ script "js_get_business_units", type: "javascript" do
         "Cookie": auth_cookie
       }
     }
-EOS
+  EOS
 end
 
-##
-script "js_get_action_details", type: "javascript" do
-  result "request"
-  parameters "turbonomic_endpoint", "auth_cookie", "ds_get_turbonomics_recommendations"
-  code <<-EOS
-  //replace cookie every day this is run
-    var uuids = []
-    _.each(ds_get_turbonomics_recommendations, function(instance){
-      uuids.push(instance.uuid)
-    })
-    var request = {
-      verb: "POST",
-      host: turbonomic_endpoint,
-      path: "/api/v3/actions/details",
-      body_fields: {
-        "uuids": uuids,
-      },
-      headers: {
-        "Content-Type": "application/json"
-        "Cookie": auth_cookie
-      }
-    }
-EOS
+datasource "ds_filtered_turbonomics_recommendations" do
+  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_action_details, $ds_get_business_units, $param_provider, $param_turbonomic_endpoint
 end
 
 script "js_filtered_turbonomics_recommendations", type: "javascript" do
   result "result"
-  parameters "ds_get_turbonomics_recommendations", "ds_get_action_details", "ds_get_business_units", "param_provider"
+  parameters "ds_get_turbonomics_recommendations", "ds_get_action_details", "ds_get_business_units", "param_provider", "turbonomic_endpoint"
   code <<-EOS
     instances = []
     monthlySavings = 0.0
@@ -244,6 +241,10 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
       _.each(ds_get_turbonomics_recommendations, function(vm, index){
         if (vm.uuid === uuid) {
           ds_get_turbonomics_recommendations[index].uptime = Math.round(ds_get_action_details.uuids[uuid].entityUptime.uptimePercentage*100)/100
+          console.log(index)
+          console.log(ds_get_action_details.uuids[uuid].riCoverageBefore)
+          console.log(ds_get_action_details.uuids[uuid].riCoverageAfter)
+
         }
       })
     })
@@ -301,6 +302,7 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
         }
         vm.savings = (Math.round(vm.savings * 730 * 1000 * (vm.uptime/100)) / 1000)
         monthlySavings = monthlySavings + vm.savings
+        vm.url = "https://"+ turbonomic_endpoint + "/app/index.html#/view/main/action/" + vm.uuid
         instances.push(vm)
       }
     })
@@ -313,7 +315,114 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
       'instances': instances,
       'message': message
     }
-EOS
+  EOS
+end
+
+datasource "ds_filtered_recommendations" do
+  run_script $js_only_recommendations, $ds_filtered_turbonomics_recommendations
+end
+
+script "js_only_recommendations", type: "javascript" do
+  parameters "arg"
+  result "results"
+  code <<-EOS
+    results = []
+    results = arg.instances
+  EOS
+end
+
+datasource "ds_get_projected_statistics" do
+  iterate $ds_filtered_recommendations
+  request do
+    run_script $js_get_projected_statistics, iter_item, $param_turbonomic_endpoint, $auth_cookie
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response,"[-1]") do
+      field "uuid", val(iter_item, "tUuid")
+      field "iops", jmes_path(col_item, "statistics[?name == 'StorageAccess'].[capacity.total,histUtilizations[?type == 'percentile'].usage][][]")
+      field "vmem", jmes_path(col_item, "statistics[?name == 'VMem'].[histUtilizations[?type == 'percentile'].[capacity,usage][]][][]")
+      field "vcpu", jmes_path(col_item, "statistics[?name == 'VCPU'].[histUtilizations[?type == 'percentile'].[capacity,usage][]][][]")
+      field "iOThroughput", jmes_path(col_item, "statistics[?name == 'IOThroughput'].[capacity.total,histUtilizations[?type == 'percentile'].usage][][]")
+    end
+  end
+end
+
+datasource "ds_get_current_statistics" do
+  iterate $ds_filtered_recommendations
+  request do
+    run_script $js_get_projected_statistics, iter_item, $param_turbonomic_endpoint, $auth_cookie
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response,"[-2]") do
+      field "uuid", val(iter_item, "tUuid")
+      field "iops", jmes_path(col_item, "statistics[?name == 'StorageAccess'].[capacity.total,histUtilizations[?type == 'percentile'].usage][][]")
+      field "vmem", jmes_path(col_item, "statistics[?name == 'VMem'].[histUtilizations[?type == 'percentile'].[capacity,usage][]][][]")
+      field "vcpu", jmes_path(col_item, "statistics[?name == 'VCPU'].[histUtilizations[?type == 'percentile'].[capacity,usage][]][][]")
+      field "iOThroughput", jmes_path(col_item, "statistics[?name == 'IOThroughput'].[capacity.total,histUtilizations[?type == 'percentile'].usage][][]")
+    end
+  end
+end
+
+script "js_get_projected_statistics", type: "javascript" do
+  parameters "instance", "turbonomic_endpoint", "auth_cookie"
+  result "request"
+  code <<-EOS
+    nineHours = 1000 * 60 * 60 * 9
+    nowDay = new Date(Date.now())
+    pastDay = new Date(Date.now() + nineHours)
+
+    body_fields = {"statistics":[{"name":"VCPU","groupBy":["key","percentile"]},{"name":"VMem","groupBy":["key","percentile"]},{"name":"StorageAccess","groupBy":["key","percentile"]},{"name":"IOThroughput","groupBy":["key","percentile"]}],"startDate":nowDay.getTime(),"endDate":pastDay.getTime()}
+
+    request = {
+      verb: "POST",
+      host: turbonomic_endpoint,
+      path: "/api/v3/stats/" + instance.tUuid,
+      body_fields: body_fields
+      headers: {
+        "Content-Type": "application/json"
+        "Cookie": auth_cookie
+      }
+    }
+  EOS
+end
+
+datasource "ds_combined_data" do
+  run_script $js_combined_data, $ds_filtered_turbonomics_recommendations, $ds_get_projected_statistics, $ds_get_current_statistics
+end
+
+script "js_combined_data", type: "javascript" do
+  result "result"
+  parameters "ds_get_turbonomic_recommendations", "ds_get_projected_statistics", "ds_get_current_statistics"
+  code <<-EOS
+    _.each(ds_get_projected_statistics, function (projectedStatistic) {
+      _.each(ds_get_turbonomic_recommendations.instances, function (db, index) {
+          if (db.tUuid === projectedStatistic.uuid) {
+            db.iops = ds_get_current_statistics[index].iops[0]
+            db.iopsP95 = ((ds_get_current_statistics[index].iops[1]*100)/ds_get_current_statistics[index].iops[0]).toFixed(2)
+            db.newIops = projectedStatistic.iops[0]
+            db.newIopsP95 = ((projectedStatistic.iops[1]*100)/projectedStatistic.iops[0]).toFixed(2)
+            db.mem = (ds_get_current_statistics[index].vmem[0]/1048576).toFixed(2)
+            db.memP95 = ((ds_get_current_statistics[index].vmem[1]*100)/ds_get_current_statistics[index].vmem[0]).toFixed(2)
+            db.newMem = (projectedStatistic.vmem[0]/1048576).toFixed(2)
+            db.newMemP95 = ((projectedStatistic.vmem[1]*100)/projectedStatistic.vmem[0]).toFixed(2)
+            db.cpu = (ds_get_current_statistics[index].vcpu[0]/1000).toFixed(2)
+            db.cpuP95 = ((ds_get_current_statistics[index].vcpu[1]*100)/ds_get_current_statistics[index].vcpu[0]).toFixed(2)
+            db.newCpu = (projectedStatistic.vcpu[0]/1000).toFixed(2)
+            db.newCpuP95 = ((projectedStatistic.vcpu[1]*100)/projectedStatistic.vcpu[0]).toFixed(2)
+            db.throughput = (ds_get_current_statistics[index].iOThroughput[0]*0.000125).toFixed(2)
+            db.throughputP95 = ((ds_get_current_statistics[index].iOThroughput[1]*100)/ds_get_current_statistics[index].iOThroughput[0]).toFixed(2)
+            db.newThroughput = (projectedStatistic.iOThroughput[0]*0.000125).toFixed(2)
+            db.newThroughputP95 = ((projectedStatistic.iOThroughput[1]*100)/projectedStatistic.iOThroughput[0]).toFixed(2)
+          }
+      })
+    })
+    result = {
+      'instances': ds_get_turbonomic_recommendations.instances,
+      'message': ds_get_turbonomic_recommendations.message
+    }
+  EOS
 end
 
 ###############################################################################
@@ -321,12 +430,12 @@ end
 ###############################################################################
 
 policy "pol_turbonomics_scale_vms" do
-  validate $ds_filtered_turbonomics_recommendations do
-    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data.instances }} Rightsize recommendations for Virtual Machines found"
+  validate $ds_combined_data do
+    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data.instances }} Rightsize Azure recommendations for Virtual Machines found"
     detail_template <<-EOS
-## Turbonomic Rightsize Virtual Machines Recommendations
-{{data.message}}
-EOS
+      ## Turbonomic Rightsize Azure Virtual Machines Recommendations
+      {{data.message}}
+    EOS
     check eq(size(val(data, "instances")), 0)
     export "instances" do
       field "accountID" do
@@ -376,7 +485,58 @@ EOS
         label "Cloud Provider"
       end
       field "createdTime" do
-        label "Created Time"
+        label "Recommendation Created Time"
+      end
+      field "url" do
+        label "System Details URL"
+      end
+      field "iops" do
+        label "IOPs Capacity"
+      end
+      field "iopsP95" do
+        label "IOPs Utilization (%)"
+      end
+      field "newIops" do
+        label "New IOPs Capacity"
+      end
+      field "newIopsP95" do
+        label "New IOPs Utilization (%)"
+      end
+      field "mem" do
+        label "Memory (GB)"
+      end
+      field "memP95" do
+        label "Memory Utilization (%)"
+      end
+      field "newMem" do
+        label "New Memory (GB)"
+      end
+      field "newMemP95" do
+        label "New Memory Utilization (%)"
+      end
+      field "cpu" do
+        label "CPU (GHz)"
+      end
+      field "cpuP95" do
+        label "CPU Utilization (%)"
+      end
+      field "newCpu" do
+        label "New CPU (GHz)"
+      end
+      field "newCpuP95" do
+        label "new CPU Utilization (%)"
+      end
+      field "throughput" do
+        label "Throughput (MB/s)"
+      end
+      field "throughputP95" do
+        label "Throughput Utilization (%)"
+      end
+      field "newThroughput" do
+        label "New Throughput (MB/s)"
+      end
+      field "newThroughputP95" do
+        label "New Throughput Utilization (%)"
       end
     end
     escalate $esc_email


### PR DESCRIPTION
### Description

Azure Rightsize VMs policy needs to show the following information: RI coverage before/after, VM age, uptime, vCPU capacity before/after, vCPU utilization before/after, Memory capacity before/after, memory utilization before/after, storage throughput capacity before/after, storage throughput utilization before/after, NET throughput capacity and utilization before/after, system details URL.

### Issues Resolved

[FOPTS-1331](https://flexera.atlassian.net/browse/FOPTS-1331)

### Link to Example Applied Policy

[Turbonomic Rightsize Virtual Machines Recommendations Azure - Policy Template Applied](https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/107982?policyId=64e6ee9953379b0001babe53)


### Contribution Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
