### PR TITLE
FOPTS-1330 Turbonomic Rightsize VMs (AWS)

### DIFF
--- a/cost/turbonomics/scale_virtual_machines_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/aws/CHANGELOG.md
@@ -13,12 +13,12 @@
 - Added `New Memory (GB)` incident field.
 - Added `Memory P95 Utilization (%)` incident field.
 - Added `New Memory P95 Utilization (%)` incident field.
-- Added `Storage Throughput (MB/s)` incident field.
-- Added `New Storage Throughput (MB/s)` incident field.
+- Added `Storage Throughput Capacity (MB/s)` incident field.
+- Added `New Storage Throughput Capacity (MB/s)` incident field.
 - Added `Storage Throughput P95 Utilization (%)` incident field.
 - Added `New Storage Throughput P95 Utilization (%)` incident field.
-- Added `Net Throughput (MB/s)` incident field.
-- Added `New Net Throughput (MB/s)` incident field.
+- Added `Net Throughput Capacity (MB/s)` incident field.
+- Added `New Net Throughput Capacity (MB/s)` incident field.
 - Added `Net Throughput P95 Utilization (%)` incident field.
 - Added `New Net Throughput P95 Utilization (%)` incident field.
 - Added `System Details URL` incident field.

--- a/cost/turbonomics/scale_virtual_machines_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/aws/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## v0.4
+
+- Added `RI Coverage` incident field.
+- Added `New RI Coverage` incident field.
+- Added `VM Age (Days)` incident field.
+- Added `CPU (GHz)` incident field.
+- Added `New CPU (GHz)` incident field.
+- Added `CPU P95 Utilization (%)` incident field.
+- Added `New CPU P95 Utilization (%)` incident field.
+- Added `Memory (GB)` incident field.
+- Added `New Memory (GB)` incident field.
+- Added `Memory P95 Utilization (%)` incident field.
+- Added `New Memory P95 Utilization (%)` incident field.
+- Added `Storage Throughput (MB/s)` incident field.
+- Added `New Storage Throughput (MB/s)` incident field.
+- Added `Storage Throughput P95 Utilization (%)` incident field.
+- Added `New Storage Throughput P95 Utilization (%)` incident field.
+- Added `Net Throughput (MB/s)` incident field.
+- Added `New Net Throughput (MB/s)` incident field.
+- Added `Net Throughput P95 Utilization (%)` incident field.
+- Added `New Net Throughput P95 Utilization (%)` incident field.
+- Added `System Details URL` incident field.
+- Renamed `Created time` incident field to `Action Created time`.
+- Changed internal names of several incident fields to ensure that they are properly scraped for dashboards.
+
 ## v0.3
 
 - Fixed readme Link in the policy.

--- a/cost/turbonomics/scale_virtual_machines_recommendations/aws/turbonomics_scale_virtual_machines.pt
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/aws/turbonomics_scale_virtual_machines.pt
@@ -319,7 +319,7 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
         }
         vm.savings = (Math.round(vm.savings * 730 * 1000 * (vm.uptime/100)) / 1000)
         monthlySavings = monthlySavings + vm.savings
-        vm.url = param_turbonomic_endpoint + "/app/index.html#/view/main/action/" + vm.urlUUID
+        vm.url = "https://" + param_turbonomic_endpoint + "/app/index.html#/view/main/action/" + vm.urlUUID
         instances.push(vm)
       }
     })
