### PR TITLE
POL 847 Policy Automated Updates on Releases 2

### DIFF
--- a/.github/workflows/generate-policy-release-notifications.yaml
+++ b/.github/workflows/generate-policy-release-notifications.yaml
@@ -51,6 +51,6 @@ jobs:
                 \"os\": \"default\",
                 \"uri\": \"${commit_url}\"
               }}
-            }]"
+            }]
           }"
           curl -X POST -H "Content-Type: application/json" -d "$payload" "$TEAMS_WEBHOOK_URL"

--- a/.github/workflows/generate-policy-release-notifications.yaml
+++ b/.github/workflows/generate-policy-release-notifications.yaml
@@ -47,10 +47,10 @@ jobs:
             \"potentialAction\": [{
               \"@type\": \"OpenUri\",
               \"name\": \"See full diff\",
-              \"targets\": {{
+              \"targets\": {
                 \"os\": \"default\",
                 \"uri\": \"${commit_url}\"
-              }}
+              }
             }]
           }"
           curl -X POST -H "Content-Type: application/json" -d "$payload" "$TEAMS_WEBHOOK_URL"

--- a/.github/workflows/generate-policy-release-notifications.yaml
+++ b/.github/workflows/generate-policy-release-notifications.yaml
@@ -43,6 +43,14 @@ jobs:
             \"@content\": \"http://schema.org/extensions\",
             \"themeColor\": \"0076D7\",
             \"summary\": \"New Policy Updates\",
-            \"sections\": ${notification_content}
+            \"sections\": ${notification_content},
+            \"potentialAction\": [{
+              \"@type\": \"OpenUri\",
+              \"name\": \"See full diff\",
+              \"targets\": [{
+                \"os\": \"default\",
+                \"uri\": \"${commit_url}\"
+              }]
+            }]
           }"
           curl -X POST -H "Content-Type: application/json" -d "$payload" "$TEAMS_WEBHOOK_URL"

--- a/.github/workflows/generate-policy-release-notifications.yaml
+++ b/.github/workflows/generate-policy-release-notifications.yaml
@@ -25,20 +25,32 @@ jobs:
       - name: Run Generate Policy Release Notification Content Script
         id: changelog_content
         run: |
-          changelog_output=$(ruby tools/policy_template_release_generation/generate_policy_release_notification_contents.rb)
-          echo "::set-output name=changelog_output::$changelog_output"
+          ruby tools/policy_template_release_generation/generate_policy_release_notification_contents.rb
+      # - name: Capture Outputs
+      #   run: |
+      #     echo "Section Content: ${{ steps.changelog_content.outputs.notification_content }}"
+      #     echo "Commit URL: ${{ steps.changelog_content.outputs.commit_url }}"
 
       - name: Send Teams Notification
-        if: steps.changelog_content.outputs.changelog_output != '[]'
+        if: steps.changelog_content.outputs.notification_content != '[]'
         env:
           TEAMS_WEBHOOK_URL: ${{ secrets.POLICY_CATALOG_UPDATE_TEAMS_WEBHOOK_URL }}
         run: |
-          notification_content="${{ steps.changelog_content.outputs.changelog_output }}"
+          notification_content="${{ steps.changelog_content.outputs.notification_content }}"
+          commit_url="${{ steps.changelog_content.outputs.commit_url }}"
           payload="{
             \"@type\": \"MessageCard\",
             \"@content\": \"http://schema.org/extensions\",
             \"themeColor\": \"0076D7\",
             \"summary\": \"New Policy Updates\",
-            \"sections\": ${notification_content}
+            \"sections\": ${notification_content},
+            \"potentialAction\": [{
+              \"@type\": \"OpenUri\",
+              \"name\": \"See full diff\",
+              \"targets\": {{
+                \"os\": \"default\",
+                \"uri\": \"${commit_url}\"
+              }}
+            }]"
           }"
           curl -X POST -H "Content-Type: application/json" -d "$payload" "$TEAMS_WEBHOOK_URL"

--- a/.github/workflows/generate-policy-release-notifications.yaml
+++ b/.github/workflows/generate-policy-release-notifications.yaml
@@ -43,14 +43,6 @@ jobs:
             \"@content\": \"http://schema.org/extensions\",
             \"themeColor\": \"0076D7\",
             \"summary\": \"New Policy Updates\",
-            \"sections\": ${notification_content},
-            \"potentialAction\": [{
-              \"@type\": \"OpenUri\",
-              \"name\": \"See full diff\",
-              \"targets\": {
-                \"os\": \"default\",
-                \"uri\": \"${commit_url}\"
-              }
-            }]
+            \"sections\": ${notification_content}
           }"
           curl -X POST -H "Content-Type: application/json" -d "$payload" "$TEAMS_WEBHOOK_URL"

