### PR TITLE
POL-922 AWS Superseded EC2 Instances

### DIFF
--- a/cost/aws/superseded_instances/CHANGELOG.md
+++ b/cost/aws/superseded_instances/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v1.0
+
+- initial release

--- a/cost/aws/superseded_instances/README.md
+++ b/cost/aws/superseded_instances/README.md
@@ -12,7 +12,7 @@ This policy checks all the EC2 instances in an AWS Account to determine if the i
 
 ### Policy savings details
 
-The policy includes the estimated monthly savings. The estimated monthly savings is recognized if the instance type is changed to the recommended instance type. The savings is calculated by taking the difference in the hourly list price between the current instance type and the recommended instance type. This value is then multiplied by 24 to get the daily savings, and then by 30.44 (the average number of days in a month) to get the monthly savings. The savings value is 0 if no cost information for the resource was found in our internal database.
+The policy includes the estimated monthly savings. The estimated monthly savings is recognized if the instance type is changed to the recommended instance type. The savings is calculated by taking the difference in the hourly list price between the current instance type and the recommended instance type. This value is then multiplied by 24 to get the daily savings, and then by 30.44 (the average number of days in a month) to get the monthly savings. The savings value is 0 if no cost information for the resource type was found in our internal database.
 
 The Estimated Monthly Savings column and the total estimated sum of all Superseded Instances is displayed in the incident detail message. If the Flexera organization is configured to use a currency other than USD, the savings values will be converted from USD using the exchange rate at the time that the policy executes.
 

--- a/cost/aws/superseded_instances/README.md
+++ b/cost/aws/superseded_instances/README.md
@@ -1,0 +1,97 @@
+# AWS Superseded EC2 Instances
+
+## What it does
+
+This policy checks all the EC2 instances in an AWS Account to determine if the instance type has been superseded. If it has, the virtual machine is recommended for resizing to a more modern instance type. An incident listing all of these superseded EC2 instances is emailed to the user.
+
+## Functional Details
+
+- The policy leverages the AWS API to retrieve all EC2 instances and then checks them against our internal database to see if their instance type has been superseded.
+- Optima billing data is pulled for these instances to assess the current cost of the instance as well as grab additional metadata about the instance, such as operating system, needed to calculate savings.
+- The recommendation provided for Superseded Instances is a Change Instance Type action; changing instance type can be performed in an automated manner or after approval.
+
+### Policy savings details
+
+The policy includes the estimated monthly savings. The estimated monthly savings is recognized if the instance type is changed to the recommended instance type. The savings is calculated by taking the difference in the hourly list price between the current instance type and the recommended instance type. This value is then multiplied by 24 to get the daily savings, and then by 30.44 (the average number of days in a month) to get the monthly savings. The savings value is 0 if no cost information for the resource was found in our internal database.
+
+The Estimated Monthly Savings column and the total estimated sum of all Superseded Instances is displayed in the incident detail message. If the Flexera organization is configured to use a currency other than USD, the savings values will be converted from USD using the exchange rate at the time that the policy executes.
+
+## Input Parameters
+
+- *Email Addresses* - Email addresses of the recipients you wish to notify when new incidents are created.
+- *Account Number* - The Account number for use with the AWS STS Cross Account Role. Leave blank when using AWS IAM Access key and secret. It only needs to be passed when the desired AWS account is different than the one associated with the Flexera One credential. [More information is available in our documentation.](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1123608)
+- *Instance Type Category* - Instance Type Category to pick from for recommended instance types.
+  - Regular: Standard recommendations.
+  - Next Gen: Recommend latest generation upgrade.
+  - Burstable: Burstable instance type recommendations.
+  - AMD: Recommend AMD-based latest generation upgrade. May provide additional savings.
+- *Minimum Savings Threshold* - Minimum potential savings required to generate a recommendation.
+- *Exclusion Tags (Key:Value)* - Cloud native tags to ignore resources that you don't want to produce recommendations for. Use Key:Value format for specific tag key/value pairs, and Key:\* format to match any resource with a particular key, regardless of value. Examples: env:production, DO_NOT_DELETE:\*
+- *Allow/Deny Regions* - Whether to treat Allow/Deny Regions List parameter as allow or deny list. Has no effect if Allow/Deny Regions List is left empty.
+- *Allow/Deny Regions List* - A list of regions to allow or deny for an AWS account. Please enter the regions code if SCP is enabled. See [Available Regions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) in AWS; otherwise, the policy may fail on regions that are disabled via SCP. Leave blank to consider all the regions.
+- *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).
+
+Please note that the "Automatic Actions" parameter contains a list of action(s) that can be performed on the resources. When it is selected, the policy will automatically execute the corresponding action on the data that failed the checks, post incident generation. Please leave this parameter blank for *manual* action.
+For example if a user selects the "Change Instance Type" action while applying the policy, all the resources that didn't satisfy the policy condition will have their instance type changed.
+
+## Policy Actions
+
+- Sends an email notification
+- Change instance type after approval
+
+## Prerequisites
+
+This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).
+
+### Credential configuration
+
+For administrators [creating and managing credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) to use with this policy, the following information is needed:
+
+- [**AWS Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1121575) (*provider=aws*) which has the following permissions:
+  - `ec2:DescribeRegions`
+  - `ec2:DescribeInstances`
+  - `ec2:DescribeInstanceStatus`*
+  - `ec2:DescribeTags`
+  - `ec2:ModifyInstanceAttribute`*
+  - `ec2:StartInstances`*
+  - `ec2:StopInstances`*
+  - `sts:GetCallerIdentity`
+
+\* Only required for taking action (changing instance type); the policy will still function in a read-only capacity without these permissions.
+
+  Example IAM Permission Policy:
+
+  ```json
+  {
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "ec2:DescribeRegions",
+                  "ec2:DescribeInstances",
+                  "ec2:DescribeInstanceStatus",
+                  "ec2:DescribeTags",
+                  "ec2:ModifyInstanceAttribute",
+                  "ec2:StartInstances",
+                  "ec2:StopInstances",
+                  "sts:GetCallerIdentity"
+              ],
+              "Resource": "*"
+          }
+      ]
+  }
+  ```
+
+- [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
+  - `billing_center_viewer`
+
+The [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) page in the docs has detailed instructions for setting up Credentials for the most common providers.
+
+## Supported Clouds
+
+- AWS
+
+## Cost
+
+This Policy Template does not incur any cloud costs.

--- a/cost/aws/superseded_instances/README.md
+++ b/cost/aws/superseded_instances/README.md
@@ -14,7 +14,7 @@ This policy checks all the EC2 instances in an AWS Account to determine if the i
 
 The policy includes the estimated monthly savings. The estimated monthly savings is recognized if the instance type is changed to the recommended instance type. The savings is calculated by taking the difference in the hourly list price between the current instance type and the recommended instance type. This value is then multiplied by 24 to get the daily savings, and then by 30.44 (the average number of days in a month) to get the monthly savings. The savings value is 0 if no cost information for the resource type was found in our internal database.
 
-The Estimated Monthly Savings column and the total estimated sum of all Superseded Instances is displayed in the incident detail message. If the Flexera organization is configured to use a currency other than USD, the savings values will be converted from USD using the exchange rate at the time that the policy executes.
+The savings is displayed in the Estimated Monthly Savings column. The incident message detail includes the sum of each resource *Estimated Monthly Savings* as *Potential Monthly Savings*. If the Flexera organization is configured to use a currency other than USD, the savings values will be converted from USD using the exchange rate at the time that the policy executes.
 
 ## Input Parameters
 

--- a/cost/aws/superseded_instances/README.md
+++ b/cost/aws/superseded_instances/README.md
@@ -14,7 +14,7 @@ This policy checks all the EC2 instances in an AWS Account to determine if the i
 
 The policy includes the estimated monthly savings. The estimated monthly savings is recognized if the instance type is changed to the recommended instance type. The savings is calculated by taking the difference in the hourly list price between the current instance type and the recommended instance type. This value is then multiplied by 24 to get the daily savings, and then by 30.44 (the average number of days in a month) to get the monthly savings. The savings value is 0 if no cost information for the resource type was found in our internal database.
 
-The Estimated Monthly Savings column and the total estimated sum of all Superseded Instances is displayed in the incident detail message. If the Flexera organization is configured to use a currency other than USD, the savings values will be converted from USD using the exchange rate at the time that the policy executes.
+The Estimated Monthly Savings column and the total estimated sum of all Superseded Instances is displayed in the incident detail message. If the Flexera organization is configured to use a currency other than USD, the savings values will be converted from USD using the exchange rate at the time that the policy executes.
 
 ## Input Parameters
 

--- a/cost/aws/superseded_instances/aws_superseded_instances.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances.pt
@@ -989,6 +989,10 @@ define change_instances($data) return $all_responses do
       end
     end
   end
+
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
 end
 
 # CWF function to change an instance type

--- a/cost/aws/superseded_instances/aws_superseded_instances.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances.pt
@@ -966,32 +966,26 @@ end
 
 # Core CWF function to downsize instances
 define change_instances($data) return $all_responses do
-  # Change "No" to "Yes" to enable CWF debug logging
-  $log_to_cm_audit_entries = "No"
-
-  $$debug = $log_to_cm_audit_entries == "Yes"
-  $$log = []
-  $all_responses = []
-  $syslog_subject = "AWS Superseded EC2 Instances [Change Type]: "
-
-  call sys_log(join([$syslog_subject, "Identified Instances"]), to_s($data))
+  $$all_responses = []
 
   foreach $instance in $data do
-    call get_instance_state($instance) retrieve $state_response, $initial_state
-    $all_responses << $state_response
+    sub on_error: handle_error() do
+      call get_instance_state($instance) retrieve $state_response, $initial_state
+      $$all_responses << $state_response
 
-    if $initial_state != "terminated" && $initial_state != "pending"
-      if $initial_state != "stopped"
-        call stop_instance($instance) retrieve $stop_response
-        $all_responses << $stop_response
-      end
+      if $initial_state != "terminated" && $initial_state != "pending"
+        if $initial_state != "stopped"
+          call stop_instance($instance) retrieve $stop_response
+          $$all_responses << $stop_response
+        end
 
-      call change_instance($instance) retrieve $change_response
-      $all_responses << $change_response
+        call change_instance($instance) retrieve $change_response
+        $$all_responses << $change_response
 
-      if $initial_state == "running"
-        call start_instance($instance) retrieve $start_response
-        $all_responses << $start_response
+        if $initial_state == "running"
+          call start_instance($instance) retrieve $start_response
+          $$all_responses << $start_response
+        end
       end
     end
   end
@@ -999,9 +993,8 @@ end
 
 # CWF function to change an instance type
 define change_instance($instance) return $response do
-  $syslog_subject = "AWS Change Instance Type : "
-
-  call sys_log(join([$syslog_subject, "Instance"]), to_s($instance["resourceID"]))
+  $change_url = "https://" + "ec2." + $instance["region"] + ".amazonaws.com/?Action=ModifyInstanceAttribute&Version=2016-11-15&InstanceId=" + $instance["resourceID"] + "&InstanceType.Value=" + $instance["newResourceType"]
+  task_label("POST " + $change_url)
 
   $response = http_request(
     auth: $$auth_aws,
@@ -1017,22 +1010,29 @@ define change_instance($instance) return $response do
     }
   )
 
-  $current_state = "dummy_value"
+  task_label("Post AWS EC2 instance response: " + $item["resourceID"] + " " + to_json($response))
+  $$all_responses << to_json({"req": "POST " + $change_url, "resp": $response})
 
-  while $current_state != "stopped" do
-    sleep(30)
+  if $response["code"] != 200 && $response["code"] != 202 && $response["code"] != 204
+    raise "Unexpected response posting AWS EC2 instance: "+ $item["resourceID"] + " " + to_json($response)
+  else
+    task_label("Post AWS EC2 instance request Accepted and the operation will complete asynchronously")
+
     call get_instance_state($instance) retrieve $state_response, $current_state
+    sleep(5)
+
+    while $current_state != "stopped" do
+      task_label('Post AWS EC2 instance Status (waiting for "stopped" state): ' + $current_state) + ' ' + $item["resourceID"]
+      call get_instance_state($instance) retrieve $state_response, $current_state
+      sleep(5)
+    end
   end
-
-  call sys_log(join([$syslog_subject, "Responses"]), to_s($response))
 end
-
 
 # CWF function to start an instance
 define start_instance($instance) return $response do
-  $syslog_subject = "AWS Starting Instance: "
-
-  call sys_log(join([$syslog_subject, "Instance"]), to_s($instance["resourceID"]))
+  $start_url = "https://" + "ec2." + $instance["region"] + ".amazonaws.com/?Action=StartInstances&Version=2016-11-15&InstanceId.1=" + $instance["resourceID"]
+  task_label("POST " + $start_url)
 
   $response = http_request(
     auth: $$auth_aws,
@@ -1047,14 +1047,18 @@ define start_instance($instance) return $response do
     }
   )
 
-  call sys_log(join([$syslog_subject, "Responses"]), to_s($response))
+  task_label("Post AWS EC2 instance response: " + $item["resourceID"] + " " + to_json($response))
+  $$all_responses << to_json({"req": "POST " + $start_url, "resp": $response})
+
+  if $response["code"] != 200 && $response["code"] != 202 && $response["code"] != 204
+    raise "Unexpected response posting AWS EC2 instance: "+ $item["resourceID"] + " " + to_json($response)
+  end
 end
 
 # CWF function to stop an instance
 define stop_instance($instance) return $response do
