### PR TITLE
POL-920 Azure Unused Volumes Read/Write Metrics Support

### DIFF
--- a/cost/azure/unused_volumes/CHANGELOG.md
+++ b/cost/azure/unused_volumes/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v7.0
+
+- Policy now retrieves read/write stats to determine if a volume is unused
+- Added ability to include attached volumes in the incident and to action on them
+- Added parameters to allow the user to configure the new functionality above
+
 ## v6.0
 
 - Several parameters altered to be more descriptive and human-readable

--- a/cost/azure/unused_volumes/README.md
+++ b/cost/azure/unused_volumes/README.md
@@ -2,7 +2,7 @@
 
 ## What it does
 
-This Policy Template scans all volumes in the given account and identifies any unattached volume that is older than a user-specified number of days. Any volumes that meet this criteria are considered unused. If any unused volumes are found, an incident report will show the volumes and related information. An email will be sent to the user-specified email address.
+This Policy Template scans all volumes in the given account and identifies any volume that meets the user-specified criteria for being unused. The user can filter volumes based on age, whether they are currently attached to a VM, whether there has been any read/write activity on the volume over a user-specified number of days, or any combination of these. Any volumes that meet the user-specified criteria are considered unused. If any unused volumes are found, an incident report will show the volumes and related information. An email will be sent to the user-specified email address.
 
 If the user approves that the volumes should be deleted, the policy will delete the volumes.
 If the volume is not getting deleted, say, because it is locked, then the volume will be tagged to indicate the error that was received.
@@ -26,6 +26,8 @@ This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Auto
   - `Microsoft.Compute/disks/read`
   - `Microsoft.Compute/disks/write`*
   - `Microsoft.Compute/snapshots/write`*
+  - `Microsoft.Compute/virtualMachines/read`*
+  - `Microsoft.Compute/virtualMachines/write`*
   - `Microsoft.Insights/metrics/read`
 
 \* Only required for taking action; the policy will still function in a read-only capacity without these permissions.

--- a/cost/azure/unused_volumes/README.md
+++ b/cost/azure/unused_volumes/README.md
@@ -2,15 +2,10 @@
 
 ## What it does
 
-This Policy Template scans all volumes in the given account and identifies any volume that meets the user-specified criteria for being unused. The user can filter volumes based on age, whether they are currently attached to a VM, whether there has been any read/write activity on the volume over a user-specified number of days, or any combination of these. Any volumes that meet the user-specified criteria are considered unused. If any unused volumes are found, an incident report will show the volumes and related information. An email will be sent to the user-specified email address.
+This Policy Template scans all volumes in the given account and identifies any volume that meets the user-specified criteria for being unused. The user can filter volumes based on age, whether they are currently attached to a VM, whether there has been any read/write activity on the volume over a user-specified number of days, or any combination of these. Any volumes that meet the user-specified criteria are considered unused. If any unused volumes are found, an incident report will show the volumes and related information. An email will be sent to the user-specified email addresses.
 
 If the user approves that the volumes should be deleted, the policy will delete the volumes.
-If the volume is not getting deleted, say, because it is locked, then the volume will be tagged to indicate the error that was received.
-
-If the issue causing delete failure is removed, the next run of the policy will delete the volume.
-Note: Unused volumes report will reflect the updated set of unused volumes on the subsequent run.
-
-Optionally, the user can specify one or more tags that if found on a volume will exclude the volume from the list.
+If the volume is not getting deleted because it is locked, then the volume will be tagged to indicate the error that was received. If the issue causing delete failure is removed, the next run of the policy will delete the volume. The unused volumes report will reflect the updated set of unused volumes on the subsequent run.
 
 Note: Previous versions of this policy had the option to filter results by how long a volume was detached. This functionality did not work as expected due to Azure volume logs not recording detachment events. Such events are recorded in the logs of the VM the volume was detached from, and there is currently no way to determine the most recently attached VM for a volume through Azure's APIs. For this reason, this functionality was removed.
 
@@ -62,8 +57,8 @@ For example if a user selects the "Delete Unused Volumes" action while applying 
 
 The following policy actions are taken on any resources found to be out of compliance.
 
-- Delete unused volumes after approval
 - Send an email report
+- Delete unused volumes after approval
 
 ## Supported Clouds
 

--- a/cost/azure/unused_volumes/README.md
+++ b/cost/azure/unused_volumes/README.md
@@ -26,6 +26,7 @@ This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Auto
   - `Microsoft.Compute/disks/read`
   - `Microsoft.Compute/disks/write`*
   - `Microsoft.Compute/snapshots/write`*
+  - `Microsoft.Insights/metrics/read`
 
 \* Only required for taking action; the policy will still function in a read-only capacity without these permissions.
 
@@ -41,7 +42,9 @@ This policy has the following input parameters required when launching the polic
 - *Email addresses to notify* - Email addresses of the recipients you wish to notify when new incidents are created.
 - *Azure Endpoint* - The endpoint to send Azure API requests to. Recommended to leave this at default unless using this policy with Azure China.
 - *Minimum Savings Threshold* - Minimum potential savings required to generate a recommendation.
-- *Minimum Age (Days)* - The minimum age, in days, since a volume was created to produce recommendations for it. Set to 0 to ignore age entirely and report all unattached volumes.
+- *Minimum Age (Days)* - The minimum age, in days, since a volume was created to produce recommendations for it. Set to 0 to ignore age entirely.
+- *Statistic Lookback Period* - How many days back to look at read/write metrics for volumes. This value cannot be set higher than 90 because Azure does not retain metrics for longer than 90 days.
+- *Volume Status* - Whether to include attached volumes, unattached, or both in the results.
 - *Allow/Deny Subscriptions* - Determines whether the Allow/Deny Subscriptions List parameter functions as an allow list (only providing results for the listed subscriptions) or a deny list (providing results for all subscriptions except for the listed subscriptions).
 - *Allow/Deny Subscriptions List* - A list of allowed or denied Subscription IDs/names. If empty, no filtering will occur and recommendations will be produced for all subscriptions.
 - *Allow/Deny Regions* - Whether to treat Allow/Deny Regions List parameter as allow or deny list. Has no effect if Allow/Deny Regions List is left empty.

--- a/cost/azure/unused_volumes/README.md
+++ b/cost/azure/unused_volumes/README.md
@@ -43,7 +43,7 @@ This policy has the following input parameters required when launching the polic
 - *Azure Endpoint* - The endpoint to send Azure API requests to. Recommended to leave this at default unless using this policy with Azure China.
 - *Minimum Savings Threshold* - Minimum potential savings required to generate a recommendation.
 - *Minimum Age (Days)* - The minimum age, in days, since a volume was created to produce recommendations for it. Set to 0 to ignore age entirely.
