### PR TITLE
POL-909 Update Azure instance_types.json with NFUs and No. of vCPUs

### DIFF
--- a/data/azure/instance_types.json
+++ b/data/azure/instance_types.json
@@ -1,700 +1,4679 @@
 {
-  "Basic_A0": {"up": "Basic_A1", "down": null, "superseded": null},
-  "Basic_A1": {"up": "Basic_A2", "down": "Basic_A0", "superseded": null},
-  "Basic_A2": {"up": "Basic_A3", "down": "Basic_A1", "superseded": null},
-  "Basic_A3": {"up": "Basic_A4", "down": "Basic_A2", "superseded": null},
-  "Basic_A4": {"up": null, "down": "Basic_A3", "superseded": null},
-  "Standard_A0": {"up": "Standard_A1", "down": null, "superseded": null},
-  "Standard_A1": {"up": "Standard_A2", "down": "Standard_A0", "superseded": {"regular": "Standard_A1_v2"}},
-  "Standard_A2": {"up": "Standard_A3", "down": "Standard_A1", "superseded": {"regular": "Standard_A2_v2"}},
-  "Standard_A3": {"up": "Standard_A4", "down": "Standard_A2", "superseded": {"regular": "Standard_A4_v2"}},
-  "Standard_A4": {"up": "Standard_A5", "down": "Standard_A3", "superseded": {"regular": "Standard_A8_v2"}},
-  "Standard_A5": {"up": "Standard_A6", "down": "Standard_A4", "superseded": {"regular": "Standard_A2m_v2"}},
-  "Standard_A6": {"up": "Standard_A7", "down": "Standard_A5", "superseded": {"regular": "Standard_A4m_v2"}},
-  "Standard_A7": {"up": "Standard_A8", "down": "Standard_A6", "superseded": {"regular": "Standard_A8m_v2"}},
-  "Standard_A8": {"up": "Standard_A9", "down": "Standard_A7", "superseded": null},
-  "Standard_A9": {"up": "Standard_A10", "down": "Standard_A8", "superseded": null},
-  "Standard_A10": {"up": "Standard_A11", "down": "Standard_A9", "superseded": {"regular": "Standard_H8"}},
-  "Standard_A11": {"up": null, "down": "Standard_A10", "superseded": {"regular": "Standard_H16"}},
-  "Standard_A1_v2": {"up": "Standard_A2_v2", "down": null, "superseded": null},
-  "Standard_A2_v2": {"up": "Standard_A4_v2", "down": "Standard_A1_v2", "superseded": null},
-  "Standard_A4_v2": {"up": "Standard_A8_v2", "down": "Standard_A2_v2", "superseded": null},
-  "Standard_A8_v2": {"up": null, "down": "Standard_A4_v2", "superseded": null},
-  "Standard_A2m_v2": {"up": "Standard_A4m_v2", "down": null, "superseded": null},
-  "Standard_A4m_v2": {"up": "Standard_A8m_v2", "down": "Standard_A2m_v2", "superseded": null},
-  "Standard_A8m_v2": {"up": null, "down": "Standard_A4m_v2", "superseded": null},
-  "Standard_B1ls": {"up": "Standard_B1s", "down": null, "superseded": null},
-  "Standard_B1s": {"up": "Standard_B1ms", "down": "Standard_B1ls", "superseded": null},
-  "Standard_B1ms": {"up": "Standard_B2s", "down": "Standard_B1s", "superseded": null},
-  "Standard_B2s": {"up": "Standard_B2ms", "down": "Standard_B1ms", "superseded": null},
-  "Standard_B2ms": {"up": "Standard_B4ms", "down": "Standard_B2s", "superseded": null},
-  "Standard_B4ms": {"up": "Standard_B8ms", "down": "Standard_B2ms", "superseded": null},
-  "Standard_B8ms": {"up": "Standard_B12ms", "down": "Standard_B4ms", "superseded": null},
-  "Standard_B12ms": {"up": "Standard_B16ms", "down": "Standard_B8ms", "superseded": null},
-  "Standard_B16ms": {"up": "Standard_B20ms", "down": "Standard_B12ms", "superseded": null},
-  "Standard_B20ms": {"up": null, "down": "Standard_B16ms", "superseded": null},
-  "Standard_D1": {"up": "Standard_D2", "down": null, "superseded": {"regular": "Standard_D1_v2"}},
-  "Standard_D2": {"up": "Standard_D3", "down": "Standard_D1", "superseded": {"regular": "Standard_D2_v3"}},
-  "Standard_D3": {"up": null, "down": "Standard_D2", "superseded": {"regular": "Standard_D4_v3"}},
-  "Standard_D4": {"up": null, "down": "Standard_D3", "superseded": {"regular": "Standard_D8_v3"}},
-  "Standard_D11": {"up": "Standard_D12", "down": null, "superseded": {"regular": "Standard_E2_v3"}},
-  "Standard_D12": {"up": "Standard_D13", "down": "Standard_D11", "superseded": {"regular": "Standard_E4_v3"}},
-  "Standard_D13": {"up": "Standard_D14", "down": "Standard_D12", "superseded": {"regular": "Standard_E8_v3"}},
-  "Standard_D14": {"up": null, "down": "Standard_D13", "superseded": {"regular": "Standard_E16_v3"}},
-  "Standard_D1_v2": {"up": "Standard_D2_v2", "down": null, "superseded": null},
-  "Standard_D2_v2": {"up": "Standard_D3_v2", "down": "Standard_D1_v2", "superseded": {"regular": "Standard_D2_v3"}},
-  "Standard_D3_v2": {"up": "Standard_D4_v2", "down": "Standard_D2_v2", "superseded": {"regular": "Standard_D4_v3"}},
-  "Standard_D4_v2": {"up": "Standard_D5_v2", "down": "Standard_D3_v2", "superseded": {"regular": "Standard_D8_v3"}},
-  "Standard_D5_v2": {"up": null, "down": "Standard_D4_v2", "superseded": {"regular": "Standard_D16_v3"}},
-  "Standard_D11_v2": {"up": "Standard_D12_v2", "down": null, "superseded": {"regular": "Standard_E2_v3"}},
-  "Standard_D12_v2": {"up": "Standard_D13_v2", "down": "Standard_D11_v2", "superseded": {"regular": "Standard_E4_v3"}},
-  "Standard_D13_v2": {"up": "Standard_D14_v2", "down": "Standard_D13_v2", "superseded": {"regular": "Standard_E8_v3"}},
-  "Standard_D14_v2": {"up": "Standard_D15_v2", "down": "Standard_D14_v2", "superseded": {"regular": "Standard_E16_v3"}},
-  "Standard_D15_v2": {"up": null, "down": "Standard_D15_v2", "superseded": null},
-  "Standard_D2_v2_Promo": {"up": "Standard_D3_v2_Promo", "down": null, "superseded": {"regular": "Standard_D2_v3"}},
-  "Standard_D3_v2_Promo": {"up": "Standard_D4_v2_Promo", "down": "Standard_D2_v2_Promo", "superseded": {"regular": "Standard_D4_v3"}},
-  "Standard_D4_v2_Promo": {"up": "Standard_D5_v2_Promo", "down": "Standard_D3_v2_Promo", "superseded": {"regular": "Standard_D8_v3"}},
-  "Standard_D5_v2_Promo": {"up": null, "down": "Standard_D4_v2_Promo", "superseded": {"regular": "Standard_D16_v3"}},
-  "Standard_D11_v2_Promo": {"up": "Standard_D12_v2_Promo", "down": null, "superseded": {"regular": "Standard_E2_v3"}},
-  "Standard_D12_v2_Promo": {"up": "Standard_D13_v2_Promo", "down": "Standard_D11_v2_Promo", "superseded": {"regular": "Standard_E4_v3"}},
-  "Standard_D13_v2_Promo": {"up": "Standard_D14_v2_Promo", "down": "Standard_D12_v2_Promo", "superseded": {"regular": "Standard_E8_v3"}},
-  "Standard_D14_v2_Promo": {"up": null, "down": "Standard_D13_v2_Promo", "superseded": {"regular": "Standard_E16_v3"}},
-  "Standard_D2s_v3": {"up": "Standard_D4s_v3", "down": null, "superseded": null},
-  "Standard_D4s_v3": {"up": "Standard_D8s_v3", "down": "Standard_D2s_v3", "superseded": null},
-  "Standard_D8s_v3": {"up": "Standard_D16s_v3", "down": "Standard_D4s_v3", "superseded": null},
-  "Standard_D16s_v3": {"up": "Standard_D32s_v3", "down": "Standard_D8s_v3", "superseded": null},
-  "Standard_D32s_v3": {"up": "Standard_D48s_v3", "down": "Standard_D16s_v3", "superseded": null},
-  "Standard_D48s_v3": {"up": "Standard_D64s_v3", "down": "Standard_D32s_v3", "superseded": null},
-  "Standard_D64s_v3": {"up": null, "down": "Standard_D48s_v3", "superseded": null},
-  "Standard_D2_v3": {"up": "Standard_D4_v3", "down": null, "superseded": null},
-  "Standard_D4_v3": {"up": "Standard_D8_v3", "down": "Standard_D2_v3", "superseded": null},
-  "Standard_D8_v3": {"up": "Standard_D16_v3", "down": "Standard_D4_v3", "superseded": null},
-  "Standard_D16_v3": {"up": "Standard_D32_v3", "down": "Standard_D8_v3", "superseded": null},
-  "Standard_D32_v3": {"up": "Standard_D48_v3", "down": "Standard_D16_v3", "superseded": null},
-  "Standard_D48_v3": {"up": "Standard_D64_v3", "down": "Standard_D32_v3", "superseded": null},
-  "Standard_D64_v3": {"up": null, "down": "Standard_D48_v3", "superseded": null},
-  "Standard_D2_v4": {"up": "Standard_D4_v4", "down": null, "superseded": null},
-  "Standard_D4_v4": {"up": "Standard_D8_v4", "down": "Standard_D2_v4", "superseded": null},
-  "Standard_D8_v4": {"up": "Standard_D16_v4", "down": "Standard_D4_v4", "superseded": null},
-  "Standard_D16_v4": {"up": "Standard_D32_v4", "down": "Standard_D8_v4", "superseded": null},
-  "Standard_D32_v4": {"up": "Standard_D48_v4", "down": "Standard_D16_v4", "superseded": null},
-  "Standard_D48_v4": {"up": "Standard_D64_v4", "down": "Standard_D32_v4", "superseded": null},
-  "Standard_D64_v4": {"up": null, "down": "Standard_D48_v4", "superseded": null},
-  "Standard_D2_v5": {"up": "Standard_D4_v5", "down": null, "superseded": null},
-  "Standard_D4_v5": {"up": "Standard_D8_v5", "down": "Standard_D2_v5", "superseded": null},
-  "Standard_D8_v5": {"up": "Standard_D16_v5", "down": "Standard_D4_v5", "superseded": null},
-  "Standard_D16_v5": {"up": "Standard_D32_v5", "down": "Standard_D8_v5", "superseded": null},
-  "Standard_D32_v5": {"up": "Standard_D48_v5", "down": "Standard_D16_v5", "superseded": null},
-  "Standard_D48_v5": {"up": "Standard_D64_v5", "down": "Standard_D32_v5", "superseded": null},
-  "Standard_D64_v5": {"up": "Standard_D96_v5", "down": "Standard_D48_v5", "superseded": null},
-  "Standard_D96_v5": {"up": null, "down": "Standard_D64_v5", "superseded": null},
-  "Standard_D2s_v4": {"up": "Standard_D4s_v4", "down": null, "superseded": null},
-  "Standard_D4s_v4": {"up": "Standard_D8s_v4", "down": "Standard_D2s_v4", "superseded": null},
-  "Standard_D8s_v4": {"up": "Standard_D16s_v4", "down": "Standard_D4s_v4", "superseded": null},
-  "Standard_D16s_v4": {"up": "Standard_D32s_v4", "down": "Standard_D8s_v4", "superseded": null},
-  "Standard_D32s_v4": {"up": "Standard_D48s_v4", "down": "Standard_D16s_v4", "superseded": null},
-  "Standard_D48s_v4": {"up": "Standard_D64s_v4", "down": "Standard_D32s_v4", "superseded": null},
-  "Standard_D64s_v4": {"up": null, "down": "Standard_D48_v4", "superseded": null},
-  "Standard_D2s_v5": {"up": "Standard_D4s_v5", "down": null, "superseded": null},
-  "Standard_D4s_v5": {"up": "Standard_D8s_v5", "down": "Standard_D2s_v5", "superseded": null},
-  "Standard_D8s_v5": {"up": "Standard_D16s_v5", "down": "Standard_D4s_v5", "superseded": null},
-  "Standard_D16s_v5": {"up": "Standard_D32s_v5", "down": "Standard_D8s_v5", "superseded": null},
-  "Standard_D32s_v5": {"up": "Standard_D48s_v5", "down": "Standard_D16s_v5", "superseded": null},
-  "Standard_D48s_v5": {"up": "Standard_D64s_v5", "down": "Standard_D32s_v5", "superseded": null},
-  "Standard_D64s_v5": {"up": "Standard_D96s_v5", "down": "Standard_D48s_v5", "superseded": null},
-  "Standard_D96s_v5": {"up": null, "down": "Standard_D64s_v5", "superseded": null},
-  "Standard_DC1s_v2": {"up": "Standard_DC2s_v2", "down": null, "superseded": null},
-  "Standard_DC2s_v2": {"up": "Standard_DC4s_v2", "down": "Standard_DC1s_v2", "superseded": null},
-  "Standard_DC4s_v2": {"up": "Standard_DC8_v2", "down": "Standard_DC2s_v2", "superseded": null},
-  "Standard_DC8_v2": {"up": null, "down": "Standard_DC4s_v2", "superseded": null},
-  "Standard_DC1s_v3": {"up": "Standard_DC2s_v3", "down": null, "superseded": null},
-  "Standard_DC2s_v3": {"up": "Standard_DC4s_v3", "down": "Standard_DC1s_v3", "superseded": null},
-  "Standard_DC4s_v3": {"up": "Standard_DC8s_v3", "down": "Standard_DC2s_v3", "superseded": null},
-  "Standard_DC8s_v3": {"up": "Standard_DC16s_v3", "down": "Standard_DC4s_v3", "superseded": null},
-  "Standard_DC16s_v3": {"up": "Standard_DC24s_v3", "down": "Standard_DC8s_v3", "superseded": null},
-  "Standard_DC24s_v3": {"up": "Standard_DC32s_v3", "down": "Standard_DC16s_v3", "superseded": null},
-  "Standard_DC32s_v3": {"up": "Standard_DC48s_v3", "down": "Standard_DC24s_v3", "superseded": null},
-  "Standard_DC48s_v3": {"up": null, "down": "Standard_DC32s_v3", "superseded": null},
-  "Standard_DC1ds_v3": {"up": "Standard_DC2ds_v3", "down": null, "superseded": null},
-  "Standard_DC2ds_v3": {"up": "Standard_DC4ds_v3", "down": "Standard_DC1ds_v3", "superseded": null},
-  "Standard_DC4ds_v3": {"up": "Standard_DC8ds_v3", "down": "Standard_DC2ds_v3", "superseded": null},
-  "Standard_DC8ds_v3": {"up": "Standard_DC16ds_v3", "down": "Standard_DC4ds_v3", "superseded": null},
-  "Standard_DC16ds_v3": {"up": "Standard_DC24ds_v3", "down": "Standard_DC8ds_v3", "superseded": null},
-  "Standard_DC24ds_v3": {"up": "Standard_DC32ds_v3", "down": "Standard_DC16ds_v3", "superseded": null},
-  "Standard_DC32ds_v3": {"up": "Standard_DC48ds_v3", "down": "Standard_DC24ds_v3", "superseded": null},
-  "Standard_DC48ds_v3": {"up": null, "down": "Standard_DC32ds_v3", "superseded": null},
-  "Standard_DC2as_v5": {"up": "Standard_DC4as_v5", "down": null, "superseded": null},
-  "Standard_DC4as_v5": {"up": "Standard_DC8as_v5", "down": "Standard_DC2as_v5", "superseded": null},
-  "Standard_DC8as_v5": {"up": "Standard_DC16as_v5", "down": "Standard_DC4as_v5", "superseded": null},
-  "Standard_DC16as_v5": {"up": "Standard_DC32as_v5", "down": "Standard_DC8as_v5", "superseded": null},
-  "Standard_DC32as_v5": {"up": "Standard_DC48as_v5", "down": "Standard_DC16as_v5", "superseded": null},
-  "Standard_DC48as_v5": {"up": "Standard_DC64as_v5", "down": "Standard_DC32as_v5", "superseded": null},
-  "Standard_DC64as_v5": {"up": "Standard_DC96as_v5", "down": "Standard_DC48as_v5", "superseded": null},
-  "Standard_DC96as_v5": {"up": null, "down": "Standard_DC64as_v5", "superseded": null},
-  "Standard_DC2ads_v5": {"up": "Standard_DC4ads_v5", "down": null, "superseded": null},
-  "Standard_DC4ads_v5": {"up": "Standard_DC8ads_v5", "down": "Standard_DC2ads_v5", "superseded": null},
-  "Standard_DC8ads_v5": {"up": "Standard_DC16ads_v5", "down": "Standard_DC4ads_v5", "superseded": null},
-  "Standard_DC16ads_v5": {"up": "Standard_DC32ads_v5", "down": "Standard_DC8ads_v5", "superseded": null},
-  "Standard_DC32ads_v5": {"up": "Standard_DC48ads_v5", "down": "Standard_DC16ads_v5", "superseded": null},
-  "Standard_DC48ads_v5": {"up": "Standard_DC64ads_v5", "down": "Standard_DC32ads_v5", "superseded": null},
-  "Standard_DC64ads_v5": {"up": "Standard_DC96ads_v5", "down": "Standard_DC48ads_v5", "superseded": null},
-  "Standard_DC96ads_v5": {"up": null, "down": "Standard_DC64ads_v5", "superseded": null},
-  "Standard_D2ps_v5": {"up": "Standard_D4ps_v5", "down": null, "superseded": null},
-  "Standard_D4ps_v5": {"up": "Standard_D8ps_v5", "down": "Standard_D2ps_v5", "superseded": null},
-  "Standard_D8ps_v5": {"up": "Standard_D16ps_v5", "down": "Standard_D4ps_v5", "superseded": null},
-  "Standard_D16ps_v5": {"up": "Standard_D32ps_v5", "down": "Standard_D8ps_v5", "superseded": null},
-  "Standard_D32ps_v5": {"up": "Standard_D48ps_v5", "down": "Standard_D16ps_v5", "superseded": null},
-  "Standard_D48ps_v5": {"up": "Standard_D64ps_v5", "down": "Standard_D32ps_v5", "superseded": null},
-  "Standard_D64ps_v5": {"up": null, "down": "Standard_D48ps_v5", "superseded": null},
-  "Standard_D2pds_v5": {"up": "Standard_D4pds_v5", "down": null, "superseded": null},
-  "Standard_D4pds_v5": {"up": "Standard_D8pds_v5", "down": "Standard_D2pds_v5", "superseded": null},
-  "Standard_D8pds_v5": {"up": "Standard_D16pds_v5", "down": "Standard_D4pds_v5", "superseded": null},
-  "Standard_D16pds_v5": {"up": "Standard_D32pds_v5", "down": "Standard_D8pds_v5", "superseded": null},
-  "Standard_D32pds_v5": {"up": "Standard_D48pds_v5", "down": "Standard_D16pds_v5", "superseded": null},
-  "Standard_D48pds_v5": {"up": "Standard_D64pds_v5", "down": "Standard_D32pds_v5", "superseded": null},
-  "Standard_D64pds_v5": {"up": null, "down": "Standard_D48pds_v5", "superseded": null},
-  "Standard_D2pls_v5": {"up": "Standard_D4pls_v5", "down": null, "superseded": null},
-  "Standard_D4pls_v5": {"up": "Standard_D8pls_v5", "down": "Standard_D2pls_v5", "superseded": null},
-  "Standard_D8pls_v5": {"up": "Standard_D16pls_v5", "down": "Standard_D4pls_v5", "superseded": null},
-  "Standard_D16pls_v5": {"up": "Standard_D32pls_v5", "down": "Standard_D8pls_v5", "superseded": null},
-  "Standard_D32pls_v5": {"up": "Standard_D48pls_v5", "down": "Standard_D16pls_v5", "superseded": null},
-  "Standard_D48pls_v5": {"up": "Standard_D64pls_v5", "down": "Standard_D32pls_v5", "superseded": null},
-  "Standard_D64pls_v5": {"up": null, "down": "Standard_D48pls_v5", "superseded": null},
-  "Standard_D2plds_v5": {"up": "Standard_D4plds_v5", "down": null, "superseded": null},
-  "Standard_D4plds_v5": {"up": "Standard_D8plds_v5", "down": "Standard_D2plds_v5", "superseded": null},
-  "Standard_D8plds_v5": {"up": "Standard_D16plds_v5", "down": "Standard_D4plds_v5", "superseded": null},
-  "Standard_D16plds_v5": {"up": "Standard_D32plds_v5", "down": "Standard_D8plds_v5", "superseded": null},
-  "Standard_D32plds_v5": {"up": "Standard_D48plds_v5", "down": "Standard_D16plds_v5", "superseded": null},
-  "Standard_D48plds_v5": {"up": "Standard_D64plds_v5", "down": "Standard_D32plds_v5", "superseded": null},
-  "Standard_D64plds_v5": {"up": null, "down": "Standard_D48plds_v5", "superseded": null},
-  "Standard_DS1": {"up": "Standard_DS2", "down": null, "superseded": null},
-  "Standard_DS2": {"up": "Standard_DS3", "down": "Standard_DS1", "superseded": null},
-  "Standard_DS3": {"up": "Standard_DS4", "down": "Standard_DS2", "superseded": null},
-  "Standard_DS4": {"up": null, "down": "Standard_DS3", "superseded": null},
-  "Standard_DS11": {"up": "Standard_DS12", "down": null, "superseded": null},
-  "Standard_DS12": {"up": "Standard_DS13", "down": "Standard_DS11", "superseded": null},
-  "Standard_DS13": {"up": "Standard_DS14", "down": "Standard_DS12", "superseded": null},
-  "Standard_DS14": {"up": null, "down": "Standard_DS13", "superseded": null},
-  "Standard_DS1_v2": {"up": "Standard_DS2_v2", "down": null, "superseded": null},
-  "Standard_DS2_v2": {"up": "Standard_DS3_v2", "down": "Standard_DS1_v2", "superseded": {"regular": "Standard_D2s_v3"}},
-  "Standard_DS3_v2": {"up": "Standard_DS4_v2", "down": "Standard_DS2_v2", "superseded": {"regular": "Standard_D4s_v3"}},
-  "Standard_DS4_v2": {"up": "Standard_DS5_v2", "down": "Standard_DS3_v2", "superseded": {"regular": "Standard_D8s_v3"}},
-  "Standard_DS5_v2": {"up": null, "down": "Standard_DS4_v2", "superseded": {"regular": "Standard_D16s_v3"}},
-  "Standard_DS11_v2": {"up": "Standard_DS12_v2", "down": null, "superseded": null},
-  "Standard_DS12_v2": {"up": "Standard_DS13_v2", "down": "Standard_DS11_v2", "superseded": null},
-  "Standard_DS13_v2": {"up": "Standard_DS14_v2", "down": "Standard_DS12_v2", "superseded": null},
-  "Standard_DS14_v2": {"up": "Standard_DS15_v2", "down": "Standard_DS13_v2", "superseded": null},
-  "Standard_DS15_v2": {"up": null, "down": "Standard_DS14_v2", "superseded": null},
-  "Standard_DS2_v2_Promo": {"up": "Standard_DS3_v2_Promo", "down": null, "superseded": null},
-  "Standard_DS3_v2_Promo": {"up": "Standard_DS4_v2_Promo", "down": "Standard_DS2_v2_Promo", "superseded": null},
-  "Standard_DS4_v2_Promo": {"up": "Standard_DS5_v2_Promo", "down": "Standard_DS3_v2_Promo", "superseded": null},
-  "Standard_DS5_v2_Promo": {"up": null, "down": "Standard_DS4_v2_Promo", "superseded": null},
-  "Standard_DS11_v2_Promo": {"up": "Standard_DS12_v2_Promo", "down": null, "superseded": null},
-  "Standard_DS12_v2_Promo": {"up": "Standard_DS13_v2_Promo", "down": "Standard_DS11_v2_Promo", "superseded": null},
-  "Standard_DS13_v2_Promo": {"up": "Standard_DS14_v2_Promo", "down": "Standard_DS12_v2_Promo", "superseded": null},
-  "Standard_DS14_v2_Promo": {"up": null, "down": "Standard_DS13_v2_Promo", "superseded": null},
-  "Standard_D2a_v4": {"up": "Standard_D4a_v4", "down": null, "superseded": null},
-  "Standard_D4a_v4": {"up": "Standard_D8a_v4", "down": "Standard_D2a_v4", "superseded": null},
-  "Standard_D8a_v4": {"up": "Standard_D16a_v4", "down": "Standard_D4a_v4", "superseded": null},
-  "Standard_D16a_v4": {"up": "Standard_D32a_v4", "down": "Standard_D8a_v4", "superseded": null},
-  "Standard_D32a_v4": {"up": "Standard_D48a_v4", "down": "Standard_D16a_v4", "superseded": null},
-  "Standard_D48a_v4": {"up": "Standard_D64a_v4", "down": "Standard_D32a_v4", "superseded": null},
-  "Standard_D64a_v4": {"up": "Standard_D96a_v4", "down": "Standard_D48a_v4", "superseded": null},
-  "Standard_D96a_v4": {"up": null, "down": "Standard_D64a_v4", "superseded": null},
-  "Standard_D2as_v4": {"up": "Standard_D4as_v4", "down": null, "superseded": null},
-  "Standard_D4as_v4": {"up": "Standard_D8as_v4", "down": "Standard_D2as_v4", "superseded": null},
-  "Standard_D8as_v4": {"up": "Standard_D16as_v4", "down": "Standard_D4as_v4", "superseded": null},
-  "Standard_D16as_v4": {"up": "Standard_D32as_v4", "down": "Standard_D8as_v4", "superseded": null},
-  "Standard_D32as_v4": {"up": "Standard_D48as_v4", "down": "Standard_D16as_v4", "superseded": null},
-  "Standard_D48as_v4": {"up": "Standard_D64as_v4", "down": "Standard_D32as_v4", "superseded": null},
-  "Standard_D64as_v4": {"up": "Standard_D96as_v4", "down": "Standard_D48as_v4", "superseded": null},
-  "Standard_D96as_v4": {"up": null, "down": "Standard_D64as_v4", "superseded": null},
-  "Standard_D2d_v4": {"up": "Standard_D4d_v4", "down": null, "superseded": null},
-  "Standard_D4d_v4": {"up": "Standard_D8d_v4", "down": "Standard_D2d_v4", "superseded": null},
-  "Standard_D8d_v4": {"up": "Standard_D16d_v4", "down": "Standard_D4d_v4", "superseded": null},
-  "Standard_D16d_v4": {"up": "Standard_D32d_v4", "down": "Standard_D8d_v4", "superseded": null},
-  "Standard_D32d_v4": {"up": "Standard_D48d_v4", "down": "Standard_D16d_v4", "superseded": null},
-  "Standard_D48d_v4": {"up": "Standard_D64d_v4", "down": "Standard_D32d_v4", "superseded": null},
-  "Standard_D64d_v4": {"up": null, "down": "Standard_D48d_v4", "superseded": null},
-  "Standard_D2d_v5": {"up": "Standard_D4d_v5", "down": null, "superseded": null},
-  "Standard_D4d_v5": {"up": "Standard_D8d_v5", "down": "Standard_D2d_v5", "superseded": null},
-  "Standard_D8d_v5": {"up": "Standard_D16d_v5", "down": "Standard_D4d_v5", "superseded": null},
-  "Standard_D16d_v5": {"up": "Standard_D32d_v5", "down": "Standard_D8d_v5", "superseded": null},
-  "Standard_D32d_v5": {"up": "Standard_D48d_v5", "down": "Standard_D16d_v5", "superseded": null},
-  "Standard_D48d_v5": {"up": "Standard_D64d_v5", "down": "Standard_D32d_v5", "superseded": null},
-  "Standard_D64d_v5": {"up": "Standard_D96d_v5", "down": "Standard_D48d_v5", "superseded": null},
-  "Standard_D96d_v5": {"up": null, "down": "Standard_D64d_v5", "superseded": null},
-  "Standard_D2ds_v4": {"up": "Standard_D4ds_v4", "down": null, "superseded": null},
-  "Standard_D4ds_v4": {"up": "Standard_D8ds_v4", "down": "Standard_D2ds_v4", "superseded": null},
-  "Standard_D8ds_v4": {"up": "Standard_D16ds_v4", "down": "Standard_D4ds_v4", "superseded": null},
-  "Standard_D16ds_v4": {"up": "Standard_D32ds_v4", "down": "Standard_D8ds_v4", "superseded": null},
-  "Standard_D32ds_v4": {"up": "Standard_D48ds_v4", "down": "Standard_D16ds_v4", "superseded": null},
-  "Standard_D48ds_v4": {"up": "Standard_D64ds_v4", "down": "Standard_D32ds_v4", "superseded": null},
-  "Standard_D64ds_v4": {"up": null, "down": "Standard_D48ds_v4", "superseded": null},
-  "Standard_E2_v4": {"up": "Standard_E4_v4", "down": null, "superseded": null},
-  "Standard_E4_v4": {"up": "Standard_E8_v4", "down": "Standard_E2_v4", "superseded": null},
-  "Standard_E8_v4": {"up": "Standard_E16_v4", "down": "Standard_E4_v4", "superseded": null},
-  "Standard_E16_v4": {"up": "Standard_E20_v4", "down": "Standard_E8_v4", "superseded": null},
-  "Standard_E20_v4": {"up": "Standard_E32_v4", "down": "Standard_E16_v4", "superseded": null},
-  "Standard_E32_v4": {"up": "Standard_E48_v4", "down": "Standard_E20_v4", "superseded": null},
-  "Standard_E48_v4": {"up": "Standard_E64_v4", "down": "Standard_E32_v4", "superseded": null},
-  "Standard_E64_v4": {"up": null, "down": "Standard_E48_v4", "superseded": null},
-  "Standard_E2_v5": {"up": "Standard_E4_v5", "down": null, "superseded": null},
-  "Standard_E4_v5": {"up": "Standard_E8_v5", "down": "Standard_E2_v5", "superseded": null},
-  "Standard_E8_v5": {"up": "Standard_E16_v5", "down": "Standard_E4_v5", "superseded": null},
-  "Standard_E16_v5": {"up": "Standard_E20_v5", "down": "Standard_E8_v5", "superseded": null},
-  "Standard_E20_v5": {"up": "Standard_E32_v5", "down": "Standard_E16_v5", "superseded": null},
-  "Standard_E32_v5": {"up": "Standard_E48_v5", "down": "Standard_E20_v5", "superseded": null},
-  "Standard_E48_v5": {"up": "Standard_E64_v5", "down": "Standard_E32_v5", "superseded": null},
-  "Standard_E64_v5": {"up": "Standard_E96_v5", "down": "Standard_E48_v5", "superseded": null},
-  "Standard_E96_v5": {"up": "Standard_E104i_v5", "down": "Standard_E64_v5", "superseded": null},
-  "Standard_E104i_v5": {"up": null, "down": "Standard_E96_v5", "superseded": null},
-  "Standard_E2s_v5": {"up": "Standard_E4s_v5", "down": null, "superseded": null},
-  "Standard_E4s_v5": {"up": "Standard_E8s_v5", "down": "Standard_E2s_v5", "superseded": null},
-  "Standard_E8s_v5": {"up": "Standard_E16s_v5", "down": "Standard_E4s_v5", "superseded": null},
-  "Standard_E16s_v5": {"up": "Standard_E20s_v5", "down": "Standard_E8s_v5", "superseded": null},
-  "Standard_E20s_v5": {"up": "Standard_E32s_v5", "down": "Standard_E16s_v5", "superseded": null},
-  "Standard_E32s_v5": {"up": "Standard_E48s_v5", "down": "Standard_E20s_v5", "superseded": null},
-  "Standard_E48s_v5": {"up": "Standard_E64s_v5", "down": "Standard_E32s_v5", "superseded": null},
-  "Standard_E64s_v5": {"up": "Standard_E96s_v5", "down": "Standard_E48s_v5", "superseded": null},
-  "Standard_E96s_v5": {"up": "Standard_E104is_v5", "down": "Standard_E64s_v5", "superseded": null},
-  "Standard_E104is_v5": {"up": null, "down": "Standard_E96s_v5", "superseded": null},
-  "Standard_E2bds_v5": {"up": "Standard_E4bds_v5", "down": null, "superseded": null},
-  "Standard_E4bds_v5": {"up": "Standard_E8bds_v5", "down": "Standard_E2bds_v5", "superseded": null},
-  "Standard_E8bds_v5": {"up": "Standard_E16bds_v5", "down": "Standard_E4bds_v5", "superseded": null},
-  "Standard_E16bds_v5": {"up": "Standard_E32bds_v5", "down": "Standard_E8bds_v5", "superseded": null},
-  "Standard_E32bds_v5": {"up": "Standard_E48bds_v5", "down": "Standard_E16bds_v5", "superseded": null},
-  "Standard_E48bds_v5": {"up": "Standard_E64bds_v5", "down": "Standard_E32bds_v5", "superseded": null},
-  "Standard_E64bds_v5": {"up": null, "down": "Standard_E48bds_v5", "superseded": null},
-  "Standard_E2bs_v5": {"up": "Standard_E4bs_v5", "down": null, "superseded": null},
-  "Standard_E4bs_v5": {"up": "Standard_E8bs_v5", "down": "Standard_E2bs_v5", "superseded": null},
-  "Standard_E8bs_v5": {"up": "Standard_E16bs_v5", "down": "Standard_E4bs_v5", "superseded": null},
-  "Standard_E16bs_v5": {"up": "Standard_E32bs_v5", "down": "Standard_E8bs_v5", "superseded": null},
-  "Standard_E32bs_v5": {"up": "Standard_E48bs_v5", "down": "Standard_E16bs_v5", "superseded": null},
-  "Standard_E48bs_v5": {"up": "Standard_E64bs_v5", "down": "Standard_E32bs_v5", "superseded": null},
-  "Standard_E64bs_v5": {"up": null, "down": "Standard_E48bs_v5", "superseded": null},
-  "Standard_E8d_v5": {"up": "Standard_E16d_v5", "down": null, "superseded": null},
-  "Standard_E16d_v5": {"up": "Standard_E20d_v5", "down": "Standard_E8d_v5", "superseded": null},
-  "Standard_E20d_v5": {"up": "Standard_E32d_v5", "down": "Standard_E16d_v5", "superseded": null},
-  "Standard_E32d_v5": {"up": "Standard_E48d_v5", "down": "Standard_E20d_v5", "superseded": null},
-  "Standard_E48d_v5": {"up": "Standard_E64d_v5", "down": "Standard_E32d_v5", "superseded": null},
-  "Standard_E64d_v5": {"up": "Standard_E96d_v5", "down": "Standard_E48d_v5", "superseded": null},
-  "Standard_E96d_v5": {"up": "Standard_E104id_v5", "down": "Standard_E64d_v5", "superseded": null},
-  "Standard_E104id_v5": {"up": null, "down": "Standard_E96d_v5", "superseded": null},
-  "Standard_E2ds_v5": {"up": "Standard_E4ds_v5", "down": null, "superseded": null},
-  "Standard_E4ds_v5": {"up": "Standard_E8ds_v5", "down": "Standard_E2ds_v5", "superseded": null},
-  "Standard_E8ds_v5": {"up": "Standard_E16ds_v5", "down": "Standard_E4ds_v5", "superseded": null},
-  "Standard_E16ds_v5": {"up": "Standard_E20ds_v5", "down": "Standard_E8ds_v5", "superseded": null},
-  "Standard_E20ds_v5": {"up": "Standard_E32ds_v5", "down": "Standard_E16ds_v5", "superseded": null},
-  "Standard_E32ds_v5": {"up": "Standard_E48ds_v5", "down": "Standard_E20ds_v5", "superseded": null},
-  "Standard_E48ds_v5": {"up": "Standard_E64ds_v5", "down": "Standard_E32ds_v5", "superseded": null},
-  "Standard_E64ds_v5": {"up": "Standard_E96ds_v5", "down": "Standard_E48ds_v5", "superseded": null},
-  "Standard_E96ds_v5": {"up": null, "down": "Standard_E64ds_v5", "superseded": null},
-  "Standard_E104ids_v5": {"up": null, "down": null, "superseded": null},
-  "Standard_EC2as_v5": {"up": "Standard_EC4as_v5", "down": null, "superseded": null},
-  "Standard_EC4as_v5": {"up": "Standard_EC8as_v5", "down": "Standard_EC2as_v5", "superseded": null},
-  "Standard_EC8as_v5": {"up": "Standard_EC16as_v5", "down": "Standard_EC4as_v5", "superseded": null},
-  "Standard_EC16as_v5": {"up": "Standard_EC20as_v5", "down": "Standard_EC8as_v5", "superseded": null},
-  "Standard_EC20as_v5": {"up": "Standard_EC32as_v5", "down": "Standard_EC16as_v5", "superseded": null},
-  "Standard_EC32as_v5": {"up": "Standard_EC48as_v5", "down": "Standard_EC20as_v5", "superseded": null},
-  "Standard_EC48as_v5": {"up": "Standard_EC64as_v5", "down": "Standard_EC32as_v5", "superseded": null},
-  "Standard_EC64as_v5": {"up": "Standard_EC96as_v5", "down": "Standard_EC48as_v5", "superseded": null},
-  "Standard_EC96as_v5": {"up": null, "down": "Standard_EC64as_v5", "superseded": null},
-  "Standard_EC2ads_v5": {"up": "Standard_EC4ads_v5", "down": null, "superseded": null},
-  "Standard_EC4ads_v5": {"up": "Standard_EC8ads_v5", "down": "Standard_EC2ads_v5", "superseded": null},
-  "Standard_EC8ads_v5": {"up": "Standard_EC16ads_v5", "down": "Standard_EC4ads_v5", "superseded": null},
-  "Standard_EC16ads_v5": {"up": "Standard_EC20ads_v5", "down": "Standard_EC8ads_v5", "superseded": null},
-  "Standard_EC20ads_v5": {"up": "Standard_EC32ads_v5", "down": "Standard_EC16ads_v5", "superseded": null},
-  "Standard_EC32ads_v5": {"up": "Standard_EC48ads_v5", "down": "Standard_EC20ads_v5", "superseded": null},
-  "Standard_EC48ads_v5": {"up": "Standard_EC64ads_v5", "down": "Standard_EC32ads_v5", "superseded": null},
-  "Standard_EC64ads_v5": {"up": "Standard_EC96ads_v5", "down": "Standard_EC48ads_v5", "superseded": null},
-  "Standard_EC96ads_v5": {"up": null, "down": "Standard_EC64ads_v5", "superseded": null},
-  "Standard_E2ps_v5": {"up": "Standard_E4ps_v5", "down": null, "superseded": null},
-  "Standard_E4ps_v5": {"up": "Standard_E8ps_v5", "down": "Standard_E2ps_v5", "superseded": null},
-  "Standard_E8ps_v5": {"up": "Standard_E16ps_v5", "down": "Standard_E4ps_v5", "superseded": null},
-  "Standard_E16ps_v5": {"up": "Standard_E20ps_v5", "down": "Standard_E8ps_v5", "superseded": null},
-  "Standard_E20ps_v5": {"up": "Standard_E32ps_v5", "down": "Standard_E16ps_v5", "superseded": null},
-  "Standard_E32ps_v5": {"up": null, "down": "Standard_E20ps_v5", "superseded": null},
-  "Standard_E2pds_v5": {"up": "Standard_E4pds_v5", "down": null, "superseded": null},
-  "Standard_E4pds_v5": {"up": "Standard_E8pds_v5", "down": "Standard_E2pds_v5", "superseded": null},
-  "Standard_E8pds_v5": {"up": "Standard_E16pds_v5", "down": "Standard_E4pds_v5", "superseded": null},
-  "Standard_E16pds_v5": {"up": "Standard_E20pds_v5", "down": "Standard_E8pds_v5", "superseded": null},
-  "Standard_E20pds_v5": {"up": "Standard_E32pds_v5", "down": "Standard_E16pds_v5", "superseded": null},
-  "Standard_E32pds_v5": {"up": null, "down": "Standard_E20pds_v5", "superseded": null},
-  "Standard_M32ms_v2": {"up": "Standard_M64ms_v2", "down": null, "superseded": null},
-  "Standard_M64ms_v2": {"up": "Standard_M128ms_v2", "down": "Standard_M32ms_v2", "superseded": null},
-  "Standard_M128ms_v2": {"up": null, "down": "Standard_M64ms_v2", "superseded": null},
-  "Standard_M64s_v2": {"up": "Standard_M128s_v2", "down": null, "superseded": null},
-  "Standard_M128s_v2": {"up": null, "down": "Standard_M64s_v2", "superseded": null},
-  "Standard_M192is_v2": {"up": null, "down": null, "superseded": null},
-  "Standard_M192ims_v2": {"up": null, "down": null, "superseded": null},
-  "Standard_M32dms_v2": {"up": "Standard_M64dms_v2", "down": null, "superseded": null},
-  "Standard_M64dms_v2": {"up": "Standard_M128dms_v2", "down": "Standard_M32dms_v2", "superseded": null},
-  "Standard_M128dms_v2": {"up": null, "down": "Standard_M64dms_v2", "superseded": null},
-  "Standard_M64ds_v2": {"up": "Standard_M128ds_v2", "down": null, "superseded": null},
-  "Standard_M128ds_v2": {"up": null, "down": "Standard_M64ds_v2", "superseded": null},
-  "Standard_M192ids_v2": {"up": null, "down": null, "superseded": null},
-  "Standard_M192idms_v2": {"up": null, "down": null, "superseded": null},
-  "Standard_M8-2ms": {"up": "Standard_M8-4ms", "down": null, "superseded": null},
-  "Standard_M8-4ms": {"up": null, "down": "Standard_M8-2ms", "superseded": null},
-  "Standard_M16-4ms": {"up": "Standard_M16-8ms", "down": null, "superseded": null},
-  "Standard_M16-8ms": {"up": null, "down": "Standard_M16-4ms", "superseded": null},
-  "Standard_M32-8ms": {"up": "Standard_M32-16ms", "down": null, "superseded": null},
-  "Standard_M32-16ms": {"up": null, "down": "Standard_M32-8ms", "superseded": null},
-  "Standard_M64-16ms": {"up": "Standard_M64-32ms", "down": null, "superseded": null},
-  "Standard_M64-32ms": {"up": null, "down": "Standard_M64-16ms", "superseded": null},
-  "Standard_M128-32ms": {"up": "Standard_M128-64ms", "down": null, "superseded": null},
-  "Standard_M128-64ms": {"up": null, "down": "Standard_M128-32ms", "superseded": null},
-  "Standard_E4-2s_v3": {"up": null, "down": null, "superseded": null},
-  "Standard_E8-2s_v3": {"up": "Standard_E8-4s_v3", "down": null, "superseded": null},
-  "Standard_E8-4s_v3": {"up": null, "down": "Standard_E8-2s_v3", "superseded": null},
-  "Standard_E16-4s_v3": {"up": "Standard_E16-8s_v3", "down": null, "superseded": null},
-  "Standard_E16-8s_v3": {"up": null, "down": "Standard_E16-4s_v3", "superseded": null},
-  "Standard_E32-8s_v3": {"up": "Standard_E32-16s_v3", "down": null, "superseded": null},
-  "Standard_E32-16s_v3": {"up": null, "down": "Standard_E32-8s_v3", "superseded": null},
-  "Standard_E64-16s_v3": {"up": "Standard_E64-32s_v3", "down": null, "superseded": null},
-  "Standard_E64-32s_v3": {"up": null, "down": "Standard_E64-16s_v3", "superseded": null},
-  "Standard_E4-2s_v4": {"up": null, "down": null, "superseded": null},
-  "Standard_E8-2s_v4": {"up": "Standard_E8-4s_v4", "down": null, "superseded": null},
-  "Standard_E8-4s_v4": {"up": null, "down": "Standard_E8-2s_v4", "superseded": null},
-  "Standard_E16-4s_v4": {"up": "Standard_E16-8s_v4", "down": null, "superseded": null},
-  "Standard_E16-8s_v4": {"up": null, "down": "Standard_E16-4s_v4", "superseded": null},
-  "Standard_E32-8s_v4": {"up": "Standard_E32-16s_v4", "down": null, "superseded": null},
-  "Standard_E32-16s_v4": {"up": null, "down": "Standard_E32-8s_v4", "superseded": null},
-  "Standard_E64-16s_v4": {"up": "Standard_E64-32s_v4", "down": null, "superseded": null},
-  "Standard_E64-32s_v4": {"up": null, "down": "Standard_E64-16s_v4", "superseded": null},
-  "Standard_E4-2ds_v4": {"up": null, "down": null, "superseded": null},
-  "Standard_E8-2ds_v4": {"up": "Standard_E8-4ds_v4", "down": null, "superseded": null},
-  "Standard_E8-4ds_v4": {"up": null, "down": "Standard_E8-2ds_v4", "superseded": null},
-  "Standard_E16-4ds_v4": {"up": "Standard_E16-8ds_v4", "down": null, "superseded": null},
-  "Standard_E16-8ds_v4": {"up": null, "down": "Standard_E16-4ds_v4", "superseded": null},
-  "Standard_E32-8ds_v4": {"up": "Standard_E32-16ds_v4", "down": null, "superseded": null},
-  "Standard_E32-16ds_v4": {"up": null, "down": "Standard_E32-8ds_v4", "superseded": null},
-  "Standard_E64-16ds_v4": {"up": "Standard_E64-32ds_v4", "down": null, "superseded": null},
-  "Standard_E64-32ds_v4": {"up": null, "down": "Standard_E64-16ds_v4", "superseded": null},
-  "Standard_E4-2s_v5": {"up": null, "down": null, "superseded": null},
-  "Standard_E8-2s_v5": {"up": "Standard_E8-4s_v5", "down": null, "superseded": null},
-  "Standard_E8-4s_v5": {"up": null, "down": "Standard_E8-2s_v5", "superseded": null},
-  "Standard_E16-4s_v5": {"up": "Standard_E16-8s_v5", "down": null, "superseded": null},
-  "Standard_E16-8s_v5": {"up": null, "down": "Standard_E16-4s_v5", "superseded": null},
-  "Standard_E32-8s_v5": {"up": "Standard_E32-16s_v5", "down": null, "superseded": null},
-  "Standard_E32-16s_v5": {"up": null, "down": "Standard_E32-8s_v5", "superseded": null},
-  "Standard_E64-16s_v5": {"up": "Standard_E64-32s_v5", "down": null, "superseded": null},
-  "Standard_E64-32s_v5": {"up": null, "down": "Standard_E64-16s_v5", "superseded": null},
-  "Standard_E96-24s_v5": {"up": "Standard_E96-48s_v5", "down": null, "superseded": null},
-  "Standard_E96-48s_v5": {"up": null, "down": "Standard_E96-24s_v5", "superseded": null},
-  "Standard_E4-2ds_v5": {"up": null, "down": null, "superseded": null},
-  "Standard_E8-2ds_v5": {"up": "Standard_E8-4ds_v5", "down": null, "superseded": null},
-  "Standard_E8-4ds_v5": {"up": null, "down": "Standard_E8-2ds_v5", "superseded": null},
-  "Standard_E16-4ds_v5": {"up": "Standard_E16-8ds_v5", "down": null, "superseded": null},
-  "Standard_E16-8ds_v5": {"up": null, "down": "Standard_E16-4ds_v5", "superseded": null},
-  "Standard_E32-8ds_v5": {"up": "Standard_E32-16ds_v5", "down": null, "superseded": null},
-  "Standard_E32-16ds_v5": {"up": null, "down": "Standard_E32-8ds_v5", "superseded": null},
-  "Standard_E64-16ds_v5": {"up": "Standard_E64-32ds_v5", "down": null, "superseded": null},
-  "Standard_E64-32ds_v5": {"up": null, "down": "Standard_E64-16ds_v5", "superseded": null},
-  "Standard_E96-24ds_v5": {"up": "Standard_E96-48ds_v5", "down": null, "superseded": null},
-  "Standard_E96-48ds_v5": {"up": null, "down": "Standard_E96-24ds_v5", "superseded": null},
-  "Standard_E4-2as_v4": {"up": null, "down": null, "superseded": null},
-  "Standard_E8-2as_v4": {"up": "Standard_E8-4as_v4", "down": null, "superseded": null},
-  "Standard_E8-4as_v4": {"up": null, "down": "Standard_E8-2as_v4", "superseded": null},
-  "Standard_E16-4as_v4": {"up": "Standard_E16-8as_v4", "down": null, "superseded": null},
-  "Standard_E16-8as_v4": {"up": null, "down": "Standard_E16-4as_v4", "superseded": null},
-  "Standard_E32-8as_v4": {"up": "Standard_E32-16as_v4", "down": null, "superseded": null},
-  "Standard_E32-16as_v4": {"up": null, "down": "Standard_E32-8as_v4", "superseded": null},
-  "Standard_E64-16as_v4": {"up": "Standard_E64-32as_v4", "down": null, "superseded": null},
-  "Standard_E64-32as_v4": {"up": null, "down": "Standard_E64-16as_v4", "superseded": null},
-  "Standard_E96-24as_v4": {"up": "Standard_E96-48as_v4", "down": null, "superseded": null},
-  "Standard_E96-48as_v4": {"up": null, "down": "Standard_E96-24as_v4", "superseded": null},
-  "Standard_E4-2ads_v5": {"up": null, "down": null, "superseded": null},
-  "Standard_E8-2ads_v5": {"up": "Standard_E8-4ads_v5", "down": null, "superseded": null},
-  "Standard_E8-4ads_v5": {"up": null, "down": "Standard_E8-2ads_v5", "superseded": null},
-  "Standard_E16-4ads_v5": {"up": "Standard_E16-8ads_v5", "down": null, "superseded": null},
-  "Standard_E16-8ads_v5": {"up": null, "down": "Standard_E16-4ads_v5", "superseded": null},
-  "Standard_E32-8ads_v5": {"up": "Standard_E32-16ads_v5", "down": null, "superseded": null},
-  "Standard_E32-16ads_v5": {"up": null, "down": "Standard_E32-8ads_v5", "superseded": null},
-  "Standard_E64-16ads_v5": {"up": "Standard_E64-32ads_v5", "down": null, "superseded": null},
-  "Standard_E64-32ads_v5": {"up": null, "down": "Standard_E64-16ads_v5", "superseded": null},
-  "Standard_E96-24ads_v5": {"up": "Standard_E96-48ads_v5", "down": null, "superseded": null},
-  "Standard_E96-48ads_v5": {"up": null, "down": "Standard_E96-24ads_v5", "superseded": null},
-  "Standard_E4-2as_v5": {"up": null, "down": null, "superseded": null},
-  "Standard_E8-2as_v5": {"up": "Standard_E8-4as_v5", "down": null, "superseded": null},
-  "Standard_E8-4as_v5": {"up": null, "down": "Standard_E8-2as_v5", "superseded": null},
-  "Standard_E16-4as_v5": {"up": "Standard_E16-8as_v5", "down": null, "superseded": null},
-  "Standard_E16-8as_v5": {"up": null, "down": "Standard_E16-4as_v5", "superseded": null},
-  "Standard_E32-8as_v5": {"up": "Standard_E32-16as_v5", "down": null, "superseded": null},
-  "Standard_E32-16as_v5": {"up": null, "down": "Standard_E32-8as_v5", "superseded": null},
-  "Standard_E64-16as_v5": {"up": "Standard_E64-32as_v5", "down": null, "superseded": null},
-  "Standard_E64-32as_v5": {"up": null, "down": "Standard_E64-16as_v5", "superseded": null},
-  "Standard_E96-24as_v5": {"up": "Standard_E96-48as_v5", "down": null, "superseded": null},
-  "Standard_E96-48as_v5": {"up": null, "down": "Standard_E96-24as_v5", "superseded": null},
-  "Standard_GS4-4": {"up": "Standard_GS4-8", "down": null, "superseded": null},
-  "Standard_GS4-8": {"up": null, "down": "Standard_GS4-4", "superseded": null},
-  "Standard_GS5-8": {"up": "Standard_GS5-16", "down": null, "superseded": null},
-  "Standard_GS5-16": {"up": null, "down": "Standard_GS5-8", "superseded": null},
-  "Standard_DS11-1_v2": {"up": null, "down": null, "superseded": null},
-  "Standard_DS12-1_v2": {"up": "Standard_DS12-2_v2", "down": null, "superseded": null},
-  "Standard_DS12-2_v2": {"up": null, "down": "Standard_DS12-1_v2", "superseded": null},
-  "Standard_DS13-2_v2": {"up": "Standard_DS13-4_v2", "down": null, "superseded": null},
-  "Standard_DS13-4_v2": {"up": null, "down": "Standard_DS13-2_v2", "superseded": null},
-  "Standard_DS14-4_v2": {"up": "Standard_DS14-8_v2", "down": null, "superseded": null},
-  "Standard_DS14-8_v2": {"up": null, "down": "Standard_DS14-4_v2", "superseded": null},
-  "Standard_M416-208s_v2": {"up": null, "down": null, "superseded": null},
-  "Standard_M416-208ms_v2": {"up": null, "down": null, "superseded": null},
-  "Standard_L8s_v3": {"up": "Standard_L16s_v3", "down": null, "superseded": null},
-  "Standard_L16s_v3": {"up": "Standard_L32s_v3", "down": "Standard_L8s_v3", "superseded": null},
-  "Standard_L32s_v3": {"up": "Standard_L48s_v3", "down": "Standard_L16s_v3", "superseded": null},
-  "Standard_L48s_v3": {"up": "Standard_L64s_v3", "down": "Standard_L32s_v3", "superseded": null},
-  "Standard_L64s_v3": {"up": "Standard_L80s_v3", "down": "Standard_L48s_v3", "superseded": null},
-  "Standard_L80s_v3": {"up": null, "down": "Standard_L64s_v3", "superseded": null},
-  "Standard_L8as_v3": {"up": "Standard_L16as_v3", "down": null, "superseded": null},
-  "Standard_L16as_v3": {"up": "Standard_L32as_v3", "down": "Standard_L8as_v3", "superseded": null},
-  "Standard_L32as_v3": {"up": "Standard_L48as_v3", "down": "Standard_L16as_v3", "superseded": null},
-  "Standard_L48as_v3": {"up": "Standard_L64as_v3", "down": "Standard_L32as_v3", "superseded": null},
-  "Standard_L64as_v3": {"up": "Standard_L80as_v3", "down": "Standard_L48as_v3", "superseded": null},
-  "Standard_L80as_v3": {"up": null, "down": "Standard_L64as_v3", "superseded": null},
-  "Standard_E2_v3": {"up": "Standard_E4_v3", "down": null, "superseded": null},
-  "Standard_E4_v3": {"up": "Standard_E8_v3", "down": "Standard_E2_v3", "superseded": null},
-  "Standard_E8_v3": {"up": "Standard_E16_v3", "down": "Standard_E4_v3", "superseded": null},
-  "Standard_E16_v3": {"up": "Standard_E20_v3", "down": "Standard_E8_v3", "superseded": null},
-  "Standard_E20_v3": {"up": "Standard_E32_v3", "down": "Standard_E16_v3", "superseded": null},
-  "Standard_E32_v3": {"up": "Standard_E48_v3", "down": "Standard_E20_v3", "superseded": null},
-  "Standard_E48_v3": {"up": "Standard_E64_v3", "down": "Standard_E32_v3", "superseded": null},
-  "Standard_E64_v3": {"up": null, "down": "Standard_E48_v3", "superseded": null},
-  "Standard_E64i_v3": {"up": null, "down": "Standard_E48_v3", "superseded": null},
-  "Standard_E2ds_v4": {"up": "Standard_E4ds_v4", "down": null, "superseded": null},
-  "Standard_E4ds_v4": {"up": "Standard_E8ds_v4", "down": "Standard_E2ds_v4", "superseded": null},
-  "Standard_E8ds_v4": {"up": "Standard_E16ds_v4", "down": "Standard_E4ds_v4", "superseded": null},
-  "Standard_E16ds_v4": {"up": "Standard_E20ds_v4", "down": "Standard_E8ds_v4", "superseded": null},
-  "Standard_E20ds_v4": {"up": "Standard_E32ds_v4", "down": "Standard_E16ds_v4", "superseded": null},
-  "Standard_E32ds_v4": {"up": "Standard_E48ds_v4", "down": "Standard_E20ds_v4", "superseded": null},
-  "Standard_E48ds_v4": {"up": "Standard_E64ds_v4", "down": "Standard_E32ds_v4", "superseded": null},
-  "Standard_E64ds_v4": {"up": "Standard_E80ids_v4", "down": "Standard_E48ds_v4", "superseded": null},
-  "Standard_E80ids_v4": {"up": null, "down": "Standard_E64ds_v4", "superseded": null},
-  "Standard_E2d_v4": {"up": "Standard_E4d_v4", "down": null, "superseded": null},
-  "Standard_E4d_v4": {"up": "Standard_E8d_v4", "down": "Standard_E2d_v4", "superseded": null},
-  "Standard_E8d_v4": {"up": "Standard_E16d_v4", "down": "Standard_E4d_v4", "superseded": null},
-  "Standard_E16d_v4": {"up": "Standard_E20d_v4", "down": "Standard_E8d_v4", "superseded": null},
-  "Standard_E20d_v4": {"up": "Standard_E32d_v4", "down": "Standard_E16d_v4", "superseded": null},
-  "Standard_E32d_v4": {"up": "Standard_E48d_v4", "down": "Standard_E20d_v4", "superseded": null},
-  "Standard_E48d_v4": {"up": "Standard_E64d_v4", "down": "Standard_E32d_v4", "superseded": null},
-  "Standard_E64d_v4 ": {"up": null, "down": "Standard_E48d_v4", "superseded": null},
-  "Standard_E2s_v3": {"up": "Standard_E4s_v3", "down": null, "superseded": null},
-  "Standard_E4s_v3": {"up": "Standard_E8s_v3", "down": "Standard_E2s_v3", "superseded": null},
-  "Standard_E8s_v3": {"up": "Standard_E16s_v3", "down": "Standard_E4s_v3", "superseded": null},
-  "Standard_E16s_v3": {"up": "Standard_E20s_v3", "down": "Standard_E8s_v3", "superseded": null},
-  "Standard_E20s_v3": {"up": "Standard_E32s_v3", "down": "Standard_E16s_v3", "superseded": null},
-  "Standard_E32s_v3": {"up": "Standard_E48s_v3", "down": "Standard_E20s_v3", "superseded": null},
-  "Standard_E48s_v3": {"up": "Standard_E64s_v3", "down": "Standard_E32s_v3", "superseded": null},
-  "Standard_E64s_v3": {"up": null, "down": "Standard_E48s_v3", "superseded": null},
-  "Standard_E64is_v3": {"up": null, "down": "Standard_E48s_v3", "superseded": null},
-  "Standard_G1": {"up": "Standard_G2", "down": null, "superseded": null},
-  "Standard_G2": {"up": "Standard_G3", "down": "Standard_G1", "superseded": null},
-  "Standard_G3": {"up": "Standard_G4", "down": "Standard_G2", "superseded": null},
-  "Standard_G4": {"up": "Standard_G5", "down": "Standard_G3", "superseded": null},
-  "Standard_G5": {"up": null, "down": "Standard_G4", "superseded": null},
-  "Standard_GS1": {"up": "Standard_GS2", "down": null, "superseded": null},
-  "Standard_GS2": {"up": "Standard_GS3", "down": "Standard_GS1", "superseded": null},
-  "Standard_GS3": {"up": "Standard_GS4", "down": "Standard_GS2", "superseded": null},
-  "Standard_GS4": {"up": "Standard_GS5", "down": "Standard_GS3", "superseded": null},
-  "Standard_GS5": {"up": null, "down": "Standard_GS4", "superseded": null},
-  "Standard_L4s": {"up": "Standard_L8s", "down": null, "superseded": null},
-  "Standard_L8s": {"up": "Standard_L16s", "down": "Standard_L4s", "superseded": null},
-  "Standard_L16s": {"up": "Standard_L32s", "down": "Standard_L8s", "superseded": null},
-  "Standard_L32s": {"up": null, "down": "Standard_L16s", "superseded": null},
-  "Standard_L8s_v2": {"up": "Standard_L16s_v2", "down": null, "superseded": null},
-  "Standard_L16s_v2": {"up": "Standard_L32s_v2", "down": "Standard_L8s_v2", "superseded": null},
-  "Standard_L32s_v2": {"up": "Standard_L48s_v2", "down": "Standard_L16s_v2", "superseded": null},
-  "Standard_L48s_v2": {"up": "Standard_L64s_v2", "down": "Standard_L32s_v2", "superseded": null},
-  "Standard_L64s_v2": {"up": "Standard_L80s_v2", "down": "Standard_L48s_v2", "superseded": null},
-  "Standard_L80s_v2": {"up": null, "down": "Standard_L64s_v2", "superseded": null},
-  "Standard_E2s_v4": {"up": "Standard_E4s_v4", "down": null, "superseded": null},
-  "Standard_E4s_v4": {"up": "Standard_E8s_v4", "down": "Standard_E2s_v4", "superseded": null},
-  "Standard_E8s_v4": {"up": "Standard_E16s_v4", "down": "Standard_E4s_v4", "superseded": null},
-  "Standard_E16s_v4": {"up": "Standard_E20s_v4", "down": "Standard_E8s_v4", "superseded": null},
-  "Standard_E20s_v4": {"up": "Standard_E32s_v4", "down": "Standard_E16s_v4", "superseded": null},
-  "Standard_E32s_v4": {"up": "Standard_E48s_v4", "down": "Standard_E20s_v4", "superseded": null},
-  "Standard_E48s_v4": {"up": "Standard_E64s_v4", "down": "Standard_E32s_v4", "superseded": null},
-  "Standard_E64s_v4": {"up": "Standard_E80is_v4", "down": "Standard_E48s_v4", "superseded": null},
-  "Standard_E80is_v4": {"up": null, "down": "Standard_E64s_v4", "superseded": null},
-  "Standard_E2as_v4": {"up": "Standard_E4as_v4", "down": null, "superseded": {"regular": "Standard_E2as_v5"}},
-  "Standard_E4as_v4": {"up": "Standard_E8as_v4", "down": "Standard_E2as_v4", "superseded": {"regular": "Standard_E4as_v5"}},
-  "Standard_E8as_v4": {"up": "Standard_E16as_v4", "down": "Standard_E4as_v4", "superseded": {"regular": "Standard_E8as_v5"}},
-  "Standard_E16as_v4": {"up": "Standard_E20as_v4", "down": "Standard_E8as_v4", "superseded": {"regular": "Standard_E16as_v5"}},
-  "Standard_E20as_v4": {"up": "Standard_E32as_v4", "down": "Standard_E16as_v4", "superseded": {"regular": "Standard_E20as_v5"}},
-  "Standard_E32as_v4": {"up": "Standard_E48as_v4", "down": "Standard_E20as_v4", "superseded": {"regular": "Standard_E32as_v5"}},
-  "Standard_E48as_v4": {"up": "Standard_E64as_v4", "down": "Standard_E32as_v4", "superseded": {"regular": "Standard_E48as_v5"}},
-  "Standard_E64as_v4": {"up": "Standard_E96as_v4", "down": "Standard_E48as_v4", "superseded": {"regular": "Standard_E64as_v5"}},
-  "Standard_E96as_v4": {"up": null, "down": "Standard_E64as_v4", "superseded": {"superseded": {"regular": "Standard_E96as_v5"}}},
-  "Standard_E2a_v4": {"up": "Standard_E4a_v4", "down": null, "superseded": null},
-  "Standard_E4a_v4": {"up": "Standard_E8a_v4", "down": "Standard_E2a_v4", "superseded": null},
-  "Standard_E8a_v4": {"up": "Standard_E16a_v4", "down": "Standard_E4a_v4", "superseded": null},
-  "Standard_E16a_v4": {"up": "Standard_E20a_v4", "down": "Standard_E8a_v4", "superseded": null},
-  "Standard_E20a_v4": {"up": "Standard_E32a_v4", "down": "Standard_E16a_v4", "superseded": null},
-  "Standard_E32a_v4": {"up": "Standard_E48a_v4", "down": "Standard_E20a_v4", "superseded": null},
-  "Standard_E48a_v4": {"up": "Standard_E64a_v4", "down": "Standard_E32a_v4", "superseded": null},
-  "Standard_E64a_v4": {"up": "Standard_E96a_v4", "down": "Standard_E48a_v4", "superseded": null},
-  "Standard_E96a_v4": {"up": null, "down": "Standard_E64a_v4", "superseded": null},
-  "Standard_F1": {"up": "Standard_F2", "down": null, "superseded": null},
-  "Standard_F2": {"up": "Standard_F4", "down": "Standard_F1", "superseded": null},
-  "Standard_F4": {"up": "Standard_F8", "down": "Standard_F2", "superseded": null},
-  "Standard_F8": {"up": "Standard_F16", "down": "Standard_F4", "superseded": null},
-  "Standard_F16": {"up": null, "down": "Standard_F8", "superseded": null},
-  "Standard_F1s": {"up": "Standard_F2s", "down": null, "superseded": null},
-  "Standard_F2s": {"up": "Standard_F4s", "down": "Standard_F1s", "superseded": null},
-  "Standard_F4s": {"up": "Standard_F8s", "down": "Standard_F2s", "superseded": null},
-  "Standard_F8s": {"up": "Standard_F16s", "down": "Standard_F4s", "superseded": null},
-  "Standard_F16s": {"up": null, "down": "Standard_F8s", "superseded": null},
-  "Standard_F2s_v2": {"up": "Standard_F4s_v2", "down": null, "superseded": null},
-  "Standard_F4s_v2": {"up": "Standard_F8s_v2", "down": "Standard_F2s_v2", "superseded": null},
-  "Standard_F8s_v2": {"up": "Standard_F16s_v2", "down": "Standard_F4s_v2", "superseded": null},
-  "Standard_F16s_v2": {"up": "Standard_F32s_v2", "down": "Standard_F8s_v2", "superseded": null},
-  "Standard_F32s_v2": {"up": "Standard_F48s_v2", "down": "Standard_F16s_v2", "superseded": null},
-  "Standard_F48s_v2": {"up": "Standard_F64s_v2", "down": "Standard_F32s_v2", "superseded": null},
-  "Standard_F64s_v2": {"up": "Standard_F72s_v2", "down": "Standard_F48s_v2", "superseded": null},
-  "Standard_F72s_v2": {"up": null, "down": "Standard_F64s_v2", "superseded": null},
-  "Standard_H8": {"up": "Standard_H8m", "down": null, "superseded": null},
-  "Standard_H8m": {"up": "Standard_H16", "down": "Standard_H8", "superseded": null},
-  "Standard_H16": {"up": "Standard_H16m", "down": "Standard_H8m", "superseded": null},
-  "Standard_H16m": {"up": "Standard_H16mr", "down": "Standard_H16", "superseded": null},
-  "Standard_H16r": {"up": "Standard_H16mr", "down": "Standard_H16", "superseded": null},
-  "Standard_H16mr": {"up": null, "down": "Standard_H16r", "superseded": null},
-  "Standard_HB60rs": {"up": null, "down": null, "superseded": {"regular": "Standard_HB120rs_v2"}},
-  "Standard_NC6": {"up": "Standard_NC12", "down": null, "superseded": {"regular": "Standard_NC4as_T4_v3"}},
-  "Standard_NC12": {"up": "Standard_NC24", "down": "Standard_NC6", "superseded": {"regular": "Standard_NC16as_T4_v3"}},
-  "Standard_NC24": {"up": null, "down": "Standard_NC12", "superseded": {"regular": "Standard_NC64as_T4_v3"}},
-  "Standard_NC24r": {"up": null, "down": null, "superseded": {"regular": "Standard_ND96amsr_A100_v4"}},
-  "Standard_NC6s_v2": {"up": "Standard_NC12s_v2", "down": null, "superseded": {"regular": "Standard_NC24ads_A100_v4"}},
-  "Standard_NC12s_v2": {"up": "Standard_NC24s_v2", "down": "Standard_NC6s_v2", "superseded": {"regular": "Standard_NC48ads_A100_v4"}},
-  "Standard_NC24s_v2": {"up": "Standard_NC24rs_v2", "down": "Standard_NC12s_v2", "superseded": {"regular": "Standard_NC96ads_A100_v4"}},
-  "Standard_NC24rs_v2": {"up": null, "down": null, "superseded": {"regular": "Standard_ND96amsr_A100_v4"}},
-  "Standard_NC6s_v3": {"up": "Standard_NC12s_v3", "down": null, "superseded": null},
-  "Standard_NC12s_v3": {"up": "Standard_NC24s_v3", "down":"Standard_NC6s_v3", "superseded": null},
-  "Standard_NC24s_v3": {"up":"Standard_NC24rs_v3", "down": "Standard_NC12s_v3", "superseded": null},
-  "Standard_NC24rs_v3": {"up": null, "down": null, "superseded": null},
-  "Standard_NC4as_T4_v3": {"up": "Standard_NC8as_T4_v3", "down": null, "superseded": null},
-  "Standard_NC8as_T4_v3": {"up": "Standard_NC16as_T4_v3", "down": "Standard_NC4as_T4_v3", "superseded": null},
-  "Standard_NC16as_T4_v3": {"up": "Standard_NC64as_T4_v3", "down": "Standard_NC8as_T4_v3", "superseded": null},
-  "Standard_NC64as_T4_v3": {"up": null, "down": "Standard_NC16as_T4_v3", "superseded": null},
-  "Standard_NC24ads_A100_v4": {"up": "Standard_NC48ads_A100_v4", "down": null, "superseded": null},
-  "Standard_NC48ads_A100_v4": {"up": "Standard_NC96ads_A100_v4", "down": "Standard_NC24ads_A100_v4", "superseded": null},
-  "Standard_NC96ads_A100_v4": {"up": null, "down": "Standard_NC48ads_A100_v4", "superseded": null},
-  "Standard_ND96asr_v4": {"up": null, "down": null, "superseded": null},
-  "Standard_ND96amsr_A100_v4": {"up": null, "down": null, "superseded": null},
-  "Standard_ND40rs_v2": {"up": null, "down": null, "superseded": null},
-  "Standard_M8ms": {"up": "Standard_M16ms", "down": null, "superseded": null},
-  "Standard_M16ms": {"up": "Standard_M32ms", "down": "Standard_M8ms", "superseded": null},
-  "Standard_M32ms": {"up": "Standard_M64ms", "down": "Standard_M16ms", "superseded": null},
-  "Standard_M64ms": {"up": "Standard_M128ms", "down": "Standard_M32ms", "superseded": null},
-  "Standard_M128ms": {"up": null, "down": "Standard_M64ms", "superseded": null},
-  "Standard_M32ls": {"up": "Standard_M64ls", "down": null, "superseded": null},
-  "Standard_M64ls": {"up": null, "down": "Standard_M32ls", "superseded": null},
-  "Standard_M32ts": {"up": null, "down": null, "superseded": null},
-  "Standard_M64s": {"up": "Standard_M128s", "down": null, "superseded": null},
-  "Standard_M128s": {"up": null, "down": "Standard_M64s", "superseded": null},
-  "Standard_M64": {"up": "Standard_M128", "down": null, "superseded": null},
-  "Standard_M128": {"up": null, "down": "Standard_M64", "superseded": null},
-  "Standard_M64m": {"up": "Standard_M128m", "down": null, "superseded": null},
-  "Standard_M128m": {"up": null, "down": "Standard_M64m", "superseded": null},
-  "Standard_ND6s": {"up": "Standard_ND12s", "down": null, "superseded": null},
-  "Standard_ND12s": {"up": "Standard_ND24s", "down": "Standard_ND6s", "superseded": null},
-  "Standard_ND24s": {"up": "Standard_ND24rs", "down": "Standard_ND12s", "superseded": null},
-  "Standard_ND24rs": {"up": null, "down": null, "superseded": null},
-  "Standard_NV4as_v4": {"up": "Standard_NV8as_v4", "down": null, "superseded": null},
-  "Standard_NV8as_v4": {"up": "Standard_NV16as_v4", "down": "Standard_NV4as_v4", "superseded": null},
-  "Standard_NV16as_v4": {"up": "Standard_NV32as_v4", "down": "Standard_NV8as_v4", "superseded": null},
-  "Standard_NV32as_v4": {"up": null, "down": "Standard_NV16as_v4", "superseded": null},
-  "Standard_NV12s_v3": {"up": "Standard_NV24s_v3", "down": null, "superseded": null},
-  "Standard_NV24s_v3": {"up": "Standard_NV48s_v3", "down": "Standard_NV12s_v3", "superseded": null},
-  "Standard_NV48s_v3": {"up": null, "down": "Standard_NV24s_v3", "superseded": null},
-  "Standard_NV6": {"up": "Standard_NV12", "down": null, "superseded": {"regular": "Standard_NV16as_v4"}},
-  "Standard_NV12": {"up": "Standard_NV24", "down": "Standard_NV6", "superseded": {"regular": "Standard_NV32as_v4"}},
-  "Standard_NV24": {"up": null, "down": "Standard_NV12", "superseded": {"regular": "Standard_NV48s_v3"}},
-  "Standard_NV6ads_A10_v5": {"up": "Standard_NV12ads_A10_v5", "down": null, "superseded": null},
-  "Standard_NV12ads_A10_v5": {"up": "Standard_NV18ads_A10_v5", "down": "Standard_NV6ads_A10_v5", "superseded": null},
-  "Standard_NV18ads_A10_v5": {"up": "Standard_NV36ads_A10_v5", "down": "Standard_NV12ads_A10_v5", "superseded": null},
-  "Standard_NV36ads_A10_v5": {"up": "Standard_NV36adms_A10_v5", "down": "Standard_NV18ads_A10_v5", "superseded": null},
-  "Standard_NV36adms_A10_v5": {"up": "Standard_NV72ads_A10_v5", "down": "Standard_NV36ads_A10_v5", "superseded": null},
-  "Standard_NV72ads_A10_v5": {"up": null, "down": "Standard_NV36adms_A10_v5", "superseded": null},
-  "Standard_NP10s": {"up": "Standard_NP20s", "down": null, "superseded": null},
-  "Standard_NP20s": {"up": "Standard_NP40s", "down": "Standard_NP10s", "superseded": null},
-  "Standard_NP40s": {"up": null, "down": "Standard_NP20s", "superseded": null},
-  "Standard_E2ads_v5": {"up": "Standard_E4ads_v5", "down": null, "superseded": null},
-  "Standard_E4ads_v5": {"up": "Standard_E8ads_v5", "down": "Standard_E2ads_v5", "superseded": null},
-  "Standard_E8ads_v5": {"up": "Standard_E16ads_v5", "down": "Standard_E4ads_v5", "superseded": null},
-  "Standard_E16ads_v5": {"up": "Standard_E20ads_v5", "down": "Standard_E8ads_v5", "superseded": null},
-  "Standard_E20ads_v5": {"up": "Standard_E32ads_v5", "down": "Standard_E16ads_v5", "superseded": null},
-  "Standard_E32ads_v5": {"up": "Standard_E48ads_v5", "down": "Standard_E20ads_v5", "superseded": null},
-  "Standard_E48ads_v5": {"up": "Standard_E64ads_v5", "down": "Standard_E32ads_v5", "superseded": null},
-  "Standard_E64ads_v5": {"up": "Standard_E96ads_v5", "down": "Standard_E48ads_v5", "superseded": null},
-  "Standard_E96ads_v5": {"up": "Standard_E112iads_v5", "down": "Standard_E64ads_v5", "superseded": null},
-  "Standard_E112iads_v5": {"up": null, "down": "Standard_E96ads_v5", "superseded": null},
-  "Standard_NV6_Promo": {"up": "Standard_NV12_Promo", "down": null, "superseded": {"regular": "Standard_NV16as_v4"}},
-  "Standard_NV12_Promo": {"up": "Standard_NV24_Promo", "down": "Standard_NV6_Promo", "superseded": {"regular": "Standard_NV32as_v4"}},
-  "Standard_NV24_Promo": {"up": null, "down": "Standard_NV12_Promo", "superseded": {"regular": "Standard_NV48s_v3"}},
-  "Standard_D2ds_v5": {"up": "Standard_D4ds_v5", "down": null, "superseded": null},
-  "Standard_D4ds_v5": {"up": "Standard_D8ds_v5", "down": "Standard_D2ds_v5", "superseded": null},
-  "Standard_D8ds_v5": {"up": "Standard_D16ds_v5", "down": "Standard_D4ds_v5", "superseded": null},
-  "Standard_D16ds_v5": {"up": "Standard_D32ds_v5", "down": "Standard_D8ds_v5", "superseded": null},
-  "Standard_D32ds_v5": {"up": "Standard_D48ds_v5", "down": "Standard_D16ds_v5", "superseded": null},
-  "Standard_D48ds_v5": {"up": "Standard_D64ds_v5", "down": "Standard_D32ds_v5", "superseded": null},
-  "Standard_D64ds_v5": {"up": "Standard_D96ds_v5", "down": "Standard_D48ds_v5", "superseded": null},
-  "Standard_D96ds_v5": {"up": null, "down": "Standard_D64ds_v5", "superseded": null},
-  "Standard_M208ms_v2": {"up": "Standard_M208s_v2", "down": null, "superseded": null},
-  "Standard_M208s_v2": {"up": "Standard_M416ms_v2", "down": "Standard_M208ms_v2", "superseded": null},
-  "Standard_M416ms_v2": {"up": "Standard_M416s_v2", "down": "Standard_M208s_v2", "superseded": null},
-  "Standard_M416s_v2": {"up": null, "down": "Standard_M416ms_v2", "superseded": null},
-  "Standard_D2ads_v5": {"up": "Standard_D4ads_v5", "down": null, "superseded": null},
-  "Standard_D4ads_v5": {"up": "Standard_D8ads_v5", "down": "Standard_D2ads_v5", "superseded": null},
-  "Standard_D8ads_v5": {"up": "Standard_D16ads_v5", "down": "Standard_D4ads_v5", "superseded": null},
-  "Standard_D16ads_v5": {"up": "Standard_D32ads_v5", "down": "Standard_D8ads_v5", "superseded": null},
-  "Standard_D32ads_v5": {"up": "Standard_D48ads_v5", "down": "Standard_D16ads_v5", "superseded": null},
-  "Standard_D48ads_v5": {"up": "Standard_D64ads_v5", "down": "Standard_D32ads_v5", "superseded": null},
-  "Standard_D64ads_v5": {"up": "Standard_D96ads_v5", "down": "Standard_D48ads_v5", "superseded": null},
-  "Standard_D96ads_v5": {"up": null, "down": "Standard_D64ads_v5", "superseded": null},
-  "Standard_FX4mds": {"up": "Standard_FX12mds", "down": null, "superseded": null},
-  "Standard_FX12mds": {"up": "Standard_FX24mds", "down": "Standard_FX4mds", "superseded": null},
-  "Standard_FX24mds": {"up": "Standard_FX36mds", "down": "Standard_FX12mds", "superseded": null},
-  "Standard_FX36mds": {"up": "Standard_FX48mds", "down": "Standard_FX24mds", "superseded": null},
-  "Standard_FX48mds": {"up": null, "down": "Standard_FX36mds", "superseded": null},
-  "Standard_D2as_v5": {"up": "Standard_D4as_v5", "down": null, "superseded": null},
-  "Standard_D4as_v5": {"up": "Standard_D8as_v5", "down": "Standard_D2as_v5", "superseded": null},
-  "Standard_D8as_v5": {"up": "Standard_D16as_v5", "down": "Standard_D4as_v5", "superseded": null},
-  "Standard_D16as_v5": {"up": "Standard_D32as_v5", "down": "Standard_D8as_v5", "superseded": null},
-  "Standard_D32as_v5": {"up": "Standard_D48as_v5", "down": "Standard_D16as_v5", "superseded": null},
-  "Standard_D48as_v5": {"up": "Standard_D64as_v5", "down": "Standard_D32as_v5", "superseded": null},
-  "Standard_D64as_v5": {"up": "Standard_D96as_v5", "down": "Standard_D48as_v5", "superseded": null},
-  "Standard_D96as_v5": {"up": null, "down": "Standard_D64as_v5", "superseded": null},
-  "Standard_HB120-16rs_v2": {"up": "Standard_HB120-32rs_v2", "down": null, "superseded": null},
-  "Standard_HB120-32rs_v2": {"up": "Standard_HB120-64rs_v2", "down": "Standard_HB120-16rs_v2", "superseded": null},
-  "Standard_HB120-64rs_v2": {"up": "Standard_HB120-96rs_v2", "down": "Standard_HB120-32rs_v2", "superseded": null},
-  "Standard_HB120-96rs_v2": {"up": "Standard_HB120rs_v2", "down": "Standard_HB120-64rs_v2", "superseded": null},
-  "Standard_HB120rs_v2": {"up": null, "down": "Standard_HB120-96rs_v2", "superseded": null},
-  "Standard_HB120rs_v3": {"up": "Standard_HB120-96rs_v3", "down": null, "superseded": null},
-  "Standard_HB120-96rs_v3": {"up": "Standard_HB120-64rs_v3", "down": "Standard_HB120rs_v3", "superseded": null},
-  "Standard_HB120-64rs_v3": {"up": "Standard_HB120-32rs_v3", "down": "Standard_HB120-96rs_v3", "superseded": null},
-  "Standard_HB120-32rs_v3": {"up": "Standard_HB120-16rs_v3", "down": "Standard_HB120-64rs_v3", "superseded": null},
-  "Standard_HB120-16rs_v3": {"up": null, "down": "Standard_HB120-32rs_v3", "superseded": null},
-  "Standard_HB176-24rs_v4": {"up": "Standard_HB176-48rs_v4", "down": null, "superseded": null},
-  "Standard_HB176-48rs_v4": {"up": "Standard_HB176-96rs_v4", "down": "Standard_HB176-24rs_v4", "superseded": null},
-  "Standard_HB176-96rs_v4": {"up": "Standard_HB176-144rs_v4", "down": "Standard_HB176-48rs_v4", "superseded": null},
-  "Standard_HB176-144rs_v4": {"up": "Standard_HB176rs_v4", "down": "Standard_HB176-96rs_v4", "superseded": null},
-  "Standard_HB176rs_v4": {"up": null, "down": "Standard_HB176-144rs_v4", "superseded": null},
-  "Standard_HC44rs": {"up": "Standard_HC44-16rs", "down": null, "superseded": null},
-  "Standard_HC44-16rs": {"up": "Standard_HC44-32rs", "down": "Standard_HC44rs", "superseded": null},
-  "Standard_HC44-32rs": {"up": null, "down": "Standard_HC44-16rs", "superseded": null},
-  "Standard_HX176-24rs": {"up": "Standard_HX176-48rs", "down": null, "superseded": null},
-  "Standard_HX176-48rs": {"up": "Standard_HX176-96rs", "down": "Standard_HX176-24rs", "superseded": null},
-  "Standard_HX176-96rs": {"up": "Standard_HX176-144rs", "down": "Standard_HX176-48rs", "superseded": null},
-  "Standard_HX176-144rs": {"up": "Standard_HX176rs", "down": "Standard_HX176-96rs", "superseded": null},
-  "Standard_HX176rs": {"up": null, "down": "Standard_HX176-144rs", "superseded": null},
-  "Standard_E2as_v5":{"up": "Standard_E4as_v5", "down": null, "superseded": null},
-  "Standard_E4as_v5":{"up": "Standard_E8as_v5", "down": "Standard_E2as_v5", "superseded": null},
-  "Standard_E8as_v5":{"up": "Standard_E16as_v5", "down": "Standard_E4as_v5", "superseded": null},
-  "Standard_E16as_v5":{"up": "Standard_E20as_v5", "down": "Standard_E8as_v5", "superseded": null},
-  "Standard_E20as_v5":{"up": "Standard_E32as_v5", "down": "Standard_E16as_v5", "superseded": null},
-  "Standard_E32as_v5":{"up": "Standard_E48as_v5", "down": "Standard_E20as_v5", "superseded": null},
-  "Standard_E48as_v5":{"up": "Standard_E64as_v5", "down": "Standard_E32as_v5", "superseded": null},
-  "Standard_E64as_v5":{"up": "Standard_E96as_v5", "down": "Standard_E48as_v5", "superseded": null},
-  "Standard_E96as_v5":{"up": "Standard_E112ias_v5", "down": "Standard_E64as_v5", "superseded": null},
-  "Standard_E112ias_v5":{"up": null, "down": "Standard_E96as_v5", "superseded": null}
+  "Basic_A0": {
+    "up": "Basic_A1",
+    "down": null,
+    "superseded": null,
+    "vcpu": 1
+  },
+  "Basic_A1": {
+    "up": "Basic_A2",
+    "down": "Basic_A0",
+    "superseded": null,
+    "vcpu": 1
+  },
+  "Basic_A2": {
+    "up": "Basic_A3",
+    "down": "Basic_A1",
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Basic_A3": {
+    "up": "Basic_A4",
+    "down": "Basic_A2",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Basic_A4": {
+    "up": null,
+    "down": "Basic_A3",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_A0": {
+    "up": "Standard_A1",
+    "down": null,
+    "superseded": null,
+    "vcpu": 1
+  },
+  "Standard_A1": {
+    "up": "Standard_A2",
+    "down": "Standard_A0",
+    "superseded": {
+      "regular": "Standard_A1_v2"
+    },
+    "vcpu": 1
+  },
+  "Standard_A2": {
+    "up": "Standard_A3",
+    "down": "Standard_A1",
+    "superseded": {
+      "regular": "Standard_A2_v2"
+    },
+    "vcpu": 2
+  },
+  "Standard_A3": {
+    "up": "Standard_A4",
+    "down": "Standard_A2",
+    "superseded": {
+      "regular": "Standard_A4_v2"
+    },
+    "vcpu": 4
+  },
+  "Standard_A4": {
+    "up": "Standard_A5",
+    "down": "Standard_A3",
+    "superseded": {
+      "regular": "Standard_A8_v2"
+    },
+    "vcpu": 8
+  },
+  "Standard_A5": {
+    "up": "Standard_A6",
+    "down": "Standard_A4",
+    "superseded": {
+      "regular": "Standard_A2m_v2"
+    },
+    "vcpu": 2
+  },
+  "Standard_A6": {
+    "up": "Standard_A7",
+    "down": "Standard_A5",
+    "superseded": {
+      "regular": "Standard_A4m_v2"
+    },
+    "vcpu": 4
+  },
+  "Standard_A7": {
+    "up": "Standard_A8",
+    "down": "Standard_A6",
+    "superseded": {
+      "regular": "Standard_A8m_v2"
+    },
+    "vcpu": 8
+  },
+  "Standard_A8": {
+    "up": "Standard_A9",
+    "down": "Standard_A7",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_A9": {
+    "up": "Standard_A10",
+    "down": "Standard_A8",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_A10": {
+    "up": "Standard_A11",
+    "down": "Standard_A9",
+    "superseded": {
+      "regular": "Standard_H8"
+    },
+    "vcpu": 8
+  },
+  "Standard_A11": {
+    "up": null,
+    "down": "Standard_A10",
+    "superseded": {
+      "regular": "Standard_H16"
+    },
+    "vcpu": 16
+  },
+  "Standard_A1_v2": {
+    "up": "Standard_A2_v2",
+    "down": null,
+    "superseded": null,
+    "vcpu": 1
+  },
+  "Standard_A2_v2": {
+    "up": "Standard_A4_v2",
+    "down": "Standard_A1_v2",
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_A4_v2": {
+    "up": "Standard_A8_v2",
+    "down": "Standard_A2_v2",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_A8_v2": {
+    "up": null,
+    "down": "Standard_A4_v2",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_A2m_v2": {
+    "up": "Standard_A4m_v2",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_A4m_v2": {
+    "up": "Standard_A8m_v2",
+    "down": "Standard_A2m_v2",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_A8m_v2": {
+    "up": null,
+    "down": "Standard_A4m_v2",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_B1ls": {
+    "up": "Standard_B1s",
+    "down": null,
+    "superseded": null,
+    "vcpu": 1,
+    "nfu": "1"
+  },
+  "Standard_B1s": {
+    "up": "Standard_B1ms",
+    "down": "Standard_B1ls",
+    "superseded": null,
+    "vcpu": 1,
+    "nfu": "2"
+  },
+  "Standard_B1ms": {
+    "up": "Standard_B2s",
+    "down": "Standard_B1s",
+    "superseded": null,
+    "vcpu": 1,
+    "nfu": "1"
+  },
+  "Standard_B2s": {
+    "up": "Standard_B2ms",
+    "down": "Standard_B1ms",
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "8"
+  },
+  "Standard_B2ms": {
+    "up": "Standard_B4ms",
+    "down": "Standard_B2s",
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "4"
+  },
+  "Standard_B4ms": {
+    "up": "Standard_B8ms",
+    "down": "Standard_B2ms",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "8"
+  },
+  "Standard_B8ms": {
+    "up": "Standard_B12ms",
+    "down": "Standard_B4ms",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "16"
+  },
+  "Standard_B12ms": {
+    "up": "Standard_B16ms",
+    "down": "Standard_B8ms",
+    "superseded": null,
+    "vcpu": 12,
+    "nfu": "24"
+  },
+  "Standard_B16ms": {
+    "up": "Standard_B20ms",
+    "down": "Standard_B12ms",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "32"
+  },
+  "Standard_B20ms": {
+    "up": null,
+    "down": "Standard_B16ms",
+    "superseded": null,
+    "vcpu": 20,
+    "nfu": "40"
+  },
+  "Standard_D1": {
+    "up": "Standard_D2",
+    "down": null,
+    "superseded": {
+      "regular": "Standard_D1_v2"
+    },
+    "vcpu": 1,
+    "nfu": "1"
+  },
+  "Standard_D2": {
+    "up": "Standard_D3",
+    "down": "Standard_D1",
+    "superseded": {
+      "regular": "Standard_D2_v3"
+    },
+    "vcpu": 2,
+    "nfu": "2"
+  },
+  "Standard_D3": {
+    "up": null,
+    "down": "Standard_D2",
+    "superseded": {
+      "regular": "Standard_D4_v3"
+    },
+    "vcpu": 4,
+    "nfu": "4"
+  },
+  "Standard_D4": {
+    "up": null,
+    "down": "Standard_D3",
+    "superseded": {
+      "regular": "Standard_D8_v3"
+    },
+    "vcpu": 8,
+    "nfu": "8"
+  },
+  "Standard_D11": {
+    "up": "Standard_D12",
+    "down": null,
+    "superseded": {
+      "regular": "Standard_E2_v3"
+    },
+    "vcpu": 2,
+    "nfu": "1"
+  },
+  "Standard_D12": {
+    "up": "Standard_D13",
+    "down": "Standard_D11",
+    "superseded": {
+      "regular": "Standard_E4_v3"
+    },
+    "vcpu": 4,
+    "nfu": "2"
+  },
+  "Standard_D13": {
+    "up": "Standard_D14",
+    "down": "Standard_D12",
+    "superseded": {
+      "regular": "Standard_E8_v3"
+    },
+    "vcpu": 8,
+    "nfu": "4"
+  },
+  "Standard_D14": {
+    "up": null,
+    "down": "Standard_D13",
+    "superseded": {
+      "regular": "Standard_E16_v3"
+    },
+    "vcpu": 16,
+    "nfu": "8"
+  },
+  "Standard_D1_v2": {
+    "up": "Standard_D2_v2",
+    "down": null,
+    "superseded": null,
+    "vcpu": 1,
+    "nfu": "1"
+  },
+  "Standard_D2_v2": {
+    "up": "Standard_D3_v2",
+    "down": "Standard_D1_v2",
+    "superseded": {
+      "regular": "Standard_D2_v3"
+    },
+    "vcpu": 2,
+    "nfu": "2"
+  },
+  "Standard_D3_v2": {
+    "up": "Standard_D4_v2",
+    "down": "Standard_D2_v2",
+    "superseded": {
+      "regular": "Standard_D4_v3"
+    },
+    "vcpu": 4,
+    "nfu": "4"
+  },
+  "Standard_D4_v2": {
+    "up": "Standard_D5_v2",
+    "down": "Standard_D3_v2",
+    "superseded": {
+      "regular": "Standard_D8_v3"
+    },
+    "vcpu": 8,
+    "nfu": "8"
+  },
+  "Standard_D5_v2": {
+    "up": null,
+    "down": "Standard_D4_v2",
+    "superseded": {
+      "regular": "Standard_D16_v3"
+    },
+    "vcpu": 16,
+    "nfu": "16"
+  },
+  "Standard_D11_v2": {
+    "up": "Standard_D12_v2",
+    "down": null,
+    "superseded": {
+      "regular": "Standard_E2_v3"
+    },
+    "vcpu": 2,
+    "nfu": "1"
+  },
+  "Standard_D12_v2": {
+    "up": "Standard_D13_v2",
+    "down": "Standard_D11_v2",
+    "superseded": {
+      "regular": "Standard_E4_v3"
+    },
+    "vcpu": 4,
+    "nfu": "2"
+  },
+  "Standard_D13_v2": {
+    "up": "Standard_D14_v2",
+    "down": "Standard_D13_v2",
+    "superseded": {
+      "regular": "Standard_E8_v3"
+    },
+    "vcpu": 8,
+    "nfu": "4"
+  },
+  "Standard_D14_v2": {
+    "up": "Standard_D15_v2",
+    "down": "Standard_D14_v2",
+    "superseded": {
+      "regular": "Standard_E16_v3"
+    },
+    "vcpu": 16,
+    "nfu": "8"
+  },
+  "Standard_D15_v2": {
+    "up": null,
+    "down": "Standard_D15_v2",
+    "superseded": null,
+    "vcpu": 20,
+    "nfu": "10"
+  },
+  "Standard_D2_v2_Promo": {
+    "up": "Standard_D3_v2_Promo",
+    "down": null,
+    "superseded": {
+      "regular": "Standard_D2_v3"
+    },
+    "vcpu": 2,
+    "nfu": "2"
+  },
+  "Standard_D3_v2_Promo": {
+    "up": "Standard_D4_v2_Promo",
+    "down": "Standard_D2_v2_Promo",
+    "superseded": {
+      "regular": "Standard_D4_v3"
+    },
+    "vcpu": 4,
+    "nfu": "4"
+  },
+  "Standard_D4_v2_Promo": {
+    "up": "Standard_D5_v2_Promo",
+    "down": "Standard_D3_v2_Promo",
+    "superseded": {
+      "regular": "Standard_D8_v3"
+    },
+    "vcpu": 8,
+    "nfu": "8"
+  },
+  "Standard_D5_v2_Promo": {
+    "up": null,
+    "down": "Standard_D4_v2_Promo",
+    "superseded": {
+      "regular": "Standard_D16_v3"
+    },
+    "vcpu": 16,
+    "nfu": "16"
+  },
+  "Standard_D11_v2_Promo": {
+    "up": "Standard_D12_v2_Promo",
+    "down": null,
+    "superseded": {
+      "regular": "Standard_E2_v3"
+    },
+    "vcpu": 2,
+    "nfu": "1"
+  },
+  "Standard_D12_v2_Promo": {
+    "up": "Standard_D13_v2_Promo",
+    "down": "Standard_D11_v2_Promo",
+    "superseded": {
+      "regular": "Standard_E4_v3"
+    },
+    "vcpu": 4,
+    "nfu": "2"
+  },
+  "Standard_D13_v2_Promo": {
+    "up": "Standard_D14_v2_Promo",
+    "down": "Standard_D12_v2_Promo",
+    "superseded": {
+      "regular": "Standard_E8_v3"
+    },
+    "vcpu": 8,
+    "nfu": "4"
+  },
+  "Standard_D14_v2_Promo": {
+    "up": null,
+    "down": "Standard_D13_v2_Promo",
+    "superseded": {
+      "regular": "Standard_E16_v3"
+    },
+    "vcpu": 16,
+    "nfu": "8"
+  },
+  "Standard_D2s_v3": {
+    "up": "Standard_D4s_v3",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "1"
+  },
+  "Standard_D4s_v3": {
+    "up": "Standard_D8s_v3",
+    "down": "Standard_D2s_v3",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "2"
+  },
+  "Standard_D8s_v3": {
+    "up": "Standard_D16s_v3",
+    "down": "Standard_D4s_v3",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "4"
+  },
+  "Standard_D16s_v3": {
+    "up": "Standard_D32s_v3",
+    "down": "Standard_D8s_v3",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "8"
+  },
+  "Standard_D32s_v3": {
+    "up": "Standard_D48s_v3",
+    "down": "Standard_D16s_v3",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "16"
+  },
+  "Standard_D48s_v3": {
+    "up": "Standard_D64s_v3",
+    "down": "Standard_D32s_v3",
+    "superseded": null,
+    "vcpu": 48,
+    "nfu": "24"
+  },
+  "Standard_D64s_v3": {
+    "up": null,
+    "down": "Standard_D48s_v3",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "32"
+  },
+  "Standard_D2_v3": {
+    "up": "Standard_D4_v3",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "1"
+  },
+  "Standard_D4_v3": {
+    "up": "Standard_D8_v3",
+    "down": "Standard_D2_v3",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "2"
+  },
+  "Standard_D8_v3": {
+    "up": "Standard_D16_v3",
+    "down": "Standard_D4_v3",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "4"
+  },
+  "Standard_D16_v3": {
+    "up": "Standard_D32_v3",
+    "down": "Standard_D8_v3",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "8"
+  },
+  "Standard_D32_v3": {
+    "up": "Standard_D48_v3",
+    "down": "Standard_D16_v3",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "16"
+  },
+  "Standard_D48_v3": {
+    "up": "Standard_D64_v3",
+    "down": "Standard_D32_v3",
+    "superseded": null,
+    "vcpu": 48,
+    "nfu": "24"
+  },
+  "Standard_D64_v3": {
+    "up": null,
+    "down": "Standard_D48_v3",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "32"
+  },
+  "Standard_D2_v4": {
+    "up": "Standard_D4_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "1"
+  },
+  "Standard_D4_v4": {
+    "up": "Standard_D8_v4",
+    "down": "Standard_D2_v4",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "2"
+  },
+  "Standard_D8_v4": {
+    "up": "Standard_D16_v4",
+    "down": "Standard_D4_v4",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "4"
+  },
+  "Standard_D16_v4": {
+    "up": "Standard_D32_v4",
+    "down": "Standard_D8_v4",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "8"
+  },
+  "Standard_D32_v4": {
+    "up": "Standard_D48_v4",
+    "down": "Standard_D16_v4",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "16"
+  },
+  "Standard_D48_v4": {
+    "up": "Standard_D64_v4",
+    "down": "Standard_D32_v4",
+    "superseded": null,
+    "vcpu": 48,
+    "nfu": "24"
+  },
+  "Standard_D64_v4": {
+    "up": null,
+    "down": "Standard_D48_v4",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "32"
+  },
+  "Standard_D2_v5": {
+    "up": "Standard_D4_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_D4_v5": {
+    "up": "Standard_D8_v5",
+    "down": "Standard_D2_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_D8_v5": {
+    "up": "Standard_D16_v5",
+    "down": "Standard_D4_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_D16_v5": {
+    "up": "Standard_D32_v5",
+    "down": "Standard_D8_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_D32_v5": {
+    "up": "Standard_D48_v5",
+    "down": "Standard_D16_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_D48_v5": {
+    "up": "Standard_D64_v5",
+    "down": "Standard_D32_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_D64_v5": {
+    "up": "Standard_D96_v5",
+    "down": "Standard_D48_v5",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_D96_v5": {
+    "up": null,
+    "down": "Standard_D64_v5",
+    "superseded": null,
+    "vcpu": 96
+  },
+  "Standard_D2s_v4": {
+    "up": "Standard_D4s_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "1"
+  },
+  "Standard_D4s_v4": {
+    "up": "Standard_D8s_v4",
+    "down": "Standard_D2s_v4",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "2"
+  },
+  "Standard_D8s_v4": {
+    "up": "Standard_D16s_v4",
+    "down": "Standard_D4s_v4",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "4"
+  },
+  "Standard_D16s_v4": {
+    "up": "Standard_D32s_v4",
+    "down": "Standard_D8s_v4",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "8"
+  },
+  "Standard_D32s_v4": {
+    "up": "Standard_D48s_v4",
+    "down": "Standard_D16s_v4",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "16"
+  },
+  "Standard_D48s_v4": {
+    "up": "Standard_D64s_v4",
+    "down": "Standard_D32s_v4",
+    "superseded": null,
+    "vcpu": 48,
+    "nfu": "24"
+  },
+  "Standard_D64s_v4": {
+    "up": null,
+    "down": "Standard_D48_v4",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "32"
+  },
+  "Standard_D2s_v5": {
+    "up": "Standard_D4s_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_D4s_v5": {
+    "up": "Standard_D8s_v5",
+    "down": "Standard_D2s_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_D8s_v5": {
+    "up": "Standard_D16s_v5",
+    "down": "Standard_D4s_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_D16s_v5": {
+    "up": "Standard_D32s_v5",
+    "down": "Standard_D8s_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_D32s_v5": {
+    "up": "Standard_D48s_v5",
+    "down": "Standard_D16s_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_D48s_v5": {
+    "up": "Standard_D64s_v5",
+    "down": "Standard_D32s_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_D64s_v5": {
+    "up": "Standard_D96s_v5",
+    "down": "Standard_D48s_v5",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_D96s_v5": {
+    "up": null,
+    "down": "Standard_D64s_v5",
+    "superseded": null,
+    "vcpu": 96
+  },
+  "Standard_DC1s_v2": {
+    "up": "Standard_DC2s_v2",
+    "down": null,
+    "superseded": null,
+    "vcpu": 1,
+    "nfu": "1"
+  },
+  "Standard_DC2s_v2": {
+    "up": "Standard_DC4s_v2",
+    "down": "Standard_DC1s_v2",
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "2"
+  },
+  "Standard_DC4s_v2": {
+    "up": "Standard_DC8_v2",
+    "down": "Standard_DC2s_v2",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "4"
+  },
+  "Standard_DC8_v2": {
+    "up": null,
+    "down": "Standard_DC4s_v2",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "8"
+  },
+  "Standard_DC1s_v3": {
+    "up": "Standard_DC2s_v3",
+    "down": null,
+    "superseded": null,
+    "vcpu": 1
+  },
+  "Standard_DC2s_v3": {
+    "up": "Standard_DC4s_v3",
+    "down": "Standard_DC1s_v3",
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_DC4s_v3": {
+    "up": "Standard_DC8s_v3",
+    "down": "Standard_DC2s_v3",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_DC8s_v3": {
+    "up": "Standard_DC16s_v3",
+    "down": "Standard_DC4s_v3",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_DC16s_v3": {
+    "up": "Standard_DC24s_v3",
+    "down": "Standard_DC8s_v3",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_DC24s_v3": {
+    "up": "Standard_DC32s_v3",
+    "down": "Standard_DC16s_v3",
+    "superseded": null,
+    "vcpu": 24
+  },
+  "Standard_DC32s_v3": {
+    "up": "Standard_DC48s_v3",
+    "down": "Standard_DC24s_v3",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_DC48s_v3": {
+    "up": null,
+    "down": "Standard_DC32s_v3",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_DC1ds_v3": {
+    "up": "Standard_DC2ds_v3",
+    "down": null,
+    "superseded": null,
+    "vcpu": 1
+  },
+  "Standard_DC2ds_v3": {
+    "up": "Standard_DC4ds_v3",
+    "down": "Standard_DC1ds_v3",
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_DC4ds_v3": {
+    "up": "Standard_DC8ds_v3",
+    "down": "Standard_DC2ds_v3",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_DC8ds_v3": {
+    "up": "Standard_DC16ds_v3",
+    "down": "Standard_DC4ds_v3",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_DC16ds_v3": {
+    "up": "Standard_DC24ds_v3",
+    "down": "Standard_DC8ds_v3",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_DC24ds_v3": {
+    "up": "Standard_DC32ds_v3",
+    "down": "Standard_DC16ds_v3",
+    "superseded": null,
+    "vcpu": 24
+  },
+  "Standard_DC32ds_v3": {
+    "up": "Standard_DC48ds_v3",
+    "down": "Standard_DC24ds_v3",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_DC48ds_v3": {
+    "up": null,
+    "down": "Standard_DC32ds_v3",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_DC2as_v5": {
+    "up": "Standard_DC4as_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_DC4as_v5": {
+    "up": "Standard_DC8as_v5",
+    "down": "Standard_DC2as_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_DC8as_v5": {
+    "up": "Standard_DC16as_v5",
+    "down": "Standard_DC4as_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_DC16as_v5": {
+    "up": "Standard_DC32as_v5",
+    "down": "Standard_DC8as_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_DC32as_v5": {
+    "up": "Standard_DC48as_v5",
+    "down": "Standard_DC16as_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_DC48as_v5": {
+    "up": "Standard_DC64as_v5",
+    "down": "Standard_DC32as_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_DC64as_v5": {
+    "up": "Standard_DC96as_v5",
+    "down": "Standard_DC48as_v5",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_DC96as_v5": {
+    "up": null,
+    "down": "Standard_DC64as_v5",
+    "superseded": null,
+    "vcpu": 96
+  },
+  "Standard_DC2ads_v5": {
+    "up": "Standard_DC4ads_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_DC4ads_v5": {
+    "up": "Standard_DC8ads_v5",
+    "down": "Standard_DC2ads_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_DC8ads_v5": {
+    "up": "Standard_DC16ads_v5",
+    "down": "Standard_DC4ads_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_DC16ads_v5": {
+    "up": "Standard_DC32ads_v5",
+    "down": "Standard_DC8ads_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_DC32ads_v5": {
+    "up": "Standard_DC48ads_v5",
+    "down": "Standard_DC16ads_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_DC48ads_v5": {
+    "up": "Standard_DC64ads_v5",
+    "down": "Standard_DC32ads_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_DC64ads_v5": {
+    "up": "Standard_DC96ads_v5",
+    "down": "Standard_DC48ads_v5",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_DC96ads_v5": {
+    "up": null,
+    "down": "Standard_DC64ads_v5",
+    "superseded": null,
+    "vcpu": 96
+  },
+  "Standard_D2ps_v5": {
+    "up": "Standard_D4ps_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_D4ps_v5": {
+    "up": "Standard_D8ps_v5",
+    "down": "Standard_D2ps_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_D8ps_v5": {
+    "up": "Standard_D16ps_v5",
+    "down": "Standard_D4ps_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_D16ps_v5": {
+    "up": "Standard_D32ps_v5",
+    "down": "Standard_D8ps_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_D32ps_v5": {
+    "up": "Standard_D48ps_v5",
+    "down": "Standard_D16ps_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_D48ps_v5": {
+    "up": "Standard_D64ps_v5",
+    "down": "Standard_D32ps_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_D64ps_v5": {
+    "up": null,
+    "down": "Standard_D48ps_v5",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_D2pds_v5": {
+    "up": "Standard_D4pds_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_D4pds_v5": {
+    "up": "Standard_D8pds_v5",
+    "down": "Standard_D2pds_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_D8pds_v5": {
+    "up": "Standard_D16pds_v5",
+    "down": "Standard_D4pds_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_D16pds_v5": {
+    "up": "Standard_D32pds_v5",
+    "down": "Standard_D8pds_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_D32pds_v5": {
+    "up": "Standard_D48pds_v5",
+    "down": "Standard_D16pds_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_D48pds_v5": {
+    "up": "Standard_D64pds_v5",
+    "down": "Standard_D32pds_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_D64pds_v5": {
+    "up": null,
+    "down": "Standard_D48pds_v5",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_D2pls_v5": {
+    "up": "Standard_D4pls_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_D4pls_v5": {
+    "up": "Standard_D8pls_v5",
+    "down": "Standard_D2pls_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_D8pls_v5": {
+    "up": "Standard_D16pls_v5",
+    "down": "Standard_D4pls_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_D16pls_v5": {
+    "up": "Standard_D32pls_v5",
+    "down": "Standard_D8pls_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_D32pls_v5": {
+    "up": "Standard_D48pls_v5",
+    "down": "Standard_D16pls_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_D48pls_v5": {
+    "up": "Standard_D64pls_v5",
+    "down": "Standard_D32pls_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_D64pls_v5": {
+    "up": null,
+    "down": "Standard_D48pls_v5",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_D2plds_v5": {
+    "up": "Standard_D4plds_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_D4plds_v5": {
+    "up": "Standard_D8plds_v5",
+    "down": "Standard_D2plds_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_D8plds_v5": {
+    "up": "Standard_D16plds_v5",
+    "down": "Standard_D4plds_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_D16plds_v5": {
+    "up": "Standard_D32plds_v5",
+    "down": "Standard_D8plds_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_D32plds_v5": {
+    "up": "Standard_D48plds_v5",
+    "down": "Standard_D16plds_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_D48plds_v5": {
+    "up": "Standard_D64plds_v5",
+    "down": "Standard_D32plds_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_D64plds_v5": {
+    "up": null,
+    "down": "Standard_D48plds_v5",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_DS1": {
+    "up": "Standard_DS2",
+    "down": null,
+    "superseded": null,
+    "vcpu": 1,
+    "nfu": "1"
+  },
+  "Standard_DS2": {
+    "up": "Standard_DS3",
+    "down": "Standard_DS1",
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "2"
+  },
+  "Standard_DS3": {
+    "up": "Standard_DS4",
+    "down": "Standard_DS2",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "4"
+  },
+  "Standard_DS4": {
+    "up": null,
+    "down": "Standard_DS3",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "8"
+  },
+  "Standard_DS11": {
+    "up": "Standard_DS12",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "1"
+  },
+  "Standard_DS12": {
+    "up": "Standard_DS13",
+    "down": "Standard_DS11",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "2"
+  },
+  "Standard_DS13": {
+    "up": "Standard_DS14",
+    "down": "Standard_DS12",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "4"
+  },
+  "Standard_DS14": {
+    "up": null,
+    "down": "Standard_DS13",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "8"
+  },
+  "Standard_DS1_v2": {
+    "up": "Standard_DS2_v2",
+    "down": null,
+    "superseded": null,
+    "vcpu": 1,
+    "nfu": "1"
+  },
+  "Standard_DS2_v2": {
+    "up": "Standard_DS3_v2",
+    "down": "Standard_DS1_v2",
+    "superseded": {
+      "regular": "Standard_D2s_v3"
+    },
+    "vcpu": 2,
+    "nfu": "2"
+  },
+  "Standard_DS3_v2": {
+    "up": "Standard_DS4_v2",
+    "down": "Standard_DS2_v2",
+    "superseded": {
+      "regular": "Standard_D4s_v3"
+    },
+    "vcpu": 4,
+    "nfu": "4"
+  },
+  "Standard_DS4_v2": {
+    "up": "Standard_DS5_v2",
+    "down": "Standard_DS3_v2",
+    "superseded": {
+      "regular": "Standard_D8s_v3"
+    },
+    "vcpu": 8,
+    "nfu": "8"
+  },
+  "Standard_DS5_v2": {
+    "up": null,
+    "down": "Standard_DS4_v2",
+    "superseded": {
+      "regular": "Standard_D16s_v3"
+    },
+    "vcpu": 16,
+    "nfu": "16"
+  },
+  "Standard_DS11_v2": {
+    "up": "Standard_DS12_v2",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "1"
+  },
+  "Standard_DS12_v2": {
+    "up": "Standard_DS13_v2",
+    "down": "Standard_DS11_v2",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "2"
+  },
+  "Standard_DS13_v2": {
+    "up": "Standard_DS14_v2",
+    "down": "Standard_DS12_v2",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "4"
+  },
+  "Standard_DS14_v2": {
+    "up": "Standard_DS15_v2",
+    "down": "Standard_DS13_v2",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "8"
+  },
+  "Standard_DS15_v2": {
+    "up": null,
+    "down": "Standard_DS14_v2",
+    "superseded": null,
+    "vcpu": 20,
+    "nfu": "10"
+  },
+  "Standard_DS2_v2_Promo": {
+    "up": "Standard_DS3_v2_Promo",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "2"
+  },
+  "Standard_DS3_v2_Promo": {
+    "up": "Standard_DS4_v2_Promo",
+    "down": "Standard_DS2_v2_Promo",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "4"
+  },
+  "Standard_DS4_v2_Promo": {
+    "up": "Standard_DS5_v2_Promo",
+    "down": "Standard_DS3_v2_Promo",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "8"
+  },
+  "Standard_DS5_v2_Promo": {
+    "up": null,
+    "down": "Standard_DS4_v2_Promo",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "16"
+  },
+  "Standard_DS11_v2_Promo": {
+    "up": "Standard_DS12_v2_Promo",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "1"
+  },
+  "Standard_DS12_v2_Promo": {
+    "up": "Standard_DS13_v2_Promo",
+    "down": "Standard_DS11_v2_Promo",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "2"
+  },
+  "Standard_DS13_v2_Promo": {
+    "up": "Standard_DS14_v2_Promo",
+    "down": "Standard_DS12_v2_Promo",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "4"
+  },
+  "Standard_DS14_v2_Promo": {
+    "up": null,
+    "down": "Standard_DS13_v2_Promo",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "8"
+  },
+  "Standard_D2a_v4": {
+    "up": "Standard_D4a_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "1"
+  },
+  "Standard_D4a_v4": {
+    "up": "Standard_D8a_v4",
+    "down": "Standard_D2a_v4",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "2"
+  },
+  "Standard_D8a_v4": {
+    "up": "Standard_D16a_v4",
+    "down": "Standard_D4a_v4",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "4"
+  },
+  "Standard_D16a_v4": {
+    "up": "Standard_D32a_v4",
+    "down": "Standard_D8a_v4",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "8"
+  },
+  "Standard_D32a_v4": {
+    "up": "Standard_D48a_v4",
+    "down": "Standard_D16a_v4",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "16"
+  },
+  "Standard_D48a_v4": {
+    "up": "Standard_D64a_v4",
+    "down": "Standard_D32a_v4",
+    "superseded": null,
+    "vcpu": 48,
+    "nfu": "24"
+  },
+  "Standard_D64a_v4": {
+    "up": "Standard_D96a_v4",
+    "down": "Standard_D48a_v4",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "32"
+  },
+  "Standard_D96a_v4": {
+    "up": null,
+    "down": "Standard_D64a_v4",
+    "superseded": null,
+    "vcpu": 96,
+    "nfu": "48"
+  },
+  "Standard_D2as_v4": {
+    "up": "Standard_D4as_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "1"
+  },
+  "Standard_D4as_v4": {
+    "up": "Standard_D8as_v4",
+    "down": "Standard_D2as_v4",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "2"
+  },
+  "Standard_D8as_v4": {
+    "up": "Standard_D16as_v4",
+    "down": "Standard_D4as_v4",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "4"
+  },
+  "Standard_D16as_v4": {
+    "up": "Standard_D32as_v4",
+    "down": "Standard_D8as_v4",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "8"
+  },
+  "Standard_D32as_v4": {
+    "up": "Standard_D48as_v4",
+    "down": "Standard_D16as_v4",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "16"
+  },
+  "Standard_D48as_v4": {
+    "up": "Standard_D64as_v4",
+    "down": "Standard_D32as_v4",
+    "superseded": null,
+    "vcpu": 48,
+    "nfu": "24"
+  },
+  "Standard_D64as_v4": {
+    "up": "Standard_D96as_v4",
+    "down": "Standard_D48as_v4",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "32"
+  },
+  "Standard_D96as_v4": {
+    "up": null,
+    "down": "Standard_D64as_v4",
+    "superseded": null,
+    "vcpu": 96,
+    "nfu": "48"
+  },
+  "Standard_D2d_v4": {
+    "up": "Standard_D4d_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "1"
+  },
+  "Standard_D4d_v4": {
+    "up": "Standard_D8d_v4",
+    "down": "Standard_D2d_v4",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "2"
+  },
+  "Standard_D8d_v4": {
+    "up": "Standard_D16d_v4",
+    "down": "Standard_D4d_v4",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "4"
+  },
+  "Standard_D16d_v4": {
+    "up": "Standard_D32d_v4",
+    "down": "Standard_D8d_v4",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "8"
+  },
+  "Standard_D32d_v4": {
+    "up": "Standard_D48d_v4",
+    "down": "Standard_D16d_v4",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "16"
+  },
+  "Standard_D48d_v4": {
+    "up": "Standard_D64d_v4",
+    "down": "Standard_D32d_v4",
+    "superseded": null,
+    "vcpu": 48,
+    "nfu": "24"
+  },
+  "Standard_D64d_v4": {
+    "up": null,
+    "down": "Standard_D48d_v4",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "32"
+  },
+  "Standard_D2d_v5": {
+    "up": "Standard_D4d_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_D4d_v5": {
+    "up": "Standard_D8d_v5",
+    "down": "Standard_D2d_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_D8d_v5": {
+    "up": "Standard_D16d_v5",
+    "down": "Standard_D4d_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_D16d_v5": {
+    "up": "Standard_D32d_v5",
+    "down": "Standard_D8d_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_D32d_v5": {
+    "up": "Standard_D48d_v5",
+    "down": "Standard_D16d_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_D48d_v5": {
+    "up": "Standard_D64d_v5",
+    "down": "Standard_D32d_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_D64d_v5": {
+    "up": "Standard_D96d_v5",
+    "down": "Standard_D48d_v5",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_D96d_v5": {
+    "up": null,
+    "down": "Standard_D64d_v5",
+    "superseded": null,
+    "vcpu": 96
+  },
+  "Standard_D2ds_v4": {
+    "up": "Standard_D4ds_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "1"
+  },
+  "Standard_D4ds_v4": {
+    "up": "Standard_D8ds_v4",
+    "down": "Standard_D2ds_v4",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "2"
+  },
+  "Standard_D8ds_v4": {
+    "up": "Standard_D16ds_v4",
+    "down": "Standard_D4ds_v4",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "4"
+  },
+  "Standard_D16ds_v4": {
+    "up": "Standard_D32ds_v4",
+    "down": "Standard_D8ds_v4",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "8"
+  },
+  "Standard_D32ds_v4": {
+    "up": "Standard_D48ds_v4",
+    "down": "Standard_D16ds_v4",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "16"
+  },
+  "Standard_D48ds_v4": {
+    "up": "Standard_D64ds_v4",
+    "down": "Standard_D32ds_v4",
+    "superseded": null,
+    "vcpu": 48,
+    "nfu": "24"
+  },
+  "Standard_D64ds_v4": {
+    "up": null,
+    "down": "Standard_D48ds_v4",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "32"
+  },
+  "Standard_E2_v4": {
+    "up": "Standard_E4_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "1"
+  },
+  "Standard_E4_v4": {
+    "up": "Standard_E8_v4",
+    "down": "Standard_E2_v4",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "2"
+  },
+  "Standard_E8_v4": {
+    "up": "Standard_E16_v4",
+    "down": "Standard_E4_v4",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "4"
+  },
+  "Standard_E16_v4": {
+    "up": "Standard_E20_v4",
+    "down": "Standard_E8_v4",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "8"
+  },
+  "Standard_E20_v4": {
+    "up": "Standard_E32_v4",
+    "down": "Standard_E16_v4",
+    "superseded": null,
+    "vcpu": 20,
+    "nfu": "10"
+  },
+  "Standard_E32_v4": {
+    "up": "Standard_E48_v4",
+    "down": "Standard_E20_v4",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "16"
+  },
+  "Standard_E48_v4": {
+    "up": "Standard_E64_v4",
+    "down": "Standard_E32_v4",
+    "superseded": null,
+    "vcpu": 48,
+    "nfu": "24"
+  },
+  "Standard_E64_v4": {
+    "up": null,
+    "down": "Standard_E48_v4",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "32"
+  },
+  "Standard_E2_v5": {
+    "up": "Standard_E4_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_E4_v5": {
+    "up": "Standard_E8_v5",
+    "down": "Standard_E2_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_E8_v5": {
+    "up": "Standard_E16_v5",
+    "down": "Standard_E4_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_E16_v5": {
+    "up": "Standard_E20_v5",
+    "down": "Standard_E8_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_E20_v5": {
+    "up": "Standard_E32_v5",
+    "down": "Standard_E16_v5",
+    "superseded": null,
+    "vcpu": 20
+  },
+  "Standard_E32_v5": {
+    "up": "Standard_E48_v5",
+    "down": "Standard_E20_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_E48_v5": {
+    "up": "Standard_E64_v5",
+    "down": "Standard_E32_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_E64_v5": {
+    "up": "Standard_E96_v5",
+    "down": "Standard_E48_v5",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_E96_v5": {
+    "up": "Standard_E104i_v5",
+    "down": "Standard_E64_v5",
+    "superseded": null,
+    "vcpu": 96
+  },
+  "Standard_E104i_v5": {
+    "up": null,
+    "down": "Standard_E96_v5",
+    "superseded": null,
+    "vcpu": 104
+  },
+  "Standard_E2s_v5": {
+    "up": "Standard_E4s_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_E4s_v5": {
+    "up": "Standard_E8s_v5",
+    "down": "Standard_E2s_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_E8s_v5": {
+    "up": "Standard_E16s_v5",
+    "down": "Standard_E4s_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_E16s_v5": {
+    "up": "Standard_E20s_v5",
+    "down": "Standard_E8s_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_E20s_v5": {
+    "up": "Standard_E32s_v5",
+    "down": "Standard_E16s_v5",
+    "superseded": null,
+    "vcpu": 20
+  },
+  "Standard_E32s_v5": {
+    "up": "Standard_E48s_v5",
+    "down": "Standard_E20s_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_E48s_v5": {
+    "up": "Standard_E64s_v5",
+    "down": "Standard_E32s_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_E64s_v5": {
+    "up": "Standard_E96s_v5",
+    "down": "Standard_E48s_v5",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_E96s_v5": {
+    "up": "Standard_E104is_v5",
+    "down": "Standard_E64s_v5",
+    "superseded": null,
+    "vcpu": 96
+  },
+  "Standard_E104is_v5": {
+    "up": null,
+    "down": "Standard_E96s_v5",
+    "superseded": null,
+    "vcpu": 104
+  },
+  "Standard_E2bds_v5": {
+    "up": "Standard_E4bds_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_E4bds_v5": {
+    "up": "Standard_E8bds_v5",
+    "down": "Standard_E2bds_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_E8bds_v5": {
+    "up": "Standard_E16bds_v5",
+    "down": "Standard_E4bds_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_E16bds_v5": {
+    "up": "Standard_E32bds_v5",
+    "down": "Standard_E8bds_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_E32bds_v5": {
+    "up": "Standard_E48bds_v5",
+    "down": "Standard_E16bds_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_E48bds_v5": {
+    "up": "Standard_E64bds_v5",
+    "down": "Standard_E32bds_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_E64bds_v5": {
+    "up": null,
+    "down": "Standard_E48bds_v5",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_E2bs_v5": {
+    "up": "Standard_E4bs_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_E4bs_v5": {
+    "up": "Standard_E8bs_v5",
+    "down": "Standard_E2bs_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_E8bs_v5": {
+    "up": "Standard_E16bs_v5",
+    "down": "Standard_E4bs_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_E16bs_v5": {
+    "up": "Standard_E32bs_v5",
+    "down": "Standard_E8bs_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_E32bs_v5": {
+    "up": "Standard_E48bs_v5",
+    "down": "Standard_E16bs_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_E48bs_v5": {
+    "up": "Standard_E64bs_v5",
+    "down": "Standard_E32bs_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_E64bs_v5": {
+    "up": null,
+    "down": "Standard_E48bs_v5",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_E8d_v5": {
+    "up": "Standard_E16d_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_E16d_v5": {
+    "up": "Standard_E20d_v5",
+    "down": "Standard_E8d_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_E20d_v5": {
+    "up": "Standard_E32d_v5",
+    "down": "Standard_E16d_v5",
+    "superseded": null,
+    "vcpu": 24
+  },
+  "Standard_E32d_v5": {
+    "up": "Standard_E48d_v5",
+    "down": "Standard_E20d_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_E48d_v5": {
+    "up": "Standard_E64d_v5",
+    "down": "Standard_E32d_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_E64d_v5": {
+    "up": "Standard_E96d_v5",
+    "down": "Standard_E48d_v5",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_E96d_v5": {
+    "up": "Standard_E104id_v5",
+    "down": "Standard_E64d_v5",
+    "superseded": null,
+    "vcpu": 96
+  },
+  "Standard_E104id_v5": {
+    "up": null,
+    "down": "Standard_E96d_v5",
+    "superseded": null,
+    "vcpu": 104
+  },
+  "Standard_E2ds_v5": {
+    "up": "Standard_E4ds_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_E4ds_v5": {
+    "up": "Standard_E8ds_v5",
+    "down": "Standard_E2ds_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_E8ds_v5": {
+    "up": "Standard_E16ds_v5",
+    "down": "Standard_E4ds_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_E16ds_v5": {
+    "up": "Standard_E20ds_v5",
+    "down": "Standard_E8ds_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_E20ds_v5": {
+    "up": "Standard_E32ds_v5",
+    "down": "Standard_E16ds_v5",
+    "superseded": null,
+    "vcpu": 20
+  },
+  "Standard_E32ds_v5": {
+    "up": "Standard_E48ds_v5",
+    "down": "Standard_E20ds_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_E48ds_v5": {
+    "up": "Standard_E64ds_v5",
+    "down": "Standard_E32ds_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_E64ds_v5": {
+    "up": "Standard_E96ds_v5",
+    "down": "Standard_E48ds_v5",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_E96ds_v5": {
+    "up": null,
+    "down": "Standard_E64ds_v5",
+    "superseded": null,
+    "vcpu": 96
+  },
+  "Standard_E104ids_v5": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "vcpu": 104
+  },
+  "Standard_EC2as_v5": {
+    "up": "Standard_EC4as_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_EC4as_v5": {
+    "up": "Standard_EC8as_v5",
+    "down": "Standard_EC2as_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_EC8as_v5": {
+    "up": "Standard_EC16as_v5",
+    "down": "Standard_EC4as_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_EC16as_v5": {
+    "up": "Standard_EC20as_v5",
+    "down": "Standard_EC8as_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_EC20as_v5": {
+    "up": "Standard_EC32as_v5",
+    "down": "Standard_EC16as_v5",
+    "superseded": null,
+    "vcpu": 20
+  },
+  "Standard_EC32as_v5": {
+    "up": "Standard_EC48as_v5",
+    "down": "Standard_EC20as_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_EC48as_v5": {
+    "up": "Standard_EC64as_v5",
+    "down": "Standard_EC32as_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_EC64as_v5": {
+    "up": "Standard_EC96as_v5",
+    "down": "Standard_EC48as_v5",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_EC96as_v5": {
+    "up": null,
+    "down": "Standard_EC64as_v5",
+    "superseded": null,
+    "vcpu": 96
+  },
+  "Standard_EC2ads_v5": {
+    "up": "Standard_EC4ads_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_EC4ads_v5": {
+    "up": "Standard_EC8ads_v5",
+    "down": "Standard_EC2ads_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_EC8ads_v5": {
+    "up": "Standard_EC16ads_v5",
+    "down": "Standard_EC4ads_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_EC16ads_v5": {
+    "up": "Standard_EC20ads_v5",
+    "down": "Standard_EC8ads_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_EC20ads_v5": {
+    "up": "Standard_EC32ads_v5",
+    "down": "Standard_EC16ads_v5",
+    "superseded": null,
+    "vcpu": 20
+  },
+  "Standard_EC32ads_v5": {
+    "up": "Standard_EC48ads_v5",
+    "down": "Standard_EC20ads_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_EC48ads_v5": {
+    "up": "Standard_EC64ads_v5",
+    "down": "Standard_EC32ads_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_EC64ads_v5": {
+    "up": "Standard_EC96ads_v5",
+    "down": "Standard_EC48ads_v5",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_EC96ads_v5": {
+    "up": null,
+    "down": "Standard_EC64ads_v5",
+    "superseded": null,
+    "vcpu": 96
+  },
+  "Standard_E2ps_v5": {
+    "up": "Standard_E4ps_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_E4ps_v5": {
+    "up": "Standard_E8ps_v5",
+    "down": "Standard_E2ps_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_E8ps_v5": {
+    "up": "Standard_E16ps_v5",
+    "down": "Standard_E4ps_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_E16ps_v5": {
+    "up": "Standard_E20ps_v5",
+    "down": "Standard_E8ps_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_E20ps_v5": {
+    "up": "Standard_E32ps_v5",
+    "down": "Standard_E16ps_v5",
+    "superseded": null,
+    "vcpu": 20
+  },
+  "Standard_E32ps_v5": {
+    "up": null,
+    "down": "Standard_E20ps_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_E2pds_v5": {
+    "up": "Standard_E4pds_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_E4pds_v5": {
+    "up": "Standard_E8pds_v5",
+    "down": "Standard_E2pds_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_E8pds_v5": {
+    "up": "Standard_E16pds_v5",
+    "down": "Standard_E4pds_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_E16pds_v5": {
+    "up": "Standard_E20pds_v5",
+    "down": "Standard_E8pds_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_E20pds_v5": {
+    "up": "Standard_E32pds_v5",
+    "down": "Standard_E16pds_v5",
+    "superseded": null,
+    "vcpu": 20
+  },
+  "Standard_E32pds_v5": {
+    "up": null,
+    "down": "Standard_E20pds_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_M32ms_v2": {
+    "up": "Standard_M64ms_v2",
+    "down": null,
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "1"
+  },
+  "Standard_M64ms_v2": {
+    "up": "Standard_M128ms_v2",
+    "down": "Standard_M32ms_v2",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "1"
+  },
+  "Standard_M128ms_v2": {
+    "up": null,
+    "down": "Standard_M64ms_v2",
+    "superseded": null,
+    "vcpu": 128,
+    "nfu": "1"
+  },
+  "Standard_M64s_v2": {
+    "up": "Standard_M128s_v2",
+    "down": null,
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "1"
+  },
+  "Standard_M128s_v2": {
+    "up": null,
+    "down": "Standard_M64s_v2",
+    "superseded": null,
+    "vcpu": 128,
+    "nfu": "1"
+  },
+  "Standard_M192is_v2": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "vcpu": 192,
+    "nfu": "1"
+  },
+  "Standard_M192ims_v2": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "vcpu": 192,
+    "nfu": "1"
+  },
+  "Standard_M32dms_v2": {
+    "up": "Standard_M64dms_v2",
+    "down": null,
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "1"
+  },
+  "Standard_M64dms_v2": {
+    "up": "Standard_M128dms_v2",
+    "down": "Standard_M32dms_v2",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "1"
+  },
+  "Standard_M128dms_v2": {
+    "up": null,
+    "down": "Standard_M64dms_v2",
+    "superseded": null,
+    "vcpu": 128,
+    "nfu": "1"
+  },
+  "Standard_M64ds_v2": {
+    "up": "Standard_M128ds_v2",
+    "down": null,
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "1"
+  },
+  "Standard_M128ds_v2": {
+    "up": null,
+    "down": "Standard_M64ds_v2",
+    "superseded": null,
+    "vcpu": 128,
+    "nfu": "1"
+  },
+  "Standard_M192ids_v2": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "vcpu": 192,
+    "nfu": "1"
+  },
+  "Standard_M192idms_v2": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "vcpu": 192,
+    "nfu": "1"
+  },
+  "Standard_M8-2ms": {
+    "up": "Standard_M8-4ms",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "1"
+  },
+  "Standard_M8-4ms": {
+    "up": null,
+    "down": "Standard_M8-2ms",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "1"
+  },
+  "Standard_M16-4ms": {
+    "up": "Standard_M16-8ms",
+    "down": null,
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "2"
+  },
+  "Standard_M16-8ms": {
+    "up": null,
+    "down": "Standard_M16-4ms",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "2"
+  },
+  "Standard_M32-8ms": {
+    "up": "Standard_M32-16ms",
+    "down": null,
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "4"
+  },
+  "Standard_M32-16ms": {
+    "up": null,
+    "down": "Standard_M32-8ms",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "4"
+  },
+  "Standard_M64-16ms": {
+    "up": "Standard_M64-32ms",
+    "down": null,
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "1"
+  },
+  "Standard_M64-32ms": {
+    "up": null,
+    "down": "Standard_M64-16ms",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "1"
+  },
+  "Standard_M128-32ms": {
+    "up": "Standard_M128-64ms",
+    "down": null,
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "2"
+  },
+  "Standard_M128-64ms": {
+    "up": null,
+    "down": "Standard_M128-32ms",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "2"
+  },
+  "Standard_E4-2s_v3": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "2"
+  },
+  "Standard_E8-2s_v3": {
+    "up": "Standard_E8-4s_v3",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "4"
+  },
+  "Standard_E8-4s_v3": {
+    "up": null,
+    "down": "Standard_E8-2s_v3",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "4"
+  },
+  "Standard_E16-4s_v3": {
+    "up": "Standard_E16-8s_v3",
+    "down": null,
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "8"
+  },
+  "Standard_E16-8s_v3": {
+    "up": null,
+    "down": "Standard_E16-4s_v3",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "8"
+  },
+  "Standard_E32-8s_v3": {
+    "up": "Standard_E32-16s_v3",
+    "down": null,
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "16"
+  },
+  "Standard_E32-16s_v3": {
+    "up": null,
+    "down": "Standard_E32-8s_v3",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "16"
+  },
+  "Standard_E64-16s_v3": {
+    "up": "Standard_E64-32s_v3",
+    "down": null,
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "28.8"
+  },
+  "Standard_E64-32s_v3": {
+    "up": null,
+    "down": "Standard_E64-16s_v3",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "28.8"
+  },
+  "Standard_E4-2s_v4": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "2"
+  },
+  "Standard_E8-2s_v4": {
+    "up": "Standard_E8-4s_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "4"
+  },
+  "Standard_E8-4s_v4": {
+    "up": null,
+    "down": "Standard_E8-2s_v4",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "4"
+  },
+  "Standard_E16-4s_v4": {
+    "up": "Standard_E16-8s_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "8"
+  },
+  "Standard_E16-8s_v4": {
+    "up": null,
+    "down": "Standard_E16-4s_v4",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "8"
+  },
+  "Standard_E32-8s_v4": {
+    "up": "Standard_E32-16s_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "16"
+  },
+  "Standard_E32-16s_v4": {
+    "up": null,
+    "down": "Standard_E32-8s_v4",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "16"
+  },
+  "Standard_E64-16s_v4": {
+    "up": "Standard_E64-32s_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "32"
+  },
+  "Standard_E64-32s_v4": {
+    "up": null,
+    "down": "Standard_E64-16s_v4",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "32"
+  },
+  "Standard_E4-2ds_v4": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "2"
+  },
+  "Standard_E8-2ds_v4": {
+    "up": "Standard_E8-4ds_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "4"
+  },
+  "Standard_E8-4ds_v4": {
+    "up": null,
+    "down": "Standard_E8-2ds_v4",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "4"
+  },
+  "Standard_E16-4ds_v4": {
+    "up": "Standard_E16-8ds_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "8"
+  },
+  "Standard_E16-8ds_v4": {
+    "up": null,
+    "down": "Standard_E16-4ds_v4",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "8"
+  },
+  "Standard_E32-8ds_v4": {
+    "up": "Standard_E32-16ds_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "16"
+  },
+  "Standard_E32-16ds_v4": {
+    "up": null,
+    "down": "Standard_E32-8ds_v4",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "16"
+  },
+  "Standard_E64-16ds_v4": {
+    "up": "Standard_E64-32ds_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "32"
+  },
+  "Standard_E64-32ds_v4": {
+    "up": null,
+    "down": "Standard_E64-16ds_v4",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "32"
+  },
+  "Standard_E4-2s_v5": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_E8-2s_v5": {
+    "up": "Standard_E8-4s_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_E8-4s_v5": {
+    "up": null,
+    "down": "Standard_E8-2s_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_E16-4s_v5": {
+    "up": "Standard_E16-8s_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_E16-8s_v5": {
+    "up": null,
+    "down": "Standard_E16-4s_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_E32-8s_v5": {
+    "up": "Standard_E32-16s_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_E32-16s_v5": {
+    "up": null,
+    "down": "Standard_E32-8s_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_E64-16s_v5": {
+    "up": "Standard_E64-32s_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_E64-32s_v5": {
+    "up": null,
+    "down": "Standard_E64-16s_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_E96-24s_v5": {
+    "up": "Standard_E96-48s_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 24
+  },
+  "Standard_E96-48s_v5": {
+    "up": null,
+    "down": "Standard_E96-24s_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_E4-2ds_v5": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_E8-2ds_v5": {
+    "up": "Standard_E8-4ds_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_E8-4ds_v5": {
+    "up": null,
+    "down": "Standard_E8-2ds_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_E16-4ds_v5": {
+    "up": "Standard_E16-8ds_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_E16-8ds_v5": {
+    "up": null,
+    "down": "Standard_E16-4ds_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_E32-8ds_v5": {
+    "up": "Standard_E32-16ds_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_E32-16ds_v5": {
+    "up": null,
+    "down": "Standard_E32-8ds_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_E64-16ds_v5": {
+    "up": "Standard_E64-32ds_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_E64-32ds_v5": {
+    "up": null,
+    "down": "Standard_E64-16ds_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_E96-24ds_v5": {
+    "up": "Standard_E96-48ds_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 24
+  },
+  "Standard_E96-48ds_v5": {
+    "up": null,
+    "down": "Standard_E96-24ds_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_E4-2as_v4": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "2"
+  },
+  "Standard_E8-2as_v4": {
+    "up": "Standard_E8-4as_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "4"
+  },
+  "Standard_E8-4as_v4": {
+    "up": null,
+    "down": "Standard_E8-2as_v4",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "4"
+  },
+  "Standard_E16-4as_v4": {
+    "up": "Standard_E16-8as_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "8"
+  },
+  "Standard_E16-8as_v4": {
+    "up": null,
+    "down": "Standard_E16-4as_v4",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "8"
+  },
+  "Standard_E32-8as_v4": {
+    "up": "Standard_E32-16as_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "16"
+  },
+  "Standard_E32-16as_v4": {
+    "up": null,
+    "down": "Standard_E32-8as_v4",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "16"
+  },
+  "Standard_E64-16as_v4": {
+    "up": "Standard_E64-32as_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "32"
+  },
+  "Standard_E64-32as_v4": {
+    "up": null,
+    "down": "Standard_E64-16as_v4",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "32"
+  },
+  "Standard_E96-24as_v4": {
+    "up": "Standard_E96-48as_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 24,
+    "nfu": "48"
+  },
+  "Standard_E96-48as_v4": {
+    "up": null,
+    "down": "Standard_E96-24as_v4",
+    "superseded": null,
+    "vcpu": 48,
+    "nfu": "48"
+  },
+  "Standard_E4-2ads_v5": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_E8-2ads_v5": {
+    "up": "Standard_E8-4ads_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_E8-4ads_v5": {
+    "up": null,
+    "down": "Standard_E8-2ads_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_E16-4ads_v5": {
+    "up": "Standard_E16-8ads_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_E16-8ads_v5": {
+    "up": null,
+    "down": "Standard_E16-4ads_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_E32-8ads_v5": {
+    "up": "Standard_E32-16ads_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_E32-16ads_v5": {
+    "up": null,
+    "down": "Standard_E32-8ads_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_E64-16ads_v5": {
+    "up": "Standard_E64-32ads_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_E64-32ads_v5": {
+    "up": null,
+    "down": "Standard_E64-16ads_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_E96-24ads_v5": {
+    "up": "Standard_E96-48ads_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 24
+  },
+  "Standard_E96-48ads_v5": {
+    "up": null,
+    "down": "Standard_E96-24ads_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_E4-2as_v5": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_E8-2as_v5": {
+    "up": "Standard_E8-4as_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_E8-4as_v5": {
+    "up": null,
+    "down": "Standard_E8-2as_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_E16-4as_v5": {
+    "up": "Standard_E16-8as_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_E16-8as_v5": {
+    "up": null,
+    "down": "Standard_E16-4as_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_E32-8as_v5": {
+    "up": "Standard_E32-16as_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_E32-16as_v5": {
+    "up": null,
+    "down": "Standard_E32-8as_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_E64-16as_v5": {
+    "up": "Standard_E64-32as_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_E64-32as_v5": {
+    "up": null,
+    "down": "Standard_E64-16as_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_E96-24as_v5": {
+    "up": "Standard_E96-48as_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 24
+  },
+  "Standard_E96-48as_v5": {
+    "up": null,
+    "down": "Standard_E96-24as_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_GS4-4": {
+    "up": "Standard_GS4-8",
+    "down": null,
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_GS4-8": {
+    "up": null,
+    "down": "Standard_GS4-4",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_GS5-8": {
+    "up": "Standard_GS5-16",
+    "down": null,
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_GS5-16": {
+    "up": null,
+    "down": "Standard_GS5-8",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_DS11-1_v2": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "vcpu": 1,
+    "nfu": "1"
+  },
+  "Standard_DS12-1_v2": {
+    "up": "Standard_DS12-2_v2",
+    "down": null,
+    "superseded": null,
+    "vcpu": 1,
+    "nfu": "2"
+  },
+  "Standard_DS12-2_v2": {
+    "up": null,
+    "down": "Standard_DS12-1_v2",
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "2"
+  },
+  "Standard_DS13-2_v2": {
+    "up": "Standard_DS13-4_v2",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "4"
+  },
+  "Standard_DS13-4_v2": {
+    "up": null,
+    "down": "Standard_DS13-2_v2",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "4"
+  },
+  "Standard_DS14-4_v2": {
+    "up": "Standard_DS14-8_v2",
+    "down": null,
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "8"
+  },
+  "Standard_DS14-8_v2": {
+    "up": null,
+    "down": "Standard_DS14-4_v2",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "8"
+  },
+  "Standard_M416-208s_v2": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "vcpu": 208,
+    "nfu": "2"
+  },
+  "Standard_M416-208ms_v2": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "vcpu": 208,
+    "nfu": "2"
+  },
+  "Standard_L8s_v3": {
+    "up": "Standard_L16s_v3",
+    "down": null,
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_L16s_v3": {
+    "up": "Standard_L32s_v3",
+    "down": "Standard_L8s_v3",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_L32s_v3": {
+    "up": "Standard_L48s_v3",
+    "down": "Standard_L16s_v3",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_L48s_v3": {
+    "up": "Standard_L64s_v3",
+    "down": "Standard_L32s_v3",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_L64s_v3": {
+    "up": "Standard_L80s_v3",
+    "down": "Standard_L48s_v3",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_L80s_v3": {
+    "up": null,
+    "down": "Standard_L64s_v3",
+    "superseded": null,
+    "vcpu": 80
+  },
+  "Standard_L8as_v3": {
+    "up": "Standard_L16as_v3",
+    "down": null,
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_L16as_v3": {
+    "up": "Standard_L32as_v3",
+    "down": "Standard_L8as_v3",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_L32as_v3": {
+    "up": "Standard_L48as_v3",
+    "down": "Standard_L16as_v3",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_L48as_v3": {
+    "up": "Standard_L64as_v3",
+    "down": "Standard_L32as_v3",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_L64as_v3": {
+    "up": "Standard_L80as_v3",
+    "down": "Standard_L48as_v3",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_L80as_v3": {
+    "up": null,
+    "down": "Standard_L64as_v3",
+    "superseded": null,
+    "vcpu": 80
+  },
+  "Standard_E2_v3": {
+    "up": "Standard_E4_v3",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "1"
+  },
+  "Standard_E4_v3": {
+    "up": "Standard_E8_v3",
+    "down": "Standard_E2_v3",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "2"
+  },
+  "Standard_E8_v3": {
+    "up": "Standard_E16_v3",
+    "down": "Standard_E4_v3",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "4"
+  },
+  "Standard_E16_v3": {
+    "up": "Standard_E20_v3",
+    "down": "Standard_E8_v3",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "8"
+  },
+  "Standard_E20_v3": {
+    "up": "Standard_E32_v3",
+    "down": "Standard_E16_v3",
+    "superseded": null,
+    "vcpu": 20,
+    "nfu": "10"
+  },
+  "Standard_E32_v3": {
+    "up": "Standard_E48_v3",
+    "down": "Standard_E20_v3",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "16"
+  },
+  "Standard_E48_v3": {
+    "up": "Standard_E64_v3",
+    "down": "Standard_E32_v3",
+    "superseded": null,
+    "vcpu": 48,
+    "nfu": "24"
+  },
+  "Standard_E64_v3": {
+    "up": null,
+    "down": "Standard_E48_v3",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "28.8"
+  },
+  "Standard_E64i_v3": {
+    "up": null,
+    "down": "Standard_E48_v3",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "1"
+  },
+  "Standard_E2ds_v4": {
+    "up": "Standard_E4ds_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "1"
+  },
+  "Standard_E4ds_v4": {
+    "up": "Standard_E8ds_v4",
+    "down": "Standard_E2ds_v4",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "2"
+  },
+  "Standard_E8ds_v4": {
+    "up": "Standard_E16ds_v4",
+    "down": "Standard_E4ds_v4",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "4"
+  },
+  "Standard_E16ds_v4": {
+    "up": "Standard_E20ds_v4",
+    "down": "Standard_E8ds_v4",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "8"
+  },
+  "Standard_E20ds_v4": {
+    "up": "Standard_E32ds_v4",
+    "down": "Standard_E16ds_v4",
+    "superseded": null,
+    "vcpu": 20,
+    "nfu": "10"
+  },
+  "Standard_E32ds_v4": {
+    "up": "Standard_E48ds_v4",
+    "down": "Standard_E20ds_v4",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "16"
+  },
+  "Standard_E48ds_v4": {
+    "up": "Standard_E64ds_v4",
+    "down": "Standard_E32ds_v4",
+    "superseded": null,
+    "vcpu": 48,
+    "nfu": "24"
+  },
+  "Standard_E64ds_v4": {
+    "up": "Standard_E80ids_v4",
+    "down": "Standard_E48ds_v4",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "32"
+  },
+  "Standard_E80ids_v4": {
+    "up": null,
+    "down": "Standard_E64ds_v4",
+    "superseded": null,
+    "vcpu": 80,
+    "nfu": "1.25"
+  },
+  "Standard_E2d_v4": {
+    "up": "Standard_E4d_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "1"
+  },
+  "Standard_E4d_v4": {
+    "up": "Standard_E8d_v4",
+    "down": "Standard_E2d_v4",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "2"
+  },
+  "Standard_E8d_v4": {
+    "up": "Standard_E16d_v4",
+    "down": "Standard_E4d_v4",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "4"
+  },
+  "Standard_E16d_v4": {
+    "up": "Standard_E20d_v4",
+    "down": "Standard_E8d_v4",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "8"
+  },
+  "Standard_E20d_v4": {
+    "up": "Standard_E32d_v4",
+    "down": "Standard_E16d_v4",
+    "superseded": null,
+    "vcpu": 20,
+    "nfu": "10"
+  },
+  "Standard_E32d_v4": {
+    "up": "Standard_E48d_v4",
+    "down": "Standard_E20d_v4",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "16"
+  },
+  "Standard_E48d_v4": {
+    "up": "Standard_E64d_v4",
+    "down": "Standard_E32d_v4",
+    "superseded": null,
+    "vcpu": 48,
+    "nfu": "24"
+  },
+  "Standard_E64d_v4 ": {
+    "up": null,
+    "down": "Standard_E48d_v4",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "32"
+  },
+  "Standard_E2s_v3": {
+    "up": "Standard_E4s_v3",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "1"
+  },
+  "Standard_E4s_v3": {
+    "up": "Standard_E8s_v3",
+    "down": "Standard_E2s_v3",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "2"
+  },
+  "Standard_E8s_v3": {
+    "up": "Standard_E16s_v3",
+    "down": "Standard_E4s_v3",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "4"
+  },
+  "Standard_E16s_v3": {
+    "up": "Standard_E20s_v3",
+    "down": "Standard_E8s_v3",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "8"
+  },
+  "Standard_E20s_v3": {
+    "up": "Standard_E32s_v3",
+    "down": "Standard_E16s_v3",
+    "superseded": null,
+    "vcpu": 20,
+    "nfu": "10"
+  },
+  "Standard_E32s_v3": {
+    "up": "Standard_E48s_v3",
+    "down": "Standard_E20s_v3",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "16"
+  },
+  "Standard_E48s_v3": {
+    "up": "Standard_E64s_v3",
+    "down": "Standard_E32s_v3",
+    "superseded": null,
+    "vcpu": 48,
+    "nfu": "24"
+  },
+  "Standard_E64s_v3": {
+    "up": null,
+    "down": "Standard_E48s_v3",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "28.8"
+  },
+  "Standard_E64is_v3": {
+    "up": null,
+    "down": "Standard_E48s_v3",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "1"
+  },
+  "Standard_G1": {
+    "up": "Standard_G2",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_G2": {
+    "up": "Standard_G3",
+    "down": "Standard_G1",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_G3": {
+    "up": "Standard_G4",
+    "down": "Standard_G2",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_G4": {
+    "up": "Standard_G5",
+    "down": "Standard_G3",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_G5": {
+    "up": null,
+    "down": "Standard_G4",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_GS1": {
+    "up": "Standard_GS2",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_GS2": {
+    "up": "Standard_GS3",
+    "down": "Standard_GS1",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_GS3": {
+    "up": "Standard_GS4",
+    "down": "Standard_GS2",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_GS4": {
+    "up": "Standard_GS5",
+    "down": "Standard_GS3",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_GS5": {
+    "up": null,
+    "down": "Standard_GS4",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_L4s": {
+    "up": "Standard_L8s",
+    "down": null,
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "1"
+  },
+  "Standard_L8s": {
+    "up": "Standard_L16s",
+    "down": "Standard_L4s",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "2"
+  },
+  "Standard_L16s": {
+    "up": "Standard_L32s",
+    "down": "Standard_L8s",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "4"
+  },
+  "Standard_L32s": {
+    "up": null,
+    "down": "Standard_L16s",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "8"
+  },
+  "Standard_L8s_v2": {
+    "up": "Standard_L16s_v2",
+    "down": null,
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "1"
+  },
+  "Standard_L16s_v2": {
+    "up": "Standard_L32s_v2",
+    "down": "Standard_L8s_v2",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "2"
+  },
+  "Standard_L32s_v2": {
+    "up": "Standard_L48s_v2",
+    "down": "Standard_L16s_v2",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "4"
+  },
+  "Standard_L48s_v2": {
+    "up": "Standard_L64s_v2",
+    "down": "Standard_L32s_v2",
+    "superseded": null,
+    "vcpu": 48,
+    "nfu": "6"
+  },
+  "Standard_L64s_v2": {
+    "up": "Standard_L80s_v2",
+    "down": "Standard_L48s_v2",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "8"
+  },
+  "Standard_L80s_v2": {
+    "up": null,
+    "down": "Standard_L64s_v2",
+    "superseded": null,
+    "vcpu": 80,
+    "nfu": "10"
+  },
+  "Standard_E2s_v4": {
+    "up": "Standard_E4s_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "1"
+  },
+  "Standard_E4s_v4": {
+    "up": "Standard_E8s_v4",
+    "down": "Standard_E2s_v4",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "2"
+  },
+  "Standard_E8s_v4": {
+    "up": "Standard_E16s_v4",
+    "down": "Standard_E4s_v4",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "4"
+  },
+  "Standard_E16s_v4": {
+    "up": "Standard_E20s_v4",
+    "down": "Standard_E8s_v4",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "8"
+  },
+  "Standard_E20s_v4": {
+    "up": "Standard_E32s_v4",
+    "down": "Standard_E16s_v4",
+    "superseded": null,
+    "vcpu": 20,
+    "nfu": "10"
+  },
+  "Standard_E32s_v4": {
+    "up": "Standard_E48s_v4",
+    "down": "Standard_E20s_v4",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "16"
+  },
+  "Standard_E48s_v4": {
+    "up": "Standard_E64s_v4",
+    "down": "Standard_E32s_v4",
+    "superseded": null,
+    "vcpu": 48,
+    "nfu": "24"
+  },
+  "Standard_E64s_v4": {
+    "up": "Standard_E80is_v4",
+    "down": "Standard_E48s_v4",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "32"
+  },
+  "Standard_E80is_v4": {
+    "up": null,
+    "down": "Standard_E64s_v4",
+    "superseded": null,
+    "vcpu": 80,
+    "nfu": "1.25"
+  },
+  "Standard_E2as_v4": {
+    "up": "Standard_E4as_v4",
+    "down": null,
+    "superseded": {
+      "regular": "Standard_E2as_v5"
+    },
+    "vcpu": 2,
+    "nfu": "1"
+  },
+  "Standard_E4as_v4": {
+    "up": "Standard_E8as_v4",
+    "down": "Standard_E2as_v4",
+    "superseded": {
+      "regular": "Standard_E4as_v5"
+    },
+    "vcpu": 4,
+    "nfu": "2"
+  },
+  "Standard_E8as_v4": {
+    "up": "Standard_E16as_v4",
+    "down": "Standard_E4as_v4",
+    "superseded": {
+      "regular": "Standard_E8as_v5"
+    },
+    "vcpu": 8,
+    "nfu": "4"
+  },
+  "Standard_E16as_v4": {
+    "up": "Standard_E20as_v4",
+    "down": "Standard_E8as_v4",
+    "superseded": {
+      "regular": "Standard_E16as_v5"
+    },
+    "vcpu": 16,
+    "nfu": "8"
+  },
+  "Standard_E20as_v4": {
+    "up": "Standard_E32as_v4",
+    "down": "Standard_E16as_v4",
+    "superseded": {
+      "regular": "Standard_E20as_v5"
+    },
+    "vcpu": 20,
+    "nfu": "10"
+  },
+  "Standard_E32as_v4": {
+    "up": "Standard_E48as_v4",
+    "down": "Standard_E20as_v4",
+    "superseded": {
+      "regular": "Standard_E32as_v5"
+    },
+    "vcpu": 32,
+    "nfu": "16"
+  },
+  "Standard_E48as_v4": {
+    "up": "Standard_E64as_v4",
+    "down": "Standard_E32as_v4",
+    "superseded": {
+      "regular": "Standard_E48as_v5"
+    },
+    "vcpu": 48,
+    "nfu": "24"
+  },
+  "Standard_E64as_v4": {
+    "up": "Standard_E96as_v4",
+    "down": "Standard_E48as_v4",
+    "superseded": {
+      "regular": "Standard_E64as_v5"
+    },
+    "vcpu": 64,
+    "nfu": "32"
+  },
+  "Standard_E96as_v4": {
+    "up": null,
+    "down": "Standard_E64as_v4",
+    "superseded": {
+      "superseded": {
+        "regular": "Standard_E96as_v5"
+      }
+    },
+    "vcpu": 96,
+    "nfu": "48"
+  },
+  "Standard_E2a_v4": {
+    "up": "Standard_E4a_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "1"
+  },
+  "Standard_E4a_v4": {
+    "up": "Standard_E8a_v4",
+    "down": "Standard_E2a_v4",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "2"
+  },
+  "Standard_E8a_v4": {
+    "up": "Standard_E16a_v4",
+    "down": "Standard_E4a_v4",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "4"
+  },
+  "Standard_E16a_v4": {
+    "up": "Standard_E20a_v4",
+    "down": "Standard_E8a_v4",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "8"
+  },
+  "Standard_E20a_v4": {
+    "up": "Standard_E32a_v4",
+    "down": "Standard_E16a_v4",
+    "superseded": null,
+    "vcpu": 20,
+    "nfu": "10"
+  },
+  "Standard_E32a_v4": {
+    "up": "Standard_E48a_v4",
+    "down": "Standard_E20a_v4",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "16"
+  },
+  "Standard_E48a_v4": {
+    "up": "Standard_E64a_v4",
+    "down": "Standard_E32a_v4",
+    "superseded": null,
+    "vcpu": 48,
+    "nfu": "24"
+  },
+  "Standard_E64a_v4": {
+    "up": "Standard_E96a_v4",
+    "down": "Standard_E48a_v4",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "32"
+  },
+  "Standard_E96a_v4": {
+    "up": null,
+    "down": "Standard_E64a_v4",
+    "superseded": null,
+    "vcpu": 96,
+    "nfu": "48"
+  },
+  "Standard_F1": {
+    "up": "Standard_F2",
+    "down": null,
+    "superseded": null,
+    "vcpu": 1,
+    "nfu": "1"
+  },
+  "Standard_F2": {
+    "up": "Standard_F4",
+    "down": "Standard_F1",
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "2"
+  },
+  "Standard_F4": {
+    "up": "Standard_F8",
+    "down": "Standard_F2",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "4"
+  },
+  "Standard_F8": {
+    "up": "Standard_F16",
+    "down": "Standard_F4",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "8"
+  },
+  "Standard_F16": {
+    "up": null,
+    "down": "Standard_F8",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "16"
+  },
+  "Standard_F1s": {
+    "up": "Standard_F2s",
+    "down": null,
+    "superseded": null,
+    "vcpu": 1,
+    "nfu": "1"
+  },
+  "Standard_F2s": {
+    "up": "Standard_F4s",
+    "down": "Standard_F1s",
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "2"
+  },
+  "Standard_F4s": {
+    "up": "Standard_F8s",
+    "down": "Standard_F2s",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "4"
+  },
+  "Standard_F8s": {
+    "up": "Standard_F16s",
+    "down": "Standard_F4s",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "8"
+  },
+  "Standard_F16s": {
+    "up": null,
+    "down": "Standard_F8s",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "16"
+  },
+  "Standard_F2s_v2": {
+    "up": "Standard_F4s_v2",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2,
+    "nfu": "1"
+  },
+  "Standard_F4s_v2": {
+    "up": "Standard_F8s_v2",
+    "down": "Standard_F2s_v2",
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "2"
+  },
+  "Standard_F8s_v2": {
+    "up": "Standard_F16s_v2",
+    "down": "Standard_F4s_v2",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "4"
+  },
+  "Standard_F16s_v2": {
+    "up": "Standard_F32s_v2",
+    "down": "Standard_F8s_v2",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "8"
+  },
+  "Standard_F32s_v2": {
+    "up": "Standard_F48s_v2",
+    "down": "Standard_F16s_v2",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "16"
+  },
+  "Standard_F48s_v2": {
+    "up": "Standard_F64s_v2",
+    "down": "Standard_F32s_v2",
+    "superseded": null,
+    "vcpu": 48,
+    "nfu": "24"
+  },
+  "Standard_F64s_v2": {
+    "up": "Standard_F72s_v2",
+    "down": "Standard_F48s_v2",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "32"
+  },
+  "Standard_F72s_v2": {
+    "up": null,
+    "down": "Standard_F64s_v2",
+    "superseded": null,
+    "vcpu": 72,
+    "nfu": "36"
+  },
+  "Standard_H8": {
+    "up": "Standard_H8m",
+    "down": null,
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "1"
+  },
+  "Standard_H8m": {
+    "up": "Standard_H16",
+    "down": "Standard_H8",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "1"
+  },
+  "Standard_H16": {
+    "up": "Standard_H16m",
+    "down": "Standard_H8m",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "2"
+  },
+  "Standard_H16m": {
+    "up": "Standard_H16mr",
+    "down": "Standard_H16",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "2"
+  },
+  "Standard_H16r": {
+    "up": "Standard_H16mr",
+    "down": "Standard_H16",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "1"
+  },
+  "Standard_H16mr": {
+    "up": null,
+    "down": "Standard_H16r",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "1"
+  },
+  "Standard_HB60rs": {
+    "up": null,
+    "down": null,
+    "superseded": {
+      "regular": "Standard_HB120rs_v2"
+    },
+    "vcpu": 60,
+    "nfu": "1"
+  },
+  "Standard_NC6": {
+    "up": "Standard_NC12",
+    "down": null,
+    "superseded": {
+      "regular": "Standard_NC4as_T4_v3"
+    },
+    "vcpu": 6,
+    "nfu": "1"
+  },
+  "Standard_NC12": {
+    "up": "Standard_NC24",
+    "down": "Standard_NC6",
+    "superseded": {
+      "regular": "Standard_NC16as_T4_v3"
+    },
+    "vcpu": 12,
+    "nfu": "2"
+  },
+  "Standard_NC24": {
+    "up": null,
+    "down": "Standard_NC12",
+    "superseded": {
+      "regular": "Standard_NC64as_T4_v3"
+    },
+    "vcpu": 24,
+    "nfu": "4"
+  },
+  "Standard_NC24r": {
+    "up": null,
+    "down": null,
+    "superseded": {
+      "regular": "Standard_ND96amsr_A100_v4"
+    },
+    "vcpu": 24,
+    "nfu": "1"
+  },
+  "Standard_NC6s_v2": {
+    "up": "Standard_NC12s_v2",
+    "down": null,
+    "superseded": {
+      "regular": "Standard_NC24ads_A100_v4"
+    },
+    "vcpu": 6,
+    "nfu": "1"
+  },
+  "Standard_NC12s_v2": {
+    "up": "Standard_NC24s_v2",
+    "down": "Standard_NC6s_v2",
+    "superseded": {
+      "regular": "Standard_NC48ads_A100_v4"
+    },
+    "vcpu": 12,
+    "nfu": "2"
+  },
+  "Standard_NC24s_v2": {
+    "up": "Standard_NC24rs_v2",
+    "down": "Standard_NC12s_v2",
+    "superseded": {
+      "regular": "Standard_NC96ads_A100_v4"
+    },
+    "vcpu": 24,
+    "nfu": "4"
+  },
+  "Standard_NC24rs_v2": {
+    "up": null,
+    "down": null,
+    "superseded": {
+      "regular": "Standard_ND96amsr_A100_v4"
+    },
+    "vcpu": 24,
+    "nfu": "1"
+  },
+  "Standard_NC6s_v3": {
+    "up": "Standard_NC12s_v3",
+    "down": null,
+    "superseded": null,
+    "vcpu": 6,
+    "nfu": "1"
+  },
+  "Standard_NC12s_v3": {
+    "up": "Standard_NC24s_v3",
+    "down": "Standard_NC6s_v3",
+    "superseded": null,
+    "vcpu": 12,
+    "nfu": "2"
+  },
+  "Standard_NC24s_v3": {
+    "up": "Standard_NC24rs_v3",
+    "down": "Standard_NC12s_v3",
+    "superseded": null,
+    "vcpu": 24,
+    "nfu": "4"
+  },
+  "Standard_NC24rs_v3": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "vcpu": 24,
+    "nfu": "1"
+  },
+  "Standard_NC4as_T4_v3": {
+    "up": "Standard_NC8as_T4_v3",
+    "down": null,
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "1"
+  },
+  "Standard_NC8as_T4_v3": {
+    "up": "Standard_NC16as_T4_v3",
+    "down": "Standard_NC4as_T4_v3",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "2"
+  },
+  "Standard_NC16as_T4_v3": {
+    "up": "Standard_NC64as_T4_v3",
+    "down": "Standard_NC8as_T4_v3",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "4"
+  },
+  "Standard_NC64as_T4_v3": {
+    "up": null,
+    "down": "Standard_NC16as_T4_v3",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "16"
+  },
+  "Standard_NC24ads_A100_v4": {
+    "up": "Standard_NC48ads_A100_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 24
+  },
+  "Standard_NC48ads_A100_v4": {
+    "up": "Standard_NC96ads_A100_v4",
+    "down": "Standard_NC24ads_A100_v4",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_NC96ads_A100_v4": {
+    "up": null,
+    "down": "Standard_NC48ads_A100_v4",
+    "superseded": null,
+    "vcpu": 96
+  },
+  "Standard_ND96asr_v4": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "vcpu": 96,
+    "nfu": "1"
+  },
+  "Standard_ND96amsr_A100_v4": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "vcpu": 96
+  },
+  "Standard_ND40rs_v2": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "vcpu": 40,
+    "nfu": "1"
+  },
+  "Standard_M8ms": {
+    "up": "Standard_M16ms",
+    "down": null,
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "1"
+  },
+  "Standard_M16ms": {
+    "up": "Standard_M32ms",
+    "down": "Standard_M8ms",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "2"
+  },
+  "Standard_M32ms": {
+    "up": "Standard_M64ms",
+    "down": "Standard_M16ms",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "4"
+  },
+  "Standard_M64ms": {
+    "up": "Standard_M128ms",
+    "down": "Standard_M32ms",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "1"
+  },
+  "Standard_M128ms": {
+    "up": null,
+    "down": "Standard_M64ms",
+    "superseded": null,
+    "vcpu": 128,
+    "nfu": "2"
+  },
+  "Standard_M32ls": {
+    "up": "Standard_M64ls",
+    "down": null,
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "1"
+  },
+  "Standard_M64ls": {
+    "up": null,
+    "down": "Standard_M32ls",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "1.8846875"
+  },
+  "Standard_M32ts": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "1"
+  },
+  "Standard_M64s": {
+    "up": "Standard_M128s",
+    "down": null,
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "1"
+  },
+  "Standard_M128s": {
+    "up": null,
+    "down": "Standard_M64s",
+    "superseded": null,
+    "vcpu": 128,
+    "nfu": "2"
+  },
+  "Standard_M64": {
+    "up": "Standard_M128",
+    "down": null,
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "1"
+  },
+  "Standard_M128": {
+    "up": null,
+    "down": "Standard_M64",
+    "superseded": null,
+    "vcpu": 128,
+    "nfu": "2"
+  },
+  "Standard_M64m": {
+    "up": "Standard_M128m",
+    "down": null,
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "1"
+  },
+  "Standard_M128m": {
+    "up": null,
+    "down": "Standard_M64m",
+    "superseded": null,
+    "vcpu": 128,
+    "nfu": "2"
+  },
+  "Standard_ND6s": {
+    "up": "Standard_ND12s",
+    "down": null,
+    "superseded": null,
+    "vcpu": 6,
+    "nfu": "1"
+  },
+  "Standard_ND12s": {
+    "up": "Standard_ND24s",
+    "down": "Standard_ND6s",
+    "superseded": null,
+    "vcpu": 12,
+    "nfu": "2"
+  },
+  "Standard_ND24s": {
+    "up": "Standard_ND24rs",
+    "down": "Standard_ND12s",
+    "superseded": null,
+    "vcpu": 24,
+    "nfu": "4"
+  },
+  "Standard_ND24rs": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "vcpu": 24,
+    "nfu": "1"
+  },
+  "Standard_NV4as_v4": {
+    "up": "Standard_NV8as_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 4,
+    "nfu": "1"
+  },
+  "Standard_NV8as_v4": {
+    "up": "Standard_NV16as_v4",
+    "down": "Standard_NV4as_v4",
+    "superseded": null,
+    "vcpu": 8,
+    "nfu": "2"
+  },
+  "Standard_NV16as_v4": {
+    "up": "Standard_NV32as_v4",
+    "down": "Standard_NV8as_v4",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "4"
+  },
+  "Standard_NV32as_v4": {
+    "up": null,
+    "down": "Standard_NV16as_v4",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "8"
+  },
+  "Standard_NV12s_v3": {
+    "up": "Standard_NV24s_v3",
+    "down": null,
+    "superseded": null,
+    "vcpu": 12,
+    "nfu": "1"
+  },
+  "Standard_NV24s_v3": {
+    "up": "Standard_NV48s_v3",
+    "down": "Standard_NV12s_v3",
+    "superseded": null,
+    "vcpu": 24,
+    "nfu": "2"
+  },
+  "Standard_NV48s_v3": {
+    "up": null,
+    "down": "Standard_NV24s_v3",
+    "superseded": null,
+    "vcpu": 48,
+    "nfu": "4"
+  },
+  "Standard_NV6": {
+    "up": "Standard_NV12",
+    "down": null,
+    "superseded": {
+      "regular": "Standard_NV16as_v4"
+    },
+    "vcpu": 6,
+    "nfu": "1"
+  },
+  "Standard_NV12": {
+    "up": "Standard_NV24",
+    "down": "Standard_NV6",
+    "superseded": {
+      "regular": "Standard_NV32as_v4"
+    },
+    "vcpu": 12,
+    "nfu": "2"
+  },
+  "Standard_NV24": {
+    "up": null,
+    "down": "Standard_NV12",
+    "superseded": {
+      "regular": "Standard_NV48s_v3"
+    },
+    "vcpu": 24,
+    "nfu": "4"
+  },
+  "Standard_NV6ads_A10_v5": {
+    "up": "Standard_NV12ads_A10_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 6
+  },
+  "Standard_NV12ads_A10_v5": {
+    "up": "Standard_NV18ads_A10_v5",
+    "down": "Standard_NV6ads_A10_v5",
+    "superseded": null,
+    "vcpu": 12
+  },
+  "Standard_NV18ads_A10_v5": {
+    "up": "Standard_NV36ads_A10_v5",
+    "down": "Standard_NV12ads_A10_v5",
+    "superseded": null,
+    "vcpu": 18
+  },
+  "Standard_NV36ads_A10_v5": {
+    "up": "Standard_NV36adms_A10_v5",
+    "down": "Standard_NV18ads_A10_v5",
+    "superseded": null,
+    "vcpu": 36
+  },
+  "Standard_NV36adms_A10_v5": {
+    "up": "Standard_NV72ads_A10_v5",
+    "down": "Standard_NV36ads_A10_v5",
+    "superseded": null,
+    "vcpu": 36
+  },
+  "Standard_NV72ads_A10_v5": {
+    "up": null,
+    "down": "Standard_NV36adms_A10_v5",
+    "superseded": null,
+    "vcpu": 72
+  },
+  "Standard_NP10s": {
+    "up": "Standard_NP20s",
+    "down": null,
+    "superseded": null,
+    "vcpu": 10,
+    "nfu": "1"
+  },
+  "Standard_NP20s": {
+    "up": "Standard_NP40s",
+    "down": "Standard_NP10s",
+    "superseded": null,
+    "vcpu": 20,
+    "nfu": "2"
+  },
+  "Standard_NP40s": {
+    "up": null,
+    "down": "Standard_NP20s",
+    "superseded": null,
+    "vcpu": 40,
+    "nfu": "4"
+  },
+  "Standard_E2ads_v5": {
+    "up": "Standard_E4ads_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_E4ads_v5": {
+    "up": "Standard_E8ads_v5",
+    "down": "Standard_E2ads_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_E8ads_v5": {
+    "up": "Standard_E16ads_v5",
+    "down": "Standard_E4ads_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_E16ads_v5": {
+    "up": "Standard_E20ads_v5",
+    "down": "Standard_E8ads_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_E20ads_v5": {
+    "up": "Standard_E32ads_v5",
+    "down": "Standard_E16ads_v5",
+    "superseded": null,
+    "vcpu": 20
+  },
+  "Standard_E32ads_v5": {
+    "up": "Standard_E48ads_v5",
+    "down": "Standard_E20ads_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_E48ads_v5": {
+    "up": "Standard_E64ads_v5",
+    "down": "Standard_E32ads_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_E64ads_v5": {
+    "up": "Standard_E96ads_v5",
+    "down": "Standard_E48ads_v5",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_E96ads_v5": {
+    "up": "Standard_E112iads_v5",
+    "down": "Standard_E64ads_v5",
+    "superseded": null,
+    "vcpu": 96
+  },
+  "Standard_E112iads_v5": {
+    "up": null,
+    "down": "Standard_E96ads_v5",
+    "superseded": null,
+    "vcpu": 112
+  },
+  "Standard_NV6_Promo": {
+    "up": "Standard_NV12_Promo",
+    "down": null,
+    "superseded": {
+      "regular": "Standard_NV16as_v4"
+    },
+    "vcpu": 6,
+    "nfu": "1"
+  },
+  "Standard_NV12_Promo": {
+    "up": "Standard_NV24_Promo",
+    "down": "Standard_NV6_Promo",
+    "superseded": {
+      "regular": "Standard_NV32as_v4"
+    },
+    "vcpu": 12,
+    "nfu": "2"
+  },
+  "Standard_NV24_Promo": {
+    "up": null,
+    "down": "Standard_NV12_Promo",
+    "superseded": {
+      "regular": "Standard_NV48s_v3"
+    },
+    "vcpu": 24,
+    "nfu": "4"
+  },
+  "Standard_D2ds_v5": {
+    "up": "Standard_D4ds_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_D4ds_v5": {
+    "up": "Standard_D8ds_v5",
+    "down": "Standard_D2ds_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_D8ds_v5": {
+    "up": "Standard_D16ds_v5",
+    "down": "Standard_D4ds_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_D16ds_v5": {
+    "up": "Standard_D32ds_v5",
+    "down": "Standard_D8ds_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_D32ds_v5": {
+    "up": "Standard_D48ds_v5",
+    "down": "Standard_D16ds_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_D48ds_v5": {
+    "up": "Standard_D64ds_v5",
+    "down": "Standard_D32ds_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_D64ds_v5": {
+    "up": "Standard_D96ds_v5",
+    "down": "Standard_D48ds_v5",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_D96ds_v5": {
+    "up": null,
+    "down": "Standard_D64ds_v5",
+    "superseded": null,
+    "vcpu": 96
+  },
+  "Standard_M208ms_v2": {
+    "up": "Standard_M208s_v2",
+    "down": null,
+    "superseded": null,
+    "vcpu": 208,
+    "nfu": "1"
+  },
+  "Standard_M208s_v2": {
+    "up": "Standard_M416ms_v2",
+    "down": "Standard_M208ms_v2",
+    "superseded": null,
+    "vcpu": 208,
+    "nfu": "1"
+  },
+  "Standard_M416ms_v2": {
+    "up": "Standard_M416s_v2",
+    "down": "Standard_M208s_v2",
+    "superseded": null,
+    "vcpu": 416,
+    "nfu": "2"
+  },
+  "Standard_M416s_v2": {
+    "up": null,
+    "down": "Standard_M416ms_v2",
+    "superseded": null,
+    "vcpu": 416,
+    "nfu": "2"
+  },
+  "Standard_D2ads_v5": {
+    "up": "Standard_D4ads_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_D4ads_v5": {
+    "up": "Standard_D8ads_v5",
+    "down": "Standard_D2ads_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_D8ads_v5": {
+    "up": "Standard_D16ads_v5",
+    "down": "Standard_D4ads_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_D16ads_v5": {
+    "up": "Standard_D32ads_v5",
+    "down": "Standard_D8ads_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_D32ads_v5": {
+    "up": "Standard_D48ads_v5",
+    "down": "Standard_D16ads_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_D48ads_v5": {
+    "up": "Standard_D64ads_v5",
+    "down": "Standard_D32ads_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_D64ads_v5": {
+    "up": "Standard_D96ads_v5",
+    "down": "Standard_D48ads_v5",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_D96ads_v5": {
+    "up": null,
+    "down": "Standard_D64ads_v5",
+    "superseded": null,
+    "vcpu": 96
+  },
+  "Standard_FX4mds": {
+    "up": "Standard_FX12mds",
+    "down": null,
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_FX12mds": {
+    "up": "Standard_FX24mds",
+    "down": "Standard_FX4mds",
+    "superseded": null,
+    "vcpu": 12
+  },
+  "Standard_FX24mds": {
+    "up": "Standard_FX36mds",
+    "down": "Standard_FX12mds",
+    "superseded": null,
+    "vcpu": 24
+  },
+  "Standard_FX36mds": {
+    "up": "Standard_FX48mds",
+    "down": "Standard_FX24mds",
+    "superseded": null,
+    "vcpu": 36
+  },
+  "Standard_FX48mds": {
+    "up": null,
+    "down": "Standard_FX36mds",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_D2as_v5": {
+    "up": "Standard_D4as_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_D4as_v5": {
+    "up": "Standard_D8as_v5",
+    "down": "Standard_D2as_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_D8as_v5": {
+    "up": "Standard_D16as_v5",
+    "down": "Standard_D4as_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_D16as_v5": {
+    "up": "Standard_D32as_v5",
+    "down": "Standard_D8as_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_D32as_v5": {
+    "up": "Standard_D48as_v5",
+    "down": "Standard_D16as_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_D48as_v5": {
+    "up": "Standard_D64as_v5",
+    "down": "Standard_D32as_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_D64as_v5": {
+    "up": "Standard_D96as_v5",
+    "down": "Standard_D48as_v5",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_D96as_v5": {
+    "up": null,
+    "down": "Standard_D64as_v5",
+    "superseded": null,
+    "vcpu": 96
+  },
+  "Standard_HB120-16rs_v2": {
+    "up": "Standard_HB120-32rs_v2",
+    "down": null,
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_HB120-32rs_v2": {
+    "up": "Standard_HB120-64rs_v2",
+    "down": "Standard_HB120-16rs_v2",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_HB120-64rs_v2": {
+    "up": "Standard_HB120-96rs_v2",
+    "down": "Standard_HB120-32rs_v2",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_HB120-96rs_v2": {
+    "up": "Standard_HB120rs_v2",
+    "down": "Standard_HB120-64rs_v2",
+    "superseded": null,
+    "vcpu": 96
+  },
+  "Standard_HB120rs_v2": {
+    "up": null,
+    "down": "Standard_HB120-96rs_v2",
+    "superseded": null,
+    "vcpu": 120,
+    "nfu": "1"
+  },
+  "Standard_HB120rs_v3": {
+    "up": "Standard_HB120-96rs_v3",
+    "down": null,
+    "superseded": null,
+    "vcpu": 120,
+    "nfu": "1"
+  },
+  "Standard_HB120-96rs_v3": {
+    "up": "Standard_HB120-64rs_v3",
+    "down": "Standard_HB120rs_v3",
+    "superseded": null,
+    "vcpu": 96,
+    "nfu": "1"
+  },
+  "Standard_HB120-64rs_v3": {
+    "up": "Standard_HB120-32rs_v3",
+    "down": "Standard_HB120-96rs_v3",
+    "superseded": null,
+    "vcpu": 64,
+    "nfu": "1"
+  },
+  "Standard_HB120-32rs_v3": {
+    "up": "Standard_HB120-16rs_v3",
+    "down": "Standard_HB120-64rs_v3",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "1"
+  },
+  "Standard_HB120-16rs_v3": {
+    "up": null,
+    "down": "Standard_HB120-32rs_v3",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "1"
+  },
+  "Standard_HB176-24rs_v4": {
+    "up": "Standard_HB176-48rs_v4",
+    "down": null,
+    "superseded": null,
+    "vcpu": 24
+  },
+  "Standard_HB176-48rs_v4": {
+    "up": "Standard_HB176-96rs_v4",
+    "down": "Standard_HB176-24rs_v4",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_HB176-96rs_v4": {
+    "up": "Standard_HB176-144rs_v4",
+    "down": "Standard_HB176-48rs_v4",
+    "superseded": null,
+    "vcpu": 96
+  },
+  "Standard_HB176-144rs_v4": {
+    "up": "Standard_HB176rs_v4",
+    "down": "Standard_HB176-96rs_v4",
+    "superseded": null,
+    "vcpu": 144
+  },
+  "Standard_HB176rs_v4": {
+    "up": null,
+    "down": "Standard_HB176-144rs_v4",
+    "superseded": null,
+    "vcpu": 176
+  },
+  "Standard_HC44rs": {
+    "up": "Standard_HC44-16rs",
+    "down": null,
+    "superseded": null,
+    "vcpu": 44,
+    "nfu": "1"
+  },
+  "Standard_HC44-16rs": {
+    "up": "Standard_HC44-32rs",
+    "down": "Standard_HC44rs",
+    "superseded": null,
+    "vcpu": 16,
+    "nfu": "1"
+  },
+  "Standard_HC44-32rs": {
+    "up": null,
+    "down": "Standard_HC44-16rs",
+    "superseded": null,
+    "vcpu": 32,
+    "nfu": "1"
+  },
+  "Standard_HX176-24rs": {
+    "up": "Standard_HX176-48rs",
+    "down": null,
+    "superseded": null,
+    "vcpu": 24
+  },
+  "Standard_HX176-48rs": {
+    "up": "Standard_HX176-96rs",
+    "down": "Standard_HX176-24rs",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_HX176-96rs": {
+    "up": "Standard_HX176-144rs",
+    "down": "Standard_HX176-48rs",
+    "superseded": null,
+    "vcpu": 96
+  },
+  "Standard_HX176-144rs": {
+    "up": "Standard_HX176rs",
+    "down": "Standard_HX176-96rs",
+    "superseded": null,
+    "vcpu": 144
+  },
+  "Standard_HX176rs": {
+    "up": null,
+    "down": "Standard_HX176-144rs",
+    "superseded": null,
+    "vcpu": 176
+  },
+  "Standard_E2as_v5": {
+    "up": "Standard_E4as_v5",
+    "down": null,
+    "superseded": null,
+    "vcpu": 2
+  },
+  "Standard_E4as_v5": {
+    "up": "Standard_E8as_v5",
+    "down": "Standard_E2as_v5",
+    "superseded": null,
+    "vcpu": 4
+  },
+  "Standard_E8as_v5": {
+    "up": "Standard_E16as_v5",
+    "down": "Standard_E4as_v5",
+    "superseded": null,
+    "vcpu": 8
+  },
+  "Standard_E16as_v5": {
+    "up": "Standard_E20as_v5",
+    "down": "Standard_E8as_v5",
+    "superseded": null,
+    "vcpu": 16
+  },
+  "Standard_E20as_v5": {
+    "up": "Standard_E32as_v5",
+    "down": "Standard_E16as_v5",
+    "superseded": null,
+    "vcpu": 20
+  },
+  "Standard_E32as_v5": {
+    "up": "Standard_E48as_v5",
+    "down": "Standard_E20as_v5",
+    "superseded": null,
+    "vcpu": 32
+  },
+  "Standard_E48as_v5": {
+    "up": "Standard_E64as_v5",
+    "down": "Standard_E32as_v5",
+    "superseded": null,
+    "vcpu": 48
+  },
+  "Standard_E64as_v5": {
+    "up": "Standard_E96as_v5",
+    "down": "Standard_E48as_v5",
+    "superseded": null,
+    "vcpu": 64
+  },
+  "Standard_E96as_v5": {
+    "up": "Standard_E112ias_v5",
+    "down": "Standard_E64as_v5",
+    "superseded": null,
+    "vcpu": 96
+  },
+  "Standard_E112ias_v5": {
+    "up": null,
+    "down": "Standard_E96as_v5",
+    "superseded": null,
+    "vcpu": 112
   }
+}


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves below -->

- Added `"vcpu"` and `"nfu"` fields to instance type objects
- Formatted JSON document

### Issues Resolved

<!-- List any existing issues this PR resolves below -->
This unblocks the Azure Sustainability Report work, which requires vCPU counts to calculate normalized vCPU usage, which is in turn required for calculating Wattage.

This change will also bring the JSON file in line with its AWS counterpart here - https://github.com/flexera-public/policy_templates/blob/master/data/aws/instance_types.json

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