-  $syslog_subject = "AWS Stopping Instance: "
-
-  call sys_log(join([$syslog_subject, "Instance"]), to_s($instance["resourceID"]))
+  $stop_url = "https://" + "ec2." + $instance["region"] + ".amazonaws.com/?Action=StopInstances&Version=2016-11-15&InstanceId.1=" + $instance["resourceID"]
+  task_label("POST " + $stop_url)
 
   $response = http_request(
     auth: $$auth_aws,
@@ -1069,21 +1073,29 @@ define stop_instance($instance) return $response do
     }
   )
 
-  $current_state = "dummy_value"
+  task_label("Post AWS EC2 instance response: " + $item["resourceID"] + " " + to_json($response))
+  $$all_responses << to_json({"req": "POST " + $stop_url, "resp": $response})
 
-  while $current_state != "stopped" do
-    sleep(30)
+  if $response["code"] != 200 && $response["code"] != 202 && $response["code"] != 204
+    raise "Unexpected response posting AWS EC2 instance: "+ $item["resourceID"] + " " + to_json($response)
+  else
+    task_label("Post AWS EC2 instance request Accepted and the operation will complete asynchronously")
+
     call get_instance_state($instance) retrieve $state_response, $current_state
-  end
+    sleep(5)
 
-  call sys_log(join([$syslog_subject, "Responses"]), to_s($response))
+    while $current_state != "stopped" do
+      task_label('Post AWS EC2 instance Status (waiting for "stopped" state): ' + $current_state) + ' ' + $item["resourceID"]
+      call get_instance_state($instance) retrieve $state_response, $current_state
+      sleep(5)
+    end
+  end
 end
 
 # CWF function to get the current state of an instance
 define get_instance_state($instance) return $response, $instance_state do
-  $syslog_subject = "AWS Describing Instance: "
-
-  call sys_log(join([$syslog_subject, "Instance"]), to_s($instance["resourceID"]))
+  $state_url = "https://" + "ec2." + $instance["region"] + ".amazonaws.com/?Action=DescribeInstanceStatus&Version=2016-11-15&IncludeAllInstances=true&InstanceId.1=" + $instance["resourceID"]
+  task_label("POST " + $state_url)
 
   $response = http_request(
     auth: $$auth_aws,
@@ -1099,44 +1111,23 @@ define get_instance_state($instance) return $response, $instance_state do
     }
   )
 
-  call sys_log(join([$syslog_subject, "Responses"]), to_s($response))
+  task_label("Post AWS EC2 instance response: " + $item["resourceID"] + " " + to_json($response))
+  $$all_responses << to_json({"req": "POST " + $state_url, "resp": $response})
 
-  $instance_state = $response["body"]["DescribeInstanceStatusResponse"]["instanceStatusSet"]["item"]["instanceState"]["name"]
+  if $response["code"] != 200 && $response["code"] != 202 && $response["code"] != 204
+    raise "Unexpected response posting AWS EC2 instance: "+ $item["resourceID"] + " " + to_json($response)
+  else
+    $instance_state = $response["body"]["DescribeInstanceStatusResponse"]["instanceStatusSet"]["item"]["instanceState"]["name"]
+  end
 end
 
-# CWF function to record information to the logs
-define sys_log($subject, $detail) do
-  # Create empty errors array if doesn't already exist
+define handle_error() do
   if !$$errors
     $$errors = []
   end
-  # Check if debug is enabled
-  if $$debug
-    # Append to global $$errors
-    # This is the suggested way to capture errors
-    $$errors << "Unexpected error for " + $subject + "\n  " + to_s($detail)
-    # If Flexera NAM Zone, create audit_entries [to be deprecated]
-    # This is the legacy method for capturing errors and only supported on Flexera NAM
-    if $$rs_optima_host == "api.optima.flexeraeng.com"
-      # skip_error_and_append is used to catch error if rs_cm.audit_entries.create fails unexpectedly
-      $task_label = "Creating audit entry for " + $subject
-      sub task_label: $task, on_error: skip_error_and_append($task) do
-        rs_cm.audit_entries.create(
-          notify: "None",
-          audit_entry: {
-            auditee_href: @@account,
-            summary: $subject,
-            detail: $detail
-          }
-        )
-      end # End sub on_error
-    end # End if rs_optima_host
-  end # End if debug is enabled
-end
-
-# CWF function to handle errors
-define skip_error_and_append($subject) do
-  $$errors << "Unexpected error for " + $subject + "\n  " + to_s($_error)
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
   $_error_behavior = "skip"
 end
 

--- a/cost/aws/superseded_instances/aws_superseded_instances.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances.pt
@@ -1026,6 +1026,8 @@ define change_instance($instance) return $response do
       call get_instance_state($instance) retrieve $state_response, $current_state
       sleep(5)
     end
+
+    task_label("Post AWS EC2 instance successful: " + $item["resourceID"])
   end
 end
 
@@ -1052,6 +1054,8 @@ define start_instance($instance) return $response do
 
   if $response["code"] != 200 && $response["code"] != 202 && $response["code"] != 204
     raise "Unexpected response posting AWS EC2 instance: "+ $item["resourceID"] + " " + to_json($response)
+  else
+    task_label("Post AWS EC2 instance successful: " + $item["resourceID"])
   end
 end
 
@@ -1089,6 +1093,8 @@ define stop_instance($instance) return $response do
       call get_instance_state($instance) retrieve $state_response, $current_state
       sleep(5)
     end
+
+    task_label("Post AWS EC2 instance successful: " + $item["resourceID"])
   end
 end
 
@@ -1117,6 +1123,7 @@ define get_instance_state($instance) return $response, $instance_state do
   if $response["code"] != 200 && $response["code"] != 202 && $response["code"] != 204
     raise "Unexpected response posting AWS EC2 instance: "+ $item["resourceID"] + " " + to_json($response)
   else
+    task_label("Post AWS EC2 instance successful: " + $item["resourceID"])
     $instance_state = $response["body"]["DescribeInstanceStatusResponse"]["instanceStatusSet"]["item"]["instanceState"]["name"]
   end
 end

--- a/cost/aws/superseded_instances/aws_superseded_instances.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances.pt
@@ -1014,11 +1014,11 @@ define change_instance($instance) return $response do
     }
   )
 
-  task_label("Post AWS EC2 instance response: " + $item["resourceID"] + " " + to_json($response))
+  task_label("Post AWS EC2 instance response: " + $instance["resourceID"] + " " + to_json($response))
   $$all_responses << to_json({"req": "POST " + $change_url, "resp": $response})
 
   if $response["code"] != 200 && $response["code"] != 202 && $response["code"] != 204
-    raise "Unexpected response posting AWS EC2 instance: "+ $item["resourceID"] + " " + to_json($response)
+    raise "Unexpected response posting AWS EC2 instance: "+ $instance["resourceID"] + " " + to_json($response)
   else
     task_label("Post AWS EC2 instance request Accepted and the operation will complete asynchronously")
 
@@ -1026,12 +1026,12 @@ define change_instance($instance) return $response do
     sleep(5)
 
     while $current_state != "stopped" do
-      task_label('Post AWS EC2 instance Status (waiting for "stopped" state): ' + $current_state) + ' ' + $item["resourceID"]
+      task_label('Post AWS EC2 instance Status (waiting for "stopped" state): ' + $current_state) + ' ' + $instance["resourceID"]
       call get_instance_state($instance) retrieve $state_response, $current_state
       sleep(5)
     end
 
-    task_label("Post AWS EC2 instance successful: " + $item["resourceID"])
+    task_label("Post AWS EC2 instance successful: " + $instance["resourceID"])
   end
 end
 
@@ -1053,13 +1053,13 @@ define start_instance($instance) return $response do
     }
   )
 
-  task_label("Post AWS EC2 instance response: " + $item["resourceID"] + " " + to_json($response))
+  task_label("Post AWS EC2 instance response: " + $instance["resourceID"] + " " + to_json($response))
   $$all_responses << to_json({"req": "POST " + $start_url, "resp": $response})
 
   if $response["code"] != 200 && $response["code"] != 202 && $response["code"] != 204
-    raise "Unexpected response posting AWS EC2 instance: "+ $item["resourceID"] + " " + to_json($response)
+    raise "Unexpected response posting AWS EC2 instance: "+ $instance["resourceID"] + " " + to_json($response)
   else
-    task_label("Post AWS EC2 instance successful: " + $item["resourceID"])
+    task_label("Post AWS EC2 instance successful: " + $instance["resourceID"])
   end
 end
 
@@ -1081,11 +1081,11 @@ define stop_instance($instance) return $response do
     }
   )
 
-  task_label("Post AWS EC2 instance response: " + $item["resourceID"] + " " + to_json($response))
+  task_label("Post AWS EC2 instance response: " + $instance["resourceID"] + " " + to_json($response))
   $$all_responses << to_json({"req": "POST " + $stop_url, "resp": $response})
 
   if $response["code"] != 200 && $response["code"] != 202 && $response["code"] != 204
-    raise "Unexpected response posting AWS EC2 instance: "+ $item["resourceID"] + " " + to_json($response)
+    raise "Unexpected response posting AWS EC2 instance: "+ $instance["resourceID"] + " " + to_json($response)
   else
     task_label("Post AWS EC2 instance request Accepted and the operation will complete asynchronously")
 
@@ -1093,12 +1093,12 @@ define stop_instance($instance) return $response do
     sleep(5)
 
     while $current_state != "stopped" do
-      task_label('Post AWS EC2 instance Status (waiting for "stopped" state): ' + $current_state) + ' ' + $item["resourceID"]
+      task_label('Post AWS EC2 instance Status (waiting for "stopped" state): ' + $current_state) + ' ' + $instance["resourceID"]
       call get_instance_state($instance) retrieve $state_response, $current_state
       sleep(5)
     end
 
-    task_label("Post AWS EC2 instance successful: " + $item["resourceID"])
+    task_label("Post AWS EC2 instance successful: " + $instance["resourceID"])
   end
 end
 
@@ -1121,13 +1121,13 @@ define get_instance_state($instance) return $response, $instance_state do
     }
   )
 
-  task_label("Post AWS EC2 instance response: " + $item["resourceID"] + " " + to_json($response))
+  task_label("Post AWS EC2 instance response: " + $instance["resourceID"] + " " + to_json($response))
   $$all_responses << to_json({"req": "POST " + $state_url, "resp": $response})
 
   if $response["code"] != 200 && $response["code"] != 202 && $response["code"] != 204
-    raise "Unexpected response posting AWS EC2 instance: "+ $item["resourceID"] + " " + to_json($response)
+    raise "Unexpected response posting AWS EC2 instance: "+ $instance["resourceID"] + " " + to_json($response)
   else
-    task_label("Post AWS EC2 instance successful: " + $item["resourceID"])
+    task_label("Post AWS EC2 instance successful: " + $instance["resourceID"])
     $instance_state = $response["body"]["DescribeInstanceStatusResponse"]["instanceStatusSet"]["item"]["instanceState"]["name"]
   end
 end

--- a/cost/aws/superseded_instances/aws_superseded_instances.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances.pt
@@ -811,10 +811,10 @@ script "js_superseded_instances", type: "javascript" do
   superseded_percentage = (total_superseded / total_instances * 100).toFixed(2).toString() + '%'
 
   instance_noun = "instance"
-  if (total_instances.length > 1) { instance_noun = "instances" }
+  if (Number(total_instances) > 1) { instance_noun = "instances" }
 
   superseded_verb = "is"
-  if (total_superseded.length > 1) { superseded_verb = "are" }
+  if (Number(total_superseded) > 1) { superseded_verb = "are" }
 
   findings = [
     "Out of ", total_instances, " EC2 ", instance_noun, " analyzed, ",

--- a/cost/aws/superseded_instances/aws_superseded_instances.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances.pt
@@ -743,7 +743,13 @@ script "js_superseded_instances", type: "javascript" do
         superseded_type_price = parseFloat(superseded_type_price.toFixed(3))
       }
 
-      recommendationDetails = ""
+      recommendationDetails = [
+        "Change instance type of EC2 instance ", instance["instanceId"], " ",
+        "in AWS Account ", ds_aws_account['name'], " ",
+        "(", ds_aws_account['id'], ") ",
+        "from ", instance["resourceType"], " ",
+        "to ", superseded_type
+      ]
 
       hostname = null
 
@@ -784,6 +790,63 @@ script "js_superseded_instances", type: "javascript" do
       })
     }
   })