-- *Statistic Lookback Period* - How many days back to look at read/write metrics for volumes. This value cannot be set higher than 90 because Azure does not retain metrics for longer than 90 days.
+- *Unused Days* - The number of days a volume has been unused as determined by read/write activity. This value cannot be set higher than 90 because Azure does not retain metrics for longer than 90 days.
 - *Volume Status* - Whether to include attached volumes, unattached, or both in the results.
 - *Allow/Deny Subscriptions* - Determines whether the Allow/Deny Subscriptions List parameter functions as an allow list (only providing results for the listed subscriptions) or a deny list (providing results for all subscriptions except for the listed subscriptions).
 - *Allow/Deny Subscriptions List* - A list of allowed or denied Subscription IDs/names. If empty, no filtering will occur and recommendations will be produced for all subscriptions.

--- a/cost/azure/unused_volumes/azure_unused_volumes.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes.pt
@@ -7,11 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-<<<<<<< HEAD
   version: "7.0",
-=======
-  version: "6.1",
->>>>>>> master
   provider: "Azure",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -966,23 +962,28 @@ escalation "esc_delete_volumes" do
   automatic contains($param_automatic_action, "Delete Volumes")
   label "Delete Volumes"
   description "Approval to terminate all selected instances"
-  run "delete_volumes", data, $param_take_snapshot, rs_optima_host
+  run "delete_volumes", data, $param_take_snapshot, $param_azure_endpoint, rs_optima_host
 end
 
 ###############################################################################
 # Cloud Workflow
 ###############################################################################
 
-define delete_volumes($data, $param_take_snapshot, $$rs_optima_host) return $all_responses do
+define delete_volumes($data, $param_take_snapshot, $$param_azure_endpoint, $$rs_optima_host) return $all_responses do
   $status_code=''
   $$all_responses = []
   foreach $item in $data do
     # Break this into it's own sub task, and for any errors, capture them with handle_error
     # We check for errors at the end, and raise them all together
     sub on_error: handle_error() do
+      if $item['state'] == "Attached"
+        call detach_disk($item)
+      end
+
       if $param_take_snapshot == "true"
         call create_snapshot($item)
       end
+
       call delete_unattached_disk($item['id'])
     end
   end
@@ -990,6 +991,88 @@ define delete_volumes($data, $param_take_snapshot, $$rs_optima_host) return $all
   # If we encountered any errors, use `raise` to mark the CWF process as errored
   if inspect($$errors) != "null"
     raise join($$errors,"\n")
+  end
+end
+
+define detach_disk($item) return $response do
+  $response={}
+  $syslog_subject = "Azure detach disk API response: "
+
+  $disk_id = $item['id']
+  $vm_id = $item['attached_vm']
+
+  $get_response = http_request(
+    auth: $$auth_azure,
+    verb: "get",
+    host: $$param_azure_endpoint,
+    https: true,
+    href: $vm_id,
+    query_strings: {
+      "api-version": "2023-07-01"
+    },
+    headers: {
+      "content-type": "application/json"
+    }
+  )
+
+  $vm_properties = $get_response['body']
+  $updated_disk_list = []
+
+  foreach $item in $vm_properties['properties']['storageProfile']['dataDisks'] do
+    if $item['managedDisk']['id'] != $disk_id
+      $updated_disk_list << $item
+    end
+  end
+
+  $vm_properties['properties']['storageProfile']['dataDisks'] = $updated_disk_list
+
+  $response = http_request(
+    auth: $$auth_azure,
+    verb: "put",
+    host: $$param_azure_endpoint,
+    https: true,
+    href: $vm_id,
+    query_strings: {
+      "api-version": "2023-07-01"
+    },
+    headers: {
+      "content-type": "application/json"
+    },
+    body: $vm_properties
+  )
+
+  $still_attached = true
+
+  while $still_attached do
+    sleep(5)
+
+    $get_response = http_request(
+      auth: $$auth_azure,
+      verb: "get",
+      host: $$param_azure_endpoint,
+      https: true,
+      href: $vm_id,
+      query_strings: {
+        "api-version": "2023-07-01"
+      },
+      headers: {
+        "content-type": "application/json"
+      }
+    )
+
+    $still_attached = false
+
+    foreach $item in $get_response['body']['properties']['storageProfile']['dataDisks'] do
+      if $item['managedDisk']['id'] == $disk_id
+        $still_attached = true
+      end
+    end
+  end
+
+  $$all_responses << to_json({"req":"PUT " + $$param_azure_endpoint + $disk_id, "resp": $response})
+  task_label('Checking for expected response code for Disk Detach Request Successful')
+  if $response["code"] != 201 && $response["code"] != 200
+    raise 'Unexpected response detaching disk: '+to_json($response)
   end
 end
 
@@ -1002,7 +1085,7 @@ define create_snapshot($item) return $response do
   $response = http_request(
     auth: $$auth_azure,
     verb: "put",
-    host: "management.azure.com",
+    host: $$param_azure_endpoint,
     https: true,
     href: $snapshotName,
     query_strings: {
@@ -1022,8 +1105,8 @@ define create_snapshot($item) return $response do
       }
     }
   )
-  $$all_responses << to_json({"req":"PUT management.azure.com" + $snapshotName,"resp": $response})
-  task_label('Checking for expected response code for  Snapshot Create Request Successful')
+  $$all_responses << to_json({"req":"PUT " + $$param_azure_endpoint + $snapshotName, "resp": $response})
+  task_label('Checking for expected response code for Snapshot Create Request Successful')
   if $response["code"] != 202 && $response["code"] != 200
     raise 'Unexpected response creating snapshot: '+to_json($response)
   else
@@ -1042,13 +1125,13 @@ define get_disksnapshot($snapshotId) return $response do
     auth: $$auth_azure,
     https: true,
     verb: "get",
-    host: "management.azure.com",
+    host: $$param_azure_endpoint,
     href: $snapshotId,
     query_strings: {
       "api-version": "2019-07-01"
     }
   )
-  $$all_responses << to_json({"req":"GET management.azure.com" + $snapshotId,"resp": $response})
+  $$all_responses << to_json({"req":"GET " + $$param_azure_endpoint + $snapshotId, "resp": $response})
 end
 
 define delete_unattached_disk($disk_id) do
@@ -1056,14 +1139,14 @@ define delete_unattached_disk($disk_id) do
   $response = http_request(
     auth: $$auth_azure,
     verb: "delete",
-    host: "management.azure.com",
+    host: $$param_azure_endpoint,
     https: true,
     href: $disk_id,
     query_strings: {
       "api-version": "2019-07-01"
     }
   )