@@ -379,10 +379,10 @@ script "js_filtered_stats", type: "javascript" do
   }
   function getStats(recommendation, stats, epoch) {
     normalized = {
-      "VCPU": ["cpu", 0.001],
-      "VMem": ["mem", 1e-6],
-      "IOThroughput": ["throughput", 0.000125],
-      "NetThroughput": ["netThroughput", 0.000125]
+      "VCPU": ["cpu", 0.001 ],
+      "VMem": ["mem", (1/1024/1024)],
+      "IOThroughput": ["throughput", (1/8/1024)],
+      "NetThroughput": ["netThroughput", (1/8/1024)]
     }
     if(stats.epoch == epoch) {
       _.each(stats.statistics, function(statistic) {
@@ -519,10 +519,10 @@ EOS
         label "New Memory P95 Utilization (%)"
       end
       field "throughput" do
-        label "Storage Throughput (MB/s)"
+        label "Storage Throughput Capacity (MB/s)"
       end
       field "newThroughput" do
-        label "New Storage Throughput (MB/s)"
+        label "New Storage Throughput Capacity (MB/s)"
       end
       field "throughputP95" do
         label "Storage Throughput P95 Utilization (%)"
@@ -531,10 +531,10 @@ EOS
         label "New Storage Throughput P95 Utilization (%)"
       end
       field "netThroughput" do
-        label "Net Throughput (MB/s)"
+        label "Net Throughput Capacity (MB/s)"
       end
       field "newNetThroughput" do
-        label "New Net Throughput (MB/s)"
+        label "New Net Throughput Capacity (MB/s)"
       end
       field "netThroughputP95" do
         label "Net Throughput P95 Utilization (%)"

--- a/cost/turbonomics/scale_virtual_machines_recommendations/aws/turbonomics_scale_virtual_machines.pt
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/aws/turbonomics_scale_virtual_machines.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.3",
+  version: "0.4",
   provider: "AWS",
   source: "Turbonomic",
   service: "Compute",
@@ -32,6 +32,7 @@ parameter "auth_cookie" do
   label "Authorization Cookie"
   no_echo true
   description "authorization cookie pulled from manual source"
+  default "JSESSIONID=node01ldcwwcx6orzf15hba0sznsagh933951.node0"
 end
 
 parameter "param_email" do
@@ -44,6 +45,7 @@ parameter "param_turbonomic_endpoint" do
   type "string"
   label "Turbonomic endpoint"
   description "Host of the Turbonomic endpoint"
+  default "sales1.demo.turbonomic.com"
 end
 
 ###############################################################################
@@ -61,7 +63,7 @@ end
 # Pagination
 ###############################################################################
 
-pagination "turbonomics_vm_pagination_header" do
+pagination "turbonomic_vm_pagination_header" do
   get_page_marker do
     header "x-next-cursor"
   end
@@ -75,9 +77,9 @@ end
 ###############################################################################
 
 #get turbonomic recommendation data
-datasource "ds_get_turbonomics_recommendations" do
+datasource "ds_get_turbonomic_recommendations" do
   request do
-    run_script $js_get_turbonomics_recommendations, $param_turbonomic_endpoint, $auth_cookie
+    run_script $js_get_turbonomic_recommendations, $param_turbonomic_endpoint, $auth_cookie
   end
   result do
     encoding "json"
@@ -93,9 +95,11 @@ datasource "ds_get_turbonomics_recommendations" do
       field "provider", jmes_path(col_item, "target.discoveredBy.type")
       field "details", jmes_path(col_item, "details")
       field "tags", jmes_path(col_item, "target.tags")
-      field "createdTime", jmes_path(col_item, "createTime")
+      field "actionCreatedTime", jmes_path(col_item, "createTime")
       field "savings", jmes_path(col_item, "stats[0].value")
       field "savingsCurrency", jmes_path(col_item, "stats[0].units")
+      field "targetUUID", jmes_path(col_item, "target.uuid")
+      field "urlUUID", jmes_path(col_item, "uuid")
     end
   end
 end
@@ -103,7 +107,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_action_details" do
   request do
-    run_script $js_get_action_details, $param_turbonomic_endpoint, $auth_cookie, $ds_get_turbonomics_recommendations
+    run_script $js_get_action_details, $param_turbonomic_endpoint, $auth_cookie, $ds_get_turbonomic_recommendations
   end
   result do
     encoding "json"
@@ -126,8 +130,27 @@ datasource "ds_get_business_units" do
   end
 end
 
-datasource "ds_filtered_turbonomics_recommendations" do
-  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_action_details, $ds_get_business_units, $param_provider
+datasource "ds_filtered_turbonomic_recommendations" do
+  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_action_details, $ds_get_business_units, $param_provider, $param_turbonomic_endpoint
+end
+
+datasource "ds_get_stats" do
+  iterate $ds_filtered_turbonomic_recommendations
+  request do
+    run_script $js_get_stats, $param_turbonomic_endpoint, $auth_cookie, iter_item
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "epoch", jmes_path(col_item, "epoch")
+      field "statistics", jmes_path(col_item, "statistics")
+      field "uuid", val(iter_item, "targetUUID")
+    end
+  end
+end
+
+datasource "ds_filtered_stats" do
+  run_script $js_filtered_stats, $ds_get_stats, $ds_filtered_turbonomic_recommendations
 end
 
 ###############################################################################
@@ -135,7 +158,7 @@ end
 ###############################################################################
 
 ##script using a manually acquired turbonomic cookie and pulls hard coded scalable vm data
-script "js_get_turbonomics_recommendations", type: "javascript" do
+script "js_get_turbonomic_recommendations", type: "javascript" do
   result "request"
   parameters "turbonomic_endpoint", "auth_cookie"
   code <<-EOS
@@ -143,7 +166,7 @@ script "js_get_turbonomics_recommendations", type: "javascript" do
   //up this limit value to 1000 etc when done with POC testing
     var request = {
       verb: "POST",
-      pagination: "turbonomics_vm_pagination_header",
+      pagination: "turbonomic_vm_pagination_header",
       host: turbonomic_endpoint,
       path: "/api/v3/markets/Market/actions",
       body_fields: {
@@ -195,11 +218,11 @@ end
 ##
 script "js_get_action_details", type: "javascript" do
   result "request"
-  parameters "turbonomic_endpoint", "auth_cookie", "ds_get_turbonomics_recommendations"
+  parameters "turbonomic_endpoint", "auth_cookie", "ds_get_turbonomic_recommendations"
   code <<-EOS
   //replace cookie every day this is run
     var uuids = []
-    _.each(ds_get_turbonomics_recommendations, function(instance){
+    _.each(ds_get_turbonomic_recommendations, function(instance){
       uuids.push(instance.uuid)
     })
     var request = {
@@ -217,41 +240,38 @@ script "js_get_action_details", type: "javascript" do
 EOS
 end
 
-script "js_filtered_turbonomics_recommendations", type: "javascript" do
+script "js_filtered_turbonomic_recommendations", type: "javascript" do
   result "result"
-  parameters "ds_get_turbonomics_recommendations", "ds_get_action_details", "ds_get_business_units", "param_provider"
+  parameters "ds_get_turbonomic_recommendations", "ds_get_action_details", "ds_get_business_units", "param_provider", "param_turbonomic_endpoint"
   code <<-EOS
     instances = []
     monthlySavings = 0.0
-    function formatNumber(number, separator){
-      var numString =number.toString()
-      var values=numString.split(".")
-      var result = ''
-      while (values[0].length > 3){
-        var chunk = values[0].substr(-3)
-        values[0] = values[0].substr(0, values[0].length - 3)
-        result = separator + chunk + result
+    function getRiCoverage(actionDetails, action) {
+      if (actionDetails[action].value != "undefined" && actionDetails[action].value != null) {
+        if (actionDetails[action].capacity != "undefined" && actionDetails[action].capacity != null) {
+          if (typeof actionDetails[action].capacity.avg != "undefined" && actionDetails[action].capacity.avg != null) {
+            return (actionDetails[action].value*100/actionDetails[action].capacity.avg)
+          }
+        }
       }
-      if (values[0].length > 0){
-        result = values[0] + result
-      }
-      if(values[1]==undefined){
-        return result
-      }
-      return result+"."+values[1]
+      return 0
     }
     Object.keys(ds_get_action_details.uuids).forEach(function(uuid) {
-      _.each(ds_get_turbonomics_recommendations, function(vm, index){
+      _.each(ds_get_turbonomic_recommendations, function(vm, index){
         if (vm.uuid === uuid) {
-          ds_get_turbonomics_recommendations[index].uptime = Math.round(ds_get_action_details.uuids[uuid].entityUptime.uptimePercentage*100)/100
+          ds_get_turbonomic_recommendations[index].uptime = Math.round(ds_get_action_details.uuids[uuid].entityUptime.uptimePercentage*100)/100
+          ds_get_turbonomic_recommendations[index].riCoverage = getRiCoverage(ds_get_action_details.uuids[uuid], "riCoverageBefore").toFixed(2)
+          ds_get_turbonomic_recommendations[index].newRiCoverage = getRiCoverage(ds_get_action_details.uuids[uuid], "riCoverageAfter").toFixed(2)
+          vmAge = Math.floor(ds_get_action_details.uuids[uuid].entityUptime.totalDurationInMilliseconds / (1000*60*60*24))
+          ds_get_turbonomic_recommendations[index].vmAge = vmAge >= 30 ? "30+" : vmAge
         }
       })
     })
     _.each(ds_get_business_units, function(businessUnit) {
-      _.each(ds_get_turbonomics_recommendations, function(vm, index){
+      _.each(ds_get_turbonomic_recommendations, function(vm, index){
         if (vm.businessUUID === businessUnit.uuid) {
-          ds_get_turbonomics_recommendations[index].accountID = businessUnit.accountID
-          ds_get_turbonomics_recommendations[index].accountName = businessUnit.displayName
+          ds_get_turbonomic_recommendations[index].accountID = businessUnit.accountID
+          ds_get_turbonomic_recommendations[index].accountName = businessUnit.displayName
         }
       })
     })
@@ -260,7 +280,7 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
       "Azure Subscription":"Microsoft.Compute",
       "GCP Project": "Compute"
     }
-    _.each(ds_get_turbonomics_recommendations, function(vm){
+    _.each(ds_get_turbonomic_recommendations, function(vm){
       if (vm.provider === param_provider || param_provider === "ALL") {
         if (typeof vm.savingsCurrency != "undefined" && vm.savingsCurrency != null) {
           if (vm.savingsCurrency.indexOf("$") != -1) {
@@ -301,27 +321,117 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
         }
         vm.savings = (Math.round(vm.savings * 730 * 1000 * (vm.uptime/100)) / 1000)
         monthlySavings = monthlySavings + vm.savings
+        vm.url = param_turbonomic_endpoint + "/app/index.html#/view/main/action/" + vm.urlUUID
         instances.push(vm)
       }
     })
-    message = ""
-    if (instances.length != 0) {
-      pretty_savings = instances[0].savingsCurrency + ' ' + formatNumber(monthlySavings.toFixed(2), ",")
-      message = "The total estimated monthly savings are " + pretty_savings + '.'
-    }
-    result = {
-      'instances': instances,
-      'message': message
-    }
+    result = instances
 EOS
+end
+
+script "js_get_stats", type: "javascript" do
+  result "request"
+  parameters "turbonomic_endpoint", "auth_cookie", "instance"
+  code <<-EOS
+    var startDate = new Date(Date.now())
+    var endDate = new Date(Date.now() + (9*60*60*1000))
+    request = {
+      verb: "POST",
+      host: turbonomic_endpoint,
+      path: "/api/v3/stats/" + instance.targetUUID
+      body_fields: {
+        "statistics": [
+          {"name": "VCPU", "groupBy": ["key", "percentile"]},
+          {"name": "VMem", "groupBy": ["key", "percentile"]},
+          {"name": "IOThroughput", "groupBy": ["key", "percentile"]},
+          {"name": "NetThroughput", "groupBy": ["key", "percentile"]}
+        ],
+        "startDate": startDate.getTime(),
+        "endDate": endDate.getTime()     
+      },
+      headers: {
+        "Content-Type": "application/json"
+        "Cookie": auth_cookie
+      }
+    }
+  EOS
+end
+
+script "js_filtered_stats", type: "javascript" do
+  result "result"
+  parameters "ds_get_stats", "ds_filtered_turbonomic_recommendations"
+  code <<-EOS
+  monthlySavings = 0.0
+  function formatNumber(number, separator) {
+    var numString = number.toString()
+    var values = numString.split(".")
+    var result = ''
+    while (values[0].length > 3) {
+      var chunk = values[0].substr(-3)
+      values[0] = values[0].substr(0, values[0].length - 3)
+      result = separator + chunk + result
+    }
+    if (values[0].length > 0) {
+      result = values[0] + result
+    }
+    if (values[1] == undefined) {
+      return result
+    }
+    return result + "." + values[1]
+  }
+  function getStats(recommendation, stats, epoch) {
+    normalized = {
+      "VCPU": ["cpu", 0.001],
+      "VMem": ["mem", 1e-6],
+      "IOThroughput": ["throughput", 0.000125],
+      "NetThroughput": ["netThroughput", 0.000125]
+    }
+    if(stats.epoch == epoch) {
+      _.each(stats.statistics, function(statistic) {
+        if (statistic.name in normalized) {
+          name = epoch == "CURRENT" ? normalized[statistic.name][0] : "new" + normalized[statistic.name][0].charAt(0).toUpperCase() + normalized[statistic.name][0].slice(1)
+          if (statistic.name == "VMem") {
+            recommendation[name] = Math.floor(statistic.capacity.total * normalized[statistic.name][1])
+          } else {
+            recommendation[name] = (statistic.capacity.total * normalized[statistic.name][1]).toFixed(2)
+          }
+          _.each(statistic.histUtilizations, function(histUtilization) {
+            if (histUtilization.type == "percentile") {
+              recommendation[name + "P95"] = (histUtilization.usage*100/histUtilization.capacity).toFixed(2)
+            }
+          })
+        }
+      })
+    }
+    return recommendation
+  }
+  _.each(ds_filtered_turbonomic_recommendations, function (instance, index) {
+    monthlySavings = monthlySavings + instance.savings
+    _.each(ds_get_stats, function (stats) {
+      if (instance.targetUUID == stats.uuid) {
+        ds_filtered_turbonomic_recommendations[index] = getStats(ds_filtered_turbonomic_recommendations[index], stats, "CURRENT")
+        ds_filtered_turbonomic_recommendations[index] = getStats(ds_filtered_turbonomic_recommendations[index], stats, "PROJECTED")
+      }
+    })
+  })
+  message = ""
+  if (ds_filtered_turbonomic_recommendations.length != 0) {
+    pretty_savings = ds_filtered_turbonomic_recommendations[0].savingsCurrency + ' ' + formatNumber(monthlySavings.toFixed(2), ",")
+    message = "The total estimated monthly savings are " + pretty_savings + '.'
+  }
+  result = {
+    'instances': ds_filtered_turbonomic_recommendations,
+    'message': message
+  }
+  EOS
 end
 
 ###############################################################################
 # Policy
 ###############################################################################
 
-policy "pol_turbonomics_scale_vms" do
-  validate $ds_filtered_turbonomics_recommendations do
+policy "pol_turbonomic_scale_vms" do
+  validate $ds_filtered_stats do
     summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data.instances }}  Rightsize recommendations for Virtual Machines found"
     detail_template <<-EOS
 ## Turbonomic Rightsize Virtual Machines Recommendations
@@ -353,9 +463,8 @@ EOS
       field "uptime" do
         label "Virtual Machine Uptime Percentage"
       end
-      field "currentResourceType" do
+      field "resourceType" do
         label "Current Compute Tier"
-        path "resourceType"
       end
       field "newResourceType" do
         label "New Compute Tier"
@@ -375,8 +484,68 @@ EOS
       field "provider" do
         label "Cloud Provider"
       end
-      field "createdTime" do
-        label "Created Time"
+      field "actionCreatedTime" do
+        label "Action Created Time"
+      end
+      field "riCoverage" do
+        label "RI Coverage"
+      end
+      field "newRiCoverage" do
+        label "New RI Coverage"
+      end
+      field "vmAge" do
+        label "VM Age (Days)"
+      end
+      field "cpu" do
+        label "CPU (GHz)"
+      end
+      field "newCpu" do
+        label "New CPU (GHz)"
+      end
+      field "cpuP95" do
+        label "CPU P95 Utilization (%)"
+      end
+      field "newCpuP95" do
+        label "New CPU P95 Utilization (%)"
+      end
+      field "mem" do
+        label "Memory (GB)"
+      end
+      field "newMem" do
+        label "New Memory (GB)"
+      end
+      field "memP95" do
+        label "Memory P95 Utilization (%)"
+      end
+      field "newMemP95" do
+        label "New Memory P95 Utilization (%)"
+      end
+      field "throughput" do
+        label "Storage Throughput (MB/s)"
+      end
+      field "newThroughput" do
+        label "New Storage Throughput (MB/s)"
+      end
+      field "throughputP95" do
+        label "Storage Throughput P95 Utilization (%)"
+      end
+      field "newThroughputP95" do
+        label "New Storage Throughput P95 Utilization (%)"
+      end
+      field "netThroughput" do
+        label "Net Throughput (MB/s)"
+      end
+      field "newNetThroughput" do
+        label "New Net Throughput (MB/s)"
+      end
+      field "netThroughputP95" do
+        label "Net Throughput P95 Utilization (%)"
+      end
+      field "newNetThroughputP95" do
+        label "New Net Throughput P95 Utilization (%)"
+      end
+      field "url" do
+        label "System Details URL"
       end
     end
     escalate $esc_email

--- a/cost/turbonomics/scale_virtual_machines_recommendations/aws/turbonomics_scale_virtual_machines.pt
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/aws/turbonomics_scale_virtual_machines.pt
@@ -242,8 +242,8 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
   result "result"
   parameters "ds_get_turbonomic_recommendations", "ds_get_action_details", "ds_get_business_units", "param_provider", "param_turbonomic_endpoint"
   code <<-EOS
-    instances = []
-    monthlySavings = 0.0
+    var instances = []
+    var monthlySavings = 0.0
     function getRiCoverage(actionDetails, action) {
       if (actionDetails[action].value != "undefined" && actionDetails[action].value != null) {
         if (actionDetails[action].capacity != "undefined" && actionDetails[action].capacity != null) {
@@ -260,7 +260,7 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
           ds_get_turbonomic_recommendations[index].uptime = Math.round(ds_get_action_details.uuids[uuid].entityUptime.uptimePercentage*100)/100
           ds_get_turbonomic_recommendations[index].riCoverage = getRiCoverage(ds_get_action_details.uuids[uuid], "riCoverageBefore").toFixed(2)
           ds_get_turbonomic_recommendations[index].newRiCoverage = getRiCoverage(ds_get_action_details.uuids[uuid], "riCoverageAfter").toFixed(2)
-          vmAge = Math.floor(ds_get_action_details.uuids[uuid].entityUptime.totalDurationInMilliseconds / (1000*60*60*24))
+          var vmAge = Math.floor(ds_get_action_details.uuids[uuid].entityUptime.totalDurationInMilliseconds / (1000*60*60*24))
           ds_get_turbonomic_recommendations[index].vmAge = vmAge >= 30 ? "30+" : vmAge
         }
       })
@@ -287,7 +287,7 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
         } else {
           vm.savingsCurrency = "$"
         }
-        tags = []
+        var tags = []
         if (typeof vm.tags === "undefined" || vm.tags === null){
           vm.tags = tags
         }else{
@@ -313,7 +313,6 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
           });
         }
         vm.service = provider_service[vm.provider]
-        savingsString = ""
         if (typeof vm.savings === "undefined" || vm.savings === null || vm.savings === "" || isNaN(vm.savings)) {
           vm.savings = 0.0
         }
@@ -359,7 +358,7 @@ script "js_filtered_stats", type: "javascript" do
   result "result"
   parameters "ds_get_stats", "ds_filtered_turbonomic_recommendations"
   code <<-EOS
-  monthlySavings = 0.0
+  var monthlySavings = 0.0
   function formatNumber(number, separator) {
     var numString = number.toString()
     var values = numString.split(".")
@@ -378,7 +377,7 @@ script "js_filtered_stats", type: "javascript" do
     return result + "." + values[1]
   }
   function getStats(recommendation, stats, epoch) {
-    normalized = {
+    var normalized = {
       "VCPU": ["cpu", 0.001 ],
       "VMem": ["mem", (1/1024/1024)],
       "IOThroughput": ["throughput", (1/8/1024)],
@@ -387,7 +386,7 @@ script "js_filtered_stats", type: "javascript" do
     if(stats.epoch == epoch) {
       _.each(stats.statistics, function(statistic) {
         if (statistic.name in normalized) {
-          name = epoch == "CURRENT" ? normalized[statistic.name][0] : "new" + normalized[statistic.name][0].charAt(0).toUpperCase() + normalized[statistic.name][0].slice(1)
+          var name = epoch == "CURRENT" ? normalized[statistic.name][0] : "new" + normalized[statistic.name][0].charAt(0).toUpperCase() + normalized[statistic.name][0].slice(1)
           if (statistic.name == "VMem") {
             recommendation[name] = Math.floor(statistic.capacity.total * normalized[statistic.name][1])
           } else {
@@ -412,9 +411,9 @@ script "js_filtered_stats", type: "javascript" do
       }
     })
   })
-  message = ""
+  var message = ""
   if (ds_filtered_turbonomic_recommendations.length != 0) {
-    pretty_savings = ds_filtered_turbonomic_recommendations[0].savingsCurrency + ' ' + formatNumber(monthlySavings.toFixed(2), ",")
+    var pretty_savings = ds_filtered_turbonomic_recommendations[0].savingsCurrency + ' ' + formatNumber(monthlySavings.toFixed(2), ",")
     message = "The total estimated monthly savings are " + pretty_savings + '.'
   }
   result = {

--- a/cost/turbonomics/scale_virtual_machines_recommendations/aws/turbonomics_scale_virtual_machines.pt
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/aws/turbonomics_scale_virtual_machines.pt
@@ -32,7 +32,6 @@ parameter "auth_cookie" do
   label "Authorization Cookie"
   no_echo true
   description "authorization cookie pulled from manual source"
-  default "JSESSIONID=node01ldcwwcx6orzf15hba0sznsagh933951.node0"
 end
 
 parameter "param_email" do
@@ -45,7 +44,6 @@ parameter "param_turbonomic_endpoint" do
   type "string"
   label "Turbonomic endpoint"
   description "Host of the Turbonomic endpoint"
-  default "sales1.demo.turbonomic.com"
 end
 
 ###############################################################################


### PR DESCRIPTION
### Description

AWS Rightsize VMs policy needs to show the following information: RI coverage before/after, VM age, uptime, vCPU capacity before/after, vCPU utilization before/after, Memory capacity before/after, memory utilization before/after, storage throughput capacity before/after, storage throughput utilization before/after, NET throughput capacity and utilization before/after, system details URL.

### Issues Resolved

Added all requested fields and normalized incident fields.

### Link to Example Applied Policy

- AWS Turbonomic Rightsize VMs: https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/60073?policyId=64ee5c5c01dad60001bfe6e7

### Contribution Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