+
+  // Sort by descending order of savings value
+  result = _.sortBy(result, function(item) { return item['savings'] * -1 })
+
+  // Message for incident detailed template
+  savings_message = [
+    ds_currency['symbol'], ' ',
+    formatNumber(parseFloat(total_savings).toFixed(2), ds_currency['t_separator'])
+  ].join('')
+
+  total_instances = ds_instances.length.toString()
+  total_superseded = result.length.toString()
+  superseded_percentage = (total_instances / total_superseded * 100).toFixed(2)
+
+  instance_noun = "instance"
+  if (total_instances.length > 1) { instance_noun = "instances" }
+
+  superseded_verb = "is"
+  if (total_superseded.length > 1) { superseded_verb = "are" }
+
+  findings = [
+    "Out of ", total_instances, " EC2 ", instance_noun, " analyzed, ",
+    total_superseded, " (", superseded_percentage,
+    ") ", superseded_verb, " superseded and recommended for an instance type change. ",
+    "All recommendations are for ", param_instance_type, " instance types.\n\n"
+  ].join('')
+
+  disclaimer = "The above settings can be modified by editing the applied policy and changing the appropriate parameters.\n\n"
+
+  api_disclaimer = ""
+
+  if (ds_currency_conversion['to'] == undefined && ds_currency['code'] != 'USD') {
+    api_disclaimer = "\n\nSavings values are in USD due to a malfunction with Flexera's internal currency conversion API. Please contact Flexera support to report this issue."
+  }
+
+  savings_disclaimer = "Savings are estimated based on list price and may not reflect credits or discounts. "
+
+  if (ds_currency['code'] != "USD" && api_disclaimer == "") {
+    savings_disclaimer += "List prices were converted from USD using current exchange rates."
+  }
+
+  // Dummy entry to ensure the check statement in validation always runs at least once
+  result.push({
+    region: "",                 resourceID: "",               ipAddress: "",
+    ipv6Address: "",            imageId: "",                  resourceType: "",
+    platform: "",               privateDnsName: "",           launchTime: "",
+    operating_system: "",       billing_center: "",           purchase_option: "",
+    service: "",                tags: "",                     accountID: "",
+    accountName: "",            hostname: "",                 recommendationDetails: "",
+    newResourceType: "",        resourceName: "",             cost: "",
+    instance_type_price: "",    superseded_type_price: "",    savings: "",
+    savingsCurrency: "",        recommendationType: "",       policy_name: "",
+    total_savings: "",          message: ""
+  })
+
+  result[0]['total_savings'] = savings_message
+  result[0]['message'] = findings + disclaimer + savings_disclaimer + api_disclaimer
 EOS
 end
 

--- a/cost/aws/superseded_instances/aws_superseded_instances.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances.pt
@@ -618,7 +618,6 @@ script "js_instance_costs_grouped", type: "javascript" do
     result[id]['operating_system'] = item['operating_system']
     result[id]['billing_center'] = bc_object[item['billing_center_id']]
     result[id]['purchase_option'] = item['purchase_option']
-    result[id]['service'] = item['service']
   })
 EOS
 end
@@ -665,14 +664,12 @@ script "js_superseded_instances", type: "javascript" do
     operating_system = null
     billing_center = null
     purchase_option = null
-    service = null
 
