### PR TITLE
POL-919 Azure Long Running Instances Revamp

### DIFF
--- a/operational/azure/azure_long_running_instances/CHANGELOG.md
+++ b/operational/azure/azure_long_running_instances/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v4.0
+
+- Several parameters altered to be more descriptive and human-readable
+- Added ability to filter resources by multiple tag key:value pairs
+- Added several fields to incident export to provide additional context
+- Added additional context to incident description
+- Normalized incident export to be consistent with other policies
+- Policy no longer raises new escalations for the same resource if incidental metadata has changed
+- Streamlined code for better readability and faster execution
+- Policy now requires a valid Flexera credential
+- Added logic required for "Meta Policy" use-cases
+
 ## v3.0
 
 - Renamed Subscription List parameter for consistency and accuracy

--- a/operational/azure/azure_long_running_instances/README.md
+++ b/operational/azure/azure_long_running_instances/README.md
@@ -2,23 +2,29 @@
 
 ## What It Does
 
-This policy checks for running instances that have been running longer than the `Days Old` parameter. It will then take the appropriate action(Stop/Terminate) on the instance.
+This policy checks for running instances that have been running longer than the `Minimum Age (Days)` parameter. It will then take the appropriate action (Stop/Terminate) on the instance.
 
 ## Functional Description
 
-- This policy identifies all instances that have been running longer than the `Days Old` parameter.
+- This policy identifies all instances that have been running longer than the `Minimum Age (Days)` parameter.
 
 ## Input Parameters
 
 This policy template has the following Input parameters which require value before
 the policy can be applied.
 
-- *Email notify list* - Email addresses of the recipients you wish to notify.
-- *Days Old* - Number of days to be running before included in list.
-- *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).
+- *Email Addresses* - Email addresses of the recipients you wish to notify when new incidents are created.
+- *Azure Endpoint* - The endpoint to send Azure API requests to. Recommended to leave this at default unless using this policy with Azure China.
+- *Minimum Age (Days)* - The minimum age, in days, to consider an instance to be long running.
+- *Allow/Deny Subscriptions* - Determines whether the Allow/Deny Subscriptions List parameter functions as an allow list (only providing results for the listed subscriptions) or a deny list (providing results for all subscriptions except for the listed subscriptions).
+- *Allow/Deny Subscriptions List* - A list of allowed or denied Subscription IDs/names. If empty, no filtering will occur and recommendations will be produced for all subscriptions.
+- *Allow/Deny Regions* - Whether to treat Allow/Deny Regions List parameter as allow or deny list. Has no effect if Allow/Deny Regions List is left empty.
+- *Allow/Deny Regions List* - Filter results by region, either only allowing this list or denying it depending on how the above parameter is set. Leave blank to consider all the regions.
+- *Exclusion Tags (Key:Value)* - Cloud native tags to ignore resources that you don't want to produce recommendations for. Use Key:Value format for specific tag key/value pairs, and Key:\* format to match any resource with a particular key, regardless of value. Examples: env:production, DO_NOT_DELETE:\*
+- *Automatic Actions* - The policy will automatically take the selected action.
 
-Please note that the "Automatic Actions" parameter contains a list of action(s) that can be performed on the resources. When it is selected, the policy will automatically execute the corresponding action on the data that failed the checks, post incident generation. Please leave it blank for *manual* action.
-For example if a user selects the "Stop Instances" action while applying the policy, all the instances that didn't satisfy the policy condition will be stopped.
+Please note that the "Automatic Actions" parameter contains a list of actions that can be performed on the resources. When it is selected, the policy will automatically execute the corresponding action on the data that failed the checks, post incident generation. Please leave this parameter set to "No Automatic Actions" for *manual* action.
+For example if a user selects the "Terminate Instances" action while applying the policy, all the resources that didn't satisfy the policy condition will be terminated.
 
 ## Policy Actions
 
@@ -27,8 +33,8 @@ Policy Incident. Actions that destroy or terminate a resource generally require
 approval from the Policy Approver. This policy includes the following actions.
 
 - Sends an email notification
-- Stop the instance
-- Terminate the instance
+- Stop virtual machines after approval
+- Terminate virtual machines after approval
 
 ## Prerequisites
 
@@ -45,7 +51,9 @@ For administrators [creating and managing credentials](https://docs.flexera.com/
 
 - [**Azure Resource Manager Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_109256743_1124668) (*provider=azure_rm*) which has the following permissions:
   - `Microsoft.Compute/virtualMachines/read`
-  - `Microsoft.Compute/virtualMachines/write`
+  - `Microsoft.Compute/virtualMachines/write`*
+
+\* Only required for taking action (stopping or terminating instances); the policy will still function in a read-only capacity without these permissions.
 
 - [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
   - `billing_center_viewer`

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
@@ -599,17 +599,23 @@ script "js_long_running_instances_incident", type: "javascript" do
     result.push(instance)
   })
 
+  instance_noun = "machine"
+  if (instances_total > 1) { instance_noun = "machines" }
+
   day_noun = "day"
   if (param_minimum_age > 1) { day_noun = "days" }
+
+  has_verb = "has"
+  if (long_instances_total > 1) { day_noun = "have" }
 
   instances_total = ds_azure_instances_region_filtered.length.toString()
   long_instances_total = result.length.toString()
   long_instances_percentage = (long_instances_total / instances_total * 100).toFixed(2).toString() + '%'
 
   findings = [
-    "Out of ", instances_total, " Azure virtual machines analyzed, ",
+    "Out of ", instances_total, " Azure virtual ", instance_noun, " analyzed, ",
     long_instances_total, " (", long_instances_percentage,
-    ") have been running for longer than ", param_minimum_age,
+    ") ", has_verb, " been running for longer than ", param_minimum_age,
     " ", day_noun, ".\n\n"
   ].join('')
 

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
@@ -101,8 +101,8 @@ end
 
 credentials "auth_azure" do
   schemes "oauth2"