-  $$all_responses << to_json({"req":"DELETE management.azure.com"+$disk_id,"resp": $response})
+  $$all_responses << to_json({"req":"DELETE "+ $$param_azure_endpoint + $disk_id, "resp": $response})
   task_label('Delete Disk response: '+to_json($response["body"]))
   if $response["code"] != 202
     $error_code = $response["body"]["error"]["code"]

--- a/cost/azure/unused_volumes/azure_unused_volumes.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes.pt
@@ -523,11 +523,15 @@ script "js_unused_volumes", type: "javascript" do
     write_sum = 0
 
     _.each(read_stats, function(metric) {
-      if (typeof(metric['average']) == 'number') { read_sum += metric['average'] }
+      if (typeof(metric['average']) == 'number') {
+        read_sum += metric['average']
+      }
     })
 
     _.each(write_stats, function(metric) {
-      if (typeof(metric['average']) == 'number') { write_sum += metric['average'] }
+      if (typeof(metric['average']) == 'number') {
+        write_sum += metric['average']
+      }
     })
 
     if (read_sum + write_sum == 0) {

--- a/cost/azure/unused_volumes/azure_unused_volumes.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes.pt
@@ -53,11 +53,11 @@ parameter "param_minimum_age" do
   min_value 0
 end
 
-parameter "param_stats_lookback" do
+parameter "param_unused_days" do
   type "number"
-  category "Statistics"
-  label "Statistic Lookback Period"
-  description "How many days back to look at read/write metrics for volumes. This value cannot be set higher than 90 because Azure does not retain metrics for longer than 90 days."
+  category "Policy Settings"
+  label "Unused Days"
+  description "The number of days a volume has been unused as determined by read/write activity."
   default 30
   min_value 1
   max_value 90
@@ -335,6 +335,7 @@ datasource "ds_azure_disks" do
       field "resourceType", jmes_path(col_item, "type")
       field "region", jmes_path(col_item, "location")
       field "tags", jmes_path(col_item, "tags")
+      field "attached_vm", jmes_path(col_item, "managedBy")
       field "state", jmes_path(col_item, "properties.diskState")
       field "size", jmes_path(col_item, "properties.diskSizeGB")
       field "timeCreated", jmes_path(col_item, "properties.timeCreated")
@@ -344,16 +345,40 @@ datasource "ds_azure_disks" do
   end
 end
 
+datasource "ds_azure_disks_status_filtered" do
+  run_script $js_azure_disks_status_filtered, $ds_azure_disks, $param_include_status
+end
+
+script "js_azure_disks_status_filtered", type: "javascript" do
+  parameters "ds_azure_disks", "param_include_status"
+  result "result"
+  code <<-EOS
+  if (param_include_status != "All Volumes") {
+    if (param_include_status == "Attached Volumes") {
+      result = _.filter(ds_azure_disks, function(disk) {
+        return disk['state'] == "Attached"
+      })
+    } else {
+      result = _.filter(ds_azure_disks, function(disk) {
+        return disk['state'] == "Unattached"
+      })
+    }
+  } else {
+    result = ds_azure_disks
+  }
+EOS
+end
+
 datasource "ds_azure_disks_tag_filtered" do
-  run_script $js_azure_disks_tag_filtered, $ds_azure_disks, $param_exclusion_tags
+  run_script $js_azure_disks_tag_filtered, $ds_azure_disks_status_filtered, $param_exclusion_tags
 end
 
 script "js_azure_disks_tag_filtered", type: "javascript" do
-  parameters "ds_azure_disks", "param_exclusion_tags"
+  parameters "ds_azure_disks_status_filtered", "param_exclusion_tags"
   result "result"
   code <<-EOS
   if (param_exclusion_tags.length > 0) {
-    result = _.reject(ds_azure_disks, function(disk) {
+    result = _.reject(ds_azure_disks_status_filtered, function(disk) {
       disk_tags = []
 
       if (typeof(disk['tags']) == 'object') {
@@ -374,7 +399,7 @@ script "js_azure_disks_tag_filtered", type: "javascript" do
       return exclude_disk
     })
   } else {
-    result = ds_azure_disks
+    result = ds_azure_disks_status_filtered
   }
 EOS
 end
@@ -406,7 +431,7 @@ end
 datasource "ds_azure_disks_metrics" do
   iterate $ds_azure_disks_region_filtered
   request do
-    run_script $js_azure_disks_metrics, val(iter_item, "id"), $param_azure_endpoint, $param_stats_lookback
+    run_script $js_azure_disks_metrics, val(iter_item, "id"), $param_azure_endpoint, $param_unused_days
   end
   result do
     encoding "json"
@@ -419,6 +444,7 @@ datasource "ds_azure_disks_metrics" do
     field "tags", val(iter_item, "tags")
     field "state", val(iter_item, "state")
     field "size", val(iter_item, "size")
+    field "attached_vm", val(iter_item, "attached_vm")
     field "timeCreated", val(iter_item, "timeCreated")
     field "subscriptionID", val(iter_item, "subscriptionID")
     field "subscriptionName", val(iter_item, "subscriptionName")
@@ -427,7 +453,7 @@ end
 
 
 script "js_azure_disks_metrics", type: "javascript" do
-  parameters "resourceId", "param_azure_endpoint", "param_stats_lookback"
+  parameters "resourceId", "param_azure_endpoint", "param_unused_days"
   result "request"
   code <<-EOS
   end_date = new Date()
@@ -437,7 +463,7 @@ script "js_azure_disks_metrics", type: "javascript" do
   end_date.setHours(23)
 
   start_date = new Date()
-  start_date.setDate(start_date.getDate() - param_stats_lookback)
+  start_date.setDate(start_date.getDate() - param_unused_days)
   start_date.setMilliseconds(0)
   start_date.setSeconds(0)
   start_date.setMinutes(0)
@@ -477,75 +503,64 @@ script "js_unused_volumes", type: "javascript" do
   result = []
 
   _.each(ds_azure_disks_metrics, function(disk) {
-    include_disk = true
+    read_stats = null
+    write_stats = null
 
-    if (param_include_status == "Unattached Volumes" && disk['state'] != "Unattached") {
-      include_disk = false
-    }
-
-    if (param_include_status == "Attached Volumes" && disk['state'] == "Unattached") {
-      include_disk = false
-    }
-
-    if (include_disk) {
-      read_stats = null
-      write_stats = null
-
-      _.each(disk['value'], function(stat) {
-        if (stat["timeseries"][0] != undefined) {
-          if (stat['name']['value'] == "Composite Disk Read Operations/sec") {
-            read_stats = stat["timeseries"][0]["data"]
-          }
-
-          if (stat['name']['value'] == "Composite Disk Write Operations/sec") {
-            write_stats = stat["timeseries"][0]["data"]
-          }
-        }
-      })
-
-      read_count = 0
-      write_count = 0
-
-      _.each(read_stats, function(metric) {
-        if (typeof(metric['count']) == 'number') { read_count += metric['count'] }
-      })
-
-      _.each(write_stats, function(metric) {
-        if (typeof(metric['count']) == 'number') { write_count += metric['count'] }
-      })
-
-      if (read_count + write_count == 0) {
-        tags = []
-
-        if (typeof(disk['tags']) == 'object') {
-          _.each(Object.keys(disk['tags']), function(key) {
-            tags.push([key, "=", disk['tags'][key]].join(''))
-          })
+    _.each(disk['value'], function(stat) {
+      if (stat["timeseries"][0] != undefined) {
+        if (stat['name']['value'] == "Composite Disk Read Operations/sec") {
+          read_stats = stat["timeseries"][0]["data"]
         }
 
-        today = new Date()
-        created = new Date(disk['timeCreated'])
-        age = Math.round((today - created) / 1000 / 60 / 60 / 24)
-
-        if (param_minimum_age == 0 || age >= param_minimum_age) {
-          result.push({
-            id: disk['id'],
-            resourceName: disk['resourceName'],
-            resourceGroup: disk['resourceGroup'],
-            resourceType: disk['resourceType'],
-            region: disk['region'],
-            tags: tags.join(', '),
-            state: disk['state'],
-            size: disk['size'],
-            age: age,
-            timeCreated: created.toISOString(),
-            subscriptionID: disk['subscriptionID'],
-            subscriptionName: disk['subscriptionName'],
-            service: "Microsoft.Compute",
-            savings: 0.0,
-            savingsCurrency: ''
-          })
+        if (stat['name']['value'] == "Composite Disk Write Operations/sec") {
+          write_stats = stat["timeseries"][0]["data"]
         }
+      }
+    })
+
+    read_sum = 0
+    write_sum = 0
+
+    _.each(read_stats, function(metric) {
+      if (typeof(metric['average']) == 'number') { read_sum += metric['average'] }
+    })
+
+    _.each(write_stats, function(metric) {
+      if (typeof(metric['average']) == 'number') { write_sum += metric['average'] }
+    })
+
+    if (read_sum + write_sum == 0) {
+      tags = []
+
+      if (typeof(disk['tags']) == 'object') {
+        _.each(Object.keys(disk['tags']), function(key) {
+          tags.push([key, "=", disk['tags'][key]].join(''))
+        })
+      }
+
+      today = new Date()
+      created = new Date(disk['timeCreated'])
+      age = Math.round((today - created) / 1000 / 60 / 60 / 24)
+
+      if (param_minimum_age == 0 || age >= param_minimum_age) {
+        result.push({
+          id: disk['id'],
+          resourceName: disk['resourceName'],
+          resourceGroup: disk['resourceGroup'],
+          resourceType: disk['resourceType'],
+          region: disk['region'],
+          tags: tags.join(', '),
+          state: disk['state'],
+          size: disk['size'],
+          attached_vm: disk['attached_vm'],
+          age: age,
+          timeCreated: created.toISOString(),
+          subscriptionID: disk['subscriptionID'],
+          subscriptionName: disk['subscriptionName'],
+          service: "Microsoft.Compute",
+          savings: 0.0,
+          savingsCurrency: ''
+        })
       }
     }
   })
@@ -671,11 +686,11 @@ EOS
 end
 
 datasource "ds_volume_cost_mapping" do
-  run_script $js_volume_cost_mapping, $ds_azure_disks_region_filtered, $ds_unused_volumes, $ds_volume_costs_grouped, $ds_applied_policy, $ds_currency, $param_minimum_age, $param_take_snapshot, $param_min_savings
+  run_script $js_volume_cost_mapping, $ds_azure_disks_region_filtered, $ds_unused_volumes, $ds_volume_costs_grouped, $ds_applied_policy, $ds_currency, $param_minimum_age, $param_take_snapshot, $param_min_savings, $param_include_status, $param_unused_days
 end
 
 script "js_volume_cost_mapping", type:"javascript" do
-  parameters "ds_azure_disks_region_filtered", "ds_unused_volumes", "ds_volume_costs_grouped", "ds_applied_policy", "ds_currency", "param_minimum_age", "param_take_snapshot", "param_min_savings"
+  parameters "ds_azure_disks_region_filtered", "ds_unused_volumes", "ds_volume_costs_grouped", "ds_applied_policy", "ds_currency", "param_minimum_age", "param_take_snapshot", "param_min_savings", "param_include_status", "param_unused_days"
   result "result"
   code <<-'EOS'
   // Function for formatting currency numbers later
@@ -731,6 +746,7 @@ script "js_volume_cost_mapping", type:"javascript" do
         tags: disk['tags'],
         age: disk['age'],
         timeCreated: disk['timeCreated'],
+        attached_vm: disk['attached_vm'],
         savings: parseFloat(savings.toFixed(3)),
         savingsCurrency: ds_currency['symbol'],
         recommendationDetails: recommendationDetails,
@@ -748,22 +764,80 @@ script "js_volume_cost_mapping", type:"javascript" do
   total_unused_disks = result.length.toString()
   unused_disks_percentage = (total_unused_disks / total_disks * 100).toFixed(2).toString() + '%'
 
+  total_disks_noun = "volume"
+  if (total_disks > 1) { total_disks_noun = "volumes" }
+
+  total_unused_disks_verb = "is"
+  if (total_unused_disks > 1) { total_unused_disks_verb = "are" }
+
   findings = [
-    "Out of ", total_disks , " Azure volumes analyzed, ",
+    "Out of ", total_disks , " Azure ", total_disks_noun, " analyzed, ",
     total_unused_disks, " (", unused_disks_percentage,
-    ") are unused and are recommended for deletion. "
+    ") ", total_unused_disks_verb, " unused and are recommended for deletion. "
   ].join('')
 
   if (param_minimum_age != 0) {
-    day_message = "day"
-    if (param_minimum_age.length > 1) { day_message += "s" }
+    min_age_day_noun = "day"
+    if (param_minimum_age > 1) { min_age_day_noun += "s" }
 
-    idle_message = [
-      "An unattached volume is considered unused if it is not attached to an instance ",
-      "and is at least ", param_minimum_age, " ", day_message, " old.\n\n"
-    ].join('')
+    unused_day_noun = "day"
+    if (param_unused_days > 1) { unused_day_noun += "s" }
+
+    if (param_include_status == 'Unattached Volumes') {
+      idle_message = [
+        "Volumes are considered unused if they are unattached, ",
+        "are at least ", param_minimum_age, " ", min_age_day_noun, " old, ",
+        "and have had no read/write activity for at least ",
+        param_unused_days, " ", unused_day_noun, ".\n\n"
+      ].join('')
+    }
+
+    if (param_include_status == 'Attached Volumes') {
+      idle_message = [
+        "Volumes are considered unused if they are attached, ",
+        "are at least ", param_minimum_age, " ", min_age_day_noun, " old, ",
+        "and have had no read/write activity for at least ",
+        param_unused_days, " ", unused_day_noun, ".\n\n"
+      ].join('')
+    }
+
+    if (param_include_status == 'All Volumes') {
+      idle_message = [
+        "Volumes are considered unused if they ",
+        "are at least ", param_minimum_age, " ", min_age_day_noun, " old, ",
+        "and have had no read/write activity for at least ",
+        param_unused_days, " ", unused_day_noun, ", regardless of whether they ",
+        "are currently attached or not.\n\n"
+      ].join('')
+    }
   } else {
-    idle_message = "A volume is considered unused if it is not attached to an instance regardless of how old it is.\n\n"
+    unused_day_noun = "day"
+    if (param_unused_days > 1) { unused_day_noun += "s" }
+
+    if (param_include_status == 'Unattached Volumes') {
+      idle_message = [
+        "Volumes are considered unused if they are unattached ",
+        "and have had no read/write activity for at least ",
+        param_unused_days, " ", unused_day_noun, ".\n\n"
+      ].join('')
+    }
+
+    if (param_include_status == 'Attached Volumes') {
+      idle_message = [
+        "Volumes are considered unused if they are attached ",
+        "and have had no read/write activity for at least ",
+        param_unused_days, " ", unused_day_noun, ".\n\n"
+      ].join('')
+    }
+
+    if (param_include_status == 'All Volumes') {
+      idle_message = [
+        "Volumes are considered unused if they ",
+        "have had no read/write activity for at least ",
+        param_unused_days, " ", unused_day_noun, ", regardless of whether they ",
+        "are currently attached or not.\n\n"
+      ].join('')
+    }
   }
 
   disclaimer = "The above settings can be modified by editing the applied policy and changing the appropriate parameters."
@@ -851,6 +925,9 @@ policy "pol_azure_unattached_volumes" do
       end
       field "savingsCurrency" do
         label "Savings Currency"
+      end
+      field "attached_vm" do
+        label "Attached VM ID"
       end
       field "service" do
         label "Service"

--- a/cost/azure/unused_volumes/azure_unused_volumes.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes.pt
@@ -337,6 +337,8 @@ datasource "ds_azure_disks" do
       field "region", jmes_path(col_item, "location")
       field "tags", jmes_path(col_item, "tags")
       field "attached_vm", jmes_path(col_item, "managedBy")
+      field "provisioningState", jmes_path(col_item, "properties.provisioningState")
+      field "osType", jmes_path(col_item, "properties.osType")
       field "state", jmes_path(col_item, "properties.diskState")
       field "size", jmes_path(col_item, "properties.diskSizeGB")
       field "timeCreated", jmes_path(col_item, "properties.timeCreated")
@@ -354,18 +356,23 @@ script "js_azure_disks_status_filtered", type: "javascript" do
   parameters "ds_azure_disks", "param_include_status"
   result "result"
   code <<-EOS
+  // Note: We filter for osType == null to filter out OS disks that VMs need to boot
+  // since these disks can't be detached/deleted without just deleting the VM itself
+
   if (param_include_status != "All Volumes") {
     if (param_include_status == "Attached Volumes") {
       result = _.filter(ds_azure_disks, function(disk) {
-        return disk['state'] == "Attached"
+        return disk['state'] == "Attached" && disk['osType'] == null
       })
     } else {
       result = _.filter(ds_azure_disks, function(disk) {
-        return disk['state'] == "Unattached"
+        return disk['state'] == "Unattached" && disk['osType'] == null
       })
     }
   } else {
-    result = ds_azure_disks
+    result = _.filter(ds_azure_disks, function(disk) {
+      return disk['osType'] == null
+    })
   }
 EOS
 end
@@ -1005,7 +1012,7 @@ define detach_disk($item, $param_azure_endpoint) return $response do
   $disk_id = $item['id']
   $vm_id = $item['attached_vm']
 
-  $get_response = http_request(
+  $vm_response = http_request(
     auth: $$auth_azure,
     verb: "get",
     host: $param_azure_endpoint,
@@ -1019,18 +1026,19 @@ define detach_disk($item, $param_azure_endpoint) return $response do
     }
   )
 
+  $$all_responses << to_json({"req":"GET " + $param_azure_endpoint + $vm_id, "resp": $vm_response})
+
   $updated_disk_list = []
 
-  foreach $item in $get_response['body']['properties']['storageProfile']['dataDisks'] do
+  foreach $item in $vm_response['body']['properties']['storageProfile']['dataDisks'] do
     if $item['managedDisk']['id'] != $disk_id
       $updated_disk_list << $item
     end
   end
 
   $new_properties = {}
-  $new_properties['location'] = $get_response['body']['location']
-  $new_properties['properties'] = {}
-  $new_properties['properties']['storageProfile'] = {}
+  $new_properties['location'] = $vm_response['body']['location']
+  $new_properties['properties'] = $vm_response['body']['properties']
   $new_properties['properties']['storageProfile']['dataDisks'] = $updated_disk_list
 
 
@@ -1049,29 +1057,32 @@ define detach_disk($item, $param_azure_endpoint) return $response do
     body: $new_properties
   )
 
+  $$all_responses << to_json({"req":"PUT " + $param_azure_endpoint + $vm_id, "resp": $response})
+
   $disk_state = "Attached"
 
   while $disk_state != "Unattached" do
     sleep(5)
 
-    $get_response = http_request(
+    $disk_response = http_request(
       auth: $$auth_azure,
       verb: "get",
       host: $param_azure_endpoint,
       https: true,
       href: $disk_id,
       query_strings: {
-        "api-version": "2023-07-01"
+        "api-version": "2023-04-02"
       },
       headers: {
         "content-type": "application/json"
       }
     )
 
-    $disk_state = $get_response['body']['properties']['diskState']
+    $$all_responses << to_json({"req":"GET " + $param_azure_endpoint + $disk_id, "resp": $disk_response})
+
+    $disk_state = $disk_response['body']['properties']['diskState']
   end
 
-  $$all_responses << to_json({"req":"PUT " + $param_azure_endpoint + $disk_id, "resp": $response})
   task_label('Checking for expected response code for Disk Detach Request Successful')
   if $response["code"] != 201 && $response["code"] != 200
     raise 'Unexpected response detaching disk: '+to_json($response)
@@ -1165,7 +1176,7 @@ define delete_unattached_disk($disk_id, $param_azure_endpoint) do
     # we expect a 404 response when the disk is deleted
     while $response["code"] != 404 do
       task_label('Current Disk Status: '+$disk_id+' '+to_json($response))
-      call get_disksnapshot($disk_id) retrieve $response
+      call get_disksnapshot($disk_id, $param_azure_endpoint) retrieve $response
       sleep(1)
     end
     task_label('Delete Disk successful: '+$disk_id)

--- a/cost/azure/unused_volumes/azure_unused_volumes.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "6.0",
+  version: "7.0",
   provider: "Azure",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -48,9 +48,28 @@ parameter "param_minimum_age" do
   type "number"
   category "Policy Settings"
   label "Minimum Age (Days)"
-  description "The minimum age, in days, since a volume was created to produce recommendations for it. Set to 0 to ignore age entirely and report all unattached volumes."
+  description "The minimum age, in days, since a volume was created to produce recommendations for it. Set to 0 to ignore age entirely."
   default 0
   min_value 0
+end
+
+parameter "param_stats_lookback" do
+  type "number"
+  category "Statistics"
+  label "Statistic Lookback Period"
+  description "How many days back to look at read/write metrics for volumes. This value cannot be set higher than 90 because Azure does not retain metrics for longer than 90 days."
+  default 30
+  min_value 1
+  max_value 90
+end
+
+parameter "param_include_status" do
+  type "string"
+  category "Filters"
+  label "Volume Status"
+  description "Whether the policy should only check unattached volumes, attached volumes, or both."
+  default "Unattached Volumes"
+  allowed_values "Unattached Volumes", "Attached Volumes", "All Volumes"
 end
 
 parameter "param_subscriptions_allow_or_deny" do
@@ -384,51 +403,139 @@ script "js_azure_disks_region_filtered", type: "javascript" do
 EOS
 end
 
+datasource "ds_azure_disks_metrics" do
+  iterate $ds_azure_disks_region_filtered
+  request do
+    run_script $js_azure_disks_metrics, val(iter_item, "id"), $param_azure_endpoint, $param_stats_lookback
+  end
+  result do
+    encoding "json"
+    field "value", val(response, "value")
+    field "id", val(iter_item, "id")
+    field "resourceName", val(iter_item, "resourceName")
+    field "resourceGroup", val(iter_item, "resourceGroup")
+    field "resourceType", val(iter_item, "resourceType")
+    field "region", val(iter_item, "region")
+    field "tags", val(iter_item, "tags")
+    field "state", val(iter_item, "state")
+    field "size", val(iter_item, "size")
+    field "timeCreated", val(iter_item, "timeCreated")
+    field "subscriptionID", val(iter_item, "subscriptionID")
+    field "subscriptionName", val(iter_item, "subscriptionName")
+  end
+end
+
+
+script "js_azure_disks_metrics", type: "javascript" do
+  parameters "resourceId", "param_azure_endpoint", "param_stats_lookback"
+  result "request"
+  code <<-EOS
+  end_date = new Date()
+  end_date.setMilliseconds(999)
+  end_date.setSeconds(59)
+  end_date.setMinutes(59)
+  end_date.setHours(23)
+
+  start_date = new Date()
+  start_date.setDate(start_date.getDate() - param_stats_lookback)
+  start_date.setMilliseconds(0)
+  start_date.setSeconds(0)
+  start_date.setMinutes(0)
+
+  timespan = start_date.toISOString() + "/" + end_date.toISOString()
+
+  var request = {
+    auth: "auth_azure",
+    pagination: "pagination_azure",
+    host: param_azure_endpoint,
+    verb: "GET",
+    path: resourceId + "/providers/microsoft.insights/metrics",
+    query_params: {
+      "api-version": "2018-01-01",
+      "timespan": timespan,
+      "interval": "P1D",
+      "metricnames": "Composite Disk Read Operations/sec,Composite Disk Write Operations/sec",
+      "aggregation": "average"
+    },
+    headers: {
+      "User-Agent": "RS Policies"
+    },
+    // Ignore status 400, 403, and 404 which can be returned in certain (legacy) types of Azure Subscriptions
+    ignore_status: [400, 403, 404]
+  }
+EOS
+end
+
 datasource "ds_unused_volumes" do
-  run_script $js_unused_volumes, $ds_azure_disks_region_filtered, $param_minimum_age
+  run_script $js_unused_volumes, $ds_azure_disks_metrics, $param_minimum_age, $param_include_status
 end
 
 script "js_unused_volumes", type: "javascript" do
-  parameters "ds_azure_disks_region_filtered", "param_minimum_age"
+  parameters "ds_azure_disks_metrics", "param_minimum_age", "param_include_status"
   result "result"
   code <<-EOS
   result = []
 
-  unattached_disks = _.filter(ds_azure_disks_region_filtered, function(disk) {
-    return disk['state'] == "Unattached"
-  })
+  _.each(ds_azure_disks_metrics, function(disk) {
+    include_disk = true
 
-  _.each(unattached_disks, function(disk) {
-    tags = []
-
-    if (typeof(disk['tags']) == 'object') {
-      _.each(Object.keys(disk['tags']), function(key) {
-        tags.push([key, "=", disk['tags'][key]].join(''))
-      })
+    if (param_include_status == "Unattached Volumes" && disk['state'] != "Unattached") {
+      include_disk = false
     }
 
-    today = new Date()
-    created = new Date(disk['timeCreated'])
-    age = Math.round((today - created) / 1000 / 60 / 60 / 24)
+    if (param_include_status == "Attached Volumes" && disk['state'] == "Unattached") {
+      include_disk = false
+    }
 
-    if (param_minimum_age == 0 || age >= param_minimum_age) {
-      result.push({
-        id: disk['id'],
-        resourceName: disk['resourceName'],
-        resourceGroup: disk['resourceGroup'],
-        resourceType: disk['resourceType'],
-        region: disk['region'],
-        tags: tags.join(', '),
-        state: disk['state'],
-        size: disk['size'],
-        age: age,
-        timeCreated: created.toISOString(),
-        subscriptionID: disk['subscriptionID'],
-        subscriptionName: disk['subscriptionName'],
-        service: "Microsoft.Compute",
-        savings: 0.0,
-        savingsCurrency: ''
+    if (include_disk) {
+      read_stats = null
+      write_stats = null
+
+      _.each(disk['value'], function(stat) {
+        if (stat["timeseries"][0] != undefined) {
+          if (stat['name']['value'] == "Composite Disk Read Operations/sec") {
+            read_stats = stat["timeseries"][0]["data"]
+          }
+
+          if (stat['name']['value'] == "Composite Disk Write Operations/sec") {
+            write_stats = stat["timeseries"][0]["data"]
+          }
+        }
       })
+
+      disk_activity =
+
+      tags = []
+
+      if (typeof(disk['tags']) == 'object') {
+        _.each(Object.keys(disk['tags']), function(key) {
+          tags.push([key, "=", disk['tags'][key]].join(''))
+        })
+      }
+
+      today = new Date()
+      created = new Date(disk['timeCreated'])
+      age = Math.round((today - created) / 1000 / 60 / 60 / 24)
+
+      if (param_minimum_age == 0 || age >= param_minimum_age) {
+        result.push({
+          id: disk['id'],
+          resourceName: disk['resourceName'],
+          resourceGroup: disk['resourceGroup'],
+          resourceType: disk['resourceType'],
+          region: disk['region'],
+          tags: tags.join(', '),
+          state: disk['state'],
+          size: disk['size'],
+          age: age,
+          timeCreated: created.toISOString(),
+          subscriptionID: disk['subscriptionID'],
+          subscriptionName: disk['subscriptionName'],
+          service: "Microsoft.Compute",
+          savings: 0.0,
+          savingsCurrency: ''
+        })
+      }
     }
   })
 EOS

--- a/cost/azure/unused_volumes/azure_unused_volumes.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes.pt
@@ -973,7 +973,7 @@ end
 # Cloud Workflow
 ###############################################################################
 
-define delete_volumes($data, $param_take_snapshot, $$param_azure_endpoint, $$rs_optima_host) return $all_responses do
+define delete_volumes($data, $param_take_snapshot, $param_azure_endpoint, $$rs_optima_host) return $all_responses do
   $status_code=''
   $$all_responses = []
   foreach $item in $data do
@@ -981,14 +981,14 @@ define delete_volumes($data, $param_take_snapshot, $$param_azure_endpoint, $$rs_
     # We check for errors at the end, and raise them all together
     sub on_error: handle_error() do
       if $item['state'] == "Attached"
-        call detach_disk($item)
+        call detach_disk($item, $param_azure_endpoint)
       end
 
       if $param_take_snapshot == "true"
-        call create_snapshot($item)
+        call create_snapshot($item, $param_azure_endpoint)
       end
 
-      call delete_unattached_disk($item['id'])
+      call delete_unattached_disk($item['id'], $param_azure_endpoint)
     end
   end
 
@@ -998,7 +998,7 @@ define delete_volumes($data, $param_take_snapshot, $$param_azure_endpoint, $$rs_
   end
 end
 
-define detach_disk($item) return $response do
+define detach_disk($item, $param_azure_endpoint) return $response do
   $response={}
   $syslog_subject = "Azure detach disk API response: "
 
@@ -1008,7 +1008,7 @@ define detach_disk($item) return $response do
   $get_response = http_request(
     auth: $$auth_azure,
     verb: "get",
-    host: $$param_azure_endpoint,
+    host: $param_azure_endpoint,
     https: true,
     href: $vm_id,
     query_strings: {
@@ -1019,21 +1019,25 @@ define detach_disk($item) return $response do
     }
   )
 
-  $vm_properties = $get_response['body']
   $updated_disk_list = []
 
-  foreach $item in $vm_properties['properties']['storageProfile']['dataDisks'] do
+  foreach $item in $get_response['body']['properties']['storageProfile']['dataDisks'] do
     if $item['managedDisk']['id'] != $disk_id
       $updated_disk_list << $item
     end
   end
 
-  $vm_properties['properties']['storageProfile']['dataDisks'] = $updated_disk_list
+  $new_properties = {}
+  $new_properties['location'] = $get_response['body']['location']
+  $new_properties['properties'] = {}
+  $new_properties['properties']['storageProfile'] = {}
+  $new_properties['properties']['storageProfile']['dataDisks'] = $updated_disk_list
+
 
   $response = http_request(
     auth: $$auth_azure,
     verb: "put",
-    host: $$param_azure_endpoint,
+    host: $param_azure_endpoint,
     https: true,
     href: $vm_id,
     query_strings: {
@@ -1042,20 +1046,20 @@ define detach_disk($item) return $response do
     headers: {
       "content-type": "application/json"
     },
-    body: $vm_properties
+    body: $new_properties
   )
 
-  $still_attached = true
+  $disk_state = "Attached"
 
-  while $still_attached do
+  while $disk_state != "Unattached" do
     sleep(5)
 
     $get_response = http_request(
       auth: $$auth_azure,
       verb: "get",
-      host: $$param_azure_endpoint,
+      host: $param_azure_endpoint,
       https: true,
-      href: $vm_id,
+      href: $disk_id,
       query_strings: {
         "api-version": "2023-07-01"
       },
@@ -1064,23 +1068,17 @@ define detach_disk($item) return $response do
       }
     )
 
-    $still_attached = false
-
-    foreach $item in $get_response['body']['properties']['storageProfile']['dataDisks'] do
-      if $item['managedDisk']['id'] == $disk_id
-        $still_attached = true
-      end
-    end
+    $disk_state = $get_response['body']['properties']['diskState']
   end
 
-  $$all_responses << to_json({"req":"PUT " + $$param_azure_endpoint + $disk_id, "resp": $response})
+  $$all_responses << to_json({"req":"PUT " + $param_azure_endpoint + $disk_id, "resp": $response})
   task_label('Checking for expected response code for Disk Detach Request Successful')
   if $response["code"] != 201 && $response["code"] != 200
     raise 'Unexpected response detaching disk: '+to_json($response)
   end
 end
 
-define create_snapshot($item) return $response do
+define create_snapshot($item, $param_azure_endpoint) return $response do
   $response={}
   $syslog_subject = "Azure create snapshot API response: "
   $snapshotName=split($item['id'], "Microsoft.Compute")
@@ -1089,7 +1087,7 @@ define create_snapshot($item) return $response do
   $response = http_request(
     auth: $$auth_azure,
     verb: "put",
-    host: $$param_azure_endpoint,
+    host: $param_azure_endpoint,
     https: true,
     href: $snapshotName,
     query_strings: {
@@ -1109,7 +1107,7 @@ define create_snapshot($item) return $response do
       }
     }
   )
-  $$all_responses << to_json({"req":"PUT " + $$param_azure_endpoint + $snapshotName, "resp": $response})
+  $$all_responses << to_json({"req":"PUT " + $param_azure_endpoint + $snapshotName, "resp": $response})
   task_label('Checking for expected response code for Snapshot Create Request Successful')
   if $response["code"] != 202 && $response["code"] != 200
     raise 'Unexpected response creating snapshot: '+to_json($response)
@@ -1117,40 +1115,40 @@ define create_snapshot($item) return $response do
     task_label('Create Snapshot Request Successful: '+$snapshotName)
     while $response["body"]["properties"]["provisioningState"] != "Succeeded" do
       task_label('Create Snapshot Status: '+$response["body"]["properties"]["provisioningState"])+' '+$snapshotName
-      call get_disksnapshot($snapshotName) retrieve $response
+      call get_disksnapshot($snapshotName, $param_azure_endpoint) retrieve $response
       sleep(1)
     end
     task_label('Create Snapshot Successful: '+$snapshotName)
   end
 end
 
-define get_disksnapshot($snapshotId) return $response do
+define get_disksnapshot($snapshotId, $param_azure_endpoint) return $response do
   $response = http_request(
     auth: $$auth_azure,
     https: true,
     verb: "get",
-    host: $$param_azure_endpoint,
+    host: $param_azure_endpoint,
     href: $snapshotId,
     query_strings: {
       "api-version": "2019-07-01"
     }
   )
-  $$all_responses << to_json({"req":"GET " + $$param_azure_endpoint + $snapshotId, "resp": $response})
+  $$all_responses << to_json({"req":"GET " + $param_azure_endpoint + $snapshotId, "resp": $response})
 end
 
-define delete_unattached_disk($disk_id) do
+define delete_unattached_disk($disk_id, $param_azure_endpoint) do
   task_label('Delete Disk starting: '+$disk_id)
   $response = http_request(
     auth: $$auth_azure,
     verb: "delete",
-    host: $$param_azure_endpoint,
+    host: $param_azure_endpoint,
     https: true,
     href: $disk_id,
     query_strings: {
       "api-version": "2019-07-01"
     }
   )
-  $$all_responses << to_json({"req":"DELETE "+ $$param_azure_endpoint + $disk_id, "resp": $response})
+  $$all_responses << to_json({"req":"DELETE "+ $param_azure_endpoint + $disk_id, "resp": $response})
   task_label('Delete Disk response: '+to_json($response["body"]))
   if $response["code"] != 202
     $error_code = $response["body"]["error"]["code"]

--- a/cost/azure/unused_volumes/azure_unused_volumes.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes.pt
@@ -755,7 +755,7 @@ script "js_volume_cost_mapping", type:"javascript" do
         savings: parseFloat(savings.toFixed(3)),
         savingsCurrency: ds_currency['symbol'],
         recommendationDetails: recommendationDetails,
-        lookbackPeriod: param_minimum_age,
+        lookbackPeriod: param_unused_days,
         // These are to avoid errors when we hash_exclude these fields
         total_savings: '',
         message: '',

--- a/cost/azure/unused_volumes/azure_unused_volumes.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes.pt
@@ -503,38 +503,49 @@ script "js_unused_volumes", type: "javascript" do
         }
       })
 
-      disk_activity =
+      read_count = 0
+      write_count = 0
 
-      tags = []
+      _.each(read_stats, function(metric) {
+        if (typeof(metric['count']) == 'number') { read_count += metric['count'] }
+      })
 
-      if (typeof(disk['tags']) == 'object') {
-        _.each(Object.keys(disk['tags']), function(key) {
-          tags.push([key, "=", disk['tags'][key]].join(''))
-        })
-      }
+      _.each(write_stats, function(metric) {
+        if (typeof(metric['count']) == 'number') { write_count += metric['count'] }
+      })
 
-      today = new Date()
-      created = new Date(disk['timeCreated'])
-      age = Math.round((today - created) / 1000 / 60 / 60 / 24)
+      if (read_count + write_count == 0) {
+        tags = []
 
-      if (param_minimum_age == 0 || age >= param_minimum_age) {
-        result.push({
-          id: disk['id'],
-          resourceName: disk['resourceName'],
-          resourceGroup: disk['resourceGroup'],
-          resourceType: disk['resourceType'],
-          region: disk['region'],
-          tags: tags.join(', '),
-          state: disk['state'],
-          size: disk['size'],
-          age: age,
-          timeCreated: created.toISOString(),
-          subscriptionID: disk['subscriptionID'],
-          subscriptionName: disk['subscriptionName'],
-          service: "Microsoft.Compute",
-          savings: 0.0,
-          savingsCurrency: ''
-        })
+        if (typeof(disk['tags']) == 'object') {
+          _.each(Object.keys(disk['tags']), function(key) {
+            tags.push([key, "=", disk['tags'][key]].join(''))
+          })
+        }
+
+        today = new Date()
+        created = new Date(disk['timeCreated'])
+        age = Math.round((today - created) / 1000 / 60 / 60 / 24)
+
+        if (param_minimum_age == 0 || age >= param_minimum_age) {
+          result.push({
+            id: disk['id'],
+            resourceName: disk['resourceName'],
+            resourceGroup: disk['resourceGroup'],
+            resourceType: disk['resourceType'],
+            region: disk['region'],
+            tags: tags.join(', '),
+            state: disk['state'],
+            size: disk['size'],
+            age: age,
+            timeCreated: created.toISOString(),
+            subscriptionID: disk['subscriptionID'],
+            subscriptionName: disk['subscriptionName'],
+            service: "Microsoft.Compute",
+            savings: 0.0,
+            savingsCurrency: ''
+          })
+        }
       }
     }
   })

--- a/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "6.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "7.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 
@@ -78,9 +78,28 @@ parameter "param_minimum_age" do
   type "number"
   category "Policy Settings"
   label "Minimum Age (Days)"
-  description "The minimum age, in days, since a volume was created to produce recommendations for it. Set to 0 to ignore age entirely and report all unattached volumes."
+  description "The minimum age, in days, since a volume was created to produce recommendations for it. Set to 0 to ignore age entirely."
   default 0
   min_value 0
+end
+
+parameter "param_unused_days" do
+  type "number"
+  category "Policy Settings"
+  label "Unused Days"
+  description "The number of days a volume has been unused as determined by read/write activity."
+  default 30
+  min_value 1
+  max_value 90
+end
+
+parameter "param_include_status" do
+  type "string"
+  category "Filters"
+  label "Volume Status"
+  description "Whether the policy should only check unattached volumes, attached volumes, or both."
+  default "Unattached Volumes"
+  allowed_values "Unattached Volumes", "Attached Volumes", "All Volumes"
 end
 
 parameter "param_regions_allow_or_deny" do
@@ -819,6 +838,9 @@ policy "policy_scheduled_report" do
       end
       field "savingsCurrency" do
         label "Savings Currency"
+      end
+      field "attached_vm" do
+        label "Attached VM ID"
       end
       field "service" do
         label "Service"


### PR DESCRIPTION
### Description

The Azure Unused Volumes policy has been updated to consider read/write metrics when determining if a volume is unused, similar to the AWS version of the policy. The user can configure how far back to look at these metrics and whether or not to report on attached volumes in the resulting incident. Please see the README for more details.

New functionality has been thoroughly tested, including the Cloud Workflow to detach a volume from an attached instance before deleting it.

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=65099dd36a972a0001e50c56

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