-    if (ds_instance_costs_grouped['id'] != undefined) {
-      cost = ds_instance_costs_grouped['id']['cost']
-      operating_system = ds_instance_costs_grouped['id']['operating_system']
-      billing_center = ds_instance_costs_grouped['id']['billing_center']
-      purchase_option = ds_instance_costs_grouped['id']['purchase_option']
-      service = ds_instance_costs_grouped['id']['service']
+    if (ds_instance_costs_grouped[id] != undefined) {
+      cost = ds_instance_costs_grouped[id]['cost']
+      operating_system = ds_instance_costs_grouped[id]['operating_system']
+      billing_center = ds_instance_costs_grouped[id]['billing_center']
+      purchase_option = ds_instance_costs_grouped[id]['purchase_option']
     }
 
     type_table = {
@@ -695,14 +692,23 @@ script "js_superseded_instances", type: "javascript" do
     if (typeof(superseded_type) == 'string' && typeof(operating_system) == 'string') {
       if (ds_aws_instance_cost_map[instance['region']] != undefined) {
         instance_type_cost_map = ds_aws_instance_cost_map[instance['region']][instance_type]
-        superseded_type_cost_map = ds_aws_instance_cost_map[instance['region']][superseded_type]
 
         if (instance_type_cost_map != undefined) {
-          instance_type_price = instance_type_cost_map[operating_system]
+          instance_type_price_map = instance_type_cost_map[operating_system]
         }
 
+        if (instance_type_price_map != undefined) {
+          instance_type_price = instance_type_price_map['pricePerUnit']
+        }
+
+        superseded_type_cost_map = ds_aws_instance_cost_map[instance['region']][superseded_type]
+
         if (superseded_type_cost_map != undefined) {
-          superseded_type_price = superseded_type_cost_map[operating_system]
+          superseded_type_price_map = superseded_type_cost_map[operating_system]
+        }
+
+        if (superseded_type_price_map != undefined) {
+          superseded_type_price = superseded_type_price_map['pricePerUnit']
         }
       }
     }
@@ -731,15 +737,15 @@ script "js_superseded_instances", type: "javascript" do
 
       savings = parseFloat(savings.toFixed(3))
 
-      if (cost != null) {
+      if (typeof(cost) == 'number') {
         cost = parseFloat(cost.toFixed(3))
       }
 
-      if (instance_type_price != null) {
+      if (typeof(instance_type_price) == 'number') {
         instance_type_price = parseFloat(instance_type_price.toFixed(3))
       }
 
-      if (superseded_type_price != null) {
+      if (typeof(superseded_type_price) == 'number') {
         superseded_type_price = parseFloat(superseded_type_price.toFixed(3))
       }
 
@@ -749,7 +755,7 @@ script "js_superseded_instances", type: "javascript" do
         "(", ds_aws_account['id'], ") ",
         "from ", instance["resourceType"], " ",
         "to ", superseded_type
-      ]
+      ].join('')
 
       hostname = null
 
@@ -767,10 +773,10 @@ script "js_superseded_instances", type: "javascript" do
         platform: instance['platform'],
         privateDnsName: instance['privateDnsName'],
         launchTime: instance['launchTime'],
-        operating_system: operating_system,
+        osType: operating_system,
         billing_center: billing_center,
         purchase_option: purchase_option,
-        service: service,
+        service: "AmazonEC2",
         tags: tags.join(', '),
         accountID: ds_aws_account['id'],
         accountName: ds_aws_account['name'],
@@ -802,7 +808,7 @@ script "js_superseded_instances", type: "javascript" do
 
   total_instances = ds_instances.length.toString()
   total_superseded = result.length.toString()
-  superseded_percentage = (total_instances / total_superseded * 100).toFixed(2)
+  superseded_percentage = (total_superseded / total_instances * 100).toFixed(2).toString() + '%'
 
   instance_noun = "instance"
   if (total_instances.length > 1) { instance_noun = "instances" }
@@ -836,7 +842,7 @@ script "js_superseded_instances", type: "javascript" do
     region: "",                 resourceID: "",               ipAddress: "",
     ipv6Address: "",            imageId: "",                  resourceType: "",
     platform: "",               privateDnsName: "",           launchTime: "",
-    operating_system: "",       billing_center: "",           purchase_option: "",
+    osType: "",                 billing_center: "",           purchase_option: "",
     service: "",                tags: "",                     accountID: "",
     accountName: "",            hostname: "",                 recommendationDetails: "",
     newResourceType: "",        resourceName: "",             cost: "",
@@ -900,6 +906,9 @@ policy "pol_utilization" do
       end
       field "platform" do
         label "Platform"
+      end
+      field "osType" do
+        label "Operating System"
       end
       field "hostname" do
         label "Hostname"

--- a/cost/aws/superseded_instances/aws_superseded_instances.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances.pt
@@ -860,7 +860,7 @@ end
 # Policy
 ###############################################################################
 
-policy "pol_utilization" do
+policy "pol_superseded_instances" do
   validate_each $ds_superseded_instances do
     summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} AWS Potentially Superseded EC2 Instances Found"
     detail_template <<-'EOS'

--- a/cost/aws/superseded_instances/aws_superseded_instances.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances.pt
@@ -1001,7 +1001,7 @@ end
 define change_instance($instance) return $response do
   $syslog_subject = "AWS Change Instance Type : "
 
-  call sys_log(join([$syslog_subject, "Instance"]), to_s($instance["id"]))
+  call sys_log(join([$syslog_subject, "Instance"]), to_s($instance["resourceID"]))
 
   $response = http_request(
     auth: $$auth_aws,
@@ -1012,7 +1012,7 @@ define change_instance($instance) return $response do
     query_strings: {
       "Action": "ModifyInstanceAttribute",
       "Version": "2016-11-15",
-      "InstanceId": $instance["id"],
+      "InstanceId": $instance["resourceID"],
       "InstanceType.Value": $instance["newResourceType"]
     }
   )
@@ -1032,7 +1032,7 @@ end
 define start_instance($instance) return $response do
   $syslog_subject = "AWS Starting Instance: "
 
-  call sys_log(join([$syslog_subject, "Instance"]), to_s($instance["id"]))
+  call sys_log(join([$syslog_subject, "Instance"]), to_s($instance["resourceID"]))
 
   $response = http_request(
     auth: $$auth_aws,
@@ -1043,7 +1043,7 @@ define start_instance($instance) return $response do
     query_strings: {
       "Action": "StartInstances",
       "Version": "2016-11-15",
-      "InstanceId.1": $instance["id"]
+      "InstanceId.1": $instance["resourceID"]
     }
   )
 
@@ -1054,7 +1054,7 @@ end
 define stop_instance($instance) return $response do
   $syslog_subject = "AWS Stopping Instance: "
 
-  call sys_log(join([$syslog_subject, "Instance"]), to_s($instance["id"]))
+  call sys_log(join([$syslog_subject, "Instance"]), to_s($instance["resourceID"]))
 
   $response = http_request(
     auth: $$auth_aws,
@@ -1065,7 +1065,7 @@ define stop_instance($instance) return $response do
     query_strings: {
       "Action": "StopInstances",
       "Version": "2016-11-15",
-      "InstanceId.1": $instance["id"]
+      "InstanceId.1": $instance["resourceID"]
     }
   )
 
@@ -1083,7 +1083,7 @@ end
 define get_instance_state($instance) return $response, $instance_state do
   $syslog_subject = "AWS Describing Instance: "
 
-  call sys_log(join([$syslog_subject, "Instance"]), to_s($instance["id"]))
+  call sys_log(join([$syslog_subject, "Instance"]), to_s($instance["resourceID"]))
 
   $response = http_request(
     auth: $$auth_aws,
@@ -1095,7 +1095,7 @@ define get_instance_state($instance) return $response, $instance_state do
       "Action": "DescribeInstanceStatus",
       "Version": "2016-11-15",
       "IncludeAllInstances": "true",
-      "InstanceId.1": $instance["id"]
+      "InstanceId.1": $instance["resourceID"]
     }
   )
 

--- a/cost/aws/superseded_instances/aws_superseded_instances.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances.pt
@@ -1,0 +1,1159 @@
+name "AWS Superseded EC2 Instances"
+rs_pt_ver 20180301
+type "policy"
+short_description "Checks for AWS EC2 instance types that have been superseded and, optionally, updates the instance type. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/superseded_instance) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+long_description ""
+severity "low"
+category "Cost"
+default_frequency "weekly"
+info(
+  version: "1.0",
+  provider: "AWS",
+  service: "Compute",
+  policy_set: "Superseded Compute Instances",
+  recommendation_type: "Usage Reduction"
+)
+
+###############################################################################
+# Parameters
+###############################################################################
+
+parameter "param_email" do
+  type "list"
+  category "Policy Settings"
+  label "Email Addresses"
+  description "Email addresses of the recipients you wish to notify when new incidents are created"
+  default []
+end
+
+parameter "param_aws_account_number" do
+  type "string"
+  category "Policy Settings"
+  label "Account Number"
+  description "The account number for AWS STS Cross Account Roles."
+  default ""
+end
+
+parameter "param_instance_type" do
+  type "string"
+  category "Policy Settings"
+  label "Instance Type Category"
+  description "Instance Type Category to pick from for recommended instance types. See README for more information."
+  allowed_values "Regular", "Next Gen", "Burstable", "AMD"
+  default "Regular"
+end
+
+parameter "param_min_savings" do
+  type "number"
+  category "Policy Settings"
+  label "Minimum Savings Threshold"
+  description "Minimum potential savings required to generate a recommendation"
+  min_value 0
+  default 0
+end
+
+parameter "param_exclusion_tags" do
+  type "list"
+  category "Filters"
+  label "Exclusion Tags (Key:Value)"
+  description "Cloud native tags to ignore resources that you don't want to produce recommendations for. Use Key:Value format for specific tag key/value pairs, and Key:* format to match any resource with a particular key, regardless of value. Examples: env:production, DO_NOT_DELETE:*"
+  allowed_pattern /(^$)|[\w]*\:.*/
+  default []
+end
+
+parameter "param_regions_allow_or_deny" do
+  type "string"
+  category "Filters"
+  label "Allow/Deny Regions"
+  description "Allow or Deny entered regions. See the README for more details"
+  allowed_values "Allow", "Deny"
+  default "Allow"
+end
+
+parameter "param_regions_list" do
+  type "list"
+  category "Filters"
+  label "Allow/Deny Regions List"
+  allowed_pattern /^([a-zA-Z-_]+-[a-zA-Z0-9-_]+-[0-9-_]+,*|)+$/
+  description "A list of allowed or denied regions. See the README for more details"
+  default []
+end
+
+parameter "param_automatic_action" do
+  type "list"
+  category "Actions"
+  label "Automatic Actions"
+  description "When this value is set, this policy will automatically take the selected action(s)"
+  allowed_values ["Change Instance Type"]
+  default []
+end
+
+###############################################################################
+# Authentication
+###############################################################################
+
+credentials "auth_aws" do
+  schemes "aws", "aws_sts"
+  label "AWS"
+  description "Select the AWS Credential from the list"
+  tags "provider=aws"
+  aws_account_number $param_aws_account_number
+end
+
+credentials "auth_flexera" do
+  schemes "oauth2"
+  label "Flexera"
+  description "Select Flexera One OAuth2 credentials"
+  tags "provider=flexera"
+end
+
+###############################################################################
+# Pagination
+###############################################################################
+
+pagination "pagination_aws" do
+  get_page_marker do
+    body_path jmes_path(response, "NextToken")
+  end
+  set_page_marker do
+    body_field "NextToken"
+  end
+end
+
+###############################################################################
+# Datasources & Scripts
+###############################################################################
+
+# Various data tables needed for later in the policy
+datasource "ds_aws_instance_size_map" do
+  request do
+    verb "GET"
+    host "raw.githubusercontent.com"
+    path "/rightscale/policy_templates/master/data/aws/instance_types.json"
+    header "User-Agent", "RS Policies"
+  end
+end
+
+datasource "ds_aws_instance_cost_map" do
+  request do
+    verb "GET"
+    host "raw.githubusercontent.com"
+    path "/rightscale/policy_templates/master/data/aws/aws_ec2_pricing.json"
+    header "User-Agent", "RS Policies"
+  end
+end
+
+# Get applied policy metadata for use later
+datasource "ds_applied_policy" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    header "Api-Version", "1.0"
+  end
+end
+
+# Get region-specific Flexera API endpoints
+datasource "ds_flexera_api_hosts" do
+  run_script $js_flexera_api_hosts, rs_optima_host
+end
+
+script "js_flexera_api_hosts", type: "javascript" do
+  parameters "rs_optima_host"
+  result "result"
+  code <<-EOS
+  host_table = {
+    "api.optima.flexeraeng.com": {
+      flexera: "api.flexera.com",
+      fsm: "api.fsm.flexeraeng.com"
+    },
+    "api.optima-eu.flexeraeng.com": {
+      flexera: "api.flexera.eu",
+      fsm: "api.fsm-eu.flexeraeng.com"
+    },
+    "api.optima-au.flexeraeng.com": {
+      flexera: "api.flexera.au",
+      fsm: "api.fsm-au.flexeraeng.com"
+    }
+  }
+
+  result = host_table[rs_optima_host]
+EOS
+end
+
+# Get AWS account info
+datasource "ds_cloud_vendor_accounts" do
+  request do
+    auth $auth_flexera
+    host val($ds_flexera_api_hosts, 'flexera')
+    path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "values[*]") do
+      field "id", jmes_path(col_item, "aws.accountId")
+      field "name", jmes_path(col_item, "name")
+      field "tags", jmes_path(col_item, "tags")
+    end
+  end
+end
+
+datasource "ds_get_caller_identity" do
+  request do
+    auth $auth_aws
+    verb "GET"
+    host "sts.amazonaws.com"
+    path "/"
+    header "User-Agent", "RS Policies"
+    query "Action", "GetCallerIdentity"
+    query "Version", "2011-06-15"
+  end
+  result do
+    encoding "xml"
+    collect xpath(response, "//GetCallerIdentityResponse/GetCallerIdentityResult") do
+      field "account", xpath(col_item, "Account")
+    end
+  end
+end
+
+datasource "ds_aws_account" do
+  run_script $js_aws_account, $ds_cloud_vendor_accounts, $ds_get_caller_identity
+end
+
+script "js_aws_account", type:"javascript" do
+  parameters "ds_cloud_vendor_accounts", "ds_get_caller_identity"
+  result "result"
+  code <<-EOS
+  result = _.find(ds_cloud_vendor_accounts, function(account) {
+    return account['id'] == ds_get_caller_identity[0]['account']
+  })
+
+  // This is in case the API does not return the relevant account info
+  if (result == undefined) {
+    result = {
+      id: ds_get_caller_identity[0]['account'],
+      name: "",
+      tags: {}
+    }
+  }
+EOS
+end
+
+datasource "ds_billing_centers" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/analytics/orgs/", rs_org_id, "/billing_centers"])
+    header "Api-Version", "1.0"
+    header "User-Agent", "RS Policies"
+    query "view", "allocation_table"
+    ignore_status [403]
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "href", jmes_path(col_item, "href")
+      field "id", jmes_path(col_item, "id")
+      field "name", jmes_path(col_item, "name")
+      field "parent_id", jmes_path(col_item, "parent_id")
+    end
+  end
+end
+
+# Gather top level billing center IDs for when we pull cost data
+datasource "ds_top_level_bcs" do
+  run_script $js_top_level_bcs, $ds_billing_centers
+end
+
+script "js_top_level_bcs", type: "javascript" do
+  parameters "ds_billing_centers"
+  result "result"
+  code <<-EOS
+  filtered_bcs = _.filter(ds_billing_centers, function(bc) {
+    return bc['parent_id'] == null || bc['parent_id'] == undefined
+  })
+
+  result = _.compact(_.pluck(filtered_bcs, 'id'))
+EOS
+end
+
+# Gather local currency info
+datasource "ds_currency_reference" do
+  request do
+    host "raw.githubusercontent.com"
+    path "/rightscale/policy_templates/master/cost/scheduled_reports/currency_reference.json"
+    header "User-Agent", "RS Policies"
+  end
+end
+
+datasource "ds_currency_code" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/bill-analysis/orgs/", rs_org_id, "/settings/currency_code"])
+    header "Api-Version", "0.1"
+    header "User-Agent", "RS Policies"
+    ignore_status [403]
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+    field "value", jmes_path(response, "value")
+  end
+end
+
+datasource "ds_currency_target" do
+  run_script $js_currency_target, $ds_currency_reference, $ds_currency_code
+end
+
+script "js_currency_target", type:"javascript" do
+  parameters "ds_currency_reference", "ds_currency_code"
+  result "result"
+  code <<-EOS
+  // Default to USD if currency is not found
+  result = ds_currency_reference['USD']
+
+  if (ds_currency_code['value'] != undefined && ds_currency_reference[ds_currency_code['value']] != undefined) {
+    result = ds_currency_reference[ds_currency_code['value']]
+  }
+EOS
+end
+
+# Branching logic:
+# This datasource returns an empty array if the target currency is USD.
+# This prevents ds_currency_conversion from running if it's not needed.
+datasource "ds_conditional_currency_conversion" do
+  run_script $js_conditional_currency_conversion, $ds_currency_target
+end
+
+script "js_conditional_currency_conversion", type: "javascript" do
+  parameters "ds_currency_target"
+  result "result"
+  code <<-EOS
+  result = []
+  // Make the request only if the target currency is not USD
+  if (ds_currency_target['code'] != 'USD') {
+    result = [1]
+  }
+EOS
+end
+
+datasource "ds_currency_conversion" do
+  # Only make a request if the target currency is not USD
+  iterate $ds_conditional_currency_conversion
+  request do
+    host "api.xe-auth.flexeraeng.com"
+    path "/prod/{proxy+}"
+    query "from", "USD"
+    query "to", val($ds_currency_target, 'code')
+    query "amount", "1"
+    # Ignore currency conversion if API has issues
+    ignore_status [400, 404, 502]
+  end
+  result do
+    encoding "json"
+    field "from", jmes_path(response, "from")
+    field "to", jmes_path(response, "to")
+    field "amount", jmes_path(response, "amount")
+    field "year", jmes_path(response, "year")
+  end
+end
+
+datasource "ds_currency" do
+  run_script $js_currency, $ds_currency_target, $ds_currency_conversion
+end
+
+script "js_currency", type:"javascript" do
+  parameters "ds_currency_target", "ds_currency_conversion"
+  result "result"
+  code <<-EOS
+  result = ds_currency_target
+  result['exchange_rate'] = 1
+
+  if (ds_currency_conversion['to'] != undefined) {
+    currency_code = ds_currency_target['code']
+    current_month = parseInt(new Date().toISOString().split('-')[1])
+
+    conversion_block = _.find(ds_currency_conversion['to'][currency_code], function(item) {
+      return item['month'] == current_month
+    })
+
+    if (conversion_block != undefined) {
+      result['exchange_rate'] = conversion_block['monthlyAverage']
+    }
+  }
+EOS
+end
+
+datasource "ds_describe_regions" do
+  request do
+    auth $auth_aws
+    verb "GET"
+    host "ec2.amazonaws.com"
+    path "/"
+    query "Action", "DescribeRegions"
+    query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
+    # Header X-Meta-Flexera has no affect on datasource query, but is required for Meta Policies
+    # Forces `ds_is_deleted` datasource to run first during policy execution
+    header "Meta-Flexera", val($ds_is_deleted, "path")
+  end
+  result do
+    encoding "xml"
+    collect xpath(response, "//DescribeRegionsResponse/regionInfo/item", "array") do
+      field "region", xpath(col_item, "regionName")
+    end
+  end
+end
+
+datasource "ds_regions" do
+  run_script $js_regions, $ds_describe_regions, $param_regions_list, $param_regions_allow_or_deny
+end
+
+script "js_regions", type:"javascript" do
+  parameters "ds_describe_regions", "param_regions_list", "param_regions_allow_or_deny"
+  result "result"
+  code <<-EOS
+  allow_deny_test = { "Allow": true, "Deny": false }
+
+  if (param_regions_list.length > 0) {
+    result = _.filter(ds_describe_regions, function(item) {
+      return _.contains(param_regions_list, item['region']) == allow_deny_test[param_regions_allow_or_deny]
+    })
+  } else {
+    result = ds_describe_regions
+  }
+EOS
+end
+
+datasource "ds_instance_sets" do
+  iterate $ds_regions
+  request do
+    auth $auth_aws
+    host join(['ec2.', val(iter_item, 'region'), '.amazonaws.com'])
+    path '/'
+    header 'User-Agent', 'RS Policies'
+    header 'Content-Type', 'text/xml'
+    query 'Action', 'DescribeInstances'
+    query 'Version', '2016-11-15'
+  end
+  result do
+    encoding "xml"
+    collect xpath(response, "//DescribeInstancesResponse/reservationSet/item", "array") do
+      field "instances_set" do
+        collect xpath(col_item,"instancesSet/item","array") do
+          field "region",val(iter_item, "region")
+          field "instanceId", xpath(col_item, "instanceId")
+          field "ipAddress", xpath(col_item, "ipAddress")
+          field "ipv6Address", xpath(col_item, "ipv6Address")
+          field "imageId", xpath(col_item, "imageId")
+          field "resourceType", xpath(col_item, "instanceType")
+          field "platform", xpath(col_item, "platformDetails")
+          field "privateDnsName", xpath(col_item, "privateDnsName")
+          field "launchTime", xpath(col_item, "launchTime")
+          field "tags" do
+            collect xpath(col_item,"tagSet/item", "array") do
+              field "key", xpath(col_item, "key")
+              field "value", xpath(col_item, "value")
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+datasource "ds_instances" do
+  run_script $js_instances, $ds_instance_sets, $param_exclusion_tags
+end
+
+script "js_instances", type: "javascript" do
+  parameters "ds_instance_sets", "param_exclusion_tags"
+  result "result"
+  code <<-EOS
+  result = []
+
+  _.each(ds_instance_sets, function(item) {
+    if (param_exclusion_tags.length > 0) {
+      filtered_instances = _.reject(item['instances_set'], function(instance) {
+        instance_tags = []
+
+        if (instance['tags'] != null && instance['tags'] != undefined) {
+          _.each(instance['tags'], function(tag) {
+            instance_tags.push([tag['key'], tag['value']].join(':'))
+            instance_tags.push([tag['key'], '*'].join(':'))
+          })
+        }
+
+        exclude_instance = false
+
+        _.each(param_exclusion_tags, function(exclusion_tag) {
+          if (_.contains(instance_tags, exclusion_tag)) {
+            exclude_instance = true
+          }
+        })
+
+        return exclude_instance
+      })
+
+      result = result.concat(filtered_instances)
+    } else {
+      result = result.concat(item['instances_set'])
+    }
+  })
+EOS
+end
+
+
+datasource "ds_instance_costs" do
+  request do
+    run_script $js_instance_costs, $ds_aws_account, $ds_top_level_bcs, rs_org_id, rs_optima_host
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response,"rows[*]") do
+      field "resourceId", jmes_path(col_item, "dimensions.resource_id")
+      field "billing_center_id", jmes_path(col_item, "dimensions.billing_center_id")
+      field "operating_system", jmes_path(col_item, "dimensions.operating_system")
+      field "purchase_option", jmes_path(col_item, "dimensions.purchase_option")
+      field "service", jmes_path(col_item, "dimensions.service")
+      field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
+    end
+  end
+end
+
+script "js_instance_costs", type: "javascript" do
+  parameters "ds_aws_account", "ds_top_level_bcs", "rs_org_id", "rs_optima_host"
+  result "request"
+  code <<-EOS
+  end_date = new Date()
+  end_date.setDate(end_date.getDate() - 2)
+  end_date = end_date.toISOString().split('T')[0]
+
+  start_date = new Date()
+  start_date.setDate(start_date.getDate() - 3)
+  start_date = start_date.toISOString().split('T')[0]
+
+  var request = {
+    auth: "auth_flexera",
+    host: rs_optima_host,
+    verb: "POST",
+    path: "/bill-analysis/orgs/" + rs_org_id + "/costs/select",
+    body_fields: {
+      dimensions: ["resource_id", "billing_center_id", "operating_system", "purchase_option", "service"],
+      granularity: "day",
+      start_at: start_date,
+      end_at: end_date,
+      metrics: ["cost_amortized_unblended_adj"],
+      billing_center_ids: ds_top_level_bcs,
+      limit: 100000,
+      filter: {
+        type: "and",
+        expressions: [
+          {
+            dimension: "service",
+            type: "equal",
+            value: "AmazonEC2"
+          },
+          {
+            dimension: "resource_type",
+            type: "equal",
+            value: "Compute Instance"
+          },
+          {
+            dimension: "vendor_account",
+            type: "equal",
+            value: ds_aws_account['id']
+          },
+          {
+            type: "not",
+            expression: {
+              dimension: "adjustment_name",
+              type: "substring",
+              substring: "Shared"
+            }
+          }
+        ]
+      }
+    },
+    headers: {
+      'User-Agent': "RS Policies",
+      'Api-Version': "1.0"
+    },
+    ignore_status: [400]
+  }
+EOS
+end
+
+datasource "ds_instance_costs_grouped" do
+  run_script $js_instance_costs_grouped, $ds_instance_costs, $ds_billing_centers
+end
+
+script "js_instance_costs_grouped", type: "javascript" do
+  parameters "ds_instance_costs", "ds_billing_centers"
+  result "result"
+  code <<-EOS
+  bc_object = {}
+
+  _.each(ds_billing_centers, function(bc) {
+    bc_object[bc['id']] = bc['name']
+  })
+
+  // Multiple a single day's cost by the average number of days in a month.
+  // The 0.25 is to account for leap years for extra precision.
+  cost_multiplier = 365.25 / 12
+
+  // Group cost data by resourceId for later use
+  result = {}
+
+  _.each(ds_instance_costs, function(item) {
+    id = item['resourceId'].toLowerCase()
+
+    if (result[id] == undefined) { result[id] = { cost: 0 } }
+
+    result[id]['cost'] += item['cost'] * cost_multiplier
+    result[id]['operating_system'] = item['operating_system']
+    result[id]['billing_center'] = bc_object[item['billing_center_id']]
+    result[id]['purchase_option'] = item['purchase_option']
+    result[id]['service'] = item['service']
+  })
+EOS
+end
+
+datasource "ds_superseded_instances" do
+  run_script $js_superseded_instances, $ds_instances, $ds_instance_costs_grouped, $ds_aws_instance_size_map, $ds_aws_instance_cost_map, $ds_currency_conversion, $ds_currency, $ds_aws_account, $ds_applied_policy, $param_instance_type, $param_min_savings
+end
+
+script "js_superseded_instances", type: "javascript" do
+  parameters "ds_instances", "ds_instance_costs_grouped", "ds_aws_instance_size_map", "ds_aws_instance_cost_map", "ds_currency_conversion", "ds_currency", "ds_aws_account", "ds_applied_policy", "param_instance_type", "param_min_savings"
+  result "result"
+  code <<-'EOS'
+  // Used for formatting numbers to look pretty
+  function formatNumber(number, separator){
+    numString = number.toString()
+    values = numString.split(".")
+    formatted_number = ''
+
+    while (values[0].length > 3) {
+      var chunk = values[0].substr(-3)
+      values[0] = values[0].substr(0, values[0].length - 3)
+      formatted_number = separator + chunk + formatted_number
+    }
+
+    if (values[0].length > 0) { formatted_number = values[0] + formatted_number }
+    if (values[1] == undefined) { return formatted_number }
+
+    return formatted_number + "." + values[1]
+  }
+
+  result = []
+  total_savings = 0.0
+
+  _.each(ds_instances, function(instance) {
+    id = instance['instanceId'].toLowerCase()
+    instance_type = instance['resourceType']
+    superseded_type = null
+    instance_type_price = null
+    superseded_type_price = null
+    savings = 0.0
+    hourly_cost_multiplier = 365.25 / 12 * 24
+
+    cost = null
+    operating_system = null
+    billing_center = null
+    purchase_option = null
+    service = null
+
+    if (ds_instance_costs_grouped['id'] != undefined) {
+      cost = ds_instance_costs_grouped['id']['cost']
+      operating_system = ds_instance_costs_grouped['id']['operating_system']
+      billing_center = ds_instance_costs_grouped['id']['billing_center']
+      purchase_option = ds_instance_costs_grouped['id']['purchase_option']
+      service = ds_instance_costs_grouped['id']['service']
+    }
+
+    type_table = {
+      "Regular": "regular",
+      "Next Gen": "next_gen",
+      "Burstable": "burstable",
+      "AMD": "amd"
+    }
+
+    superseded_parameter = type_table[param_instance_type]
+
+    if (ds_aws_instance_size_map[instance_type] != undefined) {
+      superseded_table = ds_aws_instance_size_map[instance_type]['superseded']
+
+      if (typeof(superseded_table) == 'object') {
+        superseded_type = superseded_table[superseded_parameter]
+      }
+    }
+
+    if (typeof(superseded_type) == 'string' && typeof(operating_system) == 'string') {
+      if (ds_aws_instance_cost_map[instance['region']] != undefined) {
+        instance_type_cost_map = ds_aws_instance_cost_map[instance['region']][instance_type]
+        superseded_type_cost_map = ds_aws_instance_cost_map[instance['region']][superseded_type]
+
+        if (instance_type_cost_map != undefined) {
+          instance_type_price = instance_type_cost_map[operating_system]
+        }
+
+        if (superseded_type_cost_map != undefined) {
+          superseded_type_price = superseded_type_cost_map[operating_system]
+        }
+      }
+    }
+
+    if (typeof(instance_type_price) == 'number' && typeof(superseded_type_price) == 'number') {
+      instance_type_price *= ds_currency['exchange_rate'] * hourly_cost_multiplier
+      superseded_type_price *= ds_currency['exchange_rate'] * hourly_cost_multiplier
+      savings = instance_type_price - superseded_type_price
+    }
+
+    if (typeof(superseded_type) == 'string' && savings >= param_min_savings) {
+      total_savings += savings
+
+      tags = []
+      resourceName = ""
+
+      if (instance['tags'] != null && instance['tags'] != undefined) {
+        _.each(instance['tags'], function(tag) {
+          tags.push([tag['key'], tag['value']].join('='))
+
+          if (tag['key'].toLowerCase() == 'name') {
+            resourceName = tag['value']
+          }
+        })
+      }
+
+      savings = parseFloat(savings.toFixed(3))
+
+      if (cost != null) {
+        cost = parseFloat(cost.toFixed(3))
+      }
+
+      if (instance_type_price != null) {
+        instance_type_price = parseFloat(instance_type_price.toFixed(3))
+      }
+
+      if (superseded_type_price != null) {
+        superseded_type_price = parseFloat(superseded_type_price.toFixed(3))
+      }
+
+      recommendationDetails = ""
+
+      hostname = null
+
+      if (typeof(instance['privateDnsName']) == 'string') {
+        hostname = instance['privateDnsName'].split('.')[0]
+      }
+
+      result.push({
+        region: instance['region'],
+        resourceID: instance['instanceId'],
+        ipAddress: instance['ipAddress'],
+        ipv6Address: instance['ipv6Address'],
+        imageId: instance['imageId'],
+        resourceType: instance['resourceType'],
+        platform: instance['platform'],
+        privateDnsName: instance['privateDnsName'],
+        launchTime: instance['launchTime'],
+        operating_system: operating_system,
+        billing_center: billing_center,
+        purchase_option: purchase_option,
+        service: service,
+        tags: tags.join(', '),
+        accountID: ds_aws_account['id'],
+        accountName: ds_aws_account['name'],
+        hostname: hostname,
+        recommendationDetails: recommendationDetails,
+        newResourceType: superseded_type,
+        resourceName: resourceName,
+        cost: cost,
+        instance_type_price: instance_type_price,
+        superseded_type_price: superseded_type_price,
+        savings: savings,
+        savingsCurrency: ds_currency['symbol'],
+        recommendationType: param_instance_type,
+        policy_name: ds_applied_policy['name'],
+        total_savings: "",
+        message: ""
+      })
+    }
+  })
+EOS
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "pol_utilization" do
+  validate_each $ds_superseded_instances do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} AWS Potentially Superseded EC2 Instances Found"
+    detail_template <<-'EOS'
+    **Potential Monthly Savings:** {{ with index data 0 }}{{ .total_savings }}{{ end }}
+
+    {{ with index data 0 }}{{ .message }}{{ end }}
+    EOS
+    check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
+    escalate $esc_email
+    escalate $esc_change_type
+    hash_exclude "message", "total_savings", "resourceName", "tags", "cost", "instance_type_price", "superseded_type_price", "savings", "savingsCurrency"
+    export do
+      resource_level true
+      field "accountID" do
+        label "Account ID"
+      end
+      field "accountName" do
+        label "Account Name"
+      end
+      field "resourceID" do
+        label "Resource ID"
+      end
+      field "resourceName" do
+        label "Resource Name"
+      end
+      field "tags" do
+        label "Resource Tags"
+      end
+      field "recommendationDetails" do
+        label "Recommendation"
+      end
+      field "resourceType" do
+        label "Instance Size"
+      end
+      field "newResourceType" do
+        label "Recommended Instance Size"
+      end
+      field "recommendationType" do
+        label "Recommendation Type"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "platform" do
+        label "Platform"
+      end
+      field "hostname" do
+        label "Hostname"
+      end
+      field "cost" do
+        label "Estimated Monthly Cost"
+      end
+      field "instance_type_price" do
+        label "Current Monthly List Price"
+      end
+      field "superseded_type_price" do
+        label "New Monthly List Price"
+      end
+      field "savings" do
+        label "Estimated Monthly Savings"
+      end
+      field "savingsCurrency" do
+        label "Savings Currency"
+      end
+      field "launchTime" do
+        label "Launch Time"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "id" do
+        label "ID"
+        path "resourceID"
+      end
+    end
+  end
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
+
+escalation "esc_change_type" do
+  automatic contains($param_automatic_action, "Change Instance Type")
+  label "Change Instance Type"
+  description "Approval to change instance type for all superseded EC2 instances"
+  run "change_instances", data
+end
+
+###############################################################################
+# Cloud Workflow
+###############################################################################
+
+# Core CWF function to downsize instances
+define change_instances($data) return $all_responses do
+  # Change "No" to "Yes" to enable CWF debug logging
+  $log_to_cm_audit_entries = "No"
+
+  $$debug = $log_to_cm_audit_entries == "Yes"
+  $$log = []
+  $all_responses = []
+  $syslog_subject = "AWS Superseded EC2 Instances [Change Type]: "
+
+  call sys_log(join([$syslog_subject, "Identified Instances"]), to_s($data))
+
+  foreach $instance in $data do
+    call get_instance_state($instance) retrieve $state_response, $initial_state
+    $all_responses << $state_response
+
+    if $initial_state != "terminated" && $initial_state != "pending"
+      if $initial_state != "stopped"
+        call stop_instance($instance) retrieve $stop_response
+        $all_responses << $stop_response
+      end
+
+      call change_instance($instance) retrieve $change_response
+      $all_responses << $change_response
+
+      if $initial_state == "running"
+        call start_instance($instance) retrieve $start_response
+        $all_responses << $start_response
+      end
+    end
+  end
+end
+
+# CWF function to change an instance type
+define change_instance($instance) return $response do
+  $syslog_subject = "AWS Change Instance Type : "
+
+  call sys_log(join([$syslog_subject, "Instance"]), to_s($instance["id"]))
+
+  $response = http_request(
+    auth: $$auth_aws,
+    https: true,
+    verb: "post",
+    href: "/",
+    host: "ec2." + $instance["region"] + ".amazonaws.com",
+    query_strings: {
+      "Action": "ModifyInstanceAttribute",
+      "Version": "2016-11-15",
+      "InstanceId": $instance["id"],
+      "InstanceType.Value": $instance["newResourceType"]
+    }
+  )
+
+  $current_state = "dummy_value"
+
+  while $current_state != "stopped" do
+    sleep(30)
+    call get_instance_state($instance) retrieve $state_response, $current_state
+  end
+
+  call sys_log(join([$syslog_subject, "Responses"]), to_s($response))
+end
+
+
+# CWF function to start an instance
+define start_instance($instance) return $response do
+  $syslog_subject = "AWS Starting Instance: "
+
+  call sys_log(join([$syslog_subject, "Instance"]), to_s($instance["id"]))
+
+  $response = http_request(
+    auth: $$auth_aws,
+    https: true,
+    verb: "post",
+    href: "/",
+    host: "ec2." + $instance['region'] + ".amazonaws.com",
+    query_strings: {
+      "Action": "StartInstances",
+      "Version": "2016-11-15",
+      "InstanceId.1": $instance["id"]
+    }
+  )
+
+  call sys_log(join([$syslog_subject, "Responses"]), to_s($response))
+end
+
+# CWF function to stop an instance
+define stop_instance($instance) return $response do
+  $syslog_subject = "AWS Stopping Instance: "
+
+  call sys_log(join([$syslog_subject, "Instance"]), to_s($instance["id"]))
+
+  $response = http_request(
+    auth: $$auth_aws,
+    https: true,
+    verb: "post",
+    href: "/",
+    host: "ec2." + $instance['region'] + ".amazonaws.com",
+    query_strings: {
+      "Action": "StopInstances",
+      "Version": "2016-11-15",
+      "InstanceId.1": $instance["id"]
+    }
+  )
+
+  $current_state = "dummy_value"
+
+  while $current_state != "stopped" do
+    sleep(30)
+    call get_instance_state($instance) retrieve $state_response, $current_state
+  end
+
+  call sys_log(join([$syslog_subject, "Responses"]), to_s($response))
+end
+
+# CWF function to get the current state of an instance
+define get_instance_state($instance) return $response, $instance_state do
+  $syslog_subject = "AWS Describing Instance: "
+
+  call sys_log(join([$syslog_subject, "Instance"]), to_s($instance["id"]))
+
+  $response = http_request(
+    auth: $$auth_aws,
+    https: true,
+    verb: "post",
+    href: "/",
+    host: "ec2." + $instance["region"] + ".amazonaws.com",
+    query_strings: {
+      "Action": "DescribeInstanceStatus",
+      "Version": "2016-11-15",
+      "IncludeAllInstances": "true",
+      "InstanceId.1": $instance["id"]
+    }
+  )
+
+  call sys_log(join([$syslog_subject, "Responses"]), to_s($response))
+
+  $instance_state = $response["body"]["DescribeInstanceStatusResponse"]["instanceStatusSet"]["item"]["instanceState"]["name"]
+end
+
+# CWF function to record information to the logs
+define sys_log($subject, $detail) do
+  # Create empty errors array if doesn't already exist
+  if !$$errors
+    $$errors = []
+  end
+  # Check if debug is enabled
+  if $$debug
+    # Append to global $$errors
+    # This is the suggested way to capture errors
+    $$errors << "Unexpected error for " + $subject + "\n  " + to_s($detail)
+    # If Flexera NAM Zone, create audit_entries [to be deprecated]
+    # This is the legacy method for capturing errors and only supported on Flexera NAM
+    if $$rs_optima_host == "api.optima.flexeraeng.com"
+      # skip_error_and_append is used to catch error if rs_cm.audit_entries.create fails unexpectedly
+      $task_label = "Creating audit entry for " + $subject
+      sub task_label: $task, on_error: skip_error_and_append($task) do
+        rs_cm.audit_entries.create(
+          notify: "None",
+          audit_entry: {
+            auditee_href: @@account,
+            summary: $subject,
+            detail: $detail
+          }
+        )
+      end # End sub on_error
+    end # End if rs_optima_host
+  end # End if debug is enabled
+end
+
+# CWF function to handle errors
+define skip_error_and_append($subject) do
+  $$errors << "Unexpected error for " + $subject + "\n  " + to_s($_error)
+  $_error_behavior = "skip"
+end
+
+###############################################################################
+# Meta Policy [alpha]
+# Not intended to be modified or used by policy developers
+###############################################################################
+
+# If the meta_parent_policy_id is not set it will evaluate to an empty string and we will look for the policy itself,
+# if it is set we will look for the parent policy.
+datasource "ds_get_policy" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    ignore_status [404]
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", switch(ne(meta_parent_policy_id,""), meta_parent_policy_id, policy_id) ])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+  end
+end
+
+datasource "ds_parent_policy_terminated" do
+  run_script $js_decide_if_self_terminate, $ds_get_policy, policy_id, meta_parent_policy_id
+end
+
+# If the policy was applied by a meta_parent_policy we confirm it exists if it doesn't we confirm we are deleting
+# This information is used in two places:
+# - determining whether or not we make a delete call
+# - determining if we should create an incident (we don't want to create an incident on the run where we terminate)
+script "js_decide_if_self_terminate", type: "javascript" do
+  parameters "found", "self_policy_id", "meta_parent_policy_id"
+  result "result"
+  code <<-EOS
+  var result
+  if (meta_parent_policy_id != "" && found.id == undefined) {
+    result = true
+  } else {
+    result = false
+  }
+  EOS
+end
+
+# Two potentials ways to set this up:
+# - this way and make a unneeded 'get' request when not deleting
+# - make the delete request an interate and have it iterate over an empty array when not deleting and an array with one item when deleting
+script "js_make_terminate_request", type: "javascript" do
+  parameters "should_delete", "policy_id", "rs_project_id", "rs_governance_host"
+  result "request"
+  code <<-EOS
+
+  var request = {
+    auth:  'auth_flexera',
+    host: rs_governance_host,
+    path: "/api/governance/projects/" + rs_project_id + "/applied_policies/" + policy_id,
+    headers: {
+      "API-Version": "1.0",
+      "Content-Type":"application/json"
+    },
+  }
+
+  if (should_delete) {
+    request.verb = 'DELETE'
+  }
+  EOS
+end
+
+datasource "ds_terminate_self" do
+  request do
+    run_script $js_make_terminate_request, $ds_parent_policy_terminated, policy_id, rs_project_id, rs_governance_host
+  end
+end
+
+datasource "ds_is_deleted" do
+  run_script $js_check_deleted, $ds_terminate_self
+end
+
+# This is just a way to have the check delete request connect to the farthest leaf from policy.
+# We want the delete check to the first thing the policy does to avoid the policy erroring before it can decide whether or not it needs to self terminate
+# Example a customer deletes a credential and then terminates the parent policy. We still want the children to self terminate
+# The only way I could see this not happening is if the user who applied the parent_meta_policy was offboarded or lost policy access, the policies who are impersonating the user
+# would not have access to self-terminate
+# It may be useful for the backend to enable a mass terminate at some point for all meta_child_policies associated with an id.
+script "js_check_deleted", type: "javascript" do
+  parameters "response"
+  result "result"
+  code <<-EOS
+  result = {"path":"/"}
+  EOS
+end