-  label "Azure Compute credential"
-  description "Select the Azure Credential from the list"
+  label "Azure"
+  description "Select the Azure Resource Manager Credential from the list."
   tags "provider=azure_rm"
 end
 
@@ -286,7 +286,7 @@ datasource "ds_azure_instances" do
     pagination $pagination_azure
     host $param_azure_endpoint
     path join(["/subscriptions/", val(iter_item, "id"), "/providers/Microsoft.Compute/virtualMachines"])
-    query "api-version", "2019-03-01"
+    query "api-version", "2023-07-01"
     header "User-Agent", "RS Policies"
     # Ignore status 400, 403, and 404 which can be returned in certain (legacy) types of Azure Subscriptions
     ignore_status [400, 403, 404]
@@ -299,7 +299,7 @@ datasource "ds_azure_instances" do
       field "resourceKind", jmes_path(col_item, "type")
       field "name", jmes_path(col_item, "name")
       field "region", jmes_path(col_item, "location")
-      field "statuses", jmes_path(col_item, "properties.instanceView.statuses")
+      field "timeCreated", jmes_path(col_item, "properties.timeCreated")
       field "osType", jmes_path(col_item, "properties.storageProfile.osDisk.osType")
       field "resourceType", jmes_path(col_item, "properties.hardwareProfile.vmSize")
       field "tags", jmes_path(col_item, "tags")
@@ -379,9 +379,7 @@ script "js_long_running_instances", type: "javascript" do
   result = []
 
   _.each(ds_azure_instances_region_filtered, function(vm) {
-    status = _.where(vm['statuses'], {"code": "PowerState/running"})[0]["displayStatus"]
-    provisionState = _.where(vm['statuses'], {"code": "ProvisioningState/succeeded"})
-    launchTime = new Date(provisionState[0]["time"])
+    launchTime = new Date(vm["timeCreated"])
     age = parseInt((Date.now().valueOf() - launchTime.valueOf()) / 86400000)
 
     if (age >= param_minimum_age) {
@@ -406,7 +404,6 @@ script "js_long_running_instances", type: "javascript" do
         subscriptionName: vm['subscriptionName'],
         tags: tags.join(', '),
         age: parseInt(age),
-        status: status,
         launchTime: launchTime.toISOString(),
         lookbackPeriod: param_minimum_age
       })
@@ -573,7 +570,6 @@ script "js_long_running_instances_incident", type: "javascript" do
       accountName: vm['subscriptionName'],
       tags: vm['tags'],
       age: vm['age'],
-      status: vm['status'],
       launchTime: vm['launchTime'],
       lookbackPeriod: vm['lookbackPeriod'],
       policy_name: ds_applied_policy['name'],
@@ -586,7 +582,7 @@ script "js_long_running_instances_incident", type: "javascript" do
       message: ""
     }
 
-    id = item['resourceId'].toLowerCase()
+    id = vm['resourceId'].toLowerCase()
 
     if (ds_instance_costs_grouped[id] != undefined) {
       instance['cost'] = Number(ds_instance_costs_grouped[id]['cost'].toFixed(3))
@@ -599,6 +595,10 @@ script "js_long_running_instances_incident", type: "javascript" do
     result.push(instance)
   })
 
+  instances_total = ds_azure_instances_region_filtered.length.toString()
+  long_instances_total = result.length.toString()
+  long_instances_percentage = (long_instances_total / instances_total * 100).toFixed(2).toString() + '%'
+
   instance_noun = "machine"
   if (instances_total > 1) { instance_noun = "machines" }
 
@@ -607,10 +607,6 @@ script "js_long_running_instances_incident", type: "javascript" do
 
   has_verb = "has"
   if (long_instances_total > 1) { day_noun = "have" }
