### PR TITLE
POL-911 AWS Long Running Instances Revamp

### DIFF
--- a/operational/aws/long_running_instances/CHANGELOG.md
+++ b/operational/aws/long_running_instances/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Policy no longer raises new escalations for the same resource if incidental metadata has changed
 - Streamlined code for better readability and faster execution
 - Added logic required for "Meta Policy" use-cases
+- Policy now requires a valid Flexera credential to facilitate "Meta Policy" use-cases
 
 ## v3.0
 

--- a/operational/aws/long_running_instances/CHANGELOG.md
+++ b/operational/aws/long_running_instances/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v4.0
+
+- Several parameters altered to be more descriptive and human-readable
+- Removed deprecated "Log to CM Audit Entries" parameter
+- Added ability to filter resources by multiple tag key:value pairs
+- Added several fields to incident export to provide additional context
+- Normalized incident export to be consistent with other policies
+- Policy no longer raises new escalations for the same resource if incidental metadata has changed
+- Streamlined code for better readability and faster execution
+- Added logic required for "Meta Policy" use-cases
+
 ## v3.0
 
 - Added parameter to enable Allow or Deny filtering by user entered regions

--- a/operational/aws/long_running_instances/CHANGELOG.md
+++ b/operational/aws/long_running_instances/CHANGELOG.md
@@ -10,8 +10,8 @@
 - Normalized incident export to be consistent with other policies
 - Policy no longer raises new escalations for the same resource if incidental metadata has changed
 - Streamlined code for better readability and faster execution
+- Policy now requires a valid Flexera credential
 - Added logic required for "Meta Policy" use-cases
-- Policy now requires a valid Flexera credential to facilitate "Meta Policy" use-cases
 
 ## v3.0
 

--- a/operational/aws/long_running_instances/CHANGELOG.md
+++ b/operational/aws/long_running_instances/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Removed deprecated "Log to CM Audit Entries" parameter
 - Added ability to filter resources by multiple tag key:value pairs
 - Added several fields to incident export to provide additional context
+- Added additional context to incident description
 - Normalized incident export to be consistent with other policies
 - Policy no longer raises new escalations for the same resource if incidental metadata has changed
 - Streamlined code for better readability and faster execution

--- a/operational/aws/long_running_instances/README.md
+++ b/operational/aws/long_running_instances/README.md
@@ -2,78 +2,78 @@
 
 ## What It Does
 
-This policy checks for running instances that have been running longer than the `Days Old` parameter. It will then take the appropriate action(Stop/Terminate) on the instance.
+This policy checks for running instances that have been running longer than the `Minimum Age (Days)` parameter. It will then take the appropriate action (Stop/Terminate) on the instance.
 
 ## Functional Description
 
-- This policy identifies all instances that have been running longer than the `Days Old` parameter.
+- This policy identifies all instances that have been running longer than the `Minimum Age (Days)` parameter.
 
 ## Input Parameters
 
 This policy template has the following Input parameters which require value before
 the policy can be applied.
 
-- *Allowed/Denied Regions* - Whether to treat regions parameter as allow or deny list.
-- *Regions* - A list of regions to allow or deny for an AWS account. Please enter the regions code if SCP is enabled, see [Available Regions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) in AWS; otherwise, the policy may fail on regions that are disabled via SCP. Leave blank to consider all the regions.
-- *Email notify list* - Email addresses of the recipients you wish to notify.
-- *Account Number* - The Account number for use with the AWS STS Cross Account Role. Leave blank when using AWS IAM Access key and secret. It only needs to be passed when the desired AWS account is different than the one associated with the Flexera One credential. [more](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1123608)
-- *Days Old* - Number of days to be running before included in list.
-- *Exclusion Tag Key:Value* - Cloud native tag key to ignore instances. Format: Key:Value
-- *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).
+- *Email addresses to notify* - Email addresses of the recipients you wish to notify when new incidents are created.
+- *Account Number* - The Account number for use with the AWS STS Cross Account Role. Leave blank when using AWS IAM Access key and secret. It only needs to be passed when the desired AWS account is different than the one associated with the Flexera One credential. [More information is available in our documentation.](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1123608)
+- *Minimum Age (Days)* - The minimum age, in days, to consider an instance to be long running.
+- *Allow/Deny Regions* - Whether to treat Allow/Deny Regions List parameter as allow or deny list. Has no effect if Allow/Deny Regions List is left empty.
+- *Allow/Deny Regions List* - A list of regions to allow or deny for an AWS account. Please enter the regions code if SCP is enabled. See [Available Regions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) in AWS; otherwise, the policy may fail on regions that are disabled via SCP. Leave blank to consider all the regions.
+- *Exclusion Tags (Key:Value)* - Cloud native tags to ignore resources that you don't want to produce recommendations for. Use Key:Value format for specific tag key/value pairs, and Key:\* format to match any resource with a particular key, regardless of value. Examples: env:production, DO_NOT_DELETE:\*
+- *Automatic Actions* - The policy will automatically take the selected action.
 
-Please note that the "Automatic Actions" parameter contains a list of action(s) that can be performed on the resources. When it is selected, the policy will automatically execute the corresponding action on the data that failed the checks, post incident generation. Please leave it blank for *manual* action.
-For example if a user selects the "Stop Instances" action while applying the policy, all the instances that didn't satisfy the policy condition will be stopped.
+Please note that the "Automatic Actions" parameter contains a list of actions that can be performed on the resources. When it is selected, the policy will automatically execute the corresponding action on the data that failed the checks, post incident generation. Please leave this parameter set to "No Automatic Actions" for *manual* action.
+For example if a user selects the "Terminate Instances" action while applying the policy, all the resources that didn't satisfy the policy condition will be terminated.
 
 ## Policy Actions
 
-Policy actions may include automation to alert or remediate violations found in the
-Policy Incident. Actions that destroy or terminate a resource generally require
-approval from the Policy Approver. This policy includes the following actions.
-
 - Sends an email notification
-- Stop the instance
-- Terminate the instance
+- Stop virtual machines after approval
+- Terminate virtual machines after approval
 
 ## Prerequisites
 
-This policy uses [credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm)
-for connecting to the cloud -- in order to apply this policy you must have a
-credential registered in the system that is compatible with this policy. If
-there are no credentials listed when you apply the policy, please contact your
-cloud admin and ask them to register a credential that is compatible with this
-policy. The information below should be consulted when creating the credential.
+This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).
 
 ### Credential configuration
 
-For administrators [creating and managing credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm)
-to use with this policy, the following information is needed:
+For administrators [creating and managing credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) to use with this policy, the following information is needed:
 
-Provider tag value to match this policy: `aws` , `aws_sts`
+- [**AWS Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1121575) (*provider=aws*) which has the following permissions:
+  - `ec2:DescribeRegions`
+  - `ec2:DescribeInstances`
+  - `ec2:DescribeInstanceStatus`*
+  - `ec2:StopInstances`*
+  - `ec2:TerminateInstances`*
+  - `sts:GetCallerIdentity`
 
-Required permissions in the provider:
+\* Only required for taking action (stopping or terminating instances); the policy will still function in a read-only capacity without these permissions.
 
-```javascript
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:StartInstances",
-                "ec2:StopInstances",
-                "ec2:TerminateInstances"
-            ],
-            "Resource": "arn:aws:ec2:*:*:instance/*",
-        },
-        {
-            "Effect": "Allow",
-            "Action": ["ec2:DescribeInstances",
-                        "ec2:DescribeRegions"]
-            "Resource": "*"
-        }
-    ]
-}
-```
+  Example IAM Permission Policy:
+
+  ```json
+  {
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "ec2:DescribeRegions",
+                  "ec2:DescribeInstances",
+                  "ec2:DescribeInstanceStatus",
+                  "ec2:StopInstances",
+                  "ec2:TerminateInstances",
+                  "sts:GetCallerIdentity"
+              ],
+              "Resource": "*"
+          }
+      ]
+  }
+  ```
+
+- [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
+  - `billing_center_viewer`
+
+The [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) page in the docs has detailed instructions for setting up Credentials for the most common providers.
 
 ## Supported Clouds
 

--- a/operational/aws/long_running_instances/long_running_instances.pt
+++ b/operational/aws/long_running_instances/long_running_instances.pt
@@ -645,7 +645,7 @@ script "js_long_running_instances_incident", type: "javascript" do
     id = item['id'].toLowerCase()
 
     if (ds_instance_costs_grouped[id] != undefined) {
-      instance['cost'] = ds_instance_costs_grouped[id]['cost']
+      instance['cost'] = Number(ds_instance_costs_grouped[id]['cost'].toFixed(3))
       instance['operating_system'] = ds_instance_costs_grouped[id]['operating_system']
       instance['billing_center'] = ds_instance_costs_grouped[id]['billing_center']
       instance['purchase_option'] = ds_instance_costs_grouped[id]['purchase_option']

--- a/operational/aws/long_running_instances/long_running_instances.pt
+++ b/operational/aws/long_running_instances/long_running_instances.pt
@@ -641,7 +641,7 @@ script "js_long_running_instances_incident", type: "javascript" do
     if (ds_instance_costs_grouped[id] != undefined) {
       instance['cost'] = ds_instance_costs_grouped[id]['cost']
       instance['operating_system'] = ds_instance_costs_grouped[id]['operating_system']
-      instance['billing_center_id'] = ds_instance_costs_grouped[id]['billing_center_id']
+      instance['billing_center'] = ds_instance_costs_grouped[id]['billing_center_id']
       instance['purchase_option'] = ds_instance_costs_grouped[id]['purchase_option']
       instance['service'] = ds_instance_costs_grouped[id]['service']
     }
@@ -661,7 +661,8 @@ policy "pol_utilization" do
     escalate $esc_email
     escalate $esc_stop_instances
     escalate $esc_terminate_instances
-    check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
+    check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
+    hash_exclude "tags", "cost", "costCurrency", "resourceName", "age", "billing_center", "hostname", "ipAddress", "ipv6Address"
     export do
       resource_level true
       field "accountID" do
@@ -691,8 +692,17 @@ policy "pol_utilization" do
       field "platform" do
         label "Platform"
       end
+      field "operating_system" do
+        label "Operating System"
+      end
       field "hostname" do
         label "Hostname"
+      end
+      field "ipAddress" do
+        label "IP Address"
+      end
+      field "ipv6Address" do
+        label "IPv6 Address"
       end
       field "cost" do
         label "Estimated Monthly Cost"
@@ -702,6 +712,12 @@ policy "pol_utilization" do
       end
       field "launchTime" do
         label "Launch Time"
+      end
+      field "purchase_option" do
+        label "Purchase Option"
+      end
+      field "billing_center" do
+        label "Billing Center"
       end
       field "lookbackPeriod" do
         label "Look Back Period (Days)"
@@ -912,7 +928,6 @@ datasource "ds_get_policy" do
     field "id", jmes_path(response, "id")
   end
 end
-
 
 datasource "ds_parent_policy_terminated" do
   run_script $js_decide_if_self_terminate, $ds_get_policy, policy_id, meta_parent_policy_id

--- a/operational/aws/long_running_instances/long_running_instances.pt
+++ b/operational/aws/long_running_instances/long_running_instances.pt
@@ -570,13 +570,19 @@ EOS
 end
 
 datasource "ds_instance_costs_grouped" do
-  run_script $js_instance_costs_grouped, $ds_instance_costs
+  run_script $js_instance_costs_grouped, $ds_instance_costs, $ds_billing_centers
 end
 
 script "js_instance_costs_grouped", type: "javascript" do
-  parameters "ds_instance_costs"
+  parameters "ds_instance_costs", "ds_billing_centers"
   result "result"
   code <<-EOS
+  bc_object = {}
+
+  _.each(ds_billing_centers, function(bc) {
+    bc_object[bc['id']] = bc['name']
+  })
+
   // Multiple a single day's cost by the average number of days in a month.
   // The 0.25 is to account for leap years for extra precision.
   cost_multiplier = 365.25 / 12
@@ -591,7 +597,7 @@ script "js_instance_costs_grouped", type: "javascript" do
 
     result[id]['cost'] += item['cost'] * cost_multiplier
     result[id]['operating_system'] = item['operating_system']
-    result[id]['billing_center_id'] = item['billing_center_id']
+    result[id]['billing_center'] = bc_object[item['billing_center_id']]
     result[id]['purchase_option'] = item['purchase_option']
     result[id]['service'] = item['service']
   })