--- a/.github/workflows/generate-readme-policy-table-of-contents.yaml
+++ b/.github/workflows/generate-readme-policy-table-of-contents.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - POL-8477-policy-automated-updates-on-releases-2
 
   # Workflow dispatch trigger allows manually running workflow
   workflow_dispatch:

--- a/.github/workflows/generate-readme-policy-table-of-contents.yaml
+++ b/.github/workflows/generate-readme-policy-table-of-contents.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - POL-8477-policy-automated-updates-on-releases-2
 
   # Workflow dispatch trigger allows manually running workflow
   workflow_dispatch:

--- a/tools/policy_template_release_generation/generate_policy_release_notification_contents.rb
+++ b/tools/policy_template_release_generation/generate_policy_release_notification_contents.rb
@@ -88,6 +88,5 @@ changelogs.each do |changelog|
 end
 
 # Output Notification Content as a JSON string to be used directly in YAML workflow file
-puts "Array: #{all_notification_content_array}"
 all_notification_content = JSON.generate(all_notification_content_array).gsub('"', '\\"').gsub('\\\"', '\\\\\\\\\\"')
 puts all_notification_content

--- a/tools/policy_template_release_generation/generate_policy_release_notification_contents.rb
+++ b/tools/policy_template_release_generation/generate_policy_release_notification_contents.rb
@@ -88,5 +88,6 @@ changelogs.each do |changelog|
 end
 
 # Output Notification Content as a JSON string to be used directly in YAML workflow file
-all_notification_content = JSON.generate(all_notification_content_array).gsub('"', '\\"')
+puts "Array: #{all_notification_content_array}"
+all_notification_content = JSON.generate(all_notification_content_array).gsub('"', '\\"').gsub('\\\"', '\\\\\\\\\\"')
 puts all_notification_content

--- a/tools/policy_template_release_generation/generate_policy_release_notification_contents.rb
+++ b/tools/policy_template_release_generation/generate_policy_release_notification_contents.rb
@@ -63,6 +63,10 @@ changelogs.each do |changelog|
   matching_template = policy_templates.find { |template| changelog.path.include?(File.dirname(template.path)) }
   if matching_template
 
+    # Capture directory path to create GitHub README URL
+    dir_path = File.dirname(matching_template.path)
+    readme_path = "https://github.com/flexera-public/policy_templates/tree/master/" + dir_path
+
     # Format HTML for Notification API call
     # Replace backticks around words with HTML code tags
     formatted_changes = changelog.changes.map do |change|
@@ -72,7 +76,7 @@ changelogs.each do |changelog|
     formatted_changes_html = formatted_changes.map { |change| "<li>#{change}</li>"}.join('')
 
     notification_content_json = {
-      activityTitle: "<h2 style='font-size: 18px;'>#{matching_template.name}</h2>",
+      activityTitle: "<h2 style='font-size: 18px;'><a href='#{readme_path}'>#{matching_template.name}</h2>",
       facts: [{
         name: "Template Version",
         value: changelog.version
@@ -89,4 +93,9 @@ end
 
 # Output Notification Content as a JSON string to be used directly in YAML workflow file
 all_notification_content = JSON.generate(all_notification_content_array).gsub('"', '\\"').gsub('\\\"', '\\\\\\\\\\"')
-puts all_notification_content
+puts "::set-output name=notification_content::#{all_notification_content}"
+
+# Output GitHub Commit URL to be used directly in YAML workflow file
+previous_commit_id = `git rev-parse origin/master^`
+commit_path = "https://github.com/flexera-public/policy_templates/commit/" + previous_commit_id
+puts "::set-output name=commit_url::#{commit_path}"

--- a/tools/policy_template_release_generation/generate_policy_release_notification_contents.rb
+++ b/tools/policy_template_release_generation/generate_policy_release_notification_contents.rb
@@ -96,6 +96,6 @@ all_notification_content = JSON.generate(all_notification_content_array).gsub('"
 puts "::set-output name=notification_content::#{all_notification_content}"
 
 # Output GitHub Commit URL to be used directly in YAML workflow file
-previous_commit_id = `git rev-parse origin/master^`
-commit_path = "https://github.com/flexera-public/policy_templates/commit/" + previous_commit_id
+commit_id = `git rev-parse origin/master`
+commit_path = "https://github.com/flexera-public/policy_templates/commit/" + commit_id
 puts "::set-output name=commit_url::#{commit_path}"


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves below -->
Enhanced the GitHub Actions Workflow so that the Teams Notification now has the following:

- A hyperlink for each Policy Template Heading that takes the user to the Policy Template's README file.
- A hyperlink for a 'See full diff' action, which takes the user to the Commit details in GitHub, to view the full diff.

### Issues Resolved

<!-- List any existing issues this PR resolves below -->
N/A

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->
N/A

### Contribution Check List

- [x] New functionality includes testing.