-
-  instances_total = ds_azure_instances_region_filtered.length.toString()
-  long_instances_total = result.length.toString()
-  long_instances_percentage = (long_instances_total / instances_total * 100).toFixed(2).toString() + '%'
 
   findings = [
     "Out of ", instances_total, " Azure virtual ", instance_noun, " analyzed, ",
@@ -679,9 +675,6 @@ policy "pol_utilization" do
       end
       field "region" do
         label "Region"
-      end
-      field "operating_system" do
-        label "Operating System"
       end
       field "cost" do
         label "Estimated Monthly Cost"

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
@@ -589,7 +589,7 @@ script "js_long_running_instances_incident", type: "javascript" do
     id = item['resourceId'].toLowerCase()
 
     if (ds_instance_costs_grouped[id] != undefined) {
-      instance['cost'] = ds_instance_costs_grouped[id]['cost']
+      instance['cost'] = Number(ds_instance_costs_grouped[id]['cost'].toFixed(3))
       instance['operating_system'] = ds_instance_costs_grouped[id]['operating_system']
       instance['billing_center'] = ds_instance_costs_grouped[id]['billing_center']
       instance['purchase_option'] = ds_instance_costs_grouped[id]['purchase_option']

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
@@ -1,13 +1,13 @@
 name "Azure Long Running Instances"
 rs_pt_ver 20180301
 type "policy"
-short_description "Checks for running instances that have been running longer than the `Days Old` parameter. See the [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "Checks for instances that have been running longer than the `Minimum Age (Days)` parameter. See the [README](https://github.com/flexera-public/policy_templates/tree/master/operational/azure/azure_long_running_instances/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
-severity "low"
 category "Operational"
-default_frequency "daily"
+severity "low"
+default_frequency "weekly"
 info(
-  version: "3.0",
+  version: "4.0",
   provider: "Azure",
   service: "Compute",
   policy_set: "Long Running Instances"
@@ -19,36 +19,80 @@ info(
 
 parameter "param_email" do
   type "list"
-  label "Email notify list"
-  description "Email addresses of the recipients you wish to notify when new incidents are created"
+  category "Policy Settings"
+  label "Email Addresses"
+  description "A list of email addresses to notify."
+  default []
 end
 
 parameter "param_azure_endpoint" do
   type "string"
+  category "Policy Settings"
   label "Azure Endpoint"
+  description "Select the API endpoint to use for Azure. Use default value of management.azure.com unless using Azure China."
   allowed_values "management.azure.com", "management.chinacloudapi.cn"
   default "management.azure.com"
 end
 
-parameter "param_days_old" do
+parameter "param_minimum_age" do
   type "number"
-  label "Days Old"
-  description "Number of days to be running before included in list"
+  category "Policy Settings"
+  label "Minimum Age (Days)"
+  description "The minimum age, in days, to consider an instance to be long running"
   default 180
+  min_value 0
+end
+
+parameter "param_subscriptions_allow_or_deny" do
+  type "string"
+  category "Filters"
+  label "Allow/Deny Subscriptions"
+  description "Allow or Deny entered Subscriptions."
+  allowed_values "Allow", "Deny"
+  default "Allow"
 end
 
 parameter "param_subscriptions_list" do
-  label "Subscription Allowed List"
   type "list"
-  description "Allowed Subscriptions, if empty, all subscriptions will be checked"
+  category "Filters"
+  label "Allow/Deny Subscriptions List"
+  description "A list of allowed or denied Subscription IDs/names. Leave blank to check all Subscriptions."
+  default []
+end
+
+parameter "param_regions_allow_or_deny" do
+  type "string"
+  category "Filters"
+  label "Allow/Deny Regions"
+  description "Allow or Deny entered regions."
+  allowed_values "Allow", "Deny"
+  default "Allow"
+end
+
+parameter "param_regions_list" do
+  type "list"
+  category "Filters"
+  label "Allow/Deny Regions List"
+  description "A list of allowed or denied regions. Leave blank to check all regions."
+  default []
+end
+
+parameter "param_exclusion_tags" do
+  type "list"
+  category "Filters"
+  label "Exclusion Tags (Key:Value)"
+  description "Cloud native tags to ignore resources that you don't want to produce recommendations for. Use Key:Value format for specific tag key/value pairs, and Key:* format to match any resource with a particular key, regardless of value. Examples: env:production, DO_NOT_DELETE:*"
+  allowed_pattern /(^$)|[\w]*\:.*/
+  default []
 end
 
 parameter "param_automatic_action" do
   type "string"
+  category "Actions"
   label "Automatic Actions"
-  description "When this value is set, this policy will automatically take the selected action(s)"
-  default "Select Action"
-  allowed_values "Select Action", "Stop Instances", "Terminate Instances"
+  description "The policy will automatically take the selected action"
+  default "No Automatic Actions"
+  allowed_values "No Automatic Actions", "Stop Instances", "Terminate Instances"
 end
 
 ###############################################################################
@@ -86,13 +130,116 @@ end
 # Datasources & Scripts
 ###############################################################################
 
-datasource "ds_subscriptions" do
+# Get applied policy metadata for use later
+datasource "ds_applied_policy" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    header "Api-Version", "1.0"
+  end
+end
+
+datasource "ds_billing_centers" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/analytics/orgs/", rs_org_id, "/billing_centers"])
+    header "Api-Version", "1.0"
+    header "User-Agent", "RS Policies"
+    query "view", "allocation_table"
+    ignore_status [403]
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "href", jmes_path(col_item, "href")
+      field "id", jmes_path(col_item, "id")
+      field "name", jmes_path(col_item, "name")
+      field "parent_id", jmes_path(col_item, "parent_id")
+    end
+  end
+end
+
+# Gather top level billing center IDs for when we pull cost data
+datasource "ds_top_level_bcs" do
+  run_script $js_top_level_bcs, $ds_billing_centers
+end
+
+script "js_top_level_bcs", type: "javascript" do
+  parameters "ds_billing_centers"
+  result "result"
+  code <<-EOS
+  filtered_bcs = _.filter(ds_billing_centers, function(bc) {
+    return bc['parent_id'] == null || bc['parent_id'] == undefined
+  })
+
+  result = _.compact(_.pluck(filtered_bcs, 'id'))
+EOS
+end
+
+
+datasource "ds_currency_reference" do
+  request do
+    host "raw.githubusercontent.com"
+    path "/rightscale/policy_templates/master/cost/scheduled_reports/currency_reference.json"
+    header "User-Agent", "RS Policies"
+  end
+end
+
+datasource "ds_currency_code" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/bill-analysis/orgs/", rs_org_id, "/settings/currency_code"])
+    header "Api-Version", "0.1"
+    header "User-Agent", "RS Policies"
+    ignore_status [403]
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+    field "value", jmes_path(response, "value")
+  end
+end
+
+datasource "ds_currency" do
+  run_script $js_currency, $ds_currency_reference, $ds_currency_code
+end
+
+script "js_currency", type:"javascript" do
+  parameters "ds_currency_reference", "ds_currency_code"
+  result "result"
+  code <<-EOS
+  symbol = "$"
+  separator = ","
+
+  if (ds_currency_code['value'] != undefined) {
+    if (ds_currency_reference[ds_currency_code['value']] != undefined) {
+      symbol = ds_currency_reference[ds_currency_code['value']]['symbol']
+
+      if (ds_currency_reference[ds_currency_code['value']]['t_separator'] != undefined) {
+        separator = ds_currency_reference[ds_currency_code['value']]['t_separator']
+      } else {
+        separator = ""
+      }
+    }
+  }
+
+  result = {
+    symbol: symbol,
+    separator: separator
+  }
+EOS
+end
+
+datasource "ds_azure_subscriptions" do
   request do
     auth $auth_azure
     pagination $pagination_azure
     host $param_azure_endpoint
     path "/subscriptions/"
-    query "api-version", "2018-06-01"
+    query "api-version","2020-01-01"
     header "User-Agent", "RS Policies"
     # Header X-Meta-Flexera has no affect on datasource query, but is required for Meta Policies
     # Forces `ds_is_deleted` datasource to run first during policy execution
@@ -103,98 +250,386 @@ datasource "ds_subscriptions" do
     collect jmes_path(response, "value[*]") do
       field "id", jmes_path(col_item, "subscriptionId")
       field "name", jmes_path(col_item, "displayName")
+      field "state", jmes_path(col_item, "state")
     end
   end
 end
 
-datasource "ds_filtered_subscriptions" do
-  run_script $js_filtered_subscriptions, $ds_subscriptions, $param_subscriptions_list
+datasource "ds_azure_subscriptions_filtered" do
+  run_script $js_azure_subscriptions_filtered, $ds_azure_subscriptions, $param_subscriptions_allow_or_deny, $param_subscriptions_list
 end
 
-script "js_filtered_subscriptions", type: "javascript" do
-  parameters "ds_subscriptions", "param_subscriptions_list"
+script "js_azure_subscriptions_filtered", type: "javascript" do
+  parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-EOS
   if (param_subscriptions_list.length > 0) {
-    result = _.filter(ds_subscriptions, function(subscription) {
-      return _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
+    result = _.filter(ds_azure_subscriptions, function(subscription) {
+      include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
+
+      if (param_subscriptions_allow_or_deny == "Deny") {
+        include_subscription = !include_subscription
+      }
+
+      return include_subscription
     })
   } else {
-    result = ds_subscriptions
+    result = ds_azure_subscriptions
   }
 EOS
 end
 
-# Lists All Virtual Machines in each subscription
-datasource "ds_vm_list" do
-  iterate $ds_filtered_subscriptions
+datasource "ds_azure_instances" do
+  iterate $ds_azure_subscriptions_filtered
   request do
     auth $auth_azure
     pagination $pagination_azure
     host $param_azure_endpoint
     path join(["/subscriptions/", val(iter_item, "id"), "/providers/Microsoft.Compute/virtualMachines"])
-    query "api-version","2022-08-01"
-    query "statusOnly", "true"
+    query "api-version", "2019-03-01"
     header "User-Agent", "RS Policies"
+    # Ignore status 400, 403, and 404 which can be returned in certain (legacy) types of Azure Subscriptions
+    ignore_status [400, 403, 404]
   end
   result do
     encoding "json"
     collect jmes_path(response, "value[*]") do
-      field "id", jmes_path(col_item, "id")
-      field "rg", get(4, split(jmes_path(col_item,"id"), "/"))
+      field "resourceId", jmes_path(col_item, "id")
+      field "resourceGroup", get(4, split(jmes_path(col_item, "id"), '/'))
+      field "resourceKind", jmes_path(col_item, "type")
       field "name", jmes_path(col_item, "name")
+      field "region", jmes_path(col_item, "location")
       field "statuses", jmes_path(col_item, "properties.instanceView.statuses")
+      field "osType", jmes_path(col_item, "properties.storageProfile.osDisk.osType")
+      field "resourceType", jmes_path(col_item, "properties.hardwareProfile.vmSize")
+      field "tags", jmes_path(col_item, "tags")
       field "subscriptionId",val(iter_item, "id")
       field "subscriptionName",val(iter_item, "name")
     end
   end
 end
 
-# Calls the script to get only the virtual machines that are running
-datasource "ds_vm_running" do
-  run_script $js_filter_vm_running, $ds_vm_list, $param_days_old
+datasource "ds_azure_instances_tag_filtered" do
+  run_script $js_azure_instances_tag_filtered, $ds_azure_instances, $param_exclusion_tags
 end
 
-# Returns instances that are long running
-script "js_filter_vm_running", type: "javascript" do
-  parameters "ds_vm_list", "param_days_old"
+script "js_azure_instances_tag_filtered", type: "javascript" do
+  parameters "ds_azure_instances", "param_exclusion_tags"
   result "result"
   code <<-EOS
-  // Dummy value to ensure validation runs at least once
-  result = [{
-    "id": "",
-    "name": "",
-    "status": "",
-    "time_running": "",
-    "days_elapsed": -1,
-    "resourcegroup": "",
-    "subscriptionId": "",
-    "subscriptionName": ""
-  }]
+  if (param_exclusion_tags.length > 0) {
+    result = _.reject(ds_azure_instances, function(instance) {
+      instance_tags = []
 
-  _.each(ds_vm_list, function(instance){
-    var codes = _.pluck(instance.statuses, 'code')
-    if ( _.contains(codes, "PowerState/running") ) {
-      var runningState = _.where(instance.statuses, {"code": "PowerState/running"});
-      var displayStatus = runningState[0]["displayStatus"];
-      var provisionState = _.where(instance.statuses, {"code": "ProvisioningState/succeeded"});
-      var timeRunning = provisionState[0]["time"];
-      var timeofevent = new Date(timeRunning);
-      var nowtime = Date.now();
-      var res = Math.abs(timeofevent.valueOf() - nowtime.valueOf());
-      var daysElapsed = Math.ceil(res / (1000 * 3600 * 24));
+      if (typeof(instance['tags']) == 'object') {
+        _.each(Object.keys(instance['tags']), function(key) {
+          instance_tags.push([key, ":", instance['tags'][key]].join(''))
+          instance_tags.push([key, ":*"].join(''))
+        })
+      }
+
+      exclude_instance = false
+
+      _.each(param_exclusion_tags, function(exclusion_tag) {
+        if (_.contains(instance_tags, exclusion_tag)) {
+          exclude_instance = true
+        }
+      })
+
+      return exclude_instance
+    })
+  } else {
+    result = ds_azure_instances
+  }
+EOS
+end
+
+datasource "ds_azure_instances_region_filtered" do
+  run_script $js_azure_instances_region_filtered, $ds_azure_instances_tag_filtered, $param_regions_allow_or_deny, $param_regions_list
+end
+
+script "js_azure_instances_region_filtered", type: "javascript" do
+  parameters "ds_azure_instances_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
+  result "result"
+  code <<-EOS
+  if (param_regions_list.length > 0) {
+    result = _.filter(ds_azure_instances_tag_filtered, function(instance) {
+      include_instance = _.contains(param_regions_list, instance['region'])
+
+      if (param_regions_allow_or_deny == "Deny") {
+        include_instance = !include_instance
+      }
+
+      return include_instance
+    })
+  } else {
+    result = ds_azure_instances_tag_filtered
+  }
+EOS
+end
+
+datasource "ds_long_running_instances" do
+  run_script $js_long_running_instances, $ds_azure_instances_region_filtered, $param_minimum_age
+end
+
+script "js_long_running_instances", type: "javascript" do
+  parameters "ds_azure_instances_region_filtered", "param_minimum_age"
+  result "result"
+  code <<-EOS
+  result = []
+
+  _.each(ds_azure_instances_region_filtered, function(vm) {
+    status = _.where(vm['statuses'], {"code": "PowerState/running"})[0]["displayStatus"]
+    provisionState = _.where(vm['statuses'], {"code": "ProvisioningState/succeeded"})
+    launchTime = new Date(provisionState[0]["time"])
+    age = parseInt((Date.now().valueOf() - launchTime.valueOf()) / 86400000)
+
+    if (age >= param_minimum_age) {
+      tags = []
+
+      if (typeof(vm['tags']) == 'object') {
+        _.each(Object.keys(vm['tags']), function(key) {
+          tags.push([key, "=", vm['tags'][key]].join(''))
+        })
+      }
+
       result.push({
-        "id": instance["id"],
-        "name": instance["name"],
-        "status": displayStatus,
-        "time_running": timeRunning,
-        "days_elapsed": daysElapsed,
-        "resourcegroup": instance["rg"],
-        "subscriptionId": instance["subscriptionId"],
-        "subscriptionName": instance["subscriptionName"]
+        resourceId: vm['resourceId'],
+        resourceGroup: vm['resourceGroup'],
+        resourceKind: vm['resourceKind'],
+        name: vm['name'],
+        region: vm['region'],
+        statuses: vm['statuses'],
+        osType: vm['osType'],
+        resourceType: vm['resourceType'],
+        subscriptionId: vm['subscriptionId'],
+        subscriptionName: vm['subscriptionName'],
+        tags: tags.join(', '),
+        age: parseInt(age),
+        status: status,
+        launchTime: launchTime.toISOString(),
+        lookbackPeriod: param_minimum_age
       })
     }
   })
+EOS
+end
+
+datasource "ds_azure_instances_subscriptions" do
+  run_script $js_azure_instances_subscriptions, $ds_long_running_instances
+end
+
+script "js_azure_instances_subscriptions", type: "javascript" do
+  parameters "ds_long_running_instances"
+  result "result"
+  code <<-EOS
+  result = _.compact(_.uniq(_.pluck(ds_long_running_instances, 'subscriptionId')))
+EOS
+end
+
+datasource "ds_instance_costs" do
+  iterate $ds_azure_instances_subscriptions
+  request do
+    run_script $js_instance_costs, iter_item, $ds_top_level_bcs, rs_org_id, rs_optima_host
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "rows[*]") do
+      field "resourceId", jmes_path(col_item, "dimensions.resource_id")
+      field "billing_center_id", jmes_path(col_item, "dimensions.billing_center_id")
+      field "operating_system", jmes_path(col_item, "dimensions.operating_system")
+      field "purchase_option", jmes_path(col_item, "dimensions.purchase_option")
+      field "service", jmes_path(col_item, "dimensions.service")
+      field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
+    end
+  end
+end
+
+script "js_instance_costs", type: "javascript" do
+  parameters "subscription_id", "ds_top_level_bcs", "rs_org_id", "rs_optima_host"
+  result "request"
+  code <<-EOS
+  end_date = new Date()
+  end_date.setDate(end_date.getDate() - 2)
+  end_date = end_date.toISOString().split('T')[0]
+
+  start_date = new Date()
+  start_date.setDate(start_date.getDate() - 3)
+  start_date = start_date.toISOString().split('T')[0]
+
+  var request = {
+    auth: "auth_flexera",
+    host: rs_optima_host,
+    verb: "POST",
+    path: "/bill-analysis/orgs/" + rs_org_id + "/costs/select",
+    body_fields: {
+      dimensions: ["resource_id", "billing_center_id", "operating_system", "purchase_option", "service"],
+      granularity: "day",
+      start_at: start_date,
+      end_at: end_date,
+      metrics: ["cost_amortized_unblended_adj"],
+      billing_center_ids: ds_top_level_bcs,
+      limit: 100000,
+      filter: {
+        "type": "and",
+        "expressions": [
+          {
+            "type": "or",
+            "expressions": [
+              {
+                "dimension": "service",
+                "type": "equal",
+                "value": "Microsoft.Compute"
+              },
+              {
+                "dimension": "service",
+                "type": "equal",
+                "value": "microsoft.compute"
+              }
+            ]
+          },
+          {
+            "dimension": "vendor_account",
+            "type": "equal",
+            "value": subscription_id
+          },
+          {
+            "type": "not",
+            "expression": {
+              "dimension": "adjustment_name",
+              "type": "substring",
+              "substring": "Shared"
+            }
+          }
+        ]
+      }
+    },
+    headers: {
+      'User-Agent': "RS Policies",
+      'Api-Version': "1.0"
+    },
+    ignore_status: [400]
+  }
+EOS
+end
+
+datasource "ds_instance_costs_grouped" do
+  run_script $js_instance_costs_grouped, $ds_instance_costs, $ds_billing_centers
+end
+
+script "js_instance_costs_grouped", type: "javascript" do
+  parameters "ds_instance_costs", "ds_billing_centers"
+  result "result"
+  code <<-EOS
+  bc_object = {}
+
+  _.each(ds_billing_centers, function(bc) {
+    bc_object[bc['id']] = bc['name']
+  })
+
+  // Multiple a single day's cost by the average number of days in a month.
+  // The 0.25 is to account for leap years for extra precision.
+  cost_multiplier = 365.25 / 12
+
+  // Group cost data by resourceId for later use
+  result = {}
+
+  _.each(ds_instance_costs, function(item) {
+    id = item['resourceId'].toLowerCase()
+
+    if (result[id] == undefined) { result[id] = { cost: 0 } }
+
+    result[id]['cost'] += item['cost'] * cost_multiplier
+    result[id]['operating_system'] = item['operating_system']
+    result[id]['billing_center'] = bc_object[item['billing_center_id']]
+    result[id]['purchase_option'] = item['purchase_option']
+    result[id]['service'] = item['service']
+  })
+EOS
+end
+
+
+datasource "ds_long_running_instances_incident" do
+  run_script $js_long_running_instances_incident, $ds_azure_instances_region_filtered, $ds_long_running_instances, $ds_instance_costs_grouped, $ds_applied_policy, $ds_currency, $param_minimum_age
+end
+
+script "js_long_running_instances_incident", type: "javascript" do
+  parameters "ds_azure_instances_region_filtered", "ds_long_running_instances", "ds_instance_costs_grouped", "ds_applied_policy", "ds_currency", "param_minimum_age"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  _.each(ds_long_running_instances, function(vm) {
+    instance = {
+      id: vm['resourceId'],
+      resourceGroup: vm['resourceGroup'],
+      resourceKind: vm['resourceKind'],
+      resourceName: vm['name'],
+      region: vm['region'],
+      statuses: vm['statuses'],
+      osType: vm['osType'],
+      resourceType: vm['resourceType'],
+      accountID: vm['subscriptionId'],
+      accountName: vm['subscriptionName'],
+      tags: vm['tags'],
+      age: vm['age'],
+      status: vm['status'],
+      launchTime: vm['launchTime'],
+      lookbackPeriod: vm['lookbackPeriod'],
+      policy_name: ds_applied_policy['name'],
+      costCurrency: ds_currency['symbol'],
+      cost: "",
+      operating_system: "",
+      billing_center: "",
+      purchase_option: "",
+      service: "",
+      message: ""
+    }
+
+    id = item['resourceId'].toLowerCase()
+
+    if (ds_instance_costs_grouped[id] != undefined) {
+      instance['cost'] = ds_instance_costs_grouped[id]['cost']
+      instance['operating_system'] = ds_instance_costs_grouped[id]['operating_system']
+      instance['billing_center'] = ds_instance_costs_grouped[id]['billing_center']
+      instance['purchase_option'] = ds_instance_costs_grouped[id]['purchase_option']
+      instance['service'] = ds_instance_costs_grouped[id]['service']
+    }
+
+    result.push(instance)
+  })
+
+  day_noun = "day"
+  if (param_minimum_age > 1) { day_noun = "days" }
+
+  instances_total = ds_azure_instances_region_filtered.length.toString()
+  long_instances_total = result.length.toString()
+  long_instances_percentage = (long_instances_total / instances_total * 100).toFixed(2).toString() + '%'
+
+  findings = [
+    "Out of ", instances_total, " Azure virtual machines analyzed, ",
+    long_instances_total, " (", long_instances_percentage,
+    ") have been running for longer than ", param_minimum_age,
+    " ", day_noun, ".\n\n"
+  ].join('')
+
+  disclaimer = "The above settings can be modified by editing the applied policy and changing the appropriate parameters."
+
+  result = _.sortBy(result, function(item) { return item['cost'] * -1 })
+
+  // Add a dummy entry to ensure that the policy's check statement executes at least once
+  result.push({
+    id: "",                  resourceGroup: "",     resourceKind: "",
+    resourceName: "",        region: "",            statuses: "",
+    osType: "",              resourceType: "",      accountID: "",
+    accountName: "",         tags: "",              age: "",
+    status: "",              launchTime: "",        lookbackPeriod: "",
+    policy_name: "",         costCurrency: "",      cost: "",
+    operating_system: "",    billing_center: "",    purchase_option: "",
+    service: "",             message: ""
+  })
+
+  result[0]['message'] = findings + disclaimer
 EOS
 end
 
@@ -203,39 +638,72 @@ end
 ###############################################################################
 
 policy "pol_utilization" do
-  validate_each $ds_vm_running do
-    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} Azure VMs running longer than {{parameters.param_days_old}} day(s)"
+  validate_each $ds_long_running_instances_incident do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Azure Long Running Instances Found"
+    detail_template <<-'EOS'
+    {{ with index data 0 }}{{ .message }}{{ end }}
+    EOS
     escalate $esc_email
     escalate $esc_stop_instances
     escalate $esc_terminate_instances
-    check logic_or($ds_parent_policy_terminated, lt(to_n(val(item, "days_elapsed")), $param_days_old))
+    check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
+    hash_exclude "tags", "cost", "costCurrency", "age", "billing_center", "lookbackPeriod", "policy_name", "message"
     export do
       resource_level true
       field "accountID" do
         label "Subscription ID"
-        path "subscriptionId"
       end
       field "accountName" do
         label "Subscription Name"
-        path "subscriptionName"
       end
-      field "name" do
-        label "Resource Name"
-      end
-      field "id" do
-        label "Resource ID"
-      end
-      field "resourcegroup" do
+      field "resourceGroup" do
         label "Resource Group"
       end
-      field "status" do
-        label "Status"
+      field "resourceName" do
+        label "Resource Name"
       end
-      field "time_running" do
-        label "Time Running"
+      field "tags" do
+        label "Resource Tags"
       end
-      field "days_elapsed" do
-        label "Days Elapsed"
+      field "resourceType" do
+        label "Instance Size"
+      end
+      field "age" do
+        label "Resource Age (Days)"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "operating_system" do
+        label "Operating System"
+      end
+      field "cost" do
+        label "Estimated Monthly Cost"
+      end
+      field "costCurrency" do
+        label "Cost Currency"
+      end
+      field "launchTime" do
+        label "Launch Time"
+      end
+      field "purchase_option" do
+        label "Purchase Option"
+      end
+      field "billing_center" do
+        label "Billing Center"
+      end
+      field "lookbackPeriod" do
+        label "Look Back Period (Days)"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "resourceID" do
+        label "Resource ID"
+        path "id"
+      end
+      field "id" do
+        label "ID"
       end
     end
   end
@@ -255,14 +723,14 @@ end
 escalation "esc_stop_instances" do
   automatic eq($param_automatic_action, "Stop Instances")
   label "Stop Instances"
-  description "Stop selected instances"
+  description "Approval to stop all selected instances"
   run "stop_instances", data, $param_azure_endpoint
 end
 
 escalation "esc_terminate_instances" do
   automatic eq($param_automatic_action, "Terminate Instances")
   label "Terminate Instances"
-  description "Terminate selected instances"
+  description "Approval to terminate all selected instances"
   run "terminate_instances", data, $param_azure_endpoint
 end
 
@@ -272,15 +740,15 @@ end
 
 # Workflow to power off the virtual machines
 define stop_instances($data, $param_azure_endpoint) return $all_responses do
-  # https://learn.microsoft.com/en-us/rest/api/compute/virtual-machines/power-off?tabs=HTTP
   $all_responses = []
+
   foreach $item in $data do
     sub on_error: skip do
       $response = http_request(
         auth: $$auth_azure,
         verb: "POST",
         host: $param_azure_endpoint,
-        href: join(["/subscriptions/", $item['subscriptionId'], "/resourceGroups/", $item["resourcegroup"], "/providers/Microsoft.Compute/virtualMachines/", $item["name"], "/powerOff/"]),
+        href: join([$item['id'], "/powerOff/"]),
         https: true,
         query_strings: {
           "api-version": "2022-08-01"
@@ -290,22 +758,22 @@ define stop_instances($data, $param_azure_endpoint) return $all_responses do
           "content-type": "application/json"
         }
       )
+
       $all_responses << $response
     end
   end
 end
 
-# Workflow to delete the virtual machines
 define terminate_instances($data, $param_azure_endpoint) return $all_responses do
-  # https://learn.microsoft.com/en-us/rest/api/compute/virtual-machines/delete?tabs=HTTP
   $all_responses = []
+
   foreach $item in $data do
     sub on_error: skip do
       $response = http_request(
         auth: $$auth_azure,
         verb: "DELETE",
         host: $param_azure_endpoint,
-        href: join(["/subscriptions/", $item['subscriptionId'], "/resourceGroups/", $item["resourcegroup"], "/providers/Microsoft.Compute/virtualMachines/",$item["name"]]),
+        href: $item['id'],
         https: true,
         query_strings: {
           "api-version": "2022-08-01"
@@ -315,6 +783,7 @@ define terminate_instances($data, $param_azure_endpoint) return $all_responses d
           "content-type": "application/json"
         }
       )
+
       $all_responses << $response
     end
   end

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "3.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 
@@ -58,24 +58,55 @@ end
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
+  category "Policy Settings"
   label "Azure Endpoint"
+  description "Select the API endpoint to use for Azure. Use default value of management.azure.com unless using Azure China."
   allowed_values "management.azure.com", "management.chinacloudapi.cn"
   default "management.azure.com"
 end
 
-parameter "param_days_old" do
+parameter "param_minimum_age" do
   type "number"
-  label "Days Old"
-  description "Number of days to be running before included in list"
+  category "Policy Settings"
+  label "Minimum Age (Days)"
+  description "The minimum age, in days, to consider an instance to be long running"
   default 180
+  min_value 0
+end
+
+parameter "param_regions_allow_or_deny" do
+  type "string"
+  category "Filters"
+  label "Allow/Deny Regions"
+  description "Allow or Deny entered regions."
+  allowed_values "Allow", "Deny"
+  default "Allow"
+end
+
+parameter "param_regions_list" do
+  type "list"
+  category "Filters"
+  label "Allow/Deny Regions List"
+  description "A list of allowed or denied regions. Leave blank to check all regions."
+  default []
+end
+
+parameter "param_exclusion_tags" do
+  type "list"
+  category "Filters"
+  label "Exclusion Tags (Key:Value)"
+  description "Cloud native tags to ignore resources that you don't want to produce recommendations for. Use Key:Value format for specific tag key/value pairs, and Key:* format to match any resource with a particular key, regardless of value. Examples: env:production, DO_NOT_DELETE:*"
+  allowed_pattern /(^$)|[\w]*\:.*/
+  default []
 end
 
 parameter "param_automatic_action" do
   type "string"
+  category "Actions"
   label "Automatic Actions"
-  description "When this value is set, this policy will automatically take the selected action(s)"
-  default "Select Action"
-  allowed_values "Select Action", "Stop Instances", "Terminate Instances"
+  description "The policy will automatically take the selected action"
+  default "No Automatic Actions"
+  allowed_values "No Automatic Actions", "Stop Instances", "Terminate Instances"
 end
 
 ###############################################################################
@@ -694,19 +725,19 @@ datasource "ds_child_incident_details" do
   end
 end
 
-datasource "ds_vm_running_combined_incidents" do
-  run_script $js_ds_vm_running_combined_incidents, $ds_child_incident_details
+datasource "ds_long_running_instances_incident_combined_incidents" do
+  run_script $js_ds_long_running_instances_incident_combined_incidents, $ds_child_incident_details
 end
 
-script "js_ds_vm_running_combined_incidents", type: "javascript" do
+script "js_ds_long_running_instances_incident_combined_incidents", type: "javascript" do
   parameters "ds_child_incident_details"
   result "result"
   code <<-EOS
   result = []
   _.each(ds_child_incident_details, function(incident) {
     s = incident["summary"];
-    // If the incident summary contains "Azure VMs running longer than" then include it in the filter result
-    if (s.indexOf("Azure VMs running longer than") > -1) {
+    // If the incident summary contains "Azure Long Running Instances Found" then include it in the filter result
+    if (s.indexOf("Azure Long Running Instances Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
         result.push(violation);
       });
@@ -722,9 +753,9 @@ end
 # Could also just have one incident and use meta_status to determine which escalation happens
 policy "policy_scheduled_report" do
   # Consolidated Incident Check(s)
-    # Consolidated incident for Azure VMs running longer than
-  validate $ds_vm_running_combined_incidents do
-    summary_template "Consolidated Incident: {{ len data }} Azure VMs running longer than"
+    # Consolidated incident for Azure Long Running Instances Found
+  validate $ds_long_running_instances_incident_combined_incidents do
+    summary_template "Consolidated Incident: {{ len data }} Azure Long Running Instances Found"
     escalate $esc_email
     check eq(size(data), 0)
     export do
@@ -735,23 +766,53 @@ policy "policy_scheduled_report" do
       field "accountName" do
         label "Subscription Name"
       end
-      field "name" do
-        label "Resource Name"
-      end
-      field "id" do
-        label "Resource ID"
-      end
-      field "resourcegroup" do
+      field "resourceGroup" do
         label "Resource Group"
       end
-      field "status" do
-        label "Status"
+      field "resourceName" do
+        label "Resource Name"
       end
-      field "time_running" do
-        label "Time Running"
+      field "tags" do
+        label "Resource Tags"
       end
-      field "days_elapsed" do
-        label "Days Elapsed"
+      field "resourceType" do
+        label "Instance Size"
+      end
+      field "age" do
+        label "Resource Age (Days)"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "operating_system" do
+        label "Operating System"
+      end
+      field "cost" do
+        label "Estimated Monthly Cost"
+      end
+      field "costCurrency" do
+        label "Cost Currency"
+      end
+      field "launchTime" do
+        label "Launch Time"
+      end
+      field "purchase_option" do
+        label "Purchase Option"
+      end
+      field "billing_center" do
+        label "Billing Center"
+      end
+      field "lookbackPeriod" do
+        label "Look Back Period (Days)"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "resourceID" do
+        label "Resource ID"
+      end
+      field "id" do
+        label "ID"
       end
     end
   end


### PR DESCRIPTION
### Description

This is a revamp of the Azure Long Running Instances policy that adds new functionality and meta policy support. From the CHANGELOG:

- Several parameters altered to be more descriptive and human-readable
- Added ability to filter resources by multiple tag key:value pairs
- Added several fields to incident export to provide additional context
- Added additional context to incident description
- Normalized incident export to be consistent with other policies
- Policy no longer raises new escalations for the same resource if incidental metadata has changed
- Streamlined code for better readability and faster execution
- Policy now requires a valid Flexera credential
- Added logic required for "Meta Policy" use-cases

### Link to Example Applied Policy

The new functionality depends too much on valid Optima data to be easily tested in our internal environments. I've confirmed the policy works as expected in the customer environment that is primarily the driver for these changes.

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
