### PR TITLE
POL-906 - fix: conditional request for currency conversion

### DIFF
--- a/cost/aws/unused_ip_addresses/CHANGELOG.md
+++ b/cost/aws/unused_ip_addresses/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.3
+
+- Added conditional logic to only use currency conversion API when needed
+
 ## v6.2
 
 - Corrected issue where attached IP addresses were being included in the incident

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "6.2",
+  version: "6.3",
   provider: "AWS",
   service: "EC2",
   policy_set: "Unused IP Addresses",
@@ -264,7 +264,29 @@ script "js_currency_target", type:"javascript" do
 EOS
 end
 
+
+# Branching logic:
+# This datasource returns an empty array if the target currency is USD.
+# This prevents ds_currency_conversion from running if it's not needed.
+datasource "ds_conditional_currency_conversion" do
+  run_script $js_conditional_currency_conversion, $ds_currency_target
+end
+
+script "js_conditional_currency_conversion", type: "javascript" do
+  parameters "ds_currency_target"
+  result "result"
+  code <<-EOS
+  result = []
+  // Make the request only if the target currency is not USD
+  if (ds_currency_target['code'] != 'USD') {
+    result = [1]
+  }
+EOS
+end
+
 datasource "ds_currency_conversion" do
+  # Only make a request if the target currency is not USD
+  iterate $ds_conditional_currency_conversion
   request do
     host "api.xe-auth.flexeraeng.com"
     path "/prod/{proxy+}"


### PR DESCRIPTION
### Description

Fixes issue on Currency Conversion API getting too many requests by mitigating the number of requests.  The policy template does not need to make a request to Currency Conversion API when sticking to the USD currency.  This change makes the request to currency conversion API conditional, dependent if the target currency is USD or not.

### Issues Resolved

https://flexera.atlassian.net/browse/POL-906

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=64e788fb2d830e000134de6b

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in CHANGELOG.MD