--- a/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
@@ -785,6 +785,9 @@ policy "policy_scheduled_report" do
       field "platform" do
         label "Platform"
       end
+      field "osType" do
+        label "Operating System"
+      end
       field "hostname" do
         label "Hostname"
       end

--- a/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
@@ -1,0 +1,1029 @@
+name "AWS Superseded EC2 Instances Meta Parent"
+rs_pt_ver 20180301
+type "policy"
+short_description "Applies and manages \"child\" [AWS Superseded EC2 Instances](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/superseded_instances) Policies."
+severity "low"
+category "Cost"
+tenancy "single"
+default_frequency "15 minutes"
+info(
+  provider: "AWS",
+  version: "1.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  publish: "false"
+)
+
+##############################################################################
+# Parameters
+##############################################################################
+
+## Meta Parent Parameters
+## These are params specific to the meta parent policy.
+parameter "param_combined_incident_email" do
+  type "list"
+  label "Email addresses for combined incident"
+  description "A list of email addresses to notify with the consolidated child policy incident."
+  default []
+end
+
+parameter "param_dimension_filter_includes" do
+  type "list"
+  label "Dimension Include Filters"
+  description <<-EOS
+  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
+  If no include filters are provided, then all AWS Accounts are included by default.
+  Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
+  EOS
+end
+
+parameter "param_dimension_filter_excludes" do
+  type "list"
+  label "Dimension Exclude Filters"
+  description <<-EOS
+  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
+  Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
+  Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
+  EOS
+end
+
+parameter "param_policy_schedule" do
+  type "string"
+  label "Child Policy Schedule"
+  description "The interval at which the child policy checks for conditions and generates incidents."
+  default "daily"
+  allowed_values "daily", "weekly", "monthly"
+end
+
+## Child Policy Parameters
+parameter "param_instance_type" do
+  type "string"
+  category "Policy Settings"
+  label "Instance Type Category"
+  description "Instance Type Category to pick from for recommended instance types. See README for more information."
+  allowed_values "Regular", "Next Gen", "Burstable", "AMD"
+  default "Regular"
+end
+
+parameter "param_min_savings" do
+  type "number"
+  category "Policy Settings"
+  label "Minimum Savings Threshold"
+  description "Minimum potential savings required to generate a recommendation"
+  min_value 0
+  default 0
+end
+
+parameter "param_exclusion_tags" do
+  type "list"
+  category "Filters"
+  label "Exclusion Tags (Key:Value)"
+  description "Cloud native tags to ignore resources that you don't want to produce recommendations for. Use Key:Value format for specific tag key/value pairs, and Key:* format to match any resource with a particular key, regardless of value. Examples: env:production, DO_NOT_DELETE:*"
+  allowed_pattern /(^$)|[\w]*\:.*/
+  default []
+end
+
+parameter "param_regions_allow_or_deny" do
+  type "string"
+  category "Filters"
+  label "Allow/Deny Regions"
+  description "Allow or Deny entered regions. See the README for more details"
+  allowed_values "Allow", "Deny"
+  default "Allow"
+end
+
+parameter "param_regions_list" do
+  type "list"
+  category "Filters"
+  label "Allow/Deny Regions List"
+  allowed_pattern /^([a-zA-Z-_]+-[a-zA-Z0-9-_]+-[0-9-_]+,*|)+$/
+  description "A list of allowed or denied regions. See the README for more details"
+  default []
+end
+
+parameter "param_automatic_action" do
+  type "list"
+  category "Actions"
+  label "Automatic Actions"
+  description "When this value is set, this policy will automatically take the selected action(s)"
+  allowed_values ["Change Instance Type"]
+  default []
+end
+
+###############################################################################
+# Authentication
+###############################################################################
+credentials "auth_aws" do
+  schemes "aws", "aws_sts"
+  label "AWS"
+  description "Select the AWS Credential from the list"
+  tags "provider=aws"
+  aws_account_number $param_aws_account_number
+end
+
+credentials "auth_flexera" do
+  schemes "oauth2"
+  label "Flexera"
+  description "Select Flexera One OAuth2 credentials"
+  tags "provider=flexera"
+end
+
+###############################################################################
+# Datasources
+###############################################################################
+
+# Get Applied Parent Policy Details
+datasource "ds_self_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    field "name", jmes_path(response, "name")
+    field "creator_id", jmes_path(response, "created_by.id")
+    field "credentials", jmes_path(response, "credentials")
+    field "options", jmes_path(response, "options")
+  end
+end
+
+datasource "ds_child_policy_options" do
+  run_script $js_child_policy_options, $ds_self_policy_information
+end
+
+script "js_child_policy_options", type: "javascript" do
+  parameters "ds_self_policy_information"
+  result "options"
+  code <<-EOS
+  // Filter Options that are not appropriate for Child Policy
+  var options = _.map(ds_self_policy_information.options, function(option){
+    // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+      return { "name": option.name, "value": option.value };
+    }
+  });
+  // Explicitly add param_email which is disabled/does not exist in meta parent policy
+  options.push({
+    "name": "param_email",
+    "value": []
+  });
+  EOS
+end
+
+datasource "ds_child_policy_options_map" do
+  run_script $js_child_policy_options_map, $ds_child_policy_options
+end
+
+script "js_child_policy_options_map", type: "javascript" do
+  parameters "ds_child_policy_options"
+  result "options"
+  code <<-EOS
+  function format_options_keyvalue(options) {
+    var options_keyvalue_map = {};
+    _.each(options, function(option) {
+      options_keyvalue_map[option.name] = option.value;
+    });
+    return options_keyvalue_map;
+  }
+  var options = format_options_keyvalue(ds_child_policy_options)
+  EOS
+end
+
+datasource "ds_format_self" do
+  run_script $js_format_self, $ds_self_policy_information, $ds_child_policy_options_map
+end
+
+script "js_format_self", type: "javascript" do
+  parameters "ds_self_policy_information", "ds_child_policy_options_map"
+  result "formatted"
+  code <<-EOS
+  var formatted = {
+    "name": ds_self_policy_information["name"],
+    "creator_id": ds_self_policy_information["creator_id"],
+    "credentials": ds_self_policy_information["credentials"],
+    "options": ds_child_policy_options_map
+  };
+  EOS
+end
+
+# Get Child Policy Details
+datasource "ds_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/orgs/", rs_org_id, "/published_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "AWS Superseded EC2 Instances" and .created_by.email == "support@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+datasource "ds_get_billing_centers" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/analytics/orgs/",rs_org_id,"/billing_centers"])
+    header "Api-Version", "1.0"
+    header "User-Agent", "RS Policies"
+    query "view", "allocation_table"
+    ignore_status [403]
+  end
+  result do
+    encoding "json"
+    # Select the Billing Centers that have "parent_id" undefined or "" (i.e. top-level Billing Centers)
+    collect jq(response, '.[] | select(.parent_id == null)' ) do
+      field "href", jq(col_item,".href")
+      field "id", jq(col_item,".id")
+      field "name", jq(col_item,".name")
+      field "parent_id", jq(col_item,".parent_id")
+    end
+  end
+end
+
+script "js_make_billing_center_request", type: "javascript" do
+  parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
+  result "request"
+  code <<-EOS
+
+  billing_centers_formatted = []
+
+  for (x=0; x< billing_centers_unformatted.length; x++) {
+    billing_centers_formatted.push(billing_centers_unformatted[x]["id"])
+  }
+
+  finish = new Date()
+  finishFormatted = finish.toJSON().split("T")[0]
+  start = new Date()
+  start.setDate(start.getDate() - 30)
+  startFormatted = start.toJSON().split("T")[0]
+
+  // Default dimensions and filter expressions required for meta parent policy
+  var dimensions = ["vendor_account", "vendor_account_name"];
+  var filter_expressions = [
+    { dimension: "vendor", type: "equal", value: "AWS" }
+  ]
+
+  // Append to default dimensions and filter expressions using parent policy params
+  _.each(param_dimension_filter_includes, function (v) {
+    // split key=value string
+    var split = v.split("=");
+    var k = split[0];
+    var v = split[1];
+    // append to lists
+    dimensions.push(k);
+    filter_expressions.push({ dimension: k, type: "equal", value: v });
+  });
+
+  // Append to filter expressions using exclude policy params
+  _.each(param_dimension_filter_excludes, function (v) {
+    // split key=value string
+    var split = v.split("=");
+    var k = split[0];
+    var v = split[1];
+    // append to lists
+    dimensions.push(k);
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+  });
+
+  // Produces a duplicate-free version of the array
+  dimensions = _.uniq(dimensions);
+
+  var body = {
+    "dimensions": dimensions,
+    "granularity":"day",
+    "start_at": startFormatted,
+    "end_at": finishFormatted,
+    "metrics":["cost_amortized_unblended_adj"],
+    "billing_center_ids": billing_centers_formatted,
+    "filter":
+    {
+      "type": "and",
+      "expressions": filter_expressions
+    },
+    "summarized": true
+  }
+  var request = {
+    auth:  'auth_flexera',
+    host:  rs_optima_host,
+    scheme: 'https',
+    verb: 'POST',
+    path:  "/bill-analysis/orgs/"+ rs_org_id + "/costs/aggregated",
+    headers: {
+      "API-Version": "1.0",
+      "Content-Type":"application/json"
+    },
+    body: JSON.stringify(body)
+  }
+  EOS
+end
+
+# Get the AWS acounts
+datasource "ds_get_aws_accounts" do
+  request do
+    run_script $js_make_billing_center_request, rs_org_id, rs_optima_host, $ds_get_billing_centers, $param_dimension_filter_includes, $param_dimension_filter_excludes
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response,"rows[*]") do
+      field "aws_account_id", jmes_path(col_item,"dimensions.vendor_account")
+      field "aws_account_name", jmes_path(col_item,"dimensions.vendor_account_name")
+    end
+  end
+end
+
+# Get Child policies
+datasource "ds_get_existing_policies" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies"])
+    header "Api-Version", "1.0"
+    query "meta_parent_policy_id", policy_id
+  end
+  result do
+    collect jq(response, '.items[]?') do
+      field "name", jq(col_item, ".name")
+      field "applied_policy_id", jq(col_item, ".id")
+      field "options", jq(col_item, ".options")
+      field "updated_at", jq(col_item, ".updated_at")
+      field "status", jq(col_item, ".status")
+    end
+  end
+end
+
+# Get Child policies incidents
+datasource "ds_get_existing_policies_incidents" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/incidents"])
+    header "Api-Version", "1.0"
+    query "meta_parent_policy_id", policy_id
+  end
+  result do
+    collect jq(response, '.items[]?') do
+      field "incident_id", jq(col_item, ".id")
+      field "applied_policy_id", jq(col_item, ".applied_policy.id")
+      field "state", jq(col_item, ".state")
+      field "violation_data_count", jq(col_item, ".violation_data_count")
+      field "updated_at", jq(col_item, ".updated_at")
+      field "meta_parent_policy_id", jq(col_item, ".meta_parent_policy_id")
+    end
+  end
+end
+
+datasource "ds_format_incidents" do
+  run_script $js_format_existing_policies_incidents, $ds_get_existing_policies_incidents
+end
+
+script "js_format_existing_policies_incidents", type: "javascript" do
+  parameters "unformatted"
+  result "formatted"
+  code <<-EOS
+  formatted={}
+  for (x=0;x<unformatted.length; x++) {
+    current = unformatted[x]
+    formatted[current.applied_policy_id] = {incident_id: current.incident_id, state: current.state, violation_data_count: current.violation_data_count, updated_at: current.updated_at}
+  }
+  EOS
+end
+
+datasource "ds_format_existing_policies" do
+  run_script $js_format_existing_policies, $ds_get_existing_policies, $ds_format_incidents
+end
+
+# format
+# duplicates logic should compare updated at
+# we can validate update here when destructring the existing policy options, don't need updated at
+# format options
+script "js_format_existing_policies", type: "javascript" do
+  parameters "ds_get_existing_policies", "ds_format_incidents"
+  result "result"
+  code <<-EOS
+  function format_options_keyvalue(options) {
+    var options_keyvalue_map = {};
+    _.each(options, function(option) {
+      options_keyvalue_map[option.name] = option.value;
+    });
+    return options_keyvalue_map;
+  }
+
+  result = {}
+  formatted = {}
+  duplicates = []
+  // tracking holds all existing policies and later can be used to determine if existing policies should be deleted [i.e. if cloud account was removed]
+  tracking = {}
+
+  for (x=0; x<ds_get_existing_policies.length; x++) {
+    options = format_options_keyvalue(ds_get_existing_policies[x].options);
+
+    aws_account_id=options["param_aws_account_number"]
+    if (formatted[aws_account_id] == undefined) {
+      formatted[aws_account_id] = {
+        "applied_policy_id":ds_get_existing_policies[x]["applied_policy_id"],
+        "applied_policy_name":ds_get_existing_policies[x]["name"],
+        "status":ds_get_existing_policies[x]["status"],
+        "updated_at":ds_get_existing_policies[x]["updated_at"],
+        "incident": ds_format_incidents[ds_get_existing_policies[x]["applied_policy_id"]],
+        "options": options
+      }
+      tracking[aws_account_id] = false
+    } else {
+      current = formatted[aws_account_id]
+
+      currDate = new Date(current.updated_at)
+      newDate = new Date(ds_get_existing_policies[x].updated_at)
+
+      if (currDate > newDate) {
+        duplicates.push({
+          "applied_policy_id":ds_get_existing_policies[x]["applied_policy_id"],
+          "applied_policy_name":ds_get_existing_policies[x]["name"],
+          "status":ds_get_existing_policies[x]["status"],
+          "updated_at":ds_get_existing_policies[x]["updated_at"],
+          "incident": ds_format_incidents[ds_get_existing_policies[x]["applied_policy_id"]]
+        })
+      } else {
+        duplicates.push({
+          "applied_policy_id":current["applied_policy_id"],
+          "applied_policy_name":current["applied_policy_name"],
+          "status":current["status"],
+          "updated_at":current["updated_at"],
+          "incident": current["incident"]
+        })
+        formatted[aws_account_id] = {
+          "applied_policy_id":ds_get_existing_policies[x]["applied_policy_id"],
+          "applied_policy_name":ds_get_existing_policies[x]["name"],
+          "status":ds_get_existing_policies[x]["status"],
+          "updated_at":ds_get_existing_policies[x]["updated_at"],
+          "incident": ds_format_incidents[ds_get_existing_policies[x]["applied_policy_id"]],
+          "options": options
+        }
+
+      }
+    }
+  }
+
+  result.formatted=formatted
+  result.duplicates=duplicates
+  result.tracking=tracking
+  EOS
+end
+
+datasource "ds_take_in_parameters" do
+  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+end
+
+# hardcode template href with id from catalog
+# catalog policies show in customer's published templates with their org id
+# "template_href": "/api/governance/orgs/" + rs_org_id + "/published_templates/62618616e3dff80001572bf0"
+# update logic: the only reason we're going to update the child policies for is changes to options
+# and only some options, email is always blank and aws_account_id is tied to the idenity of each policy, so: new account creation, removal of account: termination
+# param_automatic_action is a list with only one action, unless the person is applying using an API and putting the same value multiple times this should either be a length of 0 or 1
+# param_log_to_cm_audit_entries is a String of Yes or No
+# param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
+# If we only want to do an update on the values changing we could sort before doing the equality check.
+script "js_take_in_parameters", type: "javascript" do
+  parameters "ds_get_aws_accounts", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  result "grid_and_cwf"
+  code <<-EOS
+
+  max_actions = 50;
+
+  grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
+
+  should_keep = ds_format_existing_policies.tracking;
+
+  // Construct UI URL prefixes for policy template summary
+  ui_url_prefix = "https://" + f1_app_host + "/orgs/" + rs_org_id;
+  applied_policy_url_prefix = ui_url_prefix + "/automation/applied-policies/projects/" + rs_project_id + "?noIndex=1&policyId=";
+  incident_url_prefix       = ui_url_prefix + "/automation/incidents/projects/" + rs_project_id + "?noIndex=1&incidentId=";
+
+  function add_to_grid(ep, action) {
+    policy_status={
+      "policy_name": ep["applied_policy_name"],
+      "policy_link": applied_policy_url_prefix + ep["applied_policy_id"],
+      "meta_policy_status": action,
+      "policy_status": ep["status"],
+      "policy_last_update": ep["updated_at"],
+    };
+    if (ep.incident != null) {
+      policy_status["incident_link"] = incident_url_prefix + ep.incident.incident_id;
+      policy_status["incident_state"] = ep.incident.state;
+      policy_status["incident_violation_data_count"] = ep.incident.violation_data_count;
+      policy_status["incident_last_update"] = ep.incident.updated_at;
+    }
+    grid_and_cwf.grid.push(policy_status);
+  }
+
+  for (x=0; x<ds_format_existing_policies.duplicates.length; x++) {
+    if (grid_and_cwf.to_delete.length < max_actions) {
+      grid_and_cwf.to_delete.push({"id":ds_format_existing_policies.duplicates[x]["applied_policy_id"], "name": ds_format_existing_policies.duplicates[x]["applied_policy_name"]})
+      add_to_grid(ds_format_existing_policies.duplicates[x], "terminating")
+    } else {
+      add_to_grid(ds_format_existing_policies.duplicates[x], "to be terminated")
+    }
+  }
+
+  for (x=0; x<ds_get_aws_accounts.length; x++) {
+    cur = ds_get_aws_accounts[x];
+    cur_aws_account_id = cur.aws_account_id.replace(/['"]+/g, '');
+
+    // Name and description do not vary between create or updates so defining them here
+    name = ds_child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
+    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + ds_child_policy_information.short_description;
+
+    // Check if child policy exists for current account id
+    if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_aws_account_id) ) {
+      console.log("Child Policy for "+cur_aws_account_id+" does not exist and should be created");
+
+      // Child Policy does not exist for current account ID and should be created
+
+
+      // Use the options from the parent policy in "name value" list format
+      options = _.toArray(ds_child_policy_options);
+
+      // Set param_aws_account_id values for this child policy
+      options.push({
+        "name": "param_aws_account_number",
+        "value": cur_aws_account_id
+      });
+
+      if (grid_and_cwf.to_create.length < max_actions) {
+        grid_and_cwf.to_create.push({
+          "name" : name,
+          "description" : description,
+          "credentials" : ds_format_self.credentials,
+          "options" : options,
+          "frequency" : param_policy_schedule,
+          "meta_parent_policy_id": meta_parent_policy_id,
+          "template_href": ds_child_policy_information.href
+        })
+        policy_status={
+          "policy_name": name,
+          "meta_policy_status": "creating policy",
+          "policy_status": "",
+          "policy_last_update": "",
+        }
+        grid_and_cwf.grid.push(policy_status)
+      } else {
+        policy_status={
+          "policy_name": name,
+          "meta_policy_status": "policy to be created",
+          "policy_status": "",
+          "policy_last_update": "",
+        }
+        grid_and_cwf.grid.push(policy_status)
+      }
+    } else {
+      console.log("Child Policy for "+cur_aws_account_id+" does exist for current account ID and may need to be updated or deleted");
+      // Child Policy does exist for current account ID and may need to be updated or deleted
+      // Assume by default we should keep it and not update it
+      should_keep[cur_aws_account_id] = true;
+      should_update = false;
+
+      // Use the options from the parent policy in "name value" list format
+      options = _.toArray(ds_child_policy_options);
+
+      // Set param_aws_account_id values for this child policy
+      options.push({
+        "name": "param_aws_account_number",
+        "value": cur_aws_account_id
+      });
+
+      // Check if child policy params match parent policy params
+      _.each(ds_format_self.options, function(value, key) {
+        // If any child and parent param values do not match, mark the child policy as should_update
+        if ( !_.isEqual(value, ds_format_existing_policies["formatted"][cur_aws_account_id]["options"][key]) ) {
+          console.log("Child Policy Param does not match Parent Policy and should be updated. "+key+" does not match "+value+"!="+ds_format_existing_policies["formatted"][cur_aws_account_id]["options"][key]);
+          should_update = true;
+        }
+      });
+
+
+      if (should_update) {
+        // Child policy needs to be updated
+        if (grid_and_cwf.to_update.length < max_actions) {
+          // Child policy needs to be updated and is within the max_actions limit
+          console.log("Child Policy needs to be updated. ds_format_existing_policies.formatted[cur_aws_account_id]="+JSON.stringify(ds_format_existing_policies.formatted[cur_aws_account_id]));
+          add_to_grid(ds_format_existing_policies.formatted[cur_aws_account_id], "updating")
+          name = ds_format_existing_policies.formatted[cur_aws_account_id].applied_policy_name
+          // Add to_update
+          grid_and_cwf.to_update.push({
+            "applied_policy_id": ds_format_existing_policies.formatted[cur_aws_account_id].applied_policy_id,
+            "name" : name,
+            "description" : description,
+            "credentials" : ds_format_self.credentials,
+            "options" : options,
+            "frequency" : param_policy_schedule,
+          })
+        } else {
+          // Child policy needs to be updated but is outside the max_actions limit
+          // Add to grid but do not add to to_update
+          console.log("Child Policy needs to be updated. ds_format_existing_policies.formatted[cur_aws_account_id]="+JSON.stringify(ds_format_existing_policies.formatted[cur_aws_account_id]));
+          add_to_grid(ds_format_existing_policies.formatted[cur_aws_account_id], "to be updated");
+        }
+      } else {
+        // Child policy does not need to be updated
+        add_to_grid(ds_format_existing_policies.formatted[cur_aws_account_id], "running");
+      }
+    }
+  }
+
+  console.log("Checking if policies should be deleted. "+JSON.stringify(should_keep));
+  _.each(should_keep, function(keep, account_id) {
+    console.log("Should keep "+account_id+"="+keep);
+    if (!keep) {
+      if (grid_and_cwf.to_delete.length < max_actions) {
+        grid_and_cwf.to_delete.push({"id":ds_format_existing_policies.formatted[account_id].applied_policy_id, "name": ds_format_existing_policies.formatted[account_id].applied_policy_name})
+        add_to_grid(ds_format_existing_policies.formatted[account_id], "terminating")
+      } else {
+        add_to_grid(ds_format_existing_policies.formatted[account_id], "to be terminated")
+      }
+    }
+  });
+
+  EOS
+end
+
+datasource "ds_only_grid" do
+  run_script $js_only_grid, $ds_take_in_parameters
+end
+
+script "js_only_grid", type: "javascript" do
+  parameters "results"
+  result "only_grid"
+  code <<-EOS
+    only_grid = results.grid
+  EOS
+end
+
+datasource "ds_to_create" do
+  run_script $js_only_create, $ds_take_in_parameters
+end
+
+script "js_only_create", type: "javascript" do
+  parameters "results"
+  result "only_create"
+  code <<-EOS
+    only_create = results.to_create
+  EOS
+end
+
+datasource "ds_to_update" do
+  run_script $js_only_update, $ds_take_in_parameters
+end
+
+script "js_only_update", type: "javascript" do
+  parameters "results"
+  result "only_update"
+  code <<-EOS
+    only_update = results.to_update
+  EOS
+end
+
+datasource "ds_to_delete" do
+  run_script $js_only_delete, $ds_take_in_parameters
+end
+
+script "js_only_delete", type: "javascript" do
+  parameters "results"
+  result "only_delete"
+  code <<-EOS
+    only_delete = results.to_delete
+  EOS
+end
+
+# The following datasources consolidate the child incident output into a single incident.
+# This is because it is more convenient for many users to have a single incident with all of the data.
+datasource "ds_child_incident_details" do
+  iterate $ds_get_existing_policies_incidents
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/incidents/", val(iter_item, 'incident_id')])
+    verb "GET"
+    header "User-Agent", "RS Policies"
+    header "Api-Version", "1.0"
+    query "view", "extended"
+  end
+end
+
+datasource "ds_superseded_instances_combined_incidents" do
+  run_script $js_ds_superseded_instances_combined_incidents, $ds_child_incident_details
+end
+
+script "js_ds_superseded_instances_combined_incidents", type: "javascript" do
+  parameters "ds_child_incident_details"
+  result "result"
+  code <<-EOS
+  result = []
+  _.each(ds_child_incident_details, function(incident) {
+    s = incident["summary"];
+    // If the incident summary contains "AWS Potentially Superseded EC" then include it in the filter result
+    if (s.indexOf("AWS Potentially Superseded EC") > -1) {
+      _.each(incident["violation_data"], function(violation) {
+        result.push(violation);
+      });
+    }
+  });
+EOS
+end
+
+
+# Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
+# Minimum of 1 incident, max of four
+# Could swap the summary to only showing running
+# Could also just have one incident and use meta_status to determine which escalation happens
+policy "policy_scheduled_report" do
+  # Consolidated Incident Check(s)
+    # Consolidated incident for AWS Potentially Superseded EC
+  validate $ds_superseded_instances_combined_incidents do
+    summary_template "Consolidated Incident: {{ len data }} AWS Potentially Superseded EC"
+    escalate $esc_email
+    check eq(size(data), 0)
+    export do
+      resource_level true
+      field "accountID" do
+        label "Account ID"
+      end
+      field "accountName" do
+        label "Account Name"
+      end
+      field "resourceID" do
+        label "Resource ID"
+      end
+      field "resourceName" do
+        label "Resource Name"
+      end
+      field "tags" do
+        label "Resource Tags"
+      end
+      field "recommendationDetails" do
+        label "Recommendation"
+      end
+      field "resourceType" do
+        label "Instance Size"
+      end
+      field "newResourceType" do
+        label "Recommended Instance Size"
+      end
+      field "recommendationType" do
+        label "Recommendation Type"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "platform" do
+        label "Platform"
+      end
+      field "hostname" do
+        label "Hostname"
+      end
+      field "cost" do
+        label "Estimated Monthly Cost"
+      end
+      field "instance_type_price" do
+        label "Current Monthly List Price"
+      end
+      field "superseded_type_price" do
+        label "New Monthly List Price"
+      end
+      field "savings" do
+        label "Estimated Monthly Savings"
+      end
+      field "savingsCurrency" do
+        label "Savings Currency"
+      end
+      field "launchTime" do
+        label "Launch Time"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "id" do
+        label "ID"
+      end
+    end
+  end
+
+  # Status Incident Check
+  validate $ds_take_in_parameters do
+    summary_template "{{ data.parent_policy.name }}: Status of Child Policies"
+    detail_template <<-EOS
+The current status of Child Policies for **{{ data.parent_policy.name }}**:
+
+Total Child Applied Policies: {{ len data.grid }}
+
+| Applied Policy | Meta Child Policy Status | Policy Status | Policy Last Update | Incident | Incident State | Violation Count | Incident Last Update |
+| -------------- | ------------------------ | ------------- | ------------------ | -------- | -------------- | --------------- | -------------------- |
+{{ range data.grid -}}
+| {{- if .policy_link }} [{{ .policy_name }}]({{ .policy_link }}) {{ else }} {{ .policy_name }} {{- end }} | {{- if .meta_policy_status }} {{ .meta_policy_status }} {{ else }} No value {{- end }} | {{- if .policy_status }} {{ .policy_status }} {{ else }} No value {{- end }} | {{- if .policy_last_update }} {{ .policy_last_update }} {{ else }} No value {{- end }} | {{- if .incident_link }} [Incident]({{ .incident_link }}) {{ else }} No Incident {{- end }} | {{- if .incident_state }} {{ .incident_state }} {{ else }} No Incident {{- end }} | {{- if .incident_last_update }} {{ .incident_violation_data_count }} {{ else }} No Incident {{- end }} | {{- if .incident_last_update }} {{ .incident_last_update }} {{ else }} No Incident {{- end }} |
+{{ end -}}
+
+EOS
+    check false # always trigger this status incident
+    # Export Table disabled for now until UI can support URL / linking
+    # Without linking the `policy_link`, `incident_link` values are not usable directly from UI
+    # export "grid" do
+    #   resource_level true
+    #   field "id" do
+    #     label "Applied Policy ID"
+    #   end
+    #   field "policy_name" do
+    #     label "Applied Policy Name"
+    #   end
+    #   field "policy_link" do
+    #     label "Applied Policy Link"
+    #   end
+    #   field "meta_policy_status" do
+    #     label "Meta Child Policy Status"
+    #   end
+    #   field "policy_status" do
+    #     label "Policy Status"
+    #   end
+    #   field "policy_last_update" do
+    #     label "Policy Last Update"
+    #   end
+    #   field "incident_link" do
+    #     label "Incident Link"
+    #   end
+    #   field "incident_state" do
+    #     label "Incident State"
+    #   end
+    #   field "incident_violation_data_count" do
+    #     label "Incident Violation Count"
+    #   end
+    #   field "incident_last_update" do
+    #     label "Incident Last Update"
+    #   end
+    # end
+  end
+
+  # Create Child Policies Incident Check
+  validate $ds_to_create do
+    summary_template "Policies being created"
+    detail_template <<-EOS
+    Policies Being Created:
+
+    | Applied Policy |
+    | --------------- |
+    {{ range data -}}
+    | {{ .name }} |
+    {{ end -}}
+    EOS
+    escalate $create_policies
+    check eq(size(data),0)
+  end
+
+  # Update Child Policies Incident Check
+  validate $ds_to_update do
+    summary_template "Policies being updated"
+    detail_template <<-EOS
+    Policies Being Updated:
+
+    | Applied Policy |
+    | --------------- |
+    {{ range data -}}
+    | {{ .name }} |
+    {{ end -}}
+    EOS
+    escalate $update_policies
+    check eq(size(data),0)
+  end
+
+  # Delete Child Policies Incident Check
+  validate $ds_to_delete do
+    summary_template "Policies being deleted"
+    detail_template <<-EOS
+    Policies being Deleted:
+
+    | Applied Policy |
+    | --------------- |
+    {{ range data -}}
+    | {{ .name }} |
+    {{ end -}}
+    EOS
+    escalate $delete_policies
+    check eq(size(data),0)
+  end
+end
+
+# Used only for emailing the combined child incident if so desired
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_combined_incident_email
+end
+
+escalation "create_policies" do
+  run "create_applied_policies", data, rs_governance_host, rs_project_id
+end
+
+# if name !=null
+define create_applied_policies($data, $governance_host, $rs_project_id) return $responses do
+  $responses = []
+  $$debug = []
+  $item_index = 0
+  $item_total = size($data)
+  foreach $item in $data do
+    $item_index = $item_index + 1
+    $status = to_s("("+$item_index+"/"+$item_total+")")
+    task_label($status+" Creating Applied Policy with Options: " + to_json($item["options"]))
+    $response = http_request(
+      auth: $$auth_flexera,
+      verb: "post",
+      https: true,
+      host: $governance_host,
+      href: join(["/api/governance/projects/", $rs_project_id, "/applied_policies"]),
+      headers: { "Api-Version": "1.0" },
+      body: {
+        "name": $item["name"],
+        "description": $item["description"],
+        "template_href": $item["template_href"],
+        "frequency": $item["frequency"],
+        "options": $item["options"],
+        "credentials": $item["credentials"],
+        "meta_parent_policy_id": $item["meta_parent_policy_id"]
+      }
+    )
+    $responses << $response
+    $$debug << to_json({
+      "response": $response,
+      "item": $item,
+      "governance_host": $governance_host
+    })
+  end
+end
+
+escalation "update_policies" do
+  run "update_applied_policies", data, rs_governance_host, rs_project_id
+end
+
+define update_applied_policies($data, $governance_host, $rs_project_id) return $responses do
+  $responses = []
+  $$debug = []
+  $item_index = 0
+  $item_total = size($data)
+  foreach $item in $data do
+    $item_index = $item_index + 1
+    $status = to_s("("+$item_index+"/"+$item_total+")")
+    task_label($status+" Updating Applied Policy with Options: " + to_json($item["options"]))
+    $response = http_request(
+      auth: $$auth_flexera,
+      verb: "patch",
+      https: true,
+      host: $governance_host,
+      href: join(["/api/governance/projects/", $rs_project_id, "/applied_policies/", $item["applied_policy_id"]]),
+      headers: { "Api-Version": "1.0" },
+      body: {
+        "options": $item["options"]
+      }
+    )
+    $responses << $response
+    $$debug << to_json({
+      "response": $response,
+      "item": $item,
+      "governance_host": $governance_host
+    })
+  end
+end
+
+escalation "delete_policies" do
+  run "delete_applied_policies", data, rs_governance_host, rs_project_id
+end
+
+define delete_applied_policies($data, $governance_host, $rs_project_id) return $responses do
+  $responses = []
+  $$debug = []
+  $item_index = 0
+  $item_total = size($data)
+  foreach $item in $data do
+    $item_index = $item_index + 1
+    $status = to_s("("+$item_index+"/"+$item_total+")")
+    task_label($status+" Deleting Applied Policy: " + $item["id"])
+    $response = http_request(
+      auth: $$auth_flexera,
+      verb: "delete",
+      https: true,
+      host: $governance_host,
+      href: join(["/api/governance/projects/", $rs_project_id, "/applied_policies/", $item["id"]]),
+      headers: { "Api-Version": "1.0" }
+    )
+    $responses << $response
+    $$debug << to_json({
+      "response": $response,
+      "item": $item,
+      "governance_host": $governance_host
+    })
+  end
+end

