### PR TITLE
Fix AWS Old Snapshots Version #

### DIFF
--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "7.1",
+  version: "7.2",
   provider: "AWS",
   service: "Storage",
   policy_set: "Old Snapshots",


### PR DESCRIPTION
This is a simple fix to bump the version number for the AWS Old Snapshots policy. A fix was recently merged but the version number in the policy was not changed. It is now bumped to 7.2 to match the CHANGELOG.