### PR TITLE
FOPTS-1542 Azure Idle Compute Instances - incident and recommendations showing error for tags

### DIFF
--- a/cost/azure/idle_compute_instances/CHANGELOG.md
+++ b/cost/azure/idle_compute_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.2
+
+- Corrected issue with policy, tags were being sent in an unsupported format
+
 ## v5.1
 
 - Corrected issue with policy not retrieving cost data on orgs using newer Azure bill connections

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "5.1",
+  version: "5.2",
   provider: "Azure",
   service: "Compute",
   policy_set: "Idle Compute Instances",
@@ -268,8 +268,12 @@ datasource "ds_top_level_billing_centers" do
   run_script $js_top_level_bc, $ds_billing_centers
 end
 
+datasource "ds_azure_instances_performance_parsed" do
+  run_script $js_parse_instance_tags, $ds_azure_instance_performance
+end
+
 datasource "ds_combineddata" do
-  run_script $js_combineddata, $param_cpu_average_percentage, $ds_azure_instance_performance
+  run_script $js_combineddata, $param_cpu_average_percentage, $ds_azure_instances_performance_parsed
 end
 
 datasource "ds_instance_cost_mapping" do
@@ -399,6 +403,24 @@ script "js_filter_instances", type: "javascript" do
   }
 EOF
 end
+
+#This is to create an array of tag names per instance based on its tags
+script "js_parse_instance_tags", type: "javascript" do
+  parameters "ds_azure_instance_performance"
+  result "results"
+  code <<-EOS
+    var results = []
+    _.each(ds_azure_instance_performance, function(result){
+      var tagsArray = []
+      for (var tag in result.tags) {
+        tagsArray.push(tag + "=" + result.tags[tag])
+      }
+      result['tags'] = tagsArray;
+      results.push(result)
+    })
+  EOS
+  end
+
 
 #This is to get the average cpu over time for the machine and return the dataset of machines with issues
 script "js_combineddata", type: "javascript" do


### PR DESCRIPTION
### Description

Was added a step to parse the tags received using the Azure API to an array of tags

### Issues Resolved

GUI was unable to parse a map of tags, so now the policy sends an array of tags with format ["key=value"]

### Link to Example Applied Policy

[Applied Policy](https://app.flexera.com/orgs/1105/automation/applied-policies/projects/60073?policyId=64f13e7a4b956f0001f2b4f9)

### Contribution Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