--- a/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
+++ b/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
@@ -12,6 +12,7 @@ default_child_policy_template_files = [
   "../../cost/aws/old_snapshots/aws_delete_old_snapshots.pt",
   "../../cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances.pt",
   "../../cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing.pt",
+  "../../cost/aws/superseded_instances/aws_superseded_instances.pt",
   "../../cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt",
   "../../cost/aws/unused_rds/unused_rds.pt",
   "../../cost/aws/unused_volumes/aws_delete_unused_volumes.pt",


### PR DESCRIPTION
### Description

This is a new AWS-specific version of the Superseded Instances policy. This policy requires an AWS credential with permissions similar to the AWS Rightsizing EC2 Instances policy, but offers several advantages over the cloud-agnostic version:

- Completely updated/rebuilt code based on the updated versions of other usage reduction policies with similar functionality where appropriate
- Since instance metadata is mostly pulled from AWS itself, any instances that are actioned should no longer appear in future incidents since their instance type will no longer be superseded and the policy is gathering this metadata in near real time from the AWS API directly
- Savings information is included based on AWS list prices for instance types with currency conversion (similar to AWS Unused IP policy)
- Policy metadata and incident output have been normalized for scraping into the Optimization dashboard
- Added ability to action on recommendations directly from the incident
- Meta policy support

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=651577db656c530001e19023
(CWF action has been tested and works. The list price/savings calculation also works, but there is no account that we can test in to provide this information because the instances were created today. I've confirmed elsewhere that it does work as expected though.)

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