@@ -641,7 +647,7 @@ script "js_long_running_instances_incident", type: "javascript" do
     if (ds_instance_costs_grouped[id] != undefined) {
       instance['cost'] = ds_instance_costs_grouped[id]['cost']
       instance['operating_system'] = ds_instance_costs_grouped[id]['operating_system']
-      instance['billing_center'] = ds_instance_costs_grouped[id]['billing_center_id']
+      instance['billing_center'] = ds_instance_costs_grouped[id]['billing_center']
       instance['purchase_option'] = ds_instance_costs_grouped[id]['purchase_option']
       instance['service'] = ds_instance_costs_grouped[id]['service']
     }

--- a/operational/aws/long_running_instances/long_running_instances.pt
+++ b/operational/aws/long_running_instances/long_running_instances.pt
@@ -1,14 +1,15 @@
 name "AWS Long Running Instances"
 rs_pt_ver 20180301
 type "policy"
-short_description "Checks for running instances that have been running longer than the `Days Old` parameter. See the [README](https://github.com/flexera-public/policy_templates/tree/master/operational/aws/long_running_instances/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "Checks for instances that have been running longer than the `Minimum Age (Days)` parameter. See the [README](https://github.com/flexera-public/policy_templates/tree/master/operational/aws/long_running_instances/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
-severity "low"
 category "Operational"
+severity "low"
+default_frequency "weekly"
 info(
-  version: "3.0",
+  version: "4.0",
   provider: "AWS",
-  service: "EC2",
+  service: "Compute",
   policy_set: "Long Running Instances"
 )
 
@@ -16,75 +17,100 @@ info(
 # Parameters
 ###############################################################################
 
-parameter "param_allowed_regions_allow_or_deny" do
+parameter "param_email" do
+  type "list"
+  category "Policy Settings"
+  label "Email addresses to notify"
+  description "Email addresses of the recipients you wish to notify when new incidents are created"
+  default []
+end
+
+parameter "param_aws_account_number" do
   type "string"
+  category "Policy Settings"
+  label "Account Number"
+  description "The account number for AWS STS Cross Account Roles."
+  default ""
+end
+
+parameter "param_regions_allow_or_deny" do
+  type "string"
+  category "Filters"
   label "Allow/Deny Regions"
   description "Allow or Deny entered regions. See the README for more details"
   allowed_values "Allow", "Deny"
   default "Allow"
 end
 
-parameter "param_allowed_regions" do
+parameter "param_regions_list" do
   type "list"
-  label "Regions"
+  category "Filters"
+  label "Allow/Deny Regions List"
   allowed_pattern /^([a-zA-Z-_]+-[a-zA-Z0-9-_]+-[0-9-_]+,*|)+$/
   description "A list of allowed or denied regions. See the README for more details"
+  default []
 end
 
-parameter "param_email" do
-  type "list"
-  label "Email notify list"
-  description "Email addresses of the recipients you wish to notify when new incidents are created"
-end
-
-parameter "param_aws_account_number" do
-  type "string"
-  label "Account Number"
-  description "The account number for AWS STS Cross Account Roles."
-  default ""
-end
-
-parameter "param_days_old" do
+parameter "param_minimum_age" do
   type "number"
-  label "Days Old"
-  description "Number of days to be running before included in list"
+  category "Policy Settings"
+  label "Minimum Age (Days)"
+  description "The minimum age, in days, to consider an instance to be long running"
   default 180
+  min_value 0
 end
 
-parameter "param_exclude_tags" do
-  category "User Inputs"
-  label "Exclusion Tag Key:Value"
-  description "Cloud native tag key to ignore instances. Format: Key:Value"
+parameter "param_exclusion_tags" do
   type "list"
-  allowed_pattern /(^$)|([\w]?)+\:([\w]?)+/
+  category "Filters"
+  label "Exclusion Tags (Key:Value)"
+  description "Cloud native tags to ignore resources that you don't want to produce recommendations for. Use Key:Value format for specific tag key/value pairs, and Key:* format to match any resource with a particular key, regardless of value. Examples: env:production, DO_NOT_DELETE:*"
+  allowed_pattern /(^$)|[\w]*\:.*/
+  default []
 end
 
 parameter "param_automatic_action" do
   type "string"
+  category "Actions"
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
-  default "Select Action"
-  allowed_values "Select Action","Stop Instances", "Terminate Instances"
+  default "No Automatic Actions"
+  allowed_values "No Automatic Actions", "Stop Instances", "Terminate Instances"
 end
 
 ###############################################################################
 # Authentication
 ###############################################################################
 
-#authenticate with AWS
 credentials "auth_aws" do
-  schemes "aws","aws_sts"
+  schemes "aws", "aws_sts"
   label "AWS"
   description "Select the AWS Credential from the list"
   tags "provider=aws"
   aws_account_number $param_aws_account_number
 end
 
+credentials "auth_flexera" do
+  schemes "oauth2"
+  label "Flexera"
+  description "Select Flexera One OAuth2 credentials"
+  tags "provider=flexera"
+end
+
 ###############################################################################
 # Pagination
 ###############################################################################
 
-pagination "aws_pagination_xml" do
+pagination "pagination_aws" do
+  get_page_marker do
+    body_path jmes_path(response, "NextToken")
+  end
+  set_page_marker do
+    body_field "NextToken"
+  end
+end
+
+pagination "pagination_aws_xml" do
   get_page_marker do
     body_path "//DescribeInstancesResponse/nextToken"
   end
@@ -94,14 +120,203 @@ pagination "aws_pagination_xml" do
 end
 
 ###############################################################################
-# Datasources
+# Datasources & Scripts
 ###############################################################################
 
-# ds_region_list is a list of regions that are opted-in or opt-in-not-required
-datasource "ds_regions_list" do
-  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+# Get applied policy metadata for use later
+datasource "ds_applied_policy" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    header "Api-Version", "1.0"
+  end
+end
+
+
+# Get region-specific Flexera API endpoints
+datasource "ds_flexera_api_hosts" do
+  run_script $js_flexera_api_hosts, rs_optima_host
+end
+
+script "js_flexera_api_hosts", type: "javascript" do
+  parameters "rs_optima_host"
+  result "result"
+  code <<-EOS
+  host_table = {
+    "api.optima.flexeraeng.com": {
+      flexera: "api.flexera.com",
+      fsm: "api.fsm.flexeraeng.com"
+    },
+    "api.optima-eu.flexeraeng.com": {
+      flexera: "api.flexera.eu",
+      fsm: "api.fsm-eu.flexeraeng.com"
+    },
+    "api.optima-au.flexeraeng.com": {
+      flexera: "api.flexera.au",
+      fsm: "api.fsm-au.flexeraeng.com"
+    }
+  }
+
+  result = host_table[rs_optima_host]
+EOS
+end
+
+# Get AWS account info
+datasource "ds_cloud_vendor_accounts" do
+  request do
+    auth $auth_flexera
+    host val($ds_flexera_api_hosts, 'flexera')
+    path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "values[*]") do
+      field "id", jmes_path(col_item, "aws.accountId")
+      field "name", jmes_path(col_item, "name")
+      field "tags", jmes_path(col_item, "tags")
+    end
+  end
+end
+
+datasource "ds_get_caller_identity" do
   request do
     auth $auth_aws
+    verb "GET"
+    host "sts.amazonaws.com"
+    path "/"
+    header "User-Agent", "RS Policies"
+    query "Action", "GetCallerIdentity"
+    query "Version", "2011-06-15"
+  end
+  result do
+    encoding "xml"
+    collect xpath(response, "//GetCallerIdentityResponse/GetCallerIdentityResult") do
+      field "account", xpath(col_item, "Account")
+    end
+  end
+end
+
+datasource "ds_aws_account" do
+  run_script $js_aws_account, $ds_cloud_vendor_accounts, $ds_get_caller_identity
+end
+
+script "js_aws_account", type:"javascript" do
+  parameters "ds_cloud_vendor_accounts", "ds_get_caller_identity"
+  result "result"
+  code <<-EOS
+  result = _.find(ds_cloud_vendor_accounts, function(account) {
+    return account['id'] == ds_get_caller_identity[0]['account']
+  })
+
+  // This is in case the API does not return the relevant account info
+  if (result == undefined) {
+    result = {
+      id: ds_get_caller_identity[0]['account'],
+      name: "",
+      tags: {}
+    }
+  }
+EOS
+end
+
+datasource "ds_billing_centers" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/analytics/orgs/", rs_org_id, "/billing_centers"])
+    header "Api-Version", "1.0"
+    header "User-Agent", "RS Policies"
+    query "view", "allocation_table"
+    ignore_status [403]
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "href", jmes_path(col_item, "href")
+      field "id", jmes_path(col_item, "id")
+      field "name", jmes_path(col_item, "name")
+      field "parent_id", jmes_path(col_item, "parent_id")
+    end
+  end
+end
+
+# Gather top level billing center IDs for when we pull cost data
+datasource "ds_top_level_bcs" do
+  run_script $js_top_level_bcs, $ds_billing_centers
+end
+
+script "js_top_level_bcs", type: "javascript" do
+  parameters "ds_billing_centers"
+  result "result"
+  code <<-EOS
+  filtered_bcs = _.filter(ds_billing_centers, function(bc) {
+    return bc['parent_id'] == null || bc['parent_id'] == undefined
+  })
+
+  result = _.compact(_.pluck(filtered_bcs, 'id'))
+EOS
+end
+
+datasource "ds_currency_reference" do
+  request do
+    host "raw.githubusercontent.com"
+    path "/rightscale/policy_templates/master/cost/scheduled_reports/currency_reference.json"
+    header "User-Agent", "RS Policies"
+  end
+end
+
+datasource "ds_currency_code" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/bill-analysis/orgs/", rs_org_id, "/settings/currency_code"])
+    header "Api-Version", "0.1"
+    header "User-Agent", "RS Policies"
+    ignore_status [403]
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+    field "value", jmes_path(response, "value")
+  end
+end
+
+datasource "ds_currency" do
+  run_script $js_currency, $ds_currency_reference, $ds_currency_code
+end
+
+script "js_currency", type:"javascript" do
+  parameters "ds_currency_reference", "ds_currency_code"
+  result "result"
+  code <<-EOS
+  symbol = "$"
+  separator = ","
+
+  if (ds_currency_code['value'] != undefined) {
+    if (ds_currency_reference[ds_currency_code['value']] != undefined) {
+      symbol = ds_currency_reference[ds_currency_code['value']]['symbol']
+
+      if (ds_currency_reference[ds_currency_code['value']]['t_separator'] != undefined) {
+        separator = ds_currency_reference[ds_currency_code['value']]['t_separator']
+      } else {
+        separator = ""
+      }
+    }
+  }
+
+  result = {
+    symbol: symbol,
+    separator: separator
+  }
+EOS
+end
+
+datasource "ds_describe_regions" do
+  request do
+    auth $auth_aws
+    pagination $pagination_aws_xml
     verb "GET"
     host "ec2.amazonaws.com"
     path "/"
@@ -110,6 +325,9 @@ datasource "ds_regions_list" do
     query "Filter.1.Name", "opt-in-status"
     query "Filter.1.Value.1", "opt-in-not-required"
     query "Filter.1.Value.2", "opted-in"
+    # Header X-Meta-Flexera has no affect on datasource query, but is required for Meta Policies
+    # Forces `ds_is_deleted` datasource to run first during policy execution
+    header "Meta-Flexera", val($ds_is_deleted, "path")
   end
   result do
     encoding "xml"
@@ -119,29 +337,39 @@ datasource "ds_regions_list" do
   end
 end
 
-# Get only SCP enabled regions
 datasource "ds_regions" do
-  run_script $js_regions, $param_allowed_regions, $ds_regions_list, $param_allowed_regions_allow_or_deny
+  run_script $js_regions, $ds_describe_regions, $param_regions_list, $param_regions_allow_or_deny
 end
 
-datasource "ds_instances" do
-  run_script $js_instances, $ds_instances_set, $param_exclude_tags
+script "js_regions", type:"javascript" do
+  parameters "ds_describe_regions", "param_regions_list", "param_regions_allow_or_deny"
+  result "result"
+  code <<-EOS
+  allow_deny_test = { "Allow": true, "Deny": false }
+
+  if (param_regions_list.length > 0) {
+    result = _.filter(ds_describe_regions, function(item) {
+      return _.contains(param_regions_list, item['region']) == allow_deny_test[param_regions_allow_or_deny]
+    })
+  } else {
+    result = ds_describe_regions
+  }
+EOS
 end
 
-datasource "ds_instances_set" do
+datasource "ds_instance_sets" do
   iterate $ds_regions
   request do
-    verb "GET"
     auth $auth_aws
-    pagination $aws_pagination_xml
-    host join(["ec2.", val(iter_item, "region"), ".amazonaws.com"])
-    path "/"
+    pagination $pagination_aws_xml
+    host join(['ec2.', val(iter_item, 'region'), '.amazonaws.com'])
+    path '/'
+    header 'User-Agent', 'RS Policies'
+    header 'Content-Type', 'text/xml'
     query "Action", "DescribeInstances"
     query "Version", "2016-11-15"
-    query "Filter.1.Name", "instance-state-name"
-    query "Filter.1.Value.1", "running"
-    header "User-Agent", "RS Policies"
-    header "Content-Type", "text/xml"
+    query 'Filter.1.Name', 'instance-state-name'
+    query 'Filter.1.Value.1', 'running'
   end
   result do
     encoding "xml"
@@ -149,16 +377,18 @@ datasource "ds_instances_set" do
       field "instances_set" do
         collect xpath(col_item,"instancesSet/item","array") do
           field "region",val(iter_item, "region")
-          field "instanceId", xpath(col_item,"instanceId")
-          field "imageId", xpath(col_item,"imageId")
-          field "instanceType", xpath(col_item, "instanceType")
-          field "platform", xpath(col_item, "platform")
+          field "instanceId", xpath(col_item, "instanceId")
+          field "ipAddress", xpath(col_item, "ipAddress")
+          field "ipv6Address", xpath(col_item, "ipv6Address")
+          field "imageId", xpath(col_item, "imageId")
+          field "resourceType", xpath(col_item, "instanceType")
+          field "platform", xpath(col_item, "platformDetails")
           field "privateDnsName", xpath(col_item, "privateDnsName")
           field "launchTime", xpath(col_item, "launchTime")
           field "tags" do
-            collect xpath(col_item,"tagSet/item","array") do
-              field "tagKey", xpath(col_item, "key")
-              field "tagValue", xpath(col_item, "value")
+            collect xpath(col_item,"tagSet/item", "array") do
+              field "key", xpath(col_item, "key")
+              field "value", xpath(col_item, "value")
             end
           end
         end
@@ -167,107 +397,257 @@ datasource "ds_instances_set" do
   end
 end
 
-###############################################################################
-# Scripts
-###############################################################################
-
-script "js_regions", type:"javascript" do
-  parameters "user_entered_regions", "all_regions", "regions_allow_or_deny"
-  result "regions"
-  code <<-EOS
-    if(_.isEmpty(user_entered_regions)){
-      regions = all_regions;
-    }else{
-      //Filter unique regions
-      var uniqueRegions = _.uniq(user_entered_regions);
-      var all_regions_list = [];
-      //Filter and remove denied regions from all_regions
-      if (regions_allow_or_deny == "Deny"){
-        var all_regions = all_regions.filter(function(obj){
-          return user_entered_regions.indexOf(obj.region) === -1;
-        });
-      }
-      all_regions.forEach(function(all_region){
-        all_regions_list.push(all_region.region)
-      })
-      //Filter valid regions
-      var valid_regions = [];
-      _.map(uniqueRegions, function(uniqueRegion){
-        if(all_regions_list.indexOf(uniqueRegion) > -1){
-          valid_regions.push({"region": uniqueRegion})
-        }
-      })
-
-      //Throw an error if no valid regions found
-      if (_.isEmpty(valid_regions)) {
-        regions = all_regions;
-      }else{
-        regions = valid_regions
-      }
-    }
-  EOS
+datasource "ds_instances" do
+  run_script $js_instances, $ds_instance_sets, $param_exclusion_tags
 end
 
 script "js_instances", type: "javascript" do
-  result "results"
-  parameters "ds_instance_set", "param_exclude_tags"
+  parameters "ds_instance_sets", "param_exclusion_tags"
+  result "result"
   code <<-EOS
+  result = []
 
-  var param_exclude_tags_lower=[];
-  for(var j=0;j<param_exclude_tags.length;j++){
-    param_exclude_tags_lower[j] = param_exclude_tags[j].toString().toLowerCase();
-  }
-  var results = []
-  for ( n=0; n < ds_instance_set.length; n++) {
-    var instance_set = ds_instance_set[n].instances_set
-    for ( i=0; i < instance_set.length; i++) {
-      var instance = instance_set[i]
-      // Check, if the tag present in entered param_exclude_tags, ignore the volume if the tag matches/present.
-      var tags = instance['tags'];
-      var isTagMatched = false;
-      var tagKeyValue = "";
-      for(var k=0; k < tags.length; k++){
-        tag = tags[k];
-        if((param_exclude_tags_lower.indexOf((tag['tagKey']).toLowerCase()) !== -1) || (param_exclude_tags_lower.indexOf((tag['tagKey']+':'+tag['tagValue']).toLowerCase()) !== -1)){
-          isTagMatched = true;
+  _.each(ds_instance_sets, function(item) {
+    if (param_exclusion_tags.length > 0) {
+      filtered_instances = _.reject(item['instances_set'], function(instance) {
+        instance_tags = []
+
+        if (instance['tags'] != null && instance['tags'] != undefined) {
+          _.each(instance['tags'], function(tag) {
+            instance_tags.push([tag['key'], tag['value']].join(':'))
+            instance_tags.push([tag['key'], '*'].join(':'))
+          })
         }
-        // Constructing tags with comma separated to display in detail_template
-        if((tag['tagValue']).length > 0){
-          tagKeyValue = tagKeyValue+" , "+tag['tagKey']+'='+tag['tagValue'];
-        }else{
-          tagKeyValue = tagKeyValue+" , "+tag['tagKey'];
-        }
-      }
-      var instance_tags = "";
-      _.each(tags, function(tag){
-        instance_tags = instance_tags + tag.tagKey+" : "+tag.tagValue+", ";
+
+        exclude_instance = false
+
+        _.each(param_exclusion_tags, function(exclusion_tag) {
+          if (_.contains(instance_tags, exclusion_tag)) {
+            exclude_instance = true
+          }
+        })
+
+        return exclude_instance
       })
 
-      if(instance_tags.length > 0){
-        instance_tags = instance_tags.substring(0, instance_tags.length - 2);
-      }
-
-      if(!(isTagMatched)){
-        var now = new Date()
-        var one_day=1000*60*60*24
-        var launchTime = new Date(instance.launchTime)
-        var difference = now.getTime() - launchTime.getTime()
-        var days_old=(difference/one_day).toFixed(2)
-        instance["hostname"] = instance.privateDnsName.split('.')[0]
-        instance["instance_tags"] = instance_tags
-        instance["days_old"] = days_old
-        results.push(instance)
-      }
+      result = result.concat(filtered_instances)
+    } else {
+      result = result.concat(item['instances_set'])
     }
-  }
+  })
+EOS
+end
 
-  results = _(results)
-    .chain()
-    .sortBy(function(result){
-      return result.region;
-    }).sortBy(function(result){
-      return result.instanceType;
-    }).value();
+datasource "ds_long_running_instances" do
+  run_script $js_long_running_instances, $ds_instances, $ds_aws_account, $param_minimum_age
+end
+
+script "js_long_running_instances", type: "javascript" do
+  parameters "ds_instances", "ds_aws_account", "param_minimum_age"
+  result "result"
+  code <<-EOS
+  result = []
+
+  _.each(ds_instances, function(instance) {
+    now = new Date()
+    launchTime = new Date(instance['launchTime'])
+    difference = now.getTime() - launchTime.getTime()
+    age = difference / (1000 * 60 * 60 * 24)
+
+    if (age >= param_minimum_age) {
+      resourceName = ""
+      instance_tags = []
+
+      if (instance['tags'] != null && instance['tags'] != undefined) {
+        _.each(instance['tags'], function(tag) {
+          instance_tags.push([tag['key'], tag['value']].join('='))
+
+          if (tag['key'].toLowerCase() == 'name') {
+            resourceName = tag['value']
+          }
+        })
+      }
+
+      result.push({
+        id: instance['instanceId'],
+        region: instance['region'],
+        imageId: instance['imageId'],
+        ipAddress: instance['ipAddress'],
+        ipv6Address: instance['ipv6Address'],
+        resourceType: instance['resourceType'],
+        platform: instance['platform'],
+        privateDnsName: instance['privateDnsName'],
+        hostname: instance['privateDnsName'].split('.')[0],
+        launchTime: instance['launchTime'],
+        resourceName: resourceName,
+        age: parseInt(age),
+        tags: instance_tags.join(', '),
+        accountId: ds_aws_account['id'],
+        accountName: ds_aws_account['name']
+      })
+    }
+  })
+EOS
+end
+
+datasource "ds_instance_costs" do
+  request do
+    run_script $js_instance_costs, $ds_aws_account, $ds_top_level_bcs, rs_org_id, rs_optima_host
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response,"rows[*]") do
+      field "resourceId", jmes_path(col_item, "dimensions.resource_id")
+      field "billing_center_id", jmes_path(col_item, "dimensions.billing_center_id")
+      field "operating_system", jmes_path(col_item, "dimensions.operating_system")
+      field "purchase_option", jmes_path(col_item, "dimensions.purchase_option")
+      field "service", jmes_path(col_item, "dimensions.service")
+      field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
+    end
+  end
+end
+
+script "js_instance_costs", type: "javascript" do
+  parameters "ds_aws_account", "ds_top_level_bcs", "rs_org_id", "rs_optima_host"
+  result "request"
+  code <<-EOS
+  end_date = new Date()
+  end_date.setDate(end_date.getDate() - 2)
+  end_date = end_date.toISOString().split('T')[0]
+
+  start_date = new Date()
+  start_date.setDate(start_date.getDate() - 3)
+  start_date = start_date.toISOString().split('T')[0]
+
+  var request = {
+    auth: "auth_flexera",
+    host: rs_optima_host,
+    verb: "POST",
+    path: "/bill-analysis/orgs/" + rs_org_id + "/costs/select",
+    body_fields: {
+      dimensions: ["resource_id", "billing_center_id", "operating_system", "purchase_option", "service"],
+      granularity: "day",
+      start_at: start_date,
+      end_at: end_date,
+      metrics: ["cost_amortized_unblended_adj"],
+      billing_center_ids: ds_top_level_bcs,
+      limit: 100000,
+      filter: {
+        type: "and",
+        expressions: [
+          {
+            dimension: "service",
+            type: "equal",
+            value: "AmazonEC2"
+          },
+          {
+            dimension: "resource_type",
+            type: "equal",
+            value: "Compute Instance"
+          },
+          {
+            dimension: "vendor_account",
+            type: "equal",
+            value: ds_aws_account['id']
+          },
+          {
+            type: "not",
+            expression: {
+              dimension: "adjustment_name",
+              type: "substring",
+              substring: "Shared"
+            }
+          }
+        ]
+      }
+    },
+    headers: {
+      'User-Agent': "RS Policies",
+      'Api-Version': "1.0"
+    },
+    ignore_status: [400]
+  }
+EOS
+end
+
+datasource "ds_instance_costs_grouped" do
+  run_script $js_instance_costs_grouped, $ds_instance_costs
+end
+
+script "js_instance_costs_grouped", type: "javascript" do
+  parameters "ds_instance_costs"
+  result "result"
+  code <<-EOS
+  // Multiple a single day's cost by the average number of days in a month.
+  // The 0.25 is to account for leap years for extra precision.
+  cost_multiplier = 365.25 / 12
+
+  // Group cost data by resourceId for later use
+  result = {}
+
+  _.each(ds_instance_costs, function(item) {
+    id = item['resourceId'].toLowerCase()
+
+    if (result[id] == undefined) { result[id] = { cost: 0 } }
+
+    result[id]['cost'] += item['cost'] * cost_multiplier
+    result[id]['operating_system'] = item['operating_system']
+    result[id]['billing_center_id'] = item['billing_center_id']
+    result[id]['purchase_option'] = item['purchase_option']
+    result[id]['service'] = item['service']
+  })
+EOS
+end
+
+datasource "ds_long_running_instances_incident" do
+  run_script $js_long_running_instances_incident, $ds_long_running_instances, $ds_instance_costs_grouped, $ds_applied_policy, $param_minimum_age
+end
+
+script "js_long_running_instances_incident", type: "javascript" do
+  parameters "ds_long_running_instances", "ds_instance_costs_grouped", "ds_applied_policy", "ds_currency", "param_minimum_age"
+  result "result"
+  code <<-EOS
+  result = []
+
+  _.each(ds_long_running_instances_incident, function(item) {
+    instance = {
+      resourceID: item['id'],
+      resourceName: item['resourceName'],
+      region: item['region'],
+      imageId: item['imageId'],
+      ipAddress: item['ipAddress'],
+      ipv6Address: item['ipv6Address'],
+      resourceType: item['resourceType'],
+      platform: item['platform'],
+      privateDnsName: item['privateDnsName'],
+      hostname: item['hostname'],
+      launchTime: item['launchTime'],
+      age: item['age'],
+      tags: item['tags'],
+      accountID: item['accountId'],
+      accountName: item['accountName'],
+      policy_name: ds_applied_policy['name'],
+      costCurrency: ds_currency['symbol'],
+      lookbackPeriod: param_minimum_age,
+      cost: "",
+      operating_system: "",
+      billing_center_id: "",
+      purchase_option: "",
+      service: ""
+    }
+
+    id = instance['id'].toLowerCase()
+
+    if (ds_instance_costs_grouped[id] != undefined) {
+      instance['cost'] = ds_instance_costs_grouped[id]['cost']
+      instance['operating_system'] = ds_instance_costs_grouped[id]['operating_system']
+      instance['billing_center_id'] = ds_instance_costs_grouped[id]['billing_center_id']
+      instance['purchase_option'] = ds_instance_costs_grouped[id]['purchase_option']
+      instance['service'] = ds_instance_costs_grouped[id]['service']
+    }
+
+    result.push(instance)
+  })
 EOS
 end
 
@@ -276,35 +656,62 @@ end
 ###############################################################################
 
 policy "pol_utilization" do
-  validate_each $ds_instances do
-    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} AWS instances running longer than {{ parameters.param_days_old}} days"
-    escalate $email
+  validate_each $ds_long_running_instances_incident do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} AWS Long Running Instances Found"
+    escalate $esc_email
     escalate $esc_stop_instances
     escalate $esc_terminate_instances
-    check lt(to_n(val(item, "days_old")),$param_days_old)
+    check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
     export do
       resource_level true
+      field "accountID" do
+        label "Account ID"
+      end
+      field "accountName" do
+        label "Account Name"
+      end
+      field "resourceID" do
+        label "Resource ID"
+      end
+      field "resourceName" do
+        label "Resource Name"
+      end
+      field "tags" do
+        label "Resource Tags"
+      end
+      field "resourceType" do
+        label "Instance Size"
+      end
+      field "age" do
+        label "Resource Age (Days)"
+      end
       field "region" do
         label "Region"
       end
-      field "instanceType" do
-        label "Instance Type"
-      end
-      field "id" do
-        label "Instance Id"
-        path "instanceId"
-      end
-      field "days_old" do
-        label "Days Old"
+      field "platform" do
+        label "Platform"
       end
       field "hostname" do
         label "Hostname"
       end
-      field "privateDnsName" do
-        label "Private DNS Name"
+      field "cost" do
+        label "Estimated Monthly Cost"
       end
-      field "instance_tags" do
-        label "Tags"
+      field "costCurrency" do
+        label "Cost Currency"
+      end
+      field "launchTime" do
+        label "Launch Time"
+      end
+      field "lookbackPeriod" do
+        label "Look Back Period (Days)"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "id" do
+        label "ID"
+        path "resourceID"
       end
     end
   end
@@ -314,7 +721,7 @@ end
 # Escalations
 ###############################################################################
 
-escalation "email" do
+escalation "esc_email" do
   automatic true
   label "Send Email"
   description "Send incident email"
@@ -324,125 +731,132 @@ end
 escalation "esc_stop_instances" do
   automatic eq($param_automatic_action, "Stop Instances")
   label "Stop Instances"
-  description "Stop selected instances"
-  run "stop_instances_cwf", data, rs_optima_host
+  description "Approval to stop all selected instances"
+  run "stop_instances", data
 end
 
 escalation "esc_terminate_instances" do
   automatic eq($param_automatic_action, "Terminate Instances")
   label "Terminate Instances"
-  description "Terminate selected instances"
-  run "terminate_instances_cwf", data, rs_optima_host
+  description "Approval to terminate all selected instances"
+  run "terminate_instances", data
 end
 
 ###############################################################################
 # Cloud Workflow
 ###############################################################################
 
-define stop_instances_cwf($data, $$rs_optima_host) return $all_responses do
-  $status_code=''
+# Core CWF function to stop instances
+define stop_instances($data) return $all_responses do
+  # Change "No" to "Yes" to enable CWF debug logging
+  $log_to_cm_audit_entries = "No"
+
+  $$debug = $log_to_cm_audit_entries == "Yes"
+  $$log = []
   $all_responses = []
-  foreach $item in $data do
-    sub on_error: skip do
-      call stop_instances($item) retrieve $status_code
-      $all_responses << $status_code
-    end
+  $syslog_subject = "AWS Long Running Instances [Stop]: "
+
+  call sys_log(join([$syslog_subject, "Identified Instances"]), to_s($data))
+
+  foreach $instance in $data do
+    call stop_instance($instance) retrieve $stop_response
+    $all_responses << $stop_response
   end
 end
 
-define terminate_instances_cwf($data, $$rs_optima_host) return $all_responses do
-  $status_code=''
+# CWF function to stop an instance
+define stop_instance($instance) return $status_code do
+  $syslog_subject = "AWS Stopping Instance: "
+
+  call sys_log(join([$syslog_subject, "Instance"]), to_s($instance["id"]))
+
+  $response = http_request(
+    auth: $$auth_aws,
+    https: true,
+    verb: "post",
+    href: "/",
+    host: "ec2." + $instance["region"] + ".amazonaws.com",
+    query_strings: {
+      "Action": "StopInstances",
+      "Version": "2016-11-15",
+      "InstanceId.1": $instance["id"]
+    }
+  )
+
+  call sys_log(join([$syslog_subject, "Responses"]), to_s($response))
+end
+
+# Core CWF function to terminate instances
+define terminate_instances($data) return $all_responses do
+  # Change "No" to "Yes" to enable CWF debug logging
+  $log_to_cm_audit_entries = "No"
+
+  $$debug = $log_to_cm_audit_entries == "Yes"
+  $$log = []
   $all_responses = []
-  foreach $item in $data do
-    sub on_error: skip do
-      call terminate_instances($item) retrieve $status_code
-      $all_responses << $status_code
+  $syslog_subject = "AWS Long Running Instances [Terminate]: "
+
+  call sys_log(join([$syslog_subject, "Identified Instances"]), to_s($data))
+
+  foreach $instance in $data do
+    call get_instance_state($instance) retrieve $state_response, $initial_state
+    $all_responses << $state_response
+
+    if $initial_state != "terminated" && $initial_state != "pending"
+      call terminate_instance($instance) retrieve $terminate_response
+      $all_responses << $terminate_response
     end
   end
 end
 
-define stop_instances($item) return $status_code do
-  $status_code={}
-  $response={}
-  sub on_error: retry, timeout: 20m, on_timeout: skip do
-    $response = http_request(
-      verb: "post",
-      host: join(["ec2.",$item["region"],".amazonaws.com"]),
-      auth: $$auth_aws,
-      href: join(["/", "?Action=StopInstances", "&InstanceId.1=", $item["id"], "&Version=2016-11-15"]),
-      https: true,
-      headers:{
-        "cache-control": "no-cache",
-        "content-type": "application/json"
-      }
-    )
-    call sys_log("StopInstanceResponseCode", to_s($response["code"]))
-  end
-  $status_code=$response["code"]
-  if($response["code"]==200)
-    $wake_condition = "stopped"
-    $state = ''
-    while $state !~ $wake_condition do
-      sub on_error: skip do
-        call get_instance($item) retrieve $status_response
-        $status_responses=$status_response["body"]["DescribeInstancesResponse"]["reservationSet"]["item"]["instancesSet"]["item"]
-        $state = to_s($status_responses["instanceState"]["name"])
-        $status_code = to_s($status_response["code"])
-      end
-    end
-  end
+# CWF function to terminate an instance
+define terminate_instance($instance) return $response do
+  $syslog_subject = "AWS Terminating Instance: "
+
+  call sys_log(join([$syslog_subject, "Instance"]), to_s($instance["id"]))
+
+  $response = http_request(
+    auth: $$auth_aws,
+    https: true,
+    verb: "post",
+    href: "/",
+    host: "ec2." + $instance["region"] + ".amazonaws.com",
+    query_strings: {
+      "Action": "TerminateInstances",
+      "Version": "2016-11-15",
+      "InstanceId.1": $instance["id"]
+    }
+  )
+
+  call sys_log(join([$syslog_subject, "Responses"]), to_s($response))
 end
 
-define terminate_instances($item) return $status_code do
-  $status_code={}
-  $response={}
-  sub on_error: retry, timeout: 20m, on_timeout: skip do
-    $response = http_request(
-      verb: "post",
-      host: join(["ec2.",$item["region"],".amazonaws.com"]),
-      auth: $$auth_aws,
-      href: join(["/", "?Action=TerminateInstances", "&InstanceId.1=", $item["id"], "&Version=2016-11-15"]),
-      https: true,
-      headers:{
-        "cache-control": "no-cache",
-        "content-type": "application/json"
-      }
-    )
-    call sys_log("TerminateInstancesResponseCode", to_s($response["code"]))
-  end
-  $status_code=$response["code"]
-  if($response["code"]==200)
-    $wake_condition = "terminated"
-    $state = ''
-    while $state !~ $wake_condition do
-      sub on_error: skip do
-        call get_instance($item) retrieve $status_response
-        $status_responses=$status_response["body"]["DescribeInstancesResponse"]["reservationSet"]["item"]["instancesSet"]["item"]
-        $state = to_s($status_responses["instanceState"]["name"])
-        $status_code = to_s($status_response["code"])
-      end
-    end
-  end
+# CWF function to get the current state of an instance
+define get_instance_state($instance) return $response, $instance_state do
+  $syslog_subject = "AWS Describing Instance: "
+
+  call sys_log(join([$syslog_subject, "Instance"]), to_s($instance["id"]))
+
+  $response = http_request(
+    auth: $$auth_aws,
+    https: true,
+    verb: "post",
+    href: "/",
+    host: "ec2." + $instance["region"] + ".amazonaws.com",
+    query_strings: {
+      "Action": "DescribeInstanceStatus",
+      "Version": "2016-11-15",
+      "IncludeAllInstances": "true",
+      "InstanceId.1": $instance["id"]
+    }
+  )
+
+  call sys_log(join([$syslog_subject, "Responses"]), to_s($response))
+
+  $instance_state = $response["body"]["DescribeInstanceStatusResponse"]["instanceStatusSet"]["item"]["instanceState"]["name"]
 end
 
-define get_instance($item) return $status_response do
-  $status_response = {}
-  sub on_error: retry, timeout: 20m, on_timeout: skip do
-    $response = http_request(
-      verb: "get",
-      host: join(["ec2.",$item["region"],".amazonaws.com"]),
-      auth: $$auth_aws,
-      href: join(["/", "?Action=DescribeInstances", "&InstanceId.1=", $item["id"], "&Version=2016-11-15"]),
-      https: true,
-      headers: {
-        "cache-control": "no-cache",
-        "Accept": "application/json"
-      }
-    )
-    $status_response=$response
-  end
-end
-
+# CWF function to record information to the logs
 define sys_log($subject, $detail) do
   # Create empty errors array if doesn't already exist
   if !$$errors
@@ -472,7 +886,99 @@ define sys_log($subject, $detail) do
   end # End if debug is enabled
 end
 
+# CWF function to handle errors
 define skip_error_and_append($subject) do
   $$errors << "Unexpected error for " + $subject + "\n  " + to_s($_error)
   $_error_behavior = "skip"
+end
+
+###############################################################################
+# Meta Policy [alpha]
+# Not intended to be modified or used by policy developers
+###############################################################################
+
+# If the meta_parent_policy_id is not set it will evaluate to an empty string and we will look for the policy itself,
+# if it is set we will look for the parent policy.
+datasource "ds_get_policy" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    ignore_status [404]
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", switch(ne(meta_parent_policy_id,""), meta_parent_policy_id, policy_id) ])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+  end
+end
+
+
+datasource "ds_parent_policy_terminated" do
+  run_script $js_decide_if_self_terminate, $ds_get_policy, policy_id, meta_parent_policy_id
+end
+
+# If the policy was applied by a meta_parent_policy we confirm it exists if it doesn't we confirm we are deleting
+# This information is used in two places:
+# - determining whether or not we make a delete call
+# - determining if we should create an incident (we don't want to create an incident on the run where we terminate)
+script "js_decide_if_self_terminate", type: "javascript" do
+  parameters "found", "self_policy_id", "meta_parent_policy_id"
+  result "result"
+  code <<-EOS
+  var result
+  if (meta_parent_policy_id != "" && found.id == undefined) {
+    result = true
+  } else {
+    result = false
+  }
+  EOS
+end
+
+# Two potentials ways to set this up:
+# - this way and make a unneeded 'get' request when not deleting
+# - make the delete request an interate and have it iterate over an empty array when not deleting and an array with one item when deleting
+script "js_make_terminate_request", type: "javascript" do
+  parameters "should_delete", "policy_id", "rs_project_id", "rs_governance_host"
+  result "request"
+  code <<-EOS
+
+  var request = {
+    auth:  'auth_flexera',
+    host: rs_governance_host,
+    path: "/api/governance/projects/" + rs_project_id + "/applied_policies/" + policy_id,
+    headers: {
+      "API-Version": "1.0",
+      "Content-Type":"application/json"
+    },
+  }
+
+  if (should_delete) {
+    request.verb = 'DELETE'
+  }
+  EOS
+end
+
+datasource "ds_terminate_self" do
+  request do
+    run_script $js_make_terminate_request, $ds_parent_policy_terminated, policy_id, rs_project_id, rs_governance_host
+  end
+end
+
+datasource "ds_is_deleted" do
+  run_script $js_check_deleted, $ds_terminate_self
+end
+
+# This is just a way to have the check delete request connect to the farthest leaf from policy.
+# We want the delete check to the first thing the policy does to avoid the policy erroring before it can decide whether or not it needs to self terminate
+# Example a customer deletes a credential and then terminates the parent policy. We still want the children to self terminate
+# The only way I could see this not happening is if the user who applied the parent_meta_policy was offboarded or lost policy access, the policies who are impersonating the user
+# would not have access to self-terminate
+# It may be useful for the backend to enable a mass terminate at some point for all meta_child_policies associated with an id.
+script "js_check_deleted", type: "javascript" do
+  parameters "response"
+  result "result"
+  code <<-EOS
+  result = {"path":"/"}
+  EOS
 end

--- a/operational/aws/long_running_instances/long_running_instances.pt
+++ b/operational/aws/long_running_instances/long_running_instances.pt
@@ -73,7 +73,7 @@ parameter "param_automatic_action" do
   type "string"
   category "Actions"
   label "Automatic Actions"
-  description "This policy will automatically take the selected action"
+  description "The policy will automatically take the selected action"
   default "No Automatic Actions"
   allowed_values "No Automatic Actions", "Stop Instances", "Terminate Instances"
 end

--- a/operational/aws/long_running_instances/long_running_instances.pt
+++ b/operational/aws/long_running_instances/long_running_instances.pt
@@ -614,7 +614,7 @@ script "js_long_running_instances_incident", type: "javascript" do
   code <<-'EOS'
   result = []
 
-  _.each(ds_long_running_instances_incident, function(item) {
+  _.each(ds_long_running_instances, function(item) {
     instance = {
       resourceID: item['id'],
       resourceName: item['resourceName'],
@@ -642,7 +642,7 @@ script "js_long_running_instances_incident", type: "javascript" do
       message: ""
     }
 
-    id = instance['id'].toLowerCase()
+    id = item['id'].toLowerCase()
 
     if (ds_instance_costs_grouped[id] != undefined) {
       instance['cost'] = ds_instance_costs_grouped[id]['cost']

--- a/operational/aws/long_running_instances/long_running_instances.pt
+++ b/operational/aws/long_running_instances/long_running_instances.pt
@@ -73,7 +73,7 @@ parameter "param_automatic_action" do
   type "string"
   category "Actions"
   label "Automatic Actions"
-  description "When this value is set, this policy will automatically take the selected action(s)"
+  description "This policy will automatically take the selected action"
   default "No Automatic Actions"
   allowed_values "No Automatic Actions", "Stop Instances", "Terminate Instances"
 end
@@ -132,7 +132,6 @@ datasource "ds_applied_policy" do
     header "Api-Version", "1.0"
   end
 end
-
 
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
@@ -600,13 +599,13 @@ EOS
 end
 
 datasource "ds_long_running_instances_incident" do
-  run_script $js_long_running_instances_incident, $ds_long_running_instances, $ds_instance_costs_grouped, $ds_applied_policy, $param_minimum_age
+  run_script $js_long_running_instances_incident, $ds_instances, $ds_long_running_instances, $ds_instance_costs_grouped, $ds_applied_policy, $ds_currency, $param_minimum_age
 end
 
 script "js_long_running_instances_incident", type: "javascript" do
-  parameters "ds_long_running_instances", "ds_instance_costs_grouped", "ds_applied_policy", "ds_currency", "param_minimum_age"
+  parameters "ds_instances", "ds_long_running_instances", "ds_instance_costs_grouped", "ds_applied_policy", "ds_currency", "param_minimum_age"
   result "result"
-  code <<-EOS
+  code <<-'EOS'
   result = []
 
   _.each(ds_long_running_instances_incident, function(item) {
@@ -631,9 +630,10 @@ script "js_long_running_instances_incident", type: "javascript" do
       lookbackPeriod: param_minimum_age,
       cost: "",
       operating_system: "",
-      billing_center_id: "",
+      billing_center: "",
       purchase_option: "",
-      service: ""
+      service: "",
+      message: ""
     }
 
     id = instance['id'].toLowerCase()
@@ -648,6 +648,38 @@ script "js_long_running_instances_incident", type: "javascript" do
 
     result.push(instance)
   })
+
+  day_noun = "day"
+  if (param_minimum_age > 1) { day_noun = "days" }
+
+  instances_total = ds_instances.length.toString()
+  long_instances_total = result.length.toString()
+  long_instances_percentage = (long_instances_total / instances_total * 100).toFixed(2).toString() + '%'
+
+  findings = [
+    "Out of ", instances_total, " instances analyzed, ",
+    long_instances_total, " (", long_instances_percentage,
+    ") have been running for longer than ", param_minimum_age,
+    " ", day_noun, ".\n\n"
+  ].join('')
+
+  disclaimer = "The above settings can be modified by editing the applied policy and changing the appropriate parameters."
+
+  result = _.sortBy(result, function(item) { return item['cost'] * -1 })
+
+  // Add a dummy entry to ensure that the policy's check statement executes at least once
+  result.push({
+    resourceID: "",      resourceName: "",     region: "",
+    imageId: "",         ipAddress: "",        ipv6Address: "",
+    resourceType: "",    platform: "",         privateDnsName: "",
+    hostname: "",        launchTime: "",       age: "",
+    tags: "",            accountID: "",        accountName: "",
+    policy_name: "",     costCurrency: "",     lookbackPeriod: "",
+    cost: "",            operating_system: "", billing_center: "",
+    purchase_option: "", service: ""
+  })
+
+  result[0]['message'] = findings + disclaimer
 EOS
 end
 
@@ -658,11 +690,14 @@ end
 policy "pol_utilization" do
   validate_each $ds_long_running_instances_incident do
     summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} AWS Long Running Instances Found"
+    detail_template <<-'EOS'
+    {{ with index data 0 }}{{ .message }}{{ end }}
+    EOS
     escalate $esc_email
     escalate $esc_stop_instances
     escalate $esc_terminate_instances
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
-    hash_exclude "tags", "cost", "costCurrency", "resourceName", "age", "billing_center", "hostname", "ipAddress", "ipv6Address"
+    hash_exclude "tags", "cost", "costCurrency", "resourceName", "age", "billing_center", "hostname", "ipAddress", "ipv6Address", "lookbackPeriod", "policy_name", "message"
     export do
       resource_level true
       field "accountID" do
@@ -775,8 +810,13 @@ define stop_instances($data) return $all_responses do
   call sys_log(join([$syslog_subject, "Identified Instances"]), to_s($data))
 
   foreach $instance in $data do
-    call stop_instance($instance) retrieve $stop_response
-    $all_responses << $stop_response
+    call get_instance_state($instance) retrieve $state_response, $initial_state
+    $all_responses << $state_response
+
+    if $initial_state != "stopping" && $initial_state != "stopped" && $initial_state != "terminated"
+      call stop_instance($instance) retrieve $stop_response
+      $all_responses << $stop_response
+    end
   end
 end
 

--- a/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
+++ b/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
@@ -1,0 +1,1008 @@
+name "AWS Long Running Instances Meta Parent"
+rs_pt_ver 20180301
+type "policy"
+short_description "Applies and manages \"child\" [AWS Long Running Instances](https://github.com/flexera-public/policy_templates/tree/master/operational/aws/long_running_instances) Policies."
+severity "low"
+category "Cost"
+tenancy "single"
+default_frequency "15 minutes"
+info(
+  provider: "AWS",
+  version: "4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  publish: "false"
+)
+
+##############################################################################
+# Parameters
+##############################################################################
+
+## Meta Parent Parameters
+## These are params specific to the meta parent policy.
+parameter "param_combined_incident_email" do
+  type "list"
+  label "Email addresses for combined incident"
+  description "A list of email addresses to notify with the consolidated child policy incident."
+  default []
+end
+
+parameter "param_dimension_filter_includes" do
+  type "list"
+  label "Dimension Include Filters"
+  description <<-EOS
+  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
+  If no include filters are provided, then all AWS Accounts are included by default.
+  Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
+  EOS
+end
+
+parameter "param_dimension_filter_excludes" do
+  type "list"
+  label "Dimension Exclude Filters"
+  description <<-EOS
+  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
+  Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
+  Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
+  EOS
+end
+
+parameter "param_policy_schedule" do
+  type "string"
+  label "Child Policy Schedule"
+  description "The interval at which the child policy checks for conditions and generates incidents."
+  default "daily"
+  allowed_values "daily", "weekly", "monthly"
+end
+
+## Child Policy Parameters
+parameter "param_regions_allow_or_deny" do
+  type "string"
+  category "Filters"
+  label "Allow/Deny Regions"
+  description "Allow or Deny entered regions. See the README for more details"
+  allowed_values "Allow", "Deny"
+  default "Allow"
+end
+
+parameter "param_regions_list" do
+  type "list"
+  category "Filters"
+  label "Allow/Deny Regions List"
+  allowed_pattern /^([a-zA-Z-_]+-[a-zA-Z0-9-_]+-[0-9-_]+,*|)+$/
+  description "A list of allowed or denied regions. See the README for more details"
+  default []
+end
+
+parameter "param_minimum_age" do
+  type "number"
+  category "Policy Settings"
+  label "Minimum Age (Days)"
+  description "The minimum age, in days, to consider an instance to be long running"
+  default 180
+  min_value 0
+end
+
+parameter "param_exclusion_tags" do
+  type "list"
+  category "Filters"
+  label "Exclusion Tags (Key:Value)"
+  description "Cloud native tags to ignore resources that you don't want to produce recommendations for. Use Key:Value format for specific tag key/value pairs, and Key:* format to match any resource with a particular key, regardless of value. Examples: env:production, DO_NOT_DELETE:*"
+  allowed_pattern /(^$)|[\w]*\:.*/
+  default []
+end
+
+parameter "param_automatic_action" do
+  type "string"
+  category "Actions"
+  label "Automatic Actions"
+  description "When this value is set, this policy will automatically take the selected action(s)"
+  default "No Automatic Actions"
+  allowed_values "No Automatic Actions", "Stop Instances", "Terminate Instances"
+end
+
+###############################################################################
+# Authentication
+###############################################################################
+credentials "auth_aws" do
+  schemes "aws", "aws_sts"
+  label "AWS"
+  description "Select the AWS Credential from the list"
+  tags "provider=aws"
+  aws_account_number $param_aws_account_number
+end
+
+credentials "auth_flexera" do
+  schemes "oauth2"
+  label "Flexera"
+  description "Select Flexera One OAuth2 credentials"
+  tags "provider=flexera"
+end
+
+###############################################################################
+# Datasources
+###############################################################################
+
+# Get Applied Parent Policy Details
+datasource "ds_self_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    field "name", jmes_path(response, "name")
+    field "creator_id", jmes_path(response, "created_by.id")
+    field "credentials", jmes_path(response, "credentials")
+    field "options", jmes_path(response, "options")
+  end
+end
+
+datasource "ds_child_policy_options" do
+  run_script $js_child_policy_options, $ds_self_policy_information
+end
+
+script "js_child_policy_options", type: "javascript" do
+  parameters "ds_self_policy_information"
+  result "options"
+  code <<-EOS
+  // Filter Options that are not appropriate for Child Policy
+  var options = _.map(ds_self_policy_information.options, function(option){
+    // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+      return { "name": option.name, "value": option.value };
+    }
+  });
+  // Explicitly add param_email which is disabled/does not exist in meta parent policy
+  options.push({
+    "name": "param_email",
+    "value": []
+  });
+  EOS
+end
+
+datasource "ds_child_policy_options_map" do
+  run_script $js_child_policy_options_map, $ds_child_policy_options
+end
+
+script "js_child_policy_options_map", type: "javascript" do
+  parameters "ds_child_policy_options"
+  result "options"
+  code <<-EOS
+  function format_options_keyvalue(options) {
+    var options_keyvalue_map = {};
+    _.each(options, function(option) {
+      options_keyvalue_map[option.name] = option.value;
+    });
+    return options_keyvalue_map;
+  }
+  var options = format_options_keyvalue(ds_child_policy_options)
+  EOS
+end
+
+datasource "ds_format_self" do
+  run_script $js_format_self, $ds_self_policy_information, $ds_child_policy_options_map
+end
+
+script "js_format_self", type: "javascript" do
+  parameters "ds_self_policy_information", "ds_child_policy_options_map"
+  result "formatted"
+  code <<-EOS
+  var formatted = {
+    "name": ds_self_policy_information["name"],
+    "creator_id": ds_self_policy_information["creator_id"],
+    "credentials": ds_self_policy_information["credentials"],
+    "options": ds_child_policy_options_map
+  };
+  EOS
+end
+
+# Get Child Policy Details
+datasource "ds_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/orgs/", rs_org_id, "/published_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "AWS Long Running Instances" and .created_by.email == "support@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+datasource "ds_get_billing_centers" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/analytics/orgs/",rs_org_id,"/billing_centers"])
+    header "Api-Version", "1.0"
+    header "User-Agent", "RS Policies"
+    query "view", "allocation_table"
+    ignore_status [403]
+  end
+  result do
+    encoding "json"
+    # Select the Billing Centers that have "parent_id" undefined or "" (i.e. top-level Billing Centers)
+    collect jq(response, '.[] | select(.parent_id == null)' ) do
+      field "href", jq(col_item,".href")
+      field "id", jq(col_item,".id")
+      field "name", jq(col_item,".name")
+      field "parent_id", jq(col_item,".parent_id")
+    end
+  end
+end
+
+script "js_make_billing_center_request", type: "javascript" do
+  parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
+  result "request"
+  code <<-EOS
+
+  billing_centers_formatted = []
+
+  for (x=0; x< billing_centers_unformatted.length; x++) {
+    billing_centers_formatted.push(billing_centers_unformatted[x]["id"])
+  }
+
+  finish = new Date()
+  finishFormatted = finish.toJSON().split("T")[0]
+  start = new Date()
+  start.setDate(start.getDate() - 30)
+  startFormatted = start.toJSON().split("T")[0]
+
+  // Default dimensions and filter expressions required for meta parent policy
+  var dimensions = ["vendor_account", "vendor_account_name"];
+  var filter_expressions = [
+    { dimension: "vendor", type: "equal", value: "AWS" }
+  ]
+
+  // Append to default dimensions and filter expressions using parent policy params
+  _.each(param_dimension_filter_includes, function (v) {
+    // split key=value string
+    var split = v.split("=");
+    var k = split[0];
+    var v = split[1];
+    // append to lists
+    dimensions.push(k);
+    filter_expressions.push({ dimension: k, type: "equal", value: v });
+  });
+
+  // Append to filter expressions using exclude policy params
+  _.each(param_dimension_filter_excludes, function (v) {
+    // split key=value string
+    var split = v.split("=");
+    var k = split[0];
+    var v = split[1];
+    // append to lists
+    dimensions.push(k);
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+  });
+
+  // Produces a duplicate-free version of the array
+  dimensions = _.uniq(dimensions);
+
+  var body = {
+    "dimensions": dimensions,
+    "granularity":"day",
+    "start_at": startFormatted,
+    "end_at": finishFormatted,
+    "metrics":["cost_amortized_unblended_adj"],
+    "billing_center_ids": billing_centers_formatted,
+    "filter":
+    {
+      "type": "and",
+      "expressions": filter_expressions
+    },
+    "summarized": true
+  }
+  var request = {
+    auth:  'auth_flexera',
+    host:  rs_optima_host,
+    scheme: 'https',
+    verb: 'POST',
+    path:  "/bill-analysis/orgs/"+ rs_org_id + "/costs/aggregated",
+    headers: {
+      "API-Version": "1.0",
+      "Content-Type":"application/json"
+    },
+    body: JSON.stringify(body)
+  }
+  EOS
+end
+
+# Get the AWS acounts
+datasource "ds_get_aws_accounts" do
+  request do
+    run_script $js_make_billing_center_request, rs_org_id, rs_optima_host, $ds_get_billing_centers, $param_dimension_filter_includes, $param_dimension_filter_excludes
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response,"rows[*]") do
+      field "aws_account_id", jmes_path(col_item,"dimensions.vendor_account")
+      field "aws_account_name", jmes_path(col_item,"dimensions.vendor_account_name")
+    end
+  end
+end
+
+# Get Child policies
+datasource "ds_get_existing_policies" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies"])
+    header "Api-Version", "1.0"
+    query "meta_parent_policy_id", policy_id
+  end
+  result do
+    collect jq(response, '.items[]?') do
+      field "name", jq(col_item, ".name")
+      field "applied_policy_id", jq(col_item, ".id")
+      field "options", jq(col_item, ".options")
+      field "updated_at", jq(col_item, ".updated_at")
+      field "status", jq(col_item, ".status")
+    end
+  end
+end
+
+# Get Child policies incidents
+datasource "ds_get_existing_policies_incidents" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/incidents"])
+    header "Api-Version", "1.0"
+    query "meta_parent_policy_id", policy_id
+  end
+  result do
+    collect jq(response, '.items[]?') do
+      field "incident_id", jq(col_item, ".id")
+      field "applied_policy_id", jq(col_item, ".applied_policy.id")
+      field "state", jq(col_item, ".state")
+      field "violation_data_count", jq(col_item, ".violation_data_count")
+      field "updated_at", jq(col_item, ".updated_at")
+      field "meta_parent_policy_id", jq(col_item, ".meta_parent_policy_id")
+    end
+  end
+end
+
+datasource "ds_format_incidents" do
+  run_script $js_format_existing_policies_incidents, $ds_get_existing_policies_incidents
+end
+
+script "js_format_existing_policies_incidents", type: "javascript" do
+  parameters "unformatted"
+  result "formatted"
+  code <<-EOS
+  formatted={}
+  for (x=0;x<unformatted.length; x++) {
+    current = unformatted[x]
+    formatted[current.applied_policy_id] = {incident_id: current.incident_id, state: current.state, violation_data_count: current.violation_data_count, updated_at: current.updated_at}
+  }
+  EOS
+end
+
+datasource "ds_format_existing_policies" do
+  run_script $js_format_existing_policies, $ds_get_existing_policies, $ds_format_incidents
+end
+
+# format
+# duplicates logic should compare updated at
+# we can validate update here when destructring the existing policy options, don't need updated at
+# format options
+script "js_format_existing_policies", type: "javascript" do
+  parameters "ds_get_existing_policies", "ds_format_incidents"
+  result "result"
+  code <<-EOS
+  function format_options_keyvalue(options) {
+    var options_keyvalue_map = {};
+    _.each(options, function(option) {
+      options_keyvalue_map[option.name] = option.value;
+    });
+    return options_keyvalue_map;
+  }
+
+  result = {}
+  formatted = {}
+  duplicates = []
+  // tracking holds all existing policies and later can be used to determine if existing policies should be deleted [i.e. if cloud account was removed]
+  tracking = {}
+
+  for (x=0; x<ds_get_existing_policies.length; x++) {
+    options = format_options_keyvalue(ds_get_existing_policies[x].options);
+
+    aws_account_id=options["param_aws_account_number"]
+    if (formatted[aws_account_id] == undefined) {
+      formatted[aws_account_id] = {
+        "applied_policy_id":ds_get_existing_policies[x]["applied_policy_id"],
+        "applied_policy_name":ds_get_existing_policies[x]["name"],
+        "status":ds_get_existing_policies[x]["status"],
+        "updated_at":ds_get_existing_policies[x]["updated_at"],
+        "incident": ds_format_incidents[ds_get_existing_policies[x]["applied_policy_id"]],
+        "options": options
+      }
+      tracking[aws_account_id] = false
+    } else {
+      current = formatted[aws_account_id]
+
+      currDate = new Date(current.updated_at)
+      newDate = new Date(ds_get_existing_policies[x].updated_at)
+
+      if (currDate > newDate) {
+        duplicates.push({
+          "applied_policy_id":ds_get_existing_policies[x]["applied_policy_id"],
+          "applied_policy_name":ds_get_existing_policies[x]["name"],
+          "status":ds_get_existing_policies[x]["status"],
+          "updated_at":ds_get_existing_policies[x]["updated_at"],
+          "incident": ds_format_incidents[ds_get_existing_policies[x]["applied_policy_id"]]
+        })
+      } else {
+        duplicates.push({
+          "applied_policy_id":current["applied_policy_id"],
+          "applied_policy_name":current["applied_policy_name"],
+          "status":current["status"],
+          "updated_at":current["updated_at"],
+          "incident": current["incident"]
+        })
+        formatted[aws_account_id] = {
+          "applied_policy_id":ds_get_existing_policies[x]["applied_policy_id"],
+          "applied_policy_name":ds_get_existing_policies[x]["name"],
+          "status":ds_get_existing_policies[x]["status"],
+          "updated_at":ds_get_existing_policies[x]["updated_at"],
+          "incident": ds_format_incidents[ds_get_existing_policies[x]["applied_policy_id"]],
+          "options": options
+        }
+
+      }
+    }
+  }
+
+  result.formatted=formatted
+  result.duplicates=duplicates
+  result.tracking=tracking
+  EOS
+end
+
+datasource "ds_take_in_parameters" do
+  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+end
+
+# hardcode template href with id from catalog
+# catalog policies show in customer's published templates with their org id
+# "template_href": "/api/governance/orgs/" + rs_org_id + "/published_templates/62618616e3dff80001572bf0"
+# update logic: the only reason we're going to update the child policies for is changes to options
+# and only some options, email is always blank and aws_account_id is tied to the idenity of each policy, so: new account creation, removal of account: termination
+# param_automatic_action is a list with only one action, unless the person is applying using an API and putting the same value multiple times this should either be a length of 0 or 1
+# param_log_to_cm_audit_entries is a String of Yes or No
+# param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
+# If we only want to do an update on the values changing we could sort before doing the equality check.
+script "js_take_in_parameters", type: "javascript" do
+  parameters "ds_get_aws_accounts", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  result "grid_and_cwf"
+  code <<-EOS
+
+  max_actions = 50;
+
+  grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
+
+  should_keep = ds_format_existing_policies.tracking;
+
+  // Construct UI URL prefixes for policy template summary
+  ui_url_prefix = "https://" + f1_app_host + "/orgs/" + rs_org_id;
+  applied_policy_url_prefix = ui_url_prefix + "/automation/applied-policies/projects/" + rs_project_id + "?noIndex=1&policyId=";
+  incident_url_prefix       = ui_url_prefix + "/automation/incidents/projects/" + rs_project_id + "?noIndex=1&incidentId=";
+
+  function add_to_grid(ep, action) {
+    policy_status={
+      "policy_name": ep["applied_policy_name"],
+      "policy_link": applied_policy_url_prefix + ep["applied_policy_id"],
+      "meta_policy_status": action,
+      "policy_status": ep["status"],
+      "policy_last_update": ep["updated_at"],
+    };
+    if (ep.incident != null) {
+      policy_status["incident_link"] = incident_url_prefix + ep.incident.incident_id;
+      policy_status["incident_state"] = ep.incident.state;
+      policy_status["incident_violation_data_count"] = ep.incident.violation_data_count;
+      policy_status["incident_last_update"] = ep.incident.updated_at;
+    }
+    grid_and_cwf.grid.push(policy_status);
+  }
+
+  for (x=0; x<ds_format_existing_policies.duplicates.length; x++) {
+    if (grid_and_cwf.to_delete.length < max_actions) {
+      grid_and_cwf.to_delete.push({"id":ds_format_existing_policies.duplicates[x]["applied_policy_id"], "name": ds_format_existing_policies.duplicates[x]["applied_policy_name"]})
+      add_to_grid(ds_format_existing_policies.duplicates[x], "terminating")
+    } else {
+      add_to_grid(ds_format_existing_policies.duplicates[x], "to be terminated")
+    }
+  }
+
+  for (x=0; x<ds_get_aws_accounts.length; x++) {
+    cur = ds_get_aws_accounts[x];
+    cur_aws_account_id = cur.aws_account_id.replace(/['"]+/g, '');
+
+    // Name and description do not vary between create or updates so defining them here
+    name = ds_child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
+    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + ds_child_policy_information.short_description;
+
+    // Check if child policy exists for current account id
+    if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_aws_account_id) ) {
+      console.log("Child Policy for "+cur_aws_account_id+" does not exist and should be created");
+
+      // Child Policy does not exist for current account ID and should be created
+
+
+      // Use the options from the parent policy in "name value" list format
+      options = _.toArray(ds_child_policy_options);
+
+      // Set param_aws_account_id values for this child policy
+      options.push({
+        "name": "param_aws_account_number",
+        "value": cur_aws_account_id
+      });
+
+      if (grid_and_cwf.to_create.length < max_actions) {
+        grid_and_cwf.to_create.push({
+          "name" : name,
+          "description" : description,
+          "credentials" : ds_format_self.credentials,
+          "options" : options,
+          "frequency" : param_policy_schedule,
+          "meta_parent_policy_id": meta_parent_policy_id,
+          "template_href": ds_child_policy_information.href
+        })
+        policy_status={
+          "policy_name": name,
+          "meta_policy_status": "creating policy",
+          "policy_status": "",
+          "policy_last_update": "",
+        }
+        grid_and_cwf.grid.push(policy_status)
+      } else {
+        policy_status={
+          "policy_name": name,
+          "meta_policy_status": "policy to be created",
+          "policy_status": "",
+          "policy_last_update": "",
+        }
+        grid_and_cwf.grid.push(policy_status)
+      }
+    } else {
+      console.log("Child Policy for "+cur_aws_account_id+" does exist for current account ID and may need to be updated or deleted");
+      // Child Policy does exist for current account ID and may need to be updated or deleted
+      // Assume by default we should keep it and not update it
+      should_keep[cur_aws_account_id] = true;
+      should_update = false;
+
+      // Use the options from the parent policy in "name value" list format
+      options = _.toArray(ds_child_policy_options);
+
+      // Set param_aws_account_id values for this child policy
+      options.push({
+        "name": "param_aws_account_number",
+        "value": cur_aws_account_id
+      });
+
+      // Check if child policy params match parent policy params
+      _.each(ds_format_self.options, function(value, key) {
+        // If any child and parent param values do not match, mark the child policy as should_update
+        if ( !_.isEqual(value, ds_format_existing_policies["formatted"][cur_aws_account_id]["options"][key]) ) {
+          console.log("Child Policy Param does not match Parent Policy and should be updated. "+key+" does not match "+value+"!="+ds_format_existing_policies["formatted"][cur_aws_account_id]["options"][key]);
+          should_update = true;
+        }
+      });
+
+
+      if (should_update) {
+        // Child policy needs to be updated
+        if (grid_and_cwf.to_update.length < max_actions) {
+          // Child policy needs to be updated and is within the max_actions limit
+          console.log("Child Policy needs to be updated. ds_format_existing_policies.formatted[cur_aws_account_id]="+JSON.stringify(ds_format_existing_policies.formatted[cur_aws_account_id]));
+          add_to_grid(ds_format_existing_policies.formatted[cur_aws_account_id], "updating")
+          name = ds_format_existing_policies.formatted[cur_aws_account_id].applied_policy_name
+          // Add to_update
+          grid_and_cwf.to_update.push({
+            "applied_policy_id": ds_format_existing_policies.formatted[cur_aws_account_id].applied_policy_id,
+            "name" : name,
+            "description" : description,
+            "credentials" : ds_format_self.credentials,
+            "options" : options,
+            "frequency" : param_policy_schedule,
+          })
+        } else {
+          // Child policy needs to be updated but is outside the max_actions limit
+          // Add to grid but do not add to to_update
+          console.log("Child Policy needs to be updated. ds_format_existing_policies.formatted[cur_aws_account_id]="+JSON.stringify(ds_format_existing_policies.formatted[cur_aws_account_id]));
+          add_to_grid(ds_format_existing_policies.formatted[cur_aws_account_id], "to be updated");
+        }
+      } else {
+        // Child policy does not need to be updated
+        add_to_grid(ds_format_existing_policies.formatted[cur_aws_account_id], "running");
+      }
+    }
+  }
+
+  console.log("Checking if policies should be deleted. "+JSON.stringify(should_keep));
+  _.each(should_keep, function(keep, account_id) {
+    console.log("Should keep "+account_id+"="+keep);
+    if (!keep) {
+      if (grid_and_cwf.to_delete.length < max_actions) {
+        grid_and_cwf.to_delete.push({"id":ds_format_existing_policies.formatted[account_id].applied_policy_id, "name": ds_format_existing_policies.formatted[account_id].applied_policy_name})
+        add_to_grid(ds_format_existing_policies.formatted[account_id], "terminating")
+      } else {
+        add_to_grid(ds_format_existing_policies.formatted[account_id], "to be terminated")
+      }
+    }
+  });
+
+  EOS
+end
+
+datasource "ds_only_grid" do
+  run_script $js_only_grid, $ds_take_in_parameters
+end
+
+script "js_only_grid", type: "javascript" do
+  parameters "results"
+  result "only_grid"
+  code <<-EOS
+    only_grid = results.grid
+  EOS
+end
+
+datasource "ds_to_create" do
+  run_script $js_only_create, $ds_take_in_parameters
+end
+
+script "js_only_create", type: "javascript" do
+  parameters "results"
+  result "only_create"
+  code <<-EOS
+    only_create = results.to_create
+  EOS
+end
+
+datasource "ds_to_update" do
+  run_script $js_only_update, $ds_take_in_parameters
+end
+
+script "js_only_update", type: "javascript" do
+  parameters "results"
+  result "only_update"
+  code <<-EOS
+    only_update = results.to_update
+  EOS
+end
+
+datasource "ds_to_delete" do
+  run_script $js_only_delete, $ds_take_in_parameters
+end
+
+script "js_only_delete", type: "javascript" do
+  parameters "results"
+  result "only_delete"
+  code <<-EOS
+    only_delete = results.to_delete
+  EOS
+end
+
+# The following datasources consolidate the child incident output into a single incident.
+# This is because it is more convenient for many users to have a single incident with all of the data.
+datasource "ds_child_incident_details" do
+  iterate $ds_get_existing_policies_incidents
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/incidents/", val(iter_item, 'incident_id')])
+    verb "GET"
+    header "User-Agent", "RS Policies"
+    header "Api-Version", "1.0"
+    query "view", "extended"
+  end
+end
+
+datasource "ds_long_running_instances_incident_combined_incidents" do
+  run_script $js_ds_long_running_instances_incident_combined_incidents, $ds_child_incident_details
+end
+
+script "js_ds_long_running_instances_incident_combined_incidents", type: "javascript" do
+  parameters "ds_child_incident_details"
+  result "result"
+  code <<-EOS
+  result = []
+  _.each(ds_child_incident_details, function(incident) {
+    s = incident["summary"];
+    // If the incident summary contains "AWS Long Running Instances Found" then include it in the filter result
+    if (s.indexOf("AWS Long Running Instances Found") > -1) {
+      _.each(incident["violation_data"], function(violation) {
+        result.push(violation);
+      });
+    }
+  });
+EOS
+end
+
+
+# Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
+# Minimum of 1 incident, max of four
+# Could swap the summary to only showing running
+# Could also just have one incident and use meta_status to determine which escalation happens
+policy "policy_scheduled_report" do
+  # Consolidated Incident Check(s)
+    # Consolidated incident for AWS Long Running Instances Found
+  validate $ds_long_running_instances_incident_combined_incidents do
+    summary_template "Consolidated Incident: {{ len data }} AWS Long Running Instances Found"
+    escalate $esc_email
+    check eq(size(data), 0)
+    export do
+      resource_level true
+      field "accountID" do
+        label "Account ID"
+      end
+      field "accountName" do
+        label "Account Name"
+      end
+      field "resourceID" do
+        label "Resource ID"
+      end
+      field "resourceName" do
+        label "Resource Name"
+      end
+      field "tags" do
+        label "Resource Tags"
+      end
+      field "resourceType" do
+        label "Instance Size"
+      end
+      field "age" do
+        label "Resource Age (Days)"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "platform" do
+        label "Platform"
+      end
+      field "hostname" do
+        label "Hostname"
+      end
+      field "cost" do
+        label "Estimated Monthly Cost"
+      end
+      field "costCurrency" do
+        label "Cost Currency"
+      end
+      field "launchTime" do
+        label "Launch Time"
+      end
+      field "lookbackPeriod" do
+        label "Look Back Period (Days)"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "id" do
+        label "ID"
+      end
+    end
+  end
+
+  # Status Incident Check
+  validate $ds_take_in_parameters do
+    summary_template "{{ data.parent_policy.name }}: Status of Child Policies"
+    detail_template <<-EOS
+The current status of Child Policies for **{{ data.parent_policy.name }}**:
+
+Total Child Applied Policies: {{ len data.grid }}
+
+| Applied Policy | Meta Child Policy Status | Policy Status | Policy Last Update | Incident | Incident State | Violation Count | Incident Last Update |
+| -------------- | ------------------------ | ------------- | ------------------ | -------- | -------------- | --------------- | -------------------- |
+{{ range data.grid -}}
+| {{- if .policy_link }} [{{ .policy_name }}]({{ .policy_link }}) {{ else }} {{ .policy_name }} {{- end }} | {{- if .meta_policy_status }} {{ .meta_policy_status }} {{ else }} No value {{- end }} | {{- if .policy_status }} {{ .policy_status }} {{ else }} No value {{- end }} | {{- if .policy_last_update }} {{ .policy_last_update }} {{ else }} No value {{- end }} | {{- if .incident_link }} [Incident]({{ .incident_link }}) {{ else }} No Incident {{- end }} | {{- if .incident_state }} {{ .incident_state }} {{ else }} No Incident {{- end }} | {{- if .incident_last_update }} {{ .incident_violation_data_count }} {{ else }} No Incident {{- end }} | {{- if .incident_last_update }} {{ .incident_last_update }} {{ else }} No Incident {{- end }} |
+{{ end -}}
+
+EOS
+    check false # always trigger this status incident
+    # Export Table disabled for now until UI can support URL / linking
+    # Without linking the `policy_link`, `incident_link` values are not usable directly from UI
+    # export "grid" do
+    #   resource_level true
+    #   field "id" do
+    #     label "Applied Policy ID"
+    #   end
+    #   field "policy_name" do
+    #     label "Applied Policy Name"
+    #   end
+    #   field "policy_link" do
+    #     label "Applied Policy Link"
+    #   end
+    #   field "meta_policy_status" do
+    #     label "Meta Child Policy Status"
+    #   end
+    #   field "policy_status" do
+    #     label "Policy Status"
+    #   end
+    #   field "policy_last_update" do
+    #     label "Policy Last Update"
+    #   end
+    #   field "incident_link" do
+    #     label "Incident Link"
+    #   end
+    #   field "incident_state" do
+    #     label "Incident State"
+    #   end
+    #   field "incident_violation_data_count" do
+    #     label "Incident Violation Count"
+    #   end
+    #   field "incident_last_update" do
+    #     label "Incident Last Update"
+    #   end
+    # end
+  end
+
+  # Create Child Policies Incident Check
+  validate $ds_to_create do
+    summary_template "Policies being created"
+    detail_template <<-EOS
+    Policies Being Created:
+
+    | Applied Policy |
+    | --------------- |
+    {{ range data -}}
+    | {{ .name }} |
+    {{ end -}}
+    EOS
+    escalate $create_policies
+    check eq(size(data),0)
+  end
+
+  # Update Child Policies Incident Check
+  validate $ds_to_update do
+    summary_template "Policies being updated"
+    detail_template <<-EOS
+    Policies Being Updated:
+
+    | Applied Policy |
+    | --------------- |
+    {{ range data -}}
+    | {{ .name }} |
+    {{ end -}}
+    EOS
+    escalate $update_policies
+    check eq(size(data),0)
+  end
+
+  # Delete Child Policies Incident Check
+  validate $ds_to_delete do
+    summary_template "Policies being deleted"
+    detail_template <<-EOS
+    Policies being Deleted:
+
+    | Applied Policy |
+    | --------------- |
+    {{ range data -}}
+    | {{ .name }} |
+    {{ end -}}
+    EOS
+    escalate $delete_policies
+    check eq(size(data),0)
+  end
+end
+
+# Used only for emailing the combined child incident if so desired
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_combined_incident_email
+end
+
+escalation "create_policies" do
+  run "create_applied_policies", data, rs_governance_host, rs_project_id
+end
+
+# if name !=null
+define create_applied_policies($data, $governance_host, $rs_project_id) return $responses do
+  $responses = []
+  $$debug = []
+  $item_index = 0
+  $item_total = size($data)
+  foreach $item in $data do
+    $item_index = $item_index + 1
+    $status = to_s("("+$item_index+"/"+$item_total+")")
+    task_label($status+" Creating Applied Policy with Options: " + to_json($item["options"]))
+    $response = http_request(
+      auth: $$auth_flexera,
+      verb: "post",
+      https: true,
+      host: $governance_host,
+      href: join(["/api/governance/projects/", $rs_project_id, "/applied_policies"]),
+      headers: { "Api-Version": "1.0" },
+      body: {
+        "name": $item["name"],
+        "description": $item["description"],
+        "template_href": $item["template_href"],
+        "frequency": $item["frequency"],
+        "options": $item["options"],
+        "credentials": $item["credentials"],
+        "meta_parent_policy_id": $item["meta_parent_policy_id"]
+      }
+    )
+    $responses << $response
+    $$debug << to_json({
+      "response": $response,
+      "item": $item,
+      "governance_host": $governance_host
+    })
+  end
+end
+
+escalation "update_policies" do
+  run "update_applied_policies", data, rs_governance_host, rs_project_id
+end
+
+define update_applied_policies($data, $governance_host, $rs_project_id) return $responses do
+  $responses = []
+  $$debug = []
+  $item_index = 0
+  $item_total = size($data)
+  foreach $item in $data do
+    $item_index = $item_index + 1
+    $status = to_s("("+$item_index+"/"+$item_total+")")
+    task_label($status+" Updating Applied Policy with Options: " + to_json($item["options"]))
+    $response = http_request(
+      auth: $$auth_flexera,
+      verb: "patch",
+      https: true,
+      host: $governance_host,
+      href: join(["/api/governance/projects/", $rs_project_id, "/applied_policies/", $item["applied_policy_id"]]),
+      headers: { "Api-Version": "1.0" },
+      body: {
+        "options": $item["options"]
+      }
+    )
+    $responses << $response
+    $$debug << to_json({
+      "response": $response,
+      "item": $item,
+      "governance_host": $governance_host
+    })
+  end
+end
+
+escalation "delete_policies" do
+  run "delete_applied_policies", data, rs_governance_host, rs_project_id
+end
+
+define delete_applied_policies($data, $governance_host, $rs_project_id) return $responses do
+  $responses = []
+  $$debug = []
+  $item_index = 0
+  $item_total = size($data)
+  foreach $item in $data do
+    $item_index = $item_index + 1
+    $status = to_s("("+$item_index+"/"+$item_total+")")
+    task_label($status+" Deleting Applied Policy: " + $item["id"])
+    $response = http_request(
+      auth: $$auth_flexera,
+      verb: "delete",
+      https: true,
+      host: $governance_host,
+      href: join(["/api/governance/projects/", $rs_project_id, "/applied_policies/", $item["id"]]),
+      headers: { "Api-Version": "1.0" }
+    )
+    $responses << $response
+    $$debug << to_json({
+      "response": $response,
+      "item": $item,
+      "governance_host": $governance_host
+    })
+  end
+end

--- a/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
+++ b/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
@@ -96,7 +96,7 @@ parameter "param_automatic_action" do
   type "string"
   category "Actions"
   label "Automatic Actions"
-  description "This policy will automatically take the selected action"
+  description "The policy will automatically take the selected action"
   default "No Automatic Actions"
   allowed_values "No Automatic Actions", "Stop Instances", "Terminate Instances"
 end

--- a/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
+++ b/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
@@ -96,7 +96,7 @@ parameter "param_automatic_action" do
   type "string"
   category "Actions"
   label "Automatic Actions"
-  description "When this value is set, this policy will automatically take the selected action(s)"
+  description "This policy will automatically take the selected action"
   default "No Automatic Actions"
   allowed_values "No Automatic Actions", "Stop Instances", "Terminate Instances"
 end

--- a/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
+++ b/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
@@ -770,8 +770,17 @@ policy "policy_scheduled_report" do
       field "platform" do
         label "Platform"
       end
+      field "operating_system" do
+        label "Operating System"
+      end
       field "hostname" do
         label "Hostname"
+      end
+      field "ipAddress" do
+        label "IP Address"
+      end
+      field "ipv6Address" do
+        label "IPv6 Address"
       end
       field "cost" do
         label "Estimated Monthly Cost"
@@ -781,6 +790,12 @@ policy "policy_scheduled_report" do
       end
       field "launchTime" do
         label "Launch Time"
+      end
+      field "purchase_option" do
+        label "Purchase Option"
+      end
+      field "billing_center" do
+        label "Billing Center"
       end
       field "lookbackPeriod" do
         label "Look Back Period (Days)"

--- a/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
+++ b/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
@@ -17,6 +17,7 @@ default_child_policy_template_files = [
   "../../cost/aws/unused_volumes/aws_delete_unused_volumes.pt",
   "../../compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt",
   "../../operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate.pt",
+  "../../operational/aws/long_running_instances/long_running_instances.pt",
   "../../security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances.pt",
   # Azure Policy Templates
   "../../compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent.pt",


### PR DESCRIPTION
### Description

This is a revamp of the AWS Long Running Instances policy that adds new functionality and meta policy support. From the CHANGELOG:

- Several parameters altered to be more descriptive and human-readable
- Removed deprecated "Log to CM Audit Entries" parameter
- Added ability to filter resources by multiple tag key:value pairs
- Added several fields to incident export to provide additional context
- Added additional context to incident description
- Normalized incident export to be consistent with other policies
- Policy no longer raises new escalations for the same resource if incidental metadata has changed
- Streamlined code for better readability and faster execution
- Added logic required for "Meta Policy" use-cases
- Policy now requires a valid Flexera credential to facilitate "Meta Policy" use-cases

### Link to Example Applied Policy

The new functionality depends too much on valid Optima data to be easily tested in our internal environments. I've confirmed the policy works as expected in the customer environment that is primarily the driver for these changes.

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD