### PR TITLE
POL-840 Azure Rightsize SQL Databases Revamp 

### DIFF
--- a/cost/azure/rightsize_sql_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_sql_instances/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v4.0
+
+- Several parameters altered to be more descriptive and human-readable
+- Removed deprecated "Log to CM Audit Entries" parameter
+- Added potential savings to recommendations
+- Added ability to only report recommendations that meet a minimum savings threshold
+- Added incident for unused instances based on lack of connections
+- Added ability to delete unused instances
+- Added ability to configure how many days back to consider when determining if instance is unused or underutilized
+- Added ability to filter resources by multiple tag key:value pairs
+- Added ability to filter resources by region
+- Added additional context to incident description
+- Normalized incident export to be consistent with other policies
+- Added human-readable recommendation to incident export
+- Policy no longer raises new escalations if statistics or savings data changed but nothing else has
+- Streamlined code for better readability and faster execution
+
 ## v3.0
 
 - Renamed Subscription List parameter for consistency and accuracy

--- a/cost/azure/rightsize_sql_instances/README.md
+++ b/cost/azure/rightsize_sql_instances/README.md
@@ -12,6 +12,15 @@ This policy checks all the Azure SQL single database instances in Azure Subscrip
 - The policy identifies all instances that have had connections but have average CPU usage below the user-specified threshold over a user-specified number of days and provides the relevant recommendation.
 - The recommendation provided for underutilized instances is a downsize action. These instances can be downsized in an automated manner or after approval.
 
+### Policy savings details
+
+The policy includes the estimated monthly savings. The estimated monthly savings is recognized if the resource is deleted or downsized. Optima is used to retrieve and calculate the estimated savings.
+
+- For unused instances, savings is the cost of the resource for a full day (3 days ago) multiplied by 30.44 (the average number of days in a month) or 0 if no cost information for the resource was found in Optima.
+- For underutilized resources, the above value is divided by the current capacity of the instance, multiplied by the recommended capacity of the instance, and then subtracted from the current cost of the instance.
+
+The savings is displayed in the Estimated Monthly Savings column. The incident message detail includes the sum of each resource *Estimated Monthly Savings* as *Potential Monthly Savings*.
+
 ## Input Parameters
 
 - *Email Addresses* - Email addresses of the recipients you wish to notify when new incidents are created.

--- a/cost/azure/rightsize_sql_instances/README.md
+++ b/cost/azure/rightsize_sql_instances/README.md
@@ -2,37 +2,39 @@
 
 ## What it does
 
-This policy will look at Utilization of Azure SQL single database and recommend up or down sizing after user approval.
+This policy checks all the Azure SQL single database instances in Azure Subscriptions for the average CPU usage and number of connections over a user-specified number of days. If there were no connections to the instance, the instance is recommended for deletion. If there were connections but the average CPU usage was below a user-specified threshold, the instance is recommended for downsizing. Both sets of instances returned from this policy are emailed to the user.
 
 ## Functional Details
 
-This policy checks all the Azure SQL databases for a Azure Subscription. It does a Average CPU usage over the last 30 days. It then checks if the Utilization is Lower than the Downsize Threshold or higher that Upsize Threshold. Finally it displays the found data, recommendations and provides option to Downsize or Upsize the SQL database after the user approval.
-
-- This policy does not support databases which are in Elastic pool
-- This policy applies only for Upsize or Downsize of DTUs/vCores within tiers.
-- This policy will not be applicable to resize between service tiers.
-- If the SQL database can not downsize because it's already at it's min size or can not upsize because it's already at it's max. then in the 'Recommended Capacity' column shows as 'n/a' and 'Recommendation' column shows as 'Change tier' for resize within tiers.
-- Pls refer the following links: <https://docs.microsoft.com/en-us/azure/sql-database/sql-database-dtu-resource-limits-single-databases> and <https://docs.microsoft.com/en-us/azure/sql-database/sql-database-vcore-resource-limits-single-databases> for detailed resource limits of Azure SQL Database using the DTU purchasing model and using the vCore purchasing model.
+- The policy leverages the Azure API to check all Azure SQL single database instances and then checks the number of connections and average CPU utilization over a user-specified number of days.
+- The policy identifies all instances that either have had no connections over a user-specified number of days and provides the relevant recommendation.
+- The recommendation provided for unused instances is a deletion action. These instances can be deleted in an automated manner or after approval.
+- The policy identifies all instances that have had connections but have average CPU usage below the user-specified threshold over a user-specified number of days and provides the relevant recommendation.
+- The recommendation provided for underutilized instances is a downsize action. These instances can be downsized in an automated manner or after approval.
 
 ## Input Parameters
 
-This policy has the following input parameters required when launching the policy.
-
-- *Average used CPU % - Upsize threshold* - Percentage of CPU utilization to identify an Upsize is recommended
-- *Average used CPU % - Downsize Threshold* - Percentage of CPU utilization to identify an Downsize is recommended
-- *Exclusion Tag Key* - Cloud native tag key to ignore instances. Example: exclude_utilization
-- *Email addresses* - Email addresses of the recipients you wish to notify
-- *Azure Endpoint* - Azure Endpoint to access resources
-- *Subscription Allowed List* - Allowed Subscriptions, if empty, all subscriptions will be checked
+- *Email Addresses* - Email addresses of the recipients you wish to notify when new incidents are created.
+- *Azure Endpoint* - The endpoint to send Azure API requests to. Recommended to leave this at default unless using this policy with Azure China.
+- *Minimum Savings Threshold* - Minimum potential savings required to generate a recommendation.
+- *Allow/Deny Subscriptions* - Determines whether the Allow/Deny Subscriptions List parameter functions as an allow list (only providing results for the listed subscriptions) or a deny list (providing results for all subscriptions except for the listed subscriptions).
+- *Allow/Deny Subscriptions List* - A list of allowed or denied Subscription IDs/names. If empty, no filtering will occur and recommendations will be produced for all subscriptions.
+- *Allow/Deny Regions* - Whether to treat Allow/Deny Regions List parameter as allow or deny list. Has no effect if Allow/Deny Regions List is left empty.
+- *Allow/Deny Regions List* - Filter results by region, either only allowing this list or denying it depending on how the above parameter is set. Leave blank to consider all the regions.
+- *Exclusion Tags (Key:Value)* - Cloud native tags to ignore instances that you don't want to consider for downsizing or deletion. Format: Key:Value
+- *Statistic Lookback Period* - How many days back to look at connection and CPU utilization data for instances. This value cannot be set higher than 90 because Azure does not retain metrics for longer than 90 days.
+- *Report Unused or Underutilized* - Whether to report on unused instances, underutilized instances, or both. If both are selected, unused instances will not appear in the list of underutilized instances regardless of CPU usage.
+- *Underutilized Instance CPU Threshold (%)* - The CPU threshold at which to consider an instance to be underutilized and therefore be flagged for downsizing.
 - *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).
 
 Please note that the "Automatic Actions" parameter contains a list of action(s) that can be performed on the resources. When it is selected, the policy will automatically execute the corresponding action on the data that failed the checks, post incident generation. Please leave it blank for *manual* action.
-For example if a user selects the "Resize Instances" action while applying the policy, all the identified resources will be resized as per the recommendation.
+For example if a user selects the "Delete Unused Instances" action while applying the policy, all the resources that didn't satisfy the policy condition will be deleted.
 
 ## Actions
 
 - Sends an email notification
-- Rightsize SQL Databases after approval
+- Delete Azure SQL single database instance (if unused) after approval
+- Downsize Azure SQL single database instance (if underutilized) after approval
 
 ## Prerequisites
 
@@ -43,9 +45,13 @@ This policy uses [credentials](https://docs.flexera.com/flexera/EN/Automation/Ma
 For administrators [creating and managing credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) to use with this policy, the following information is needed:
 
 - [**Azure Resource Manager Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_109256743_1124668) (*provider=azure_rm*) which has the following permissions:
-- Microsoft.Sql/servers/databases/read
-- Microsoft.Sql/servers/databases/update
-- Microsoft.Sql/servers/databases/metrics/read
+  - `Microsoft.Sql/servers/databases/read`
+  - `Microsoft.Sql/servers/databases/metrics/read`
+  - `Microsoft.Sql/servers/databases/update`*
+  - `Microsoft.Sql/servers/databases/delete`*
+  - `Microsoft.Insights/metrics/read`
+
+\* Only required for taking action (deleting or downsizing); the policy will still function in a read-only capacity without these permissions.
 
 - [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
   - `billing_center_viewer`

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
@@ -338,16 +338,30 @@ datasource "ds_azure_sql_databases" do
   end
 end
 
+datasource "ds_azure_sql_databases_system_filtered" do
+  run_script $js_azure_sql_databases_system_filtered, $ds_azure_sql_databases
+end
+
+script "js_azure_sql_databases_system_filtered", type: "javascript" do
+  parameters "ds_azure_sql_databases"
+  result "result"
+  code <<-EOS
+  result = _.reject(ds_azure_sql_databases, function(db) {
+    return db['sku']['name'] == 'System'
+  })
+EOS
+end
+
 datasource "ds_azure_sql_databases_tag_filtered" do
-  run_script $js_azure_sql_databases_tag_filtered, $ds_azure_sql_databases, $param_exclusion_tags
+  run_script $js_azure_sql_databases_tag_filtered, $ds_azure_sql_databases_system_filtered, $param_exclusion_tags
 end
 
 script "js_azure_sql_databases_tag_filtered", type: "javascript" do
-  parameters "ds_azure_sql_databases", "param_exclusion_tags"
+  parameters "ds_azure_sql_databases_system_filtered", "param_exclusion_tags"
   result "result"
   code <<-EOS
   if (param_exclusion_tags.length > 0) {
-    result = _.reject(ds_azure_sql_databases, function(db) {
+    result = _.reject(ds_azure_sql_databases_system_filtered, function(db) {
       db_tags = []
 
       if (typeof(db['tags']) == 'object') {
@@ -368,7 +382,7 @@ script "js_azure_sql_databases_tag_filtered", type: "javascript" do
       return exclude_db
     })
   } else {
-    result = ds_azure_sql_databases
+    result = ds_azure_sql_databases_system_filtered
   }
 EOS
 end
@@ -418,6 +432,7 @@ datasource "ds_azure_sql_database_metrics" do
   end
 end
 
+# https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-sql-servers-databases-metrics
 script "js_azure_sql_database_metrics", type: "javascript" do
   parameters "resource_id", "param_azure_endpoint", "param_stats_lookback"
   result "request"
@@ -478,6 +493,14 @@ script "js_merged_metrics", type: "javascript" do
   result = []
 
   _.each(ds_azure_sql_database_metrics, function(db) {
+    db_tags = []
+
+    if (typeof(db['tags']) == 'object') {
+      _.each(Object.keys(db['tags']), function(key) {
+        db_tags.push([key, "=", db['tags'][key]].join(''))
+      })
+    }
+
     instance = {
       id: db['id'],
       region: db['region'],
@@ -485,7 +508,7 @@ script "js_merged_metrics", type: "javascript" do
       kind: db['kind'],
       type: db['type'],
       sku: db['sku'],
-      tags: db['tags'],
+      tags: db_tags.join(', '),
       resourceGroup: db['resourceGroup'],
       subscriptionId: db['subscriptionId'],
       subscriptionName: db['subscriptionName'],
@@ -508,7 +531,13 @@ script "js_merged_metrics", type: "javascript" do
     })
 
     if (connection_metrics != null && param_unused_or_underutilized != "Underutilized") {
-      if (connection_metrics.length == 0) {
+      total_connections = 0
+
+      _.each(connection_metrics, function(metric) {
+        if (typeof(metric['count']) == 'number') { total_connections += metric['count'] }
+      })
+
+      if (total_connections == 0) {
         instance['recommendationType'] = 'Delete'
         instance['newResourceType'] = 'Delete'
 
@@ -523,13 +552,13 @@ script "js_merged_metrics", type: "javascript" do
     if (cpu_metrics != null && instance['recommendationType'] != 'Delete' && param_unused_or_underutilized != "Unused") {
       if (cpu_metrics.length > 0) {
         averages = _.pluck(cpu_metrics, 'average')
-        cpu_average = null
+        cpu_average = 0
 
         if (averages.length > 0) {
           cpu_average = _.reduce(averages, function(memo, num) { return memo + num }, 0) / averages.length
         }
 
-        if (cpu_average != null && cpu_average <= param_stats_underutil_threshold_cpu_value) {
+        if (cpu_average <= param_stats_underutil_threshold_cpu_value) {
           instance['cpu_average'] = cpu_average
           instance['recommendationType'] = 'Downsize'
 
@@ -762,20 +791,26 @@ script "js_downsize_sql_incident", type: "javascript" do
   total_underutilized_dbs = result.length.toString()
   underutilized_dbs_percentage = (total_underutilized_dbs / total_dbs * 100).toFixed(2).toString() + '%'
 
+  db_message = "Database"
+  db_verb = "is"
+
+  if (total_dbs > 1) { db_message += "s" }
+  if (total_underutilized_dbs > 1) { db_verb = "are" }
+
   findings = [
-    "Out of ", total_dbs , " Azure SQL Databases analyzed, ",
+    "Out of ", total_dbs , " Azure SQL ", db_message, " analyzed, ",
     total_underutilized_dbs, " (", underutilized_dbs_percentage,
-    ") are underutilized and recommended for downsizing. "
+    ") ", db_verb, " underutilized and recommended for downsizing. "
   ].join('')
 
   day_message = "day"
-  if (param_stats_lookback.length > 1) { day_message += "s" }
+  if (param_stats_lookback > 1) { day_message += "s" }
 
   if (param_unused_or_underutilized == 'Underutilized') {
     context_message = [
       "An Azure SQL Database is considered underutilized if it has an average CPU usage below ",
-      param_stats_underutil_threshold_cpu_value, "% for last ", param_stats_lookback, " ", day_message,
-      ", regardless of whether it has had any connections to it in that same time period."
+      param_stats_underutil_threshold_cpu_value, "% for the last ", param_stats_lookback, " ", day_message,
+      ", regardless of whether it has had any connections to it in that same time period.\n\n"
     ].join('')
   } else {
     context_message = [
@@ -885,14 +920,20 @@ script "js_unused_sql_incident", type: "javascript" do
   total_unused_dbs = result.length.toString()
   unused_dbs_percentage = (total_unused_dbs / total_dbs * 100).toFixed(2).toString() + '%'
 
+  db_message = "Database"
+  db_verb = "is"
+
+  if (total_dbs > 1) { db_message += "s" }
+  if (total_unused_dbs > 1) { db_verb = "are" }
+
   findings = [
-    "Out of ", total_dbs , " Azure SQL Databases analyzed, ",
+    "Out of ", total_dbs , " Azure SQL ", db_message, " analyzed, ",
     total_unused_dbs, " (", unused_dbs_percentage,
-    ") are unused and recommended for deletion. "
+    ") ", db_verb, " unused and recommended for deletion. "
   ].join('')
 
   day_message = "day"
-  if (param_stats_lookback.length > 1) { day_message += "s" }
+  if (param_stats_lookback > 1) { day_message += "s" }
 
   context_message = [
     "An Azure SQL Database is considered unused if it has not had any connections ",
@@ -1096,23 +1137,23 @@ escalation "esc_downsize_instances" do
   automatic contains($param_automatic_action, "Downsize Underutilized Instances")
   label "Downsize Underutilized Instances"
   description "Approval to downsize all selected underutilized instances"
-  run "downsize_instances", data, $param_azure_endpoint, rs_optima_host
+  run "downsize_instances", data, $param_azure_endpoint
 end
 
 escalation "esc_delete_instances" do
   automatic contains($param_automatic_action, "Delete Unused Instances")
   label "Delete Unused Instances"
   description "Approval to delete all selected unused instances"
-  run "delete_instances", data, $param_azure_endpoint, rs_optima_host
+  run "delete_instances", data, $param_azure_endpoint
 end
 
 ###############################################################################
 # Cloud Workflow
 ###############################################################################
 
-define downsize_instances($data, $param_azure_endpoint, $$rs_optima_host) return $all_responses do
+define downsize_instances($data, $param_azure_endpoint) return $all_responses do
   # Change "No" to "Yes" to enable CWF debug logging
-  $log_to_cm_audit_entries = "No"
+  $log_to_cm_audit_entries = "Yes"
 
   $$debug = $log_to_cm_audit_entries == "Yes"
 
@@ -1150,9 +1191,9 @@ define downsize_instances($data, $param_azure_endpoint, $$rs_optima_host) return
   end
 end
 
-define delete_instances($data, $param_azure_endpoint, $$rs_optima_host) return $all_responses do
+define delete_instances($data, $param_azure_endpoint) return $all_responses do
   # Change "No" to "Yes" to enable CWF debug logging
-  $log_to_cm_audit_entries = "No"
+  $log_to_cm_audit_entries = "Yes"
 
   $$debug = $log_to_cm_audit_entries == "Yes"
 
@@ -1184,37 +1225,16 @@ define delete_instances($data, $param_azure_endpoint, $$rs_optima_host) return $
 end
 
 define sys_log($subject, $detail) do
-  # Create empty errors array if doesn't already exist
-  if !$$errors
-    $$errors = []
-  end
-  # Check if debug is enabled
   if $$debug
-    # Append to global $$errors
-    # This is the suggested way to capture errors
-    $$errors << "Unexpected error for " + $subject + "\n  " + to_s($detail)
-    # If Flexera NAM Zone, create audit_entries [to be deprecated]
-    # This is the legacy method for capturing errors and only supported on Flexera NAM
-    if $$rs_optima_host == "api.optima.flexeraeng.com"
-      # skip_error_and_append is used to catch error if rs_cm.audit_entries.create fails unexpectedly
-      $task_label = "Creating audit entry for " + $subject
-      sub task_label: $task, on_error: skip_error_and_append($task) do
-        rs_cm.audit_entries.create(
-          notify: "None",
-          audit_entry: {
-            auditee_href: @@account,
-            summary: $subject,
-            detail: $detail
-          }
-        )
-      end # End sub on_error
-    end # End if rs_optima_host
-  end # End if debug is enabled
-end
-
-define skip_error_and_append($subject) do
-  $$errors << "Unexpected error for " + $subject + "\n  " + to_s($_error)
-  $_error_behavior = "skip"
+    rs_cm.audit_entries.create(
+      notify: "None",
+      audit_entry: {
+        auditee_href: @@account,
+        summary: $subject,
+        detail: $detail
+      }
+    )
+  end
 end
 
 ###############################################################################

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
@@ -1163,8 +1163,8 @@ define downsize_instances($data, $param_azure_endpoint) return $all_responses do
   foreach $item in $data do
     sub on_error: skip do
       $response = http_request(
-        verb: "PATCH",
         auth: $$auth_azure,
+        verb: "patch",
         host: $param_azure_endpoint,
         https: true,
         href: $item["id"],
@@ -1203,9 +1203,9 @@ define delete_instances($data, $param_azure_endpoint) return $all_responses do
   foreach $item in $data do
     sub on_error: skip do
       $response = http_request(
-        verb: "DELETE",
-        host: $param_azure_endpoint,
         auth: $$auth_azure,
+        verb: "delete",
+        host: $param_azure_endpoint,
         https: true,
         href: $item["id"],
         query_strings: {

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
@@ -34,6 +34,15 @@ parameter "param_azure_endpoint" do
   default "management.azure.com"
 end
 
+parameter "param_min_savings" do
+  type "number"
+  category "Policy Settings"
+  label "Minimum Savings Threshold"
+  description "Minimum potential savings required to generate a recommendation"
+  min_value 0
+  default 0
+end
+
 parameter "param_subscriptions_allow_or_deny" do
   type "string"
   category "Filters"
@@ -447,11 +456,11 @@ datasource "ds_azure_sql_resize_map" do
 end
 
 datasource "ds_merged_metrics" do
-  run_script $js_merged_metrics, $ds_azure_sql_database_metrics, $ds_azure_sql_resize_map, $param_stats_underutil_threshold_cpu_value
+  run_script $js_merged_metrics, $ds_azure_sql_database_metrics, $ds_azure_sql_resize_map, $param_stats_underutil_threshold_cpu_value, $param_stats_lookback
 end
 
 script "js_merged_metrics", type: "javascript" do
-  parameters "ds_azure_sql_database_metrics", "ds_azure_sql_resize_map", "param_stats_underutil_threshold_cpu_value"
+  parameters "ds_azure_sql_database_metrics", "ds_azure_sql_resize_map", "param_stats_underutil_threshold_cpu_value", "param_stats_lookback"
   result "result"
   code <<-EOS
   result = []
@@ -467,7 +476,9 @@ script "js_merged_metrics", type: "javascript" do
       tags: db['tags'],
       resourceGroup: db['resourceGroup'],
       subscriptionId: db['subscriptionId'],
-      subscriptionName: db['subscriptionName']
+      subscriptionName: db['subscriptionName'],
+      lookbackPeriod: param_stats_lookback,
+      threshold: param_stats_underutil_threshold_cpu_value
     }
 
     connection_metrics = null
@@ -541,7 +552,6 @@ script "js_merged_metrics", type: "javascript" do
   })
 EOS
 end
-
 
 datasource "ds_cost_subscriptions" do
   run_script $js_cost_subscriptions, $ds_merged_metrics
@@ -661,12 +671,102 @@ script "js_sql_costs_grouped", type: "javascript" do
 EOS
 end
 
+datasource "ds_unused_sql_incident" do
+  run_script $js_unused_sql_incident, $ds_merged_metrics, $ds_sql_costs_grouped, $ds_currency, $param_min_savings
+end
+
+script "js_unused_sql_incident", type: "javascript" do
+  parameters "ds_merged_metrics", "ds_sql_costs_grouped", "ds_currency", "param_min_savings"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  unused_instances = _.filter(ds_merged_metrics, function(item) {
+    return item['recommendationType'] == 'Delete'
+  })
+
+  _.each(unused_instances, function(db) {
+    savings = ds_sql_costs_grouped[db['id'].toLowerCase()]
+
+    if (savings != null && savings != undefined) {
+      savings = parseFloat(savings.toFixed(3))
+    }
+
+    if (savings >= param_min_savings || param_min_savings == 0) {
+      result.push({
+        id: db['id'],
+        region: db['region'],
+        resourceName: db['name'],
+        kind: db['kind'],
+        type: db['type'],
+        sku: db['sku'],
+        tags: db['tags'],
+        resourceGroup: db['resourceGroup'],
+        accountID: db['subscriptionId'],
+        accountName: db['subscriptionName'],
+        recommendationType: db['recommendationType'],
+        recommendationDetails: db['recommendationDetails'],
+        lookbackPeriod: db['lookbackPeriod'],
+        savings: savings,
+        savingsCurrency: ds_currency['symbol']
+      })
+    }
+  })
+EOS
+end
+
+datasource "ds_rightsize_sql_incident" do
+  run_script $js_rightsize_sql_incident, $ds_merged_metrics, $ds_sql_costs_grouped, $ds_currency, $param_min_savings
+end
+
+script "js_rightsize_sql_incident", type: "javascript" do
+  parameters "ds_merged_metrics", "ds_sql_costs_grouped", "ds_currency", "param_min_savings"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  unused_instances = _.filter(ds_merged_metrics, function(item) {
+    return item['recommendationType'] == 'Downsize'
+  })
+
+  _.each(unused_instances, function(db) {
+    savings = ds_sql_costs_grouped[db['id'].toLowerCase()]
+
+    if (savings != null && savings != undefined) {
+      savings = parseFloat(savings.toFixed(3))
+    }
+
+    if (savings >= param_min_savings || param_min_savings == 0) {
+      result.push({
+        id: db['id'],
+        region: db['region'],
+        resourceName: db['name'],
+        kind: db['kind'],
+        type: db['type'],
+        sku: db['sku'],
+        tags: db['tags'],
+        resourceGroup: db['resourceGroup'],
+        accountID: db['subscriptionId'],
+        accountName: db['subscriptionName'],
+        recommendationType: db['recommendationType'],
+        recommendationDetails: db['recommendationDetails'],
+        newResourceType: db['newResourceType'],
+        cpuAverage: db['cpu_average'],
+        lookbackPeriod: db['lookbackPeriod'],
+        savings: savings,
+        savingsCurrency: ds_currency['symbol']
+      })
+    }
+  })
+EOS
+end
+
 ###############################################################################
 # Policy
 ###############################################################################
 
-policy 'policy_azure_db_utilization' do
-  validate $ds_merged_metrics do
+policy "pol_azure_unused_sql" do
+  validate_each $ds_unused_sql_incident do
     summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): Found {{ len data }} Azure Rightsize SQL single Database"
     detail_template <<-EOS
       ### Thresholds for Consideration

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
@@ -1,16 +1,17 @@
 name "Azure Rightsize SQL Databases"
 rs_pt_ver 20180301
 type "policy"
-short_description "Check for Inefficient Azure SQL single database services that are inside or outside the CPU threshold for the last 30 days and resizes them after approval. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/rightsize_sql_instances/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "Checks for SQL database instances that have inefficient utilization for the last 30 days and downsizes or deletes them after approval. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/rightsize_sql_instances/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
-severity "low"
 category "Cost"
-default_frequency "daily"
+severity "low"
+default_frequency "weekly"
 info(
   version: "4.0",
   provider: "Azure",
   service: "SQL",
-  policy_set: "RightSize Database Services"
+  policy_set: "Rightsize Database Instances",
+  recommendation_type: "Usage Reduction"
 )
 
 ###############################################################################
@@ -86,12 +87,21 @@ parameter "param_exclusion_tags" do
   default []
 end
 
+parameter "param_unused_or_underutilized" do
+  type "string"
+  category "Filters"
+  label "Report Unused or Underutilized"
+  description "Whether to report on unused instances, underutilized instances, or both."
+  allowed_values "Unused & Underutilized", "Unused", "Underutilized"
+  default "Unused & Underutilized"
+end
+
 parameter "param_stats_underutil_threshold_cpu_value" do
   type "number"
   category "Statistics"
   label "Underutilized Instance CPU Threshold (%)"
-  description "The CPU threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing. Set to -1 to ignore CPU utilization and only report unused instances"
-  min_value -1
+  description "The CPU threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing."
+  min_value 0
   max_value 100
   default 60
 end
@@ -108,9 +118,11 @@ end
 
 parameter "param_automatic_action" do
   type "list"
+  category "Actions"
   label "Automatic Actions"
-  description "When this value is set, this policy will automatically take the selected action(s)"
-  allowed_values ["Resize Instances"]
+  description "When this value is set, this policy will automatically take the selected action."
+  allowed_values ["Downsize Underutilized Instances", "Delete Unused Instances"]
+  default []
 end
 
 ###############################################################################
@@ -456,11 +468,11 @@ datasource "ds_azure_sql_resize_map" do
 end
 
 datasource "ds_merged_metrics" do
-  run_script $js_merged_metrics, $ds_azure_sql_database_metrics, $ds_azure_sql_resize_map, $param_stats_underutil_threshold_cpu_value, $param_stats_lookback
+  run_script $js_merged_metrics, $ds_azure_sql_database_metrics, $ds_azure_sql_resize_map, $ds_applied_policy, $param_stats_underutil_threshold_cpu_value, $param_stats_lookback, $param_unused_or_underutilized
 end
 
 script "js_merged_metrics", type: "javascript" do
-  parameters "ds_azure_sql_database_metrics", "ds_azure_sql_resize_map", "param_stats_underutil_threshold_cpu_value", "param_stats_lookback"
+  parameters "ds_azure_sql_database_metrics", "ds_azure_sql_resize_map", "ds_applied_policy", "param_stats_underutil_threshold_cpu_value", "param_stats_lookback", "param_unused_or_underutilized"
   result "result"
   code <<-EOS
   result = []
@@ -478,7 +490,8 @@ script "js_merged_metrics", type: "javascript" do
       subscriptionId: db['subscriptionId'],
       subscriptionName: db['subscriptionName'],
       lookbackPeriod: param_stats_lookback,
-      threshold: param_stats_underutil_threshold_cpu_value
+      threshold: param_stats_underutil_threshold_cpu_value,
+      policy_name: ds_applied_policy['name']
     }
 
     connection_metrics = null
@@ -494,22 +507,20 @@ script "js_merged_metrics", type: "javascript" do
       }
     })
 
-    if (connection_metrics != null) {
+    if (connection_metrics != null && param_unused_or_underutilized != "Underutilized") {
       if (connection_metrics.length == 0) {
         instance['recommendationType'] = 'Delete'
         instance['newResourceType'] = 'Delete'
 
-        recommendationDetails = [
+        instance["recommendationDetails"] = [
           "Delete Azure SQL database ", instance["name"], " ",
           "in Azure Subscription ", instance["subscriptionName"], " ",
           "(", instance["subscriptionId"], ")"
-        ]
-
-        instance["recommendationDetails"] = recommendationDetails.join('')
+        ].join('')
       }
     }
 
-    if (cpu_metrics != null && instance['recommendationType'] != 'Delete' && param_stats_underutil_threshold_cpu_value != -1) {
+    if (cpu_metrics != null && instance['recommendationType'] != 'Delete' && param_unused_or_underutilized != "Unused") {
       if (cpu_metrics.length > 0) {
         averages = _.pluck(cpu_metrics, 'average')
         cpu_average = null
@@ -530,15 +541,13 @@ script "js_merged_metrics", type: "javascript" do
               if (typeof(ds_azure_sql_resize_map[tier][type]['down']) == 'string') {
                 instance['newResourceType'] = ds_azure_sql_resize_map[tier][type]['down']
 
-                recommendationDetails = [
+                instance["recommendationDetails"] = [
                   "Downsize Azure SQL database ", instance["name"], " ",
                   "in Azure Subscription ", instance["subscriptionName"], " ",
                   "(", instance["subscriptionId"], ") ",
                   "from ", instance['sku']['capacity'], " capacity ",
                   "to ", instance["newResourceType"], " capacity"
-                ]
-
-                instance["recommendationDetails"] = recommendationDetails.join('')
+                ].join('')
               }
             }
           }
@@ -671,78 +680,59 @@ script "js_sql_costs_grouped", type: "javascript" do
 EOS
 end
 
-datasource "ds_unused_sql_incident" do
-  run_script $js_unused_sql_incident, $ds_merged_metrics, $ds_sql_costs_grouped, $ds_currency, $param_min_savings
+datasource "ds_downsize_sql_incident" do
+  run_script $js_downsize_sql_incident, $ds_merged_metrics, $ds_azure_sql_databases_region_filtered, $ds_sql_costs_grouped, $ds_currency, $param_min_savings, $param_stats_lookback, $param_stats_underutil_threshold_cpu_value, $param_unused_or_underutilized
 end
 
-script "js_unused_sql_incident", type: "javascript" do
-  parameters "ds_merged_metrics", "ds_sql_costs_grouped", "ds_currency", "param_min_savings"
+script "js_downsize_sql_incident", type: "javascript" do
+  parameters "ds_merged_metrics", "ds_azure_sql_databases_region_filtered", "ds_sql_costs_grouped", "ds_currency", "param_min_savings", "param_stats_lookback", "param_stats_underutil_threshold_cpu_value", "param_unused_or_underutilized"
   result "result"
   code <<-'EOS'
-  result = []
+  // Function for formatting currency numbers later
+  function formatNumber(number, separator) {
+    var numString = number.toString()
+    var values = numString.split(".")
+    var formatted_number = ''
 
-  unused_instances = _.filter(ds_merged_metrics, function(item) {
-    return item['recommendationType'] == 'Delete'
-  })
-
-  _.each(unused_instances, function(db) {
-    savings = ds_sql_costs_grouped[db['id'].toLowerCase()]
-
-    if (savings != null && savings != undefined) {
-      savings = parseFloat(savings.toFixed(3))
+    while (values[0].length > 3) {
+      var chunk = values[0].substr(-3)
+      values[0] = values[0].substr(0, values[0].length - 3)
+      formatted_number = separator + chunk + formatted_number
     }
 
-    if (savings >= param_min_savings || param_min_savings == 0) {
-      result.push({
-        id: db['id'],
-        region: db['region'],
-        resourceName: db['name'],
-        kind: db['kind'],
-        type: db['type'],
-        sku: db['sku'],
-        tags: db['tags'],
-        resourceGroup: db['resourceGroup'],
-        accountID: db['subscriptionId'],
-        accountName: db['subscriptionName'],
-        recommendationType: db['recommendationType'],
-        recommendationDetails: db['recommendationDetails'],
-        lookbackPeriod: db['lookbackPeriod'],
-        savings: savings,
-        savingsCurrency: ds_currency['symbol']
-      })
-    }
-  })
-EOS
-end
+    if (values[0].length > 0) { formatted_number = values[0] + formatted_number }
 
-datasource "ds_rightsize_sql_incident" do
-  run_script $js_rightsize_sql_incident, $ds_merged_metrics, $ds_sql_costs_grouped, $ds_currency, $param_min_savings
-end
+    if (values[1] == undefined) { return formatted_number }
 
-script "js_rightsize_sql_incident", type: "javascript" do
-  parameters "ds_merged_metrics", "ds_sql_costs_grouped", "ds_currency", "param_min_savings"
-  result "result"
-  code <<-'EOS'
+    return formatted_number + "." + values[1]
+  }
+
   result = []
 
-  unused_instances = _.filter(ds_merged_metrics, function(item) {
+  downsize_instances = _.filter(ds_merged_metrics, function(item) {
     return item['recommendationType'] == 'Downsize'
   })
 
-  _.each(unused_instances, function(db) {
-    savings = ds_sql_costs_grouped[db['id'].toLowerCase()]
+  total_savings = 0.0
 
-    if (savings != null && savings != undefined) {
-      savings = parseFloat(savings.toFixed(3))
+  _.each(downsize_instances, function(db) {
+    id = db['id'].toLowerCase()
+    savings = 0.0
+
+    if (ds_sql_costs_grouped[id] != null && ds_sql_costs_grouped[id] != undefined) {
+      cost = ds_sql_costs_grouped[id]
+      savings = cost - (cost / db['sku']['capacity'] * db['newResourceType'])
     }
 
     if (savings >= param_min_savings || param_min_savings == 0) {
+      total_savings += savings
+
       result.push({
         id: db['id'],
         region: db['region'],
         resourceName: db['name'],
-        kind: db['kind'],
-        type: db['type'],
+        resourceKind: db['kind'],
+        resourceType: db['type'],
         sku: db['sku'],
         tags: db['tags'],
         resourceGroup: db['resourceGroup'],
@@ -751,13 +741,181 @@ script "js_rightsize_sql_incident", type: "javascript" do
         recommendationType: db['recommendationType'],
         recommendationDetails: db['recommendationDetails'],
         newResourceType: db['newResourceType'],
-        cpuAverage: db['cpu_average'],
+        cpuAverage: parseFloat(db['cpu_average'].toFixed(2)),
         lookbackPeriod: db['lookbackPeriod'],
-        savings: savings,
-        savingsCurrency: ds_currency['symbol']
+        threshold: db['threshold'],
+        policy_name: db['policy_name'],
+        savings: parseFloat(savings.toFixed(3)),
+        savingsCurrency: ds_currency['symbol'],
+        service: "Microsoft.Sql",
+        platform: "Azure SQL Database",
+        total_savings: "",
+        message: ""
       })
     }
   })
+
+  result = _.sortBy(result, function(item) { return item['savings'] * -1 })
+
+  // Message for incident output
+  total_dbs = ds_azure_sql_databases_region_filtered.length.toString()
+  total_underutilized_dbs = result.length.toString()
+  underutilized_dbs_percentage = (total_underutilized_dbs / total_dbs * 100).toFixed(2).toString() + '%'
+
+  findings = [
+    "Out of ", total_dbs , " Azure SQL Databases analyzed, ",
+    total_underutilized_dbs, " (", underutilized_dbs_percentage,
+    ") are underutilized and recommended for downsizing. "
+  ].join('')
+
+  day_message = "day"
+  if (param_stats_lookback.length > 1) { day_message += "s" }
+
+  if (param_unused_or_underutilized == 'Underutilized') {
+    context_message = [
+      "An Azure SQL Database is considered underutilized if it has an average CPU usage below ",
+      param_stats_underutil_threshold_cpu_value, "% for last ", param_stats_lookback, " ", day_message,
+      ", regardless of whether it has had any connections to it in that same time period."
+    ].join('')
+  } else {
+    context_message = [
+      "An Azure SQL Database is considered underutilized if it has had at least one connection to it ",
+      "in the last ", param_stats_lookback, " ", day_message, " but has an average CPU usage below ",
+      param_stats_underutil_threshold_cpu_value, "% for that same time period.\n\n"
+    ].join('')
+  }
+
+  disclaimer = "The above settings can be modified by editing the applied policy and changing the appropriate parameters.\n\n"
+
+  savings_message = ds_currency['symbol'] + ' ' + formatNumber(parseFloat(total_savings).toFixed(2), ds_currency['separator'])
+
+  // Dummy entry to ensure validation runs at least once
+  result.push({
+    id: "",                 region: "",                resourceName: "",
+    resourceKind: "",       resourceType: "",          sku: "",
+    tags: "",               resourceGroup: "",         accountID: "",
+    accountName: "",        recommendationType: "",    recommendationDetails: "",
+    newResourceType: "",    cpuAverage: "",            lookbackPeriod: "",
+    threshold: "",          policy_name: "",           savings: "",
+    savingsCurrency: "",    service: "",               platform: "",
+    total_savings: "",      message: ""
+  })
+
+  result[0]['total_savings'] = savings_message
+  result[0]['message'] = findings + context_message + disclaimer
+EOS
+end
+
+datasource "ds_unused_sql_incident" do
+  run_script $js_unused_sql_incident, $ds_merged_metrics, $ds_azure_sql_databases_region_filtered, $ds_sql_costs_grouped, $ds_currency, $param_min_savings, $param_stats_lookback
+end
+
+script "js_unused_sql_incident", type: "javascript" do
+  parameters "ds_merged_metrics", "ds_azure_sql_databases_region_filtered", "ds_sql_costs_grouped", "ds_currency", "param_min_savings", "param_stats_lookback"
+  result "result"
+  code <<-'EOS'
+  // Function for formatting currency numbers later
+  function formatNumber(number, separator) {
+    var numString = number.toString()
+    var values = numString.split(".")
+    var formatted_number = ''
+
+    while (values[0].length > 3) {
+      var chunk = values[0].substr(-3)
+      values[0] = values[0].substr(0, values[0].length - 3)
+      formatted_number = separator + chunk + formatted_number
+    }
+
+    if (values[0].length > 0) { formatted_number = values[0] + formatted_number }
+
+    if (values[1] == undefined) { return formatted_number }
+
+    return formatted_number + "." + values[1]
+  }
+
+  result = []
+
+  unused_instances = _.filter(ds_merged_metrics, function(item) {
+    return item['recommendationType'] == 'Delete'
+  })
+
+  total_savings = 0.0
+
+  _.each(unused_instances, function(db) {
+    id = db['id'].toLowerCase()
+    savings = 0.0
+
+    if (ds_sql_costs_grouped[id] != null && ds_sql_costs_grouped[id] != undefined) {
+      savings = ds_sql_costs_grouped[id]
+    }
+
+    if (savings >= param_min_savings || param_min_savings == 0) {
+      total_savings += savings
+
+      result.push({
+        id: db['id'],
+        region: db['region'],
+        resourceName: db['name'],
+        resourceKind: db['kind'],
+        resourceType: db['type'],
+        sku: db['sku'],
+        tags: db['tags'],
+        resourceGroup: db['resourceGroup'],
+        accountID: db['subscriptionId'],
+        accountName: db['subscriptionName'],
+        recommendationType: db['recommendationType'],
+        recommendationDetails: db['recommendationDetails'],
+        lookbackPeriod: db['lookbackPeriod'],
+        threshold: db['threshold'],
+        policy_name: db['policy_name'],
+        savings: parseFloat(savings.toFixed(3)),
+        savingsCurrency: ds_currency['symbol'],
+        service: "Microsoft.Sql",
+        platform: "Azure SQL Database",
+        total_savings: "",
+        message: ""
+      })
+    }
+  })
+
+  result = _.sortBy(result, function(item) { return item['savings'] * -1 })
+
+  // Message for incident output
+  total_dbs = ds_azure_sql_databases_region_filtered.length.toString()
+  total_unused_dbs = result.length.toString()
+  unused_dbs_percentage = (total_unused_dbs / total_dbs * 100).toFixed(2).toString() + '%'
+
+  findings = [
+    "Out of ", total_dbs , " Azure SQL Databases analyzed, ",
+    total_unused_dbs, " (", unused_dbs_percentage,
+    ") are unused and recommended for deletion. "
+  ].join('')
+
+  day_message = "day"
+  if (param_stats_lookback.length > 1) { day_message += "s" }
+
+  context_message = [
+    "An Azure SQL Database is considered unused if it has not had any connections ",
+    "for at least ", param_stats_lookback, " ", day_message, ".\n\n"
+  ].join('')
+
+  disclaimer = "The above settings can be modified by editing the applied policy and changing the appropriate parameters.\n\n"
+
+  savings_message = ds_currency['symbol'] + ' ' + formatNumber(parseFloat(total_savings).toFixed(2), ds_currency['separator'])
+
+  // Dummy entry to ensure validation runs at least once
+  result.push({
+    id: "",                region: "",                resourceName: "",
+    resourceKind: "",      resourceType: "",          sku: "",
+    tags: "",              resourceGroup: "",         accountID: "",
+    accountName: "",       recommendationType: "",    recommendationDetails: "",
+    lookbackPeriod: "",    threshold: "",             policy_name: "",
+    savings: "",           savingsCurrency: "",       service: "",
+    platform: "",          total_savings: "",         message: ""
+  })
+
+  result[0]['total_savings'] = savings_message
+  result[0]['message'] = findings + context_message + disclaimer
 EOS
 end
 
@@ -765,53 +923,45 @@ end
 # Policy
 ###############################################################################
 
-policy "pol_azure_unused_sql" do
-  validate_each $ds_unused_sql_incident do
-    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): Found {{ len data }} Azure Rightsize SQL single Database"
-    detail_template <<-EOS
-      ### Thresholds for Consideration
-      - Upsize Average CPU% threshold   : {{ parameters.param_stats_cpu_avg_upsize }}
-      - Downsize Average CPU% threshold : {{ parameters.param_stats_underutil_threshold_cpu_value }}
+policy "pol_azure_sql_utilization" do
+  validate_each $ds_downsize_sql_incident do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Azure Underutilized SQL Databases Found"
+    detail_template <<-'EOS'
+    **Potential Monthly Savings:** {{ with index data 0 }}{{ .total_savings }}{{ end }}
+
+    {{ with index data 0 }}{{ .message }}{{ end }}
     EOS
-    escalate $email_report
-    escalate $esc_update_rightsize_sql_databases_approval
     # Policy check fails and incident is created only if data is not empty and the Parent Policy has not been terminated
-    check logic_or($ds_parent_policy_terminated, eq(size(data),0))
+    check logic_or($ds_parent_policy_terminated, ne(val(item, "recommendationType"), "Downsize"))
+    escalate $esc_email
+    escalate $esc_downsize_instances
+    hash_exclude "savings", "savingsCurrency", "tags", "cpuAverage", "policy_name", "total_savings", "message"
     export do
       resource_level true
       field "accountID" do
         label "Subscription ID"
-        path "subscriptionId"
       end
       field "accountName" do
         label "Subscription Name"
-        path "subscriptionName"
-      end
-      field "region" do
-        label "Location"
-        path "location"
-      end
-      field "resourceName" do
-        label "Name"
-        path "name"
       end
       field "resourceGroup" do
         label "Resource Group"
-        path "resource_group"
       end
-      field "kind" do
-        label "Kind"
+      field "resourceName" do
+        label "Resource Name"
       end
-      field "type" do
-        label "Type"
+      field "tags" do
+        label "Resource Tags"
+      end
+      field "recommendationDetails" do
+        label "Recommendation"
       end
       field "skuCapacity" do
         label "Current Capacity"
         path "sku.capacity"
       end
       field "newResourceType" do
-        label "Recommended Resource Type"
-        path "recommended_capacity"
+        label "Recommended Capacity"
       end
       field "skuName" do
         label "SKU - Name"
@@ -821,24 +971,111 @@ policy "pol_azure_unused_sql" do
         label "SKU - Tier"
         path "sku.tier"
       end
-      field "cpuAverage" do
-        label "CPU Average %"
-        path "average_cpu"
-      end
-      field "recommendation" do
-        label "Recommendation"
-      end
-      field "id" do
-        label "Id"
-      end
       field "resourceType" do
         label "Resource Type"
+      end
+      field "resourceKind" do
+        label "Resource Kind"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "savings" do
+        label "Estimated Monthly Savings"
+      end
+      field "savingsCurrency" do
+        label "Savings Currency"
+      end
+      field "cpuAverage" do
+        label "CPU Average %"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "platform" do
+        label "Platform"
+      end
+      field "id" do
+        label "Resource ID"
+      end
+      field "threshold" do
+        label "CPU Threshold"
       end
       field "lookbackPeriod" do
         label "Lookback Period"
       end
-      field "threshold" do
-        label "Threshold"
+    end
+  end
+  validate_each $ds_unused_sql_incident do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Azure Unused SQL Databases Found"
+    detail_template <<-'EOS'
+    **Potential Monthly Savings:** {{ with index data 0 }}{{ .total_savings }}{{ end }}
+
+    {{ with index data 0 }}{{ .message }}{{ end }}
+    EOS
+    # Policy check fails and incident is created only if data is not empty and the Parent Policy has not been terminated
+    check logic_or($ds_parent_policy_terminated, ne(val(item, "recommendationType"), "Delete"))
+    escalate $esc_email
+    escalate $esc_delete_instances
+    hash_exclude "savings", "savingsCurrency", "tags", "policy_name", "total_savings", "message"
+    export do
+      resource_level true
+      field "accountID" do
+        label "Subscription ID"
+      end
+      field "accountName" do
+        label "Subscription Name"
+      end
+      field "resourceGroup" do
+        label "Resource Group"
+      end
+      field "resourceName" do
+        label "Resource Name"
+      end
+      field "tags" do
+        label "Resource Tags"
+      end
+      field "recommendationDetails" do
+        label "Recommendation"
+      end
+      field "resourceType" do
+        label "Type"
+      end
+      field "resourceKind" do
+        label "Kind"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "skuName" do
+        label "SKU - Name"
+        path "sku.name"
+      end
+      field "skuTier" do
+        label "SKU - Tier"
+        path "sku.tier"
+      end
+      field "skuCapacity" do
+        label "SKU - Capacity"
+        path "sku.capacity"
+      end
+      field "savings" do
+        label "Estimated Monthly Savings"
+      end
+      field "savingsCurrency" do
+        label "Savings Currency"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "platform" do
+        label "Platform"
+      end
+      field "id" do
+        label "Resource ID"
+      end
+      field "lookbackPeriod" do
+        label "Lookback Period"
       end
     end
   end
@@ -848,58 +1085,100 @@ end
 # Escalations
 ###############################################################################
 
-escalation "email_report" do
+escalation "esc_email" do
   automatic true
   label "Send Email"
-  description "Sends incident email"
+  description "Send incident email"
   email $param_email
 end
 
-escalation "esc_update_rightsize_sql_databases_approval" do
-  automatic contains($param_automatic_action, "Resize Instances")
-  label "Resize Database"
-  description "Resized selected  SQL database"
-  run "update_rightsize_sql_databases", data, $param_azure_endpoint, rs_optima_host
+escalation "esc_downsize_instances" do
+  automatic contains($param_automatic_action, "Downsize Underutilized Instances")
+  label "Downsize Underutilized Instances"
+  description "Approval to downsize all selected underutilized instances"
+  run "downsize_instances", data, $param_azure_endpoint, rs_optima_host
+end
+
+escalation "esc_delete_instances" do
+  automatic contains($param_automatic_action, "Delete Unused Instances")
+  label "Delete Unused Instances"
+  description "Approval to delete all selected unused instances"
+  run "delete_instances", data, $param_azure_endpoint, rs_optima_host
 end
 
 ###############################################################################
 # Cloud Workflow
 ###############################################################################
 
-define update_rightsize_sql_databases($data, $param_azure_endpoint, $$rs_optima_host) return $all_responses do
+define downsize_instances($data, $param_azure_endpoint, $$rs_optima_host) return $all_responses do
   # Change "No" to "Yes" to enable CWF debug logging
   $log_to_cm_audit_entries = "No"
 
   $$debug = $log_to_cm_audit_entries == "Yes"
 
+  $$errors = []
   $all_responses = []
+
   foreach $item in $data do
-    if $item["recommended_capacity"] != "n/a"
-      sub on_error: skip do
-        $response = http_request(
-          auth: $$auth_azure,
-          verb: "patch",
-          host: $param_azure_endpoint,
-          https: true,
-          href: $item["id"],
-          query_strings: {
-            "api-version": "2017-10-01-preview"
-          },
-          headers: {
-            "cache-control": "no-cache",
-            "content-type": "application/json"
-          },
-          body: {
-            "sku": {
-              "name": $item["skuName"],
-              "tier": $item["skuTier"],
-              "capacity": $item["recommended_capacity"]
-            }
+    sub on_error: skip do
+      $response = http_request(
+        verb: "PATCH",
+        auth: $$auth_azure,
+        host: $param_azure_endpoint,
+        https: true,
+        href: $item["id"],
+        query_strings: {
+          "api-version": "2017-10-01-preview"
+        },
+        headers: {
+          "cache-control": "no-cache",
+          "content-type": "application/json"
+        },
+        body: {
+          "sku": {
+            "name": $item["skuName"],
+            "tier": $item["skuTier"],
+            "capacity": $item["newResourceType"]
           }
-        )
-        call sys_log('Update RightSize Azure SQL Databases: ',to_s($response))
-        $all_responses << $response
-      end
+        }
+      )
+
+      call sys_log('Downsize Azure SQL Databases: ', to_s($response))
+
+      $all_responses << $response
+    end
+  end
+end
+
+define delete_instances($data, $param_azure_endpoint, $$rs_optima_host) return $all_responses do
+  # Change "No" to "Yes" to enable CWF debug logging
+  $log_to_cm_audit_entries = "No"
+
+  $$debug = $log_to_cm_audit_entries == "Yes"
+
+  $$errors = []
+  $all_responses = []
+
+  foreach $item in $data do
+    sub on_error: skip do
+      $response = http_request(
+        verb: "DELETE",
+        host: $param_azure_endpoint,
+        auth: $$auth_azure,
+        https: true,
+        href: $item["id"],
+        query_strings: {
+          "api-version": "2017-10-01-preview"
+        },
+        headers: {
+          "cache-control": "no-cache",
+          "content-type": "application/json"
+        }
+      )
+
+      call sys_log('Deleted Azure SQL Databases: ', to_s($response))
+
+      $all_responses << $response
     end
   end
 end
@@ -958,7 +1237,6 @@ datasource "ds_get_policy" do
     field "id", jmes_path(response, "id")
   end
 end
-
 
 datasource "ds_parent_policy_terminated" do
   run_script $js_decide_if_self_terminate, $ds_get_policy, policy_id, meta_parent_policy_id

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "3.0",
+  version: "4.0",
   provider: "Azure",
   service: "SQL",
   policy_set: "RightSize Database Services"
@@ -17,48 +17,84 @@ info(
 # Parameters
 ###############################################################################
 
-parameter "param_avg_cpu_upsize" do
-  type "number"
-  label "Average used CPU % - Upsize threshold"
-  description "Set to -1 to ignore CPU utilization"
-  default 80
-  min_value -1
-  max_value 100
-end
-
-parameter "param_avg_cpu_downsize" do
-  type "number"
-  label "Average used CPU % - Downsize Threshold"
-  description "Set to -1 to ignore CPU utilization"
-  default 60
-  min_value -1
-  max_value 100
-end
-
-parameter "param_exclusion_tag_key" do
-  category "User Inputs"
-  label "Exclusion Tag Key"
-  description "Cloud native tag key to ignore instances. Example: exclude_utilization"
-  type "string"
-end
-
 parameter "param_email" do
   type "list"
-  label "Email addresses"
-  description "Email addresses of the recipients you wish to notify"
+  category "Policy Settings"
+  label "Email Addresses"
+  description "A list of email addresses to notify."
+  default []
 end
 
 parameter "param_azure_endpoint" do
   type "string"
+  category "Policy Settings"
   label "Azure Endpoint"
+  description "Select the API endpoint to use for Azure. Use default value of management.azure.com unless using Azure China."
   allowed_values "management.azure.com", "management.chinacloudapi.cn"
   default "management.azure.com"
 end
 
+parameter "param_subscriptions_allow_or_deny" do
+  type "string"
+  category "Filters"
+  label "Allow/Deny Subscriptions"
+  description "Allow or Deny entered Subscriptions. See the README for more details."
+  allowed_values "Allow", "Deny"
+  default "Allow"
+end
+
 parameter "param_subscriptions_list" do
-  label "Subscription Allowed List"
   type "list"
-  description "Allowed Subscriptions, if empty, all subscriptions will be checked"
+  category "Filters"
+  label "Allow/Deny Subscriptions List"
+  description "A list of allowed or denied Subscription IDs/names. See the README for more details."
+  default []
+end
+
+parameter "param_regions_allow_or_deny" do
+  type "string"
+  category "Filters"
+  label "Allow/Deny Regions"
+  description "Allow or Deny entered regions. See the README for more details."
+  allowed_values "Allow", "Deny"
+  default "Allow"
+end
+
+parameter "param_regions_list" do
+  type "list"
+  category "Filters"
+  label "Allow/Deny Regions List"
+  description "A list of allowed or denied regions. See the README for more details."
+  default []
+end
+
+parameter "param_exclusion_tags" do
+  type "list"
+  category "Filters"
+  label "Exclusion Tags (Key:Value)"
+  description "Cloud native tags to ignore resources that you don't want to produce recommendations for. Use Key:Value format for specific tag key/value pairs, and Key:* format to match any resource with a particular key, regardless of value. Examples: env:production, DO_NOT_DELETE:*"
+  allowed_pattern /(^$)|[\w]*\:.*/
+  default []
+end
+
+parameter "param_stats_underutil_threshold_cpu_value" do
+  type "number"
+  category "Statistics"
+  label "Underutilized Instance CPU Threshold (%)"
+  description "The CPU threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing. Set to -1 to ignore CPU utilization and only report unused instances"
+  min_value -1
+  max_value 100
+  default 60
+end
+
+parameter "param_stats_lookback" do
+  type "number"
+  category "Statistics"
+  label "Statistic Lookback Period"
+  description "How many days back to look at instance metrics to determine if an instance is underutilized or unused. This value cannot be set higher than 90 because Azure does not retain metrics for longer than 90 days."
+  default 30
+  min_value 1
+  max_value 90
 end
 
 parameter "param_automatic_action" do
@@ -68,19 +104,10 @@ parameter "param_automatic_action" do
   allowed_values ["Resize Instances"]
 end
 
-parameter "param_log_to_cm_audit_entries" do
-  type "string"
-  label "Log to CM Audit Entries"
-  description "Boolean for whether or not to log any debugging information from actions to CM Audit Entries, this should be left set to No on Flexera EU"
-  default "No"
-  allowed_values "Yes", "No"
-end
-
 ###############################################################################
 # Authentication
 ###############################################################################
 
-#authenticate with Azure
 credentials "auth_azure" do
   schemes "oauth2"
   label "Azure"
@@ -90,7 +117,7 @@ end
 
 credentials "auth_flexera" do
   schemes "oauth2"
-  label "flexera"
+  label "Flexera"
   description "Select Flexera One OAuth2 credentials"
   tags "provider=flexera"
 end
@@ -98,7 +125,8 @@ end
 ###############################################################################
 # Pagination
 ###############################################################################
-pagination "azure_pagination" do
+
+pagination "pagination_azure" do
   get_page_marker do
     body_path "nextLink"
   end
@@ -108,16 +136,118 @@ pagination "azure_pagination" do
 end
 
 ###############################################################################
-# Datasources
+# Datasources & Scripts
 ###############################################################################
 
-datasource "ds_subscriptions" do
+# Get applied policy metadata for use later
+datasource "ds_applied_policy" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    header "Api-Version", "1.0"
+  end
+end
+
+datasource "ds_billing_centers" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/analytics/orgs/", rs_org_id, "/billing_centers"])
+    header "Api-Version", "1.0"
+    header "User-Agent", "RS Policies"
+    query "view", "allocation_table"
+    ignore_status [403]
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "href", jmes_path(col_item, "href")
+      field "id", jmes_path(col_item, "id")
+      field "name", jmes_path(col_item, "name")
+      field "parent_id", jmes_path(col_item, "parent_id")
+    end
+  end
+end
+
+# Gather top level billing center IDs for when we pull cost data
+datasource "ds_top_level_bcs" do
+  run_script $js_top_level_bcs, $ds_billing_centers
+end
+
+script "js_top_level_bcs", type: "javascript" do
+  parameters "ds_billing_centers"
+  result "result"
+  code <<-EOS
+  filtered_bcs = _.filter(ds_billing_centers, function(bc) {
+    return bc['parent_id'] == null || bc['parent_id'] == undefined
+  })
+
+  result = _.compact(_.pluck(filtered_bcs, 'id'))
+EOS
+end
+
+datasource "ds_currency_reference" do
+  request do
+    host "raw.githubusercontent.com"
+    path "/rightscale/policy_templates/master/cost/scheduled_reports/currency_reference.json"
+    header "User-Agent", "RS Policies"
+  end
+end
+
+datasource "ds_currency_code" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/bill-analysis/orgs/", rs_org_id, "/settings/currency_code"])
+    header "Api-Version", "0.1"
+    header "User-Agent", "RS Policies"
+    ignore_status [403]
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+    field "value", jmes_path(response, "value")
+  end
+end
+
+datasource "ds_currency" do
+  run_script $js_currency, $ds_currency_reference, $ds_currency_code
+end
+
+script "js_currency", type:"javascript" do
+  parameters "ds_currency_reference", "ds_currency_code"
+  result "result"
+  code <<-EOS
+  symbol = "$"
+  separator = ","
+
+  if (ds_currency_code['value'] != undefined) {
+    if (ds_currency_reference[ds_currency_code['value']] != undefined) {
+      symbol = ds_currency_reference[ds_currency_code['value']]['symbol']
+
+      if (ds_currency_reference[ds_currency_code['value']]['t_separator'] != undefined) {
+        separator = ds_currency_reference[ds_currency_code['value']]['t_separator']
+      } else {
+        separator = ""
+      }
+    }
+  }
+
+  result = {
+    symbol: symbol,
+    separator: separator
+  }
+EOS
+end
+
+datasource "ds_azure_subscriptions" do
   request do
     auth $auth_azure
-    pagination $azure_pagination
+    pagination $pagination_azure
     host $param_azure_endpoint
     path "/subscriptions/"
-    query "api-version","2019-06-01"
+    query "api-version","2020-01-01"
     header "User-Agent", "RS Policies"
     # Header X-Meta-Flexera has no affect on datasource query, but is required for Meta Policies
     # Forces `ds_is_deleted` datasource to run first during policy execution
@@ -126,26 +256,45 @@ datasource "ds_subscriptions" do
   result do
     encoding "json"
     collect jmes_path(response, "value[*]") do
-      field "subscriptionId", jmes_path(col_item,"subscriptionId")
-      field "displayName", jmes_path(col_item,"displayName")
-      field "state", jmes_path(col_item,"state")
+      field "id", jmes_path(col_item, "subscriptionId")
+      field "name", jmes_path(col_item, "displayName")
+      field "state", jmes_path(col_item, "state")
     end
   end
 end
 
-datasource "ds_filtered_subscriptions" do
-  run_script $js_filtered_subscriptions, $ds_subscriptions, $param_subscriptions_list
+datasource "ds_azure_subscriptions_filtered" do
+  run_script $js_azure_subscriptions_filtered, $ds_azure_subscriptions, $param_subscriptions_allow_or_deny, $param_subscriptions_list
 end
 
-#https://docs.microsoft.com/en-us/rest/api/resources/resources/list
+script "js_azure_subscriptions_filtered", type: "javascript" do
+  parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
+  result "result"
+  code <<-EOS
+  if (param_subscriptions_list.length > 0) {
+    result = _.filter(ds_azure_subscriptions, function(subscription) {
+      include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
+
+      if (param_subscriptions_allow_or_deny == "Deny") {
+        include_subscription = !include_subscription
+      }
+
+      return include_subscription
+    })
+  } else {
+    result = ds_azure_subscriptions
+  }
+EOS
+end
+
 datasource "ds_azure_sql_databases" do
-  iterate $ds_filtered_subscriptions
+  iterate $ds_azure_subscriptions_filtered
   request do
     auth $auth_azure
-    pagination $azure_pagination
+    pagination $pagination_azure
     host $param_azure_endpoint
-    path join(["/subscriptions/", val(iter_item,"subscriptionId"), "/resources"])
-    query "api-version","2019-08-01"
+    path join(["/subscriptions/", val(iter_item, "id"), "/resources"])
+    query "api-version", "2019-08-01"
     query "$filter", "resourceType eq 'Microsoft.Sql/servers/databases'"
     header "User-Agent", "RS Policies"
     # Ignore status 400, 403, and 404 which can be returned in certain (legacy) types of Azure Subscriptions
@@ -154,43 +303,140 @@ datasource "ds_azure_sql_databases" do
   result do
     encoding "json"
     collect jmes_path(response, "value") do
-      field "id", jmes_path(col_item,"id")
-      field "name", jmes_path(col_item,"name")
-      field "location", jmes_path(col_item,"location")
-      field "type", jmes_path(col_item,"type")
-      field "kind", jmes_path(col_item,"kind")
-      field "sku" , jmes_path(col_item,"sku")
-      field "tags", jmes_path(col_item,"tags")
-      field "subscriptionId",val(iter_item,"subscriptionId")
-      field "subscriptionName",val(iter_item,"displayName")
+      field "id", jmes_path(col_item, "id")
+      field "name", jmes_path(col_item, "name")
+      field "region", jmes_path(col_item, "location")
+      field "type", jmes_path(col_item, "type")
+      field "kind", jmes_path(col_item, "kind")
+      field "sku" , jmes_path(col_item, "sku")
+      field "tags", jmes_path(col_item, "tags")
+      field "resourceGroup", get(4, split(jmes_path(col_item,"id"), "/"))
+      field "subscriptionId",val(iter_item, "id")
+      field "subscriptionName",val(iter_item, "name")
     end
   end
+end
+
+datasource "ds_azure_sql_databases_tag_filtered" do
+  run_script $js_azure_sql_databases_tag_filtered, $ds_azure_sql_databases, $param_exclusion_tags
+end
+
+script "js_azure_sql_databases_tag_filtered", type: "javascript" do
+  parameters "ds_azure_sql_databases", "param_exclusion_tags"
+  result "result"
+  code <<-EOS
+  if (param_exclusion_tags.length > 0) {
+    result = _.reject(ds_azure_sql_databases, function(db) {
+      db_tags = []
+
+      if (typeof(db['tags']) == 'object') {
+        _.each(Object.keys(db['tags']), function(key) {
+          db_tags.push([key, ":", db['tags'][key]].join(''))
+          db_tags.push([key, ":*"].join(''))
+        })
+      }
+
+      exclude_db = false
+
+      _.each(param_exclusion_tags, function(exclusion_tag) {
+        if (_.contains(db_tags, exclusion_tag)) {
+          exclude_db = true
+        }
+      })
+
+      return exclude_db
+    })
+  } else {
+    result = ds_azure_sql_databases
+  }
+EOS
+end
+
+datasource "ds_azure_sql_databases_region_filtered" do
+  run_script $js_azure_sql_databases_region_filtered, $ds_azure_sql_databases_tag_filtered, $param_regions_allow_or_deny, $param_regions_list
+end
+
+script "js_azure_sql_databases_region_filtered", type: "javascript" do
+  parameters "ds_azure_sql_databases_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
+  result "result"
+  code <<-EOS
+  if (param_regions_list.length > 0) {
+    result = _.filter(ds_azure_sql_databases_tag_filtered, function(ip) {
+      include_db = _.contains(param_regions_list, db['region'])
+
+      if (param_regions_allow_or_deny == "Deny") {
+        include_db = !include_db
+      }
+
+      return include_db
+    })
+  } else {
+    result = ds_azure_sql_databases_tag_filtered
+  }
+EOS
 end
 
 datasource "ds_azure_sql_database_metrics" do
-  iterate $ds_azure_sql_databases
+  iterate $ds_azure_sql_databases_region_filtered
   request do
-    run_script $js_utilization_request, val(iter_item,"id"), $param_azure_endpoint
+    run_script $js_azure_sql_database_metrics, val(iter_item,"id"), $param_azure_endpoint, $param_stats_lookback
   end
   result do
     encoding "json"
-    collect jmes_path(response, "value") do
-      field "id", val(iter_item,"id")
-      field "location", val(iter_item,"location")
-      field "name", val(iter_item,"name")
-      field "kind", val(iter_item,"kind")
-      field "type", val(iter_item,"type")
-      field "sku" , val(iter_item,"sku")
-      field "tags", val(iter_item,"tags")
-      field "unit", jmes_path(col_item,"unit")
-      field "timeseries", jmes_path(col_item,"timeseries")
-      field "subscriptionId",val(iter_item,"subscriptionId")
-      field "subscriptionName",val(iter_item,"subscriptionName")
-    end
+    field "value", jmes_path(response, "value")
+    field "id", val(iter_item, "id")
+    field "region", val(iter_item, "region")
+    field "name", val(iter_item, "name")
+    field "kind", val(iter_item, "kind")
+    field "type", val(iter_item, "type")
+    field "sku" , val(iter_item, "sku")
+    field "tags", val(iter_item, "tags")
+    field "resourceGroup", val(iter_item, "resourceGroup")
+    field "subscriptionId", val(iter_item, "subscriptionId")
+    field "subscriptionName", val(iter_item, "subscriptionName")
   end
 end
 
-#Generates list of service tiers.
+script "js_azure_sql_database_metrics", type: "javascript" do
+  parameters "resource_id", "param_azure_endpoint", "param_stats_lookback"
+  result "request"
+  code <<-EOS
+  end_date = new Date()
+  end_date.setMilliseconds(999)
+  end_date.setSeconds(59)
+  end_date.setMinutes(59)
+  end_date.setHours(23)
+
+  start_date = new Date()
+  start_date.setDate(start_date.getDate() - param_stats_lookback)
+  start_date.setMilliseconds(0)
+  start_date.setSeconds(0)
+  start_date.setMinutes(0)
+
+  timespan = start_date.toISOString() + "/" + end_date.toISOString()
+
+  var request = {
+    auth: "auth_azure",
+    pagination: "pagination_azure",
+    host: param_azure_endpoint,
+    verb: "GET",
+    path: resource_id + "/providers/microsoft.insights/metrics",
+    query_params: {
+      "api-version": "2018-01-01",
+      "timespan": timespan,
+      "metricnames": "cpu_percent,connection_successful",
+      "aggregation": "Average,count",
+      "interval":  "P1D"
+    },
+    headers: {
+      "User-Agent": "RS Policies"
+    },
+    // Ignore status 400, 403, and 404 which can be returned in certain (legacy) types of Azure Subscriptions
+    ignore_status: [400, 403, 404]
+  }
+EOS
+end
+
 datasource "ds_azure_sql_resize_map" do
   request do
     verb "GET"
@@ -201,187 +447,218 @@ datasource "ds_azure_sql_resize_map" do
 end
 
 datasource "ds_merged_metrics" do
-  run_script $js_merged_metrics, $ds_azure_sql_database_metrics, $ds_azure_sql_resize_map, $param_exclusion_tag_key, $param_avg_cpu_downsize, $param_avg_cpu_upsize
-end
-
-###############################################################################
-# Scripts
-###############################################################################
-
-script "js_filtered_subscriptions", type: "javascript" do
-  parameters "ds_subscriptions", "param_subscriptions_list"
-  result "results"
-  code <<-EOS
-  var results = []
-  if ( param_subscriptions_list.length != 0){
-    results = []
-    _.each(param_subscriptions_list, function(sub){
-      var found = _.find(ds_subscriptions, function(item){
-        return item.subscriptionId == sub || item.displayName.toLowerCase() == sub.toLowerCase();
-      })
-      results.push(found)
-    })
-  } else {
-    results = ds_subscriptions
-  }
-EOS
-end
-
-# Build the API request object dynamically
-script "js_utilization_request", type: "javascript" do
-  parameters "resource_id", "param_azure_endpoint"
-  result "request"
-  code <<-EOS
-    var end_date_tmp = new Date()
-    end_date_tmp.setMilliseconds(999)
-    end_date_tmp.setSeconds(59)
-    end_date_tmp.setMinutes(59)
-    end_date_tmp.setHours(23)
-    var end_date = new Date(end_date_tmp).toISOString()
-    var start_date_tmp = new Date(new Date().setDate(new Date().getDate() - 30))
-    start_date_tmp.setMilliseconds(0)
-    start_date_tmp.setSeconds(0)
-    start_date_tmp.setMinutes(0)
-    var start_date = new Date(start_date_tmp).toISOString()
-    var sTimespan = start_date  + "/" + end_date;
-    var request = {
-      auth: "auth_azure",
-      verb : "GET",
-      scheme : "https",
-      host : param_azure_endpoint,
-      path : "" + resource_id + "/providers/microsoft.insights/metrics",
-      query_params: {
-        "api-version" : "2018-01-01",
-        "timespan" : sTimespan,
-        "metricnames" : "cpu_percent"
-        "aggregation" : "Average,count",
-        "interval" :  "P1D"                    //Dailey
-      },
-      // Ignore status 400, 403, and 404 which can be returned in certain (legacy) types of Azure Subscriptions
-      ignore_status: [400,403,404],
-      headers: {
-        "User-Agent" : "RS Policies"
-      }
-    }
-  EOS
+  run_script $js_merged_metrics, $ds_azure_sql_database_metrics, $ds_azure_sql_resize_map, $param_stats_underutil_threshold_cpu_value
 end
 
 script "js_merged_metrics", type: "javascript" do
-  parameters "databases_metrics", "ds_azure_sql_resize_map", "exclusion_tag" , "down_threshold", "up_threshold"
+  parameters "ds_azure_sql_database_metrics", "ds_azure_sql_resize_map", "param_stats_underutil_threshold_cpu_value"
   result "result"
   code <<-EOS
-    var result = [];
+  result = []
 
-    //exclude the database with the exclution tags, and the system databases
-    for(i=0; i< databases_metrics.length; i++){
-      if (databases_metrics[i].sku !== undefined && databases_metrics[i].sku != null){
-        if(!(_.has(databases_metrics[i].tags, exclusion_tag) || databases_metrics[i].kind.toLowerCase().indexOf(",system") > -1)){
-          //Find the Resource group
-          var capacity = "";
-          var recommended_capacity = "";
-          var recommendation = "";
-          var aTemp = databases_metrics[i].id.split("/resourceGroups/")
-          var resource_group="";
-          if(aTemp.length > 1){
-            aTemp = aTemp[1].split("/");
-            resource_group = aTemp[0];
-          }else{
-            resource_group = "";
-          }
+  _.each(ds_azure_sql_database_metrics, function(db) {
+    instance = {
+      id: db['id'],
+      region: db['region'],
+      name: db['name'],
+      kind: db['kind'],
+      type: db['type'],
+      sku: db['sku'],
+      tags: db['tags'],
+      resourceGroup: db['resourceGroup'],
+      subscriptionId: db['subscriptionId'],
+      subscriptionName: db['subscriptionName']
+    }
 
-          //now find the metrics for the devices
-          var objMetric = databases_metrics[i];
-          var total = 0.0;
-          var average_cpu = "";
-          if (typeof objMetric == "object" && typeof objMetric.timeseries[0].data == "object"){
-            var ts_data =  objMetric.timeseries[0].data;
-            for (x=0; x < ts_data.length; x++) {
-              total += ts_data[x].average;
+    connection_metrics = null
+    cpu_metrics = null
+
+    _.each(db['value'], function(metric) {
+      if (metric['name']['value'] == 'connection_successful') {
+        connection_metrics = metric['timeseries'][0]['data']
+      }
+
+      if (metric['name']['value'] == 'cpu_percent') {
+        cpu_metrics = metric['timeseries'][0]['data']
+      }
+    })
+
+    if (connection_metrics != null) {
+      if (connection_metrics.length == 0) {
+        instance['recommendationType'] = 'Delete'
+        instance['newResourceType'] = 'Delete'
+
+        recommendationDetails = [
+          "Delete Azure SQL database ", instance["name"], " ",
+          "in Azure Subscription ", instance["subscriptionName"], " ",
+          "(", instance["subscriptionId"], ")"
+        ]
+
+        instance["recommendationDetails"] = recommendationDetails.join('')
+      }
+    }
+
+    if (cpu_metrics != null && instance['recommendationType'] != 'Delete' && param_stats_underutil_threshold_cpu_value != -1) {
+      if (cpu_metrics.length > 0) {
+        averages = _.pluck(cpu_metrics, 'average')
+        cpu_average = null
+
+        if (averages.length > 0) {
+          cpu_average = _.reduce(averages, function(memo, num) { return memo + num }, 0) / averages.length
+        }
+
+        if (cpu_average != null && cpu_average <= param_stats_underutil_threshold_cpu_value) {
+          instance['cpu_average'] = cpu_average
+          instance['recommendationType'] = 'Downsize'
+
+          tier = instance['sku']['tier']
+          type = instance['sku']['name'] + '_' + instance['sku']['capacity']
+
+          if (ds_azure_sql_resize_map[tier] != undefined) {
+            if (ds_azure_sql_resize_map[tier][type] != undefined) {
+              if (typeof(ds_azure_sql_resize_map[tier][type]['down']) == 'string') {
+                instance['newResourceType'] = ds_azure_sql_resize_map[tier][type]['down']
+
+                recommendationDetails = [
+                  "Downsize Azure SQL database ", instance["name"], " ",
+                  "in Azure Subscription ", instance["subscriptionName"], " ",
+                  "(", instance["subscriptionId"], ") ",
+                  "from ", instance['sku']['capacity'], " capacity ",
+                  "to ", instance["newResourceType"], " capacity"
+                ]
+
+                instance["recommendationDetails"] = recommendationDetails.join('')
+              }
             }
-            average_cpu = total / ts_data.length;
-            average_cpu = average_cpu.toFixed(2);
-          }else{
-            average_cpu = "n/a";
-          }
-          var sku = databases_metrics[i].sku;
-          var threshold = "";
-          //Now check for recommendation
-          if(average_cpu !== "n/a"){
-            if(Number(average_cpu) >= Number(up_threshold)){
-              //Upsize
-              threshold = up_threshold;
-              recommendation = "Upsize";
-              if (databases_metrics[i].sku !== undefined && databases_metrics[i].sku != null && ds_azure_sql_resize_map[sku.tier] !== undefined && ds_azure_sql_resize_map[sku.tier] != null){
-                var json_tier = ds_azure_sql_resize_map[sku.tier];
-                if (json_tier[sku.name+"_"+sku.capacity] !== undefined && json_tier[sku.name+"_"+sku.capacity] != null){
-                  var json_name = json_tier[sku.name+"_"+sku.capacity];
-                  if (json_name["up"] !== undefined && json_name["up"] != null){
-                    capacity = json_name["up"];
-                  }
-                }
-              }
-              if(capacity != null && capacity.length > 0){
-                recommended_capacity = capacity;
-              }else{
-                recommended_capacity = "n/a";
-              }
-            }else if(Number(average_cpu) <= Number(down_threshold)){
-              //Downsize
-              threshold = down_threshold;
-              recommendation = "Downsize";
-              if (databases_metrics[i].sku !== undefined && databases_metrics[i].sku != null && ds_azure_sql_resize_map[sku.tier] !== undefined && ds_azure_sql_resize_map[sku.tier] != null){
-                if (sku.tier === "Basic"){
-                  recommendation = "-";
-                }
-                var json_tier = ds_azure_sql_resize_map[sku["tier"]];
-                if (json_tier[sku.name+"_"+sku.capacity] !== undefined && json_tier[sku.name+"_"+sku.capacity] != null){
-                  var json_name = json_tier[sku.name+"_"+sku.capacity];
-                  if (json_name["down"] !== undefined && json_name["down"] != null){
-                    capacity = json_name["down"];
-                  }
-                }
-              }
-              if(capacity != null && capacity.length > 0){
-                recommended_capacity = capacity;
-              }else{
-                recommended_capacity = "n/a";
-              }
-            }
-          }else{
-            recommendation = "-";
-            recommended_capacity = "n/a";
-          }
-          if (recommended_capacity === "n/a" && recommendation !== "-"){
-            recommendation = "Change tier"
-          }
-          if(average_cpu !== "n/a" && sku.name !== "ElasticPool"){
-            result.push({
-              id: databases_metrics[i].id,
-              location: databases_metrics[i].location,
-              average_cpu: average_cpu,
-              name: databases_metrics[i].name,
-              resource_group: resource_group,
-              kind: databases_metrics[i].kind,
-              type: databases_metrics[i].type,
-              sku: databases_metrics[i].sku,
-              unit: databases_metrics[i].unit,
-              tags: databases_metrics[i].tags,
-              recommendation: recommendation,
-              recommended_capacity:recommended_capacity,
-              subscriptionId: databases_metrics[i].subscriptionId,
-              subscriptionName: databases_metrics[i].subscriptionName,
-              lookbackPeriod: "30 days",
-              resourceType: databases_metrics[i].sku.name + "_" + databases_metrics[i].sku.tier,
-              threshold: threshold
-            })
           }
         }
       }
     }
-    result=_.sortBy(result, 'subscriptionName');
-    result=_.sortBy(result, 'location');
-    result=_.sortBy(result, 'name');
-  EOS
+
+    if (instance["recommendationDetails"] != undefined) {
+      result.push(instance)
+    }
+  })
+EOS
+end
+
+
+datasource "ds_cost_subscriptions" do
+  run_script $js_cost_subscriptions, $ds_merged_metrics
+end
+
+script "js_cost_subscriptions", type: "javascript" do
+  parameters "ds_merged_metrics"
+  result "result"
+  code <<-EOS
+  result = _.compact(_.uniq(_.pluck(ds_merged_metrics, 'subscriptionId')))
+EOS
+end
+
+datasource "ds_sql_costs" do
+  iterate $ds_cost_subscriptions
+  request do
+    run_script $js_sql_costs, iter_item, $ds_top_level_bcs, rs_org_id, rs_optima_host
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "rows[*]") do
+      field "resourceId", jmes_path(col_item, "dimensions.resource_id")
+      field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
+    end
+  end
+end
+
+script "js_sql_costs", type:"javascript" do
+  parameters "subscriptionId", "ds_top_level_bcs", "rs_org_id", "rs_optima_host"
+  result "request"
+  code <<-EOS
+  start_date = new Date()
+  start_date.setDate(start_date.getDate() - 3)
+  start_date = start_date.toISOString().split('T')[0]
+
+  end_date = new Date()
+  end_date.setDate(end_date.getDate() - 2)
+  end_date = end_date.toISOString().split('T')[0]
+
+  var request = {
+    auth: "auth_flexera",
+    host: rs_optima_host,
+    verb: "POST",
+    path: "/bill-analysis/orgs/" + rs_org_id + "/costs/select",
+    body_fields: {
+      "dimensions": ["resource_id"],
+      "granularity": "day",
+      "start_at": start_date,
+      "end_at": end_date,
+      "metrics": ["cost_amortized_unblended_adj"],
+      "billing_center_ids": ds_top_level_bcs,
+      "limit": 100000,
+      "filter": {
+        "type": "and",
+        "expressions": [
+          {
+            "type": "or",
+            "expressions": [
+              {
+                "dimension": "service",
+                "type": "equal",
+                "value": "Microsoft.Sql"
+              },
+              {
+                "dimension": "service",
+                "type": "equal",
+                "value": "microsoft.sql"
+              }
+            ]
+          },
+          {
+            "dimension": "vendor_account",
+            "type": "equal",
+            "value": subscriptionId
+          },
+          {
+            "type": "not",
+            "expression": {
+              "dimension": "adjustment_name",
+              "type": "substring",
+              "substring": "Shared"
+            }
+          }
+        ]
+      }
+    },
+    headers: {
+      "User-Agent": "RS Policies",
+      "Api-Version": "1.0"
+    },
+    ignore_status: [400]
+  }
+EOS
+end
+
+datasource "ds_sql_costs_grouped" do
+  run_script $js_sql_costs_grouped, $ds_sql_costs
+end
+
+script "js_sql_costs_grouped", type: "javascript" do
+  parameters "ds_sql_costs"
+  result "result"
+  code <<-EOS
+  // Multiple a single day's cost by the average number of days in a month.
+  // The 0.25 is to account for leap years for extra precision.
+  cost_multiplier = 365.25 / 12
+
+  // Group cost data by resourceId for later use
+  result = {}
+
+  _.each(ds_sql_costs, function(item) {
+    id = item['resourceId'].toLowerCase()
+
+    if (result[id] == undefined) { result[id] = 0.0 }
+    result[id] += item['cost'] * cost_multiplier
+  })
+EOS
 end
 
 ###############################################################################
@@ -393,8 +670,8 @@ policy 'policy_azure_db_utilization' do
     summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): Found {{ len data }} Azure Rightsize SQL single Database"
     detail_template <<-EOS
       ### Thresholds for Consideration
-      - Upsize Average CPU% threshold   : {{ parameters.param_avg_cpu_upsize }}
-      - Downsize Average CPU% threshold : {{ parameters.param_avg_cpu_downsize }}
+      - Upsize Average CPU% threshold   : {{ parameters.param_stats_cpu_avg_upsize }}
+      - Downsize Average CPU% threshold : {{ parameters.param_stats_underutil_threshold_cpu_value }}
     EOS
     escalate $email_report
     escalate $esc_update_rightsize_sql_databases_approval
@@ -482,15 +759,19 @@ escalation "esc_update_rightsize_sql_databases_approval" do
   automatic contains($param_automatic_action, "Resize Instances")
   label "Resize Database"
   description "Resized selected  SQL database"
-  run "update_rightsize_sql_databases", data, $param_log_to_cm_audit_entries, $param_azure_endpoint, rs_optima_host
+  run "update_rightsize_sql_databases", data, $param_azure_endpoint, rs_optima_host
 end
 
 ###############################################################################
 # Cloud Workflow
 ###############################################################################
 
-define update_rightsize_sql_databases($data, $param_log_to_cm_audit_entries, $param_azure_endpoint, $$rs_optima_host) return $all_responses do
-  $$debug = $param_log_to_cm_audit_entries == "Yes"
+define update_rightsize_sql_databases($data, $param_azure_endpoint, $$rs_optima_host) return $all_responses do
+  # Change "No" to "Yes" to enable CWF debug logging
+  $log_to_cm_audit_entries = "No"
+
+  $$debug = $log_to_cm_audit_entries == "Yes"
+
   $all_responses = []
   foreach $item in $data do
     if $item["recommended_capacity"] != "n/a"

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "3.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 
@@ -56,51 +56,86 @@ parameter "param_policy_schedule" do
 end
 
 ## Child Policy Parameters
-parameter "param_avg_cpu_upsize" do
-  type "number"
-  label "Average used CPU % - Upsize threshold"
-  description "Set to -1 to ignore CPU utilization"
-  default 80
-  min_value -1
-  max_value 100
-end
-
-parameter "param_avg_cpu_downsize" do
-  type "number"
-  label "Average used CPU % - Downsize Threshold"
-  description "Set to -1 to ignore CPU utilization"
-  default 60
-  min_value -1
-  max_value 100
-end
-
-parameter "param_exclusion_tag_key" do
-  category "User Inputs"
-  label "Exclusion Tag Key"
-  description "Cloud native tag key to ignore instances. Example: exclude_utilization"
-  type "string"
-end
-
 parameter "param_azure_endpoint" do
   type "string"
+  category "Policy Settings"
   label "Azure Endpoint"
+  description "Select the API endpoint to use for Azure. Use default value of management.azure.com unless using Azure China."
   allowed_values "management.azure.com", "management.chinacloudapi.cn"
   default "management.azure.com"
 end
 
-parameter "param_automatic_action" do
-  type "list"
-  label "Automatic Actions"
-  description "When this value is set, this policy will automatically take the selected action(s)"
-  allowed_values ["Resize Instances"]
+parameter "param_min_savings" do
+  type "number"
+  category "Policy Settings"
+  label "Minimum Savings Threshold"
+  description "Minimum potential savings required to generate a recommendation"
+  min_value 0
+  default 0
 end
 
-parameter "param_log_to_cm_audit_entries" do
+parameter "param_regions_allow_or_deny" do
   type "string"
-  label "Log to CM Audit Entries"
-  description "Boolean for whether or not to log any debugging information from actions to CM Audit Entries, this should be left set to No on Flexera EU"
-  default "No"
-  allowed_values "Yes", "No"
+  category "Filters"
+  label "Allow/Deny Regions"
+  description "Allow or Deny entered regions. See the README for more details."
+  allowed_values "Allow", "Deny"
+  default "Allow"
+end
+
+parameter "param_regions_list" do
+  type "list"
+  category "Filters"
+  label "Allow/Deny Regions List"
+  description "A list of allowed or denied regions. See the README for more details."
+  default []
+end
+
+parameter "param_exclusion_tags" do
+  type "list"
+  category "Filters"
+  label "Exclusion Tags (Key:Value)"
+  description "Cloud native tags to ignore resources that you don't want to produce recommendations for. Use Key:Value format for specific tag key/value pairs, and Key:* format to match any resource with a particular key, regardless of value. Examples: env:production, DO_NOT_DELETE:*"
+  allowed_pattern /(^$)|[\w]*\:.*/
+  default []
+end
+
+parameter "param_unused_or_underutilized" do
+  type "string"
+  category "Filters"
+  label "Report Unused or Underutilized"
+  description "Whether to report on unused instances, underutilized instances, or both."
+  allowed_values "Unused & Underutilized", "Unused", "Underutilized"
+  default "Unused & Underutilized"
+end
+
+parameter "param_stats_underutil_threshold_cpu_value" do
+  type "number"
+  category "Statistics"
+  label "Underutilized Instance CPU Threshold (%)"
+  description "The CPU threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing."
+  min_value 0
+  max_value 100
+  default 60
+end
+
+parameter "param_stats_lookback" do
+  type "number"
+  category "Statistics"
+  label "Statistic Lookback Period"
+  description "How many days back to look at instance metrics to determine if an instance is underutilized or unused. This value cannot be set higher than 90 because Azure does not retain metrics for longer than 90 days."
+  default 30
+  min_value 1
+  max_value 90
+end
+
+parameter "param_automatic_action" do
+  type "list"
+  category "Actions"
+  label "Automatic Actions"
+  description "When this value is set, this policy will automatically take the selected action."
+  allowed_values ["Downsize Underutilized Instances", "Delete Unused Instances"]
+  default []
 end
 
 ###############################################################################
@@ -115,7 +150,7 @@ end
 
 credentials "auth_flexera" do
   schemes "oauth2"
-  label "flexera"
+  label "Flexera"
   description "Select Flexera One OAuth2 credentials"
   tags "provider=flexera"
 end
@@ -719,19 +754,40 @@ datasource "ds_child_incident_details" do
   end
 end
 
-datasource "ds_merged_metrics_combined_incidents" do
-  run_script $js_ds_merged_metrics_combined_incidents, $ds_child_incident_details
+datasource "ds_downsize_sql_incident_combined_incidents" do
+  run_script $js_ds_downsize_sql_incident_combined_incidents, $ds_child_incident_details
 end
 
-script "js_ds_merged_metrics_combined_incidents", type: "javascript" do
+script "js_ds_downsize_sql_incident_combined_incidents", type: "javascript" do
   parameters "ds_child_incident_details"
   result "result"
   code <<-EOS
   result = []
   _.each(ds_child_incident_details, function(incident) {
     s = incident["summary"];
-    // If the incident summary contains "Azure Rightsize SQL single Database" then include it in the filter result
-    if (s.indexOf("Azure Rightsize SQL single Database") > -1) {
+    // If the incident summary contains "Azure Underutilized SQL Databases Found" then include it in the filter result
+    if (s.indexOf("Azure Underutilized SQL Databases Found") > -1) {
+      _.each(incident["violation_data"], function(violation) {
+        result.push(violation);
+      });
+    }
+  });
+EOS
+end
+
+datasource "ds_unused_sql_incident_combined_incidents" do
+  run_script $js_ds_unused_sql_incident_combined_incidents, $ds_child_incident_details
+end
+
+script "js_ds_unused_sql_incident_combined_incidents", type: "javascript" do
+  parameters "ds_child_incident_details"
+  result "result"
+  code <<-EOS
+  result = []
+  _.each(ds_child_incident_details, function(incident) {
+    s = incident["summary"];
+    // If the incident summary contains "Azure Unused SQL Databases Found" then include it in the filter result
+    if (s.indexOf("Azure Unused SQL Databases Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
         result.push(violation);
       });
@@ -747,9 +803,9 @@ end
 # Could also just have one incident and use meta_status to determine which escalation happens
 policy "policy_scheduled_report" do
   # Consolidated Incident Check(s)
-    # Consolidated incident for Azure Rightsize SQL single Database
-  validate $ds_merged_metrics_combined_incidents do
-    summary_template "Consolidated Incident: {{ len data }} Azure Rightsize SQL single Database"
+    # Consolidated incident for Azure Underutilized SQL Databases Found
+  validate $ds_downsize_sql_incident_combined_incidents do
+    summary_template "Consolidated Incident: {{ len data }} Azure Underutilized SQL Databases Found"
     escalate $esc_email
     check eq(size(data), 0)
     export do
@@ -760,26 +816,23 @@ policy "policy_scheduled_report" do
       field "accountName" do
         label "Subscription Name"
       end
-      field "region" do
-        label "Location"
-      end
-      field "resourceName" do
-        label "Name"
-      end
       field "resourceGroup" do
         label "Resource Group"
       end
-      field "kind" do
-        label "Kind"
+      field "resourceName" do
+        label "Resource Name"
       end
-      field "type" do
-        label "Type"
+      field "tags" do
+        label "Resource Tags"
+      end
+      field "recommendationDetails" do
+        label "Recommendation"
       end
       field "skuCapacity" do
         label "Current Capacity"
       end
       field "newResourceType" do
-        label "Recommended Resource Type"
+        label "Recommended Capacity"
       end
       field "skuName" do
         label "SKU - Name"
@@ -787,23 +840,102 @@ policy "policy_scheduled_report" do
       field "skuTier" do
         label "SKU - Tier"
       end
+      field "resourceType" do
+        label "Resource Type"
+      end
+      field "resourceKind" do
+        label "Resource Kind"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "savings" do
+        label "Estimated Monthly Savings"
+      end
+      field "savingsCurrency" do
+        label "Savings Currency"
+      end
       field "cpuAverage" do
         label "CPU Average %"
       end
-      field "recommendation" do
-        label "Recommendation"
+      field "service" do
+        label "Service"
+      end
+      field "platform" do
+        label "Platform"
       end
       field "id" do
-        label "Id"
+        label "Resource ID"
       end
-      field "resourceType" do
-        label "Resource Type"
+      field "threshold" do
+        label "CPU Threshold"
       end
       field "lookbackPeriod" do
         label "Lookback Period"
       end
-      field "threshold" do
-        label "Threshold"
+    end
+  end
+
+  # Consolidated incident for Azure Unused SQL Databases Found
+  validate $ds_unused_sql_incident_combined_incidents do
+    summary_template "Consolidated Incident: {{ len data }} Azure Unused SQL Databases Found"
+    escalate $esc_email
+    check eq(size(data), 0)
+    export do
+      resource_level true
+      field "accountID" do
+        label "Subscription ID"
+      end
+      field "accountName" do
+        label "Subscription Name"
+      end
+      field "resourceGroup" do
+        label "Resource Group"
+      end
+      field "resourceName" do
+        label "Resource Name"
+      end
+      field "tags" do
+        label "Resource Tags"
+      end
+      field "recommendationDetails" do
+        label "Recommendation"
+      end
+      field "resourceType" do
+        label "Type"
+      end
+      field "resourceKind" do
+        label "Kind"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "skuName" do
+        label "SKU - Name"
+      end
+      field "skuTier" do
+        label "SKU - Tier"
+      end
+      field "skuCapacity" do
+        label "SKU - Capacity"
+      end
+      field "savings" do
+        label "Estimated Monthly Savings"
+      end
+      field "savingsCurrency" do
+        label "Savings Currency"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "platform" do
+        label "Platform"
+      end
+      field "id" do
+        label "Resource ID"
+      end
+      field "lookbackPeriod" do
+        label "Lookback Period"
       end
     end
   end


### PR DESCRIPTION
### Description

This is a revamp of the Azure Rightsize SQL Databases policy as part of the general audit on usage and rate reduction policies. In order to have parity with the Azure Rightsize Compute policy, and to avoid duplicate recommendations, this policy now reports on both unused and underutilized SQL databases via distinct incidents. A parameter allows the user, if desired, to report on only unused or only underutilized instances, retaining existing functionality.

The policy now also offers savings estimates for rightsizing opportunities. For underutilized resources, the cost of the instance is divided by the current capacity of the instance and then multiplied by the recommended capacity of the instance to determine the new cost if the instance were downsized. This is then subtracted from the current cost of the resource to determine the savings. This works because pricing for Azure SQL databases is straightforwardly a multiple of the capacity assigned to it within a given tier. For example, a Standard instance with a capacity of 50 costs 5x what a Standard instance with a capacity of 10 costs. 

From the CHANGELOG:

- Several parameters altered to be more descriptive and human-readable
- Removed deprecated "Log to CM Audit Entries" parameter
- Added potential savings to recommendations
- Added ability to only report recommendations that meet a minimum savings threshold
- Added incident for unused instances based on lack of connections
- Added ability to delete unused instances
- Added ability to configure how many days back to consider when determining if instance is unused or underutilized
- Added ability to filter resources by multiple tag key:value pairs
- Added ability to filter resources by region
- Added additional context to incident description
- Normalized incident export to be consistent with other policies
- Added human-readable recommendation to incident export
- Policy no longer raises new escalations if statistics or savings data changed but nothing else has
- Streamlined code for better readability and faster execution

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=650069e66a972a0001e4fae6
https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=65006a676a972a0001e4fae8

Note: Both downsize and delete actions have been tested successfully. Cost data has been confirmed to work as well, but this data is not meaningfully available in our Flexera Services test account. CPU average data is also working but reports as 0 in the incident because the average CPU usage for this instance is 0.004032258064516129, which rounds down to 0 when reducing it to 2 decimal points. This can be confirmed by viewing the applied policy log.

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
