### PR TITLE
FOPTS-1632 Fix the broken link for the README for Schedule ITAM Report policy

### DIFF
--- a/operational/itam/schedule_itam_report/CHANGELOG.md
+++ b/operational/itam/schedule_itam_report/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+
+## v0.1.1
+
+- Fixed the broken link for the README at the policy template file
+
 ## v0.1.0
 
 - Initial Release

--- a/operational/itam/schedule_itam_report/CHANGELOG.md
+++ b/operational/itam/schedule_itam_report/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Changelog
 
-
 ## v0.1.1
 
 - Fixed the broken link for the README at the policy template file

--- a/operational/itam/schedule_itam_report/schedule-itam-report.pt
+++ b/operational/itam/schedule_itam_report/schedule-itam-report.pt
@@ -1,13 +1,13 @@
 name "Schedule ITAM Report"
 rs_pt_ver 20180301
 type "policy"
-short_description "Schedule a Flexera ITAM report (Custom view) and send it as a email to one or more recipients.  See the [README](https://github.com/flexera-public/policy_templates/tree/master/operational/itam/schedule_itam_reports) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "Schedule a Flexera ITAM report (Custom view) and send it as a email to one or more recipients.  See the [README](https://github.com/flexera-public/policy_templates/tree/master/operational/itam/schedule_itam_report) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 severity "medium"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "0.1.0",
+  version: "0.1.1",
   provider: "Flexera ITAM",
   service: "",
   policy_set: "Schedule Flexera ITAM Report"


### PR DESCRIPTION
### Description

The link of the README for Schedule ITAM Report policy was fixed and now it redirects to the actual README page.

### Issues Resolved

- https://flexera.atlassian.net/browse/FOPTS-1632

### Link to Example Applied Policy

No changes were done to policy code, only the version number and description were updated, here's a proof that the policy still compiles:
- https://app.flexeratest.com/orgs/1105/automation/projects/107982/policy-templates/64e79d7032d8b40001fa4ef9

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
