### PR TITLE
POL-924 Oracle Cloud CBI Broken Upload Fix

### DIFF
--- a/cost/oracle/oracle_cbi/CHANGELOG.md
+++ b/cost/oracle/oracle_cbi/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v3.2
 
 - Fixed issue where a failed file upload would sometimes stall the policy indefinitely
+- Minor code tweaks/improvements
 
 ## v3.1
 

--- a/cost/oracle/oracle_cbi/CHANGELOG.md
+++ b/cost/oracle/oracle_cbi/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2
+
+- Fixed issue where a failed file upload would sometimes stall the policy indefinitely
+
 ## v3.1
 
 - Fixed issue where bill upload would sometimes not commit

--- a/cost/oracle/oracle_cbi/oracle_cbi.pt
+++ b/cost/oracle/oracle_cbi/oracle_cbi.pt
@@ -18,6 +18,7 @@ info(
 
 parameter "param_billing_period" do
   type "string"
+  category "Policy Settings"
   label "Month To Ingest"
   description "Month to process bills for."
   default "Current Month"
@@ -26,6 +27,7 @@ end
 
 parameter "param_specific_period" do
   type "string"
+  category "Policy Settings"
   label "Billing Period"
   description "Billing period to process bills for in YYYY-MM format. Only relevant if Specific Month is selected for Month To Ingest."
   default "2020-01"
@@ -34,12 +36,14 @@ end
 
 parameter "param_cbi_endpoint" do
   type "string"
+  category "Policy Settings"
   label "Flexera CBI Endpoint"
   description "Name of the Flexera CBI endpoint to use. Ex: cbi-oi-oracle-oraclecloud"
 end
 
 parameter "param_region" do
   type "string"
+  category "Oracle"
   label "Oracle Cloud Region"
   description "Region of the Oracle Cloud Object Storage bucket containing the cost and usage reports. Ex: us-phoenix-1"
   allowed_pattern /^[a-z]{2}-[a-z]+(-[a-z]+)?-[1-9][0-9]*$/
@@ -47,12 +51,14 @@ end
 
 parameter "param_bucket" do
   type "string"
+  category "Oracle"
   label "Oracle Cloud Cost & Usage Bucket"
   description "OCID of the Oracle Cloud Object Storage bucket containing the Cost and Usage reports."
 end
 
 parameter "param_block_size" do
   type "number"
+  category "Policy Settings"
   label "Block Size"
   description "The number of files in a single block."
   default 20
@@ -62,6 +68,7 @@ end
 
 parameter "param_commit_delay" do
   type "number"
+  category "Policy Settings"
   label "Commit Delay (Hours)"
   description "Number of hours to wait between committing bill uploads."
   default 12
@@ -82,7 +89,7 @@ end
 
 credentials "auth_flexera" do
   schemes "oauth2"
-  label "flexera"
+  label "Flexera"
   description "Select FlexeraOne OAuth2 credentials"
   tags "provider=flexera"
 end

--- a/cost/oracle/oracle_cbi/oracle_cbi.pt
+++ b/cost/oracle/oracle_cbi/oracle_cbi.pt
@@ -164,6 +164,7 @@ script "js_broken_bill_uploads", type: "javascript" do
       })
     }
 
+    // Make sure we ignore any bill uploads that aren't actually in-progress
     return broken_files && bill_upload['status'] == 'in-progress'
   })
 EOS
@@ -177,12 +178,6 @@ datasource "ds_abort_broken_uploads" do
   result do
     encoding "json"
     field "id", jmes_path(response, "id")
-    field "billConnectId", jmes_path(response, "billConnectId")
-    field "billingPeriod", jmes_path(response, "billingPeriod")
-    field "createdAt", jmes_path(response, "createdAt")
-    field "files", jmes_path(response, "files")
-    field "status", jmes_path(response, "status")
-    field "updatedAt", jmes_path(response, "updatedAt")
   end
 end
 
@@ -213,15 +208,15 @@ end
 # Broken bill uploads aborted above are not considered in-progress.
 # Otherwise, it contains a single item for the next datasource to iterate over.
 datasource "ds_bill_upload_check" do
-  run_script $js_bill_upload_check, $ds_existing_bill_uploads, $ds_broken_bill_uploads, $ds_abort_broken_uploads
+  run_script $js_bill_upload_check, $ds_existing_bill_uploads, $ds_abort_broken_uploads
 end
 
 script "js_bill_upload_check", type: "javascript" do
-  parameters "ds_existing_bill_uploads", "ds_broken_bill_uploads", "ds_abort_broken_uploads"
+  parameters "ds_existing_bill_uploads", "ds_abort_broken_uploads"
   result "result"
   code <<-EOS
   result = [1]
-  broken_upload_ids = _.pluck(ds_broken_bill_uploads, 'id')
+  broken_upload_ids = _.pluck(ds_abort_broken_uploads, 'id')
 
   in_progress_uploads = _.filter(ds_existing_bill_uploads, function(bill_upload) {
     return bill_upload['status'] == 'in-progress' && _.contains(broken_upload_ids, bill_upload['id']) == false

--- a/cost/oracle/oracle_cbi/oracle_cbi.pt
+++ b/cost/oracle/oracle_cbi/oracle_cbi.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "15 minutes"
 info(
-  version: "3.1",
+  version: "3.2",
   provider: "Oracle",
   service: "Common Bill Ingestion",
   policy_set: "Common Bill Ingestion"
@@ -143,23 +143,91 @@ datasource "ds_existing_bill_uploads" do
   end
 end
 
-# Branching logic:
-# This datasource contains an empty array if a bill upload is already in progress.
-# Otherwise, it contains a single item for the next datasource to iterate over.
-datasource "ds_bill_upload_check" do
-  run_script $js_bill_upload_check, $ds_existing_bill_uploads
+# This datasource looks for any in-progress bill uploads that are broken
+# due to an in-progress file upload so that they can be aborted.
+datasource "ds_broken_bill_uploads" do
+  run_script $js_broken_bill_uploads, $ds_existing_bill_uploads
 end
 
-script "js_bill_upload_check", type: "javascript" do
+script "js_broken_bill_uploads", type: "javascript" do
   parameters "ds_existing_bill_uploads"
   result "result"
   code <<-EOS
-  result = [1]
-  statuses = _.pluck(ds_existing_bill_uploads, 'status')
+  result = _.filter(ds_existing_bill_uploads, function(bill_upload) {
+    broken_files = false
 
-  if (_.contains(statuses, 'in-progress')) {
-    result = []
+    if (typeof(bill_upload['files']) == 'object') {
+      _.each(bill_upload['files'], function(file) {
+        if (file['status'] != 'uploaded') {
+          broken_files = true
+        }
+      })
+    }
+
+    return broken_files
+  })
+EOS
+end
+
+datasource "ds_abort_broken_uploads" do
+  iterate $ds_broken_bill_uploads
+  request do
+    run_script $js_abort_broken_uploads, rs_org_id, rs_optima_host, val(iter_item, 'id')
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+    field "billConnectId", jmes_path(response, "billConnectId")
+    field "billingPeriod", jmes_path(response, "billingPeriod")
+    field "createdAt", jmes_path(response, "createdAt")
+    field "files", jmes_path(response, "files")
+    field "status", jmes_path(response, "status")
+    field "updatedAt", jmes_path(response, "updatedAt")
+  end
+end
+
+script "js_abort_broken_uploads", type: "javascript" do
+  parameters "rs_org_id", "rs_optima_host", "bill_upload_id"
+  result "request"
+  code <<-EOS
+  // Slow down rate of requests to prevent throttling
+  api_wait = 5
+  var now = new Date().getTime()
+  while(new Date().getTime() < now + (api_wait * 1000)) { /* Do nothing */ }
+
+  var request = {
+    auth: "auth_flexera",
+    verb: "POST",
+    host: rs_optima_host,
+    path: ['/optima/orgs/', rs_org_id, '/billUploads/', bill_upload_id, '/operations'].join(''),
+    headers: {
+      "User-Agent": "RS Policies",
+    },
+    body_fields: { "operation": "abort" }
   }
+EOS
+end
+
+# Branching logic:
+# This datasource contains an empty array if a bill upload is already in-progress.
+# Broken bill uploads aborted above are not considered in-progress.
+# Otherwise, it contains a single item for the next datasource to iterate over.
+datasource "ds_bill_upload_check" do
+  run_script $js_bill_upload_check, $ds_existing_bill_uploads, $ds_broken_bill_uploads, $ds_abort_broken_uploads
+end
+
+script "js_bill_upload_check", type: "javascript" do
+  parameters "ds_existing_bill_uploads", "ds_broken_bill_uploads", "ds_abort_broken_uploads"
+  result "result"
+  code <<-EOS
+  result = [1]
+  broken_upload_ids = _.pluck(ds_broken_bill_uploads, 'id')
+
+  in_progress_uploads = _.filter(ds_existing_bill_uploads, function(bill_upload) {
+    return bill_upload['status'] == 'in-progress' && _.contains(broken_upload_ids, bill_upload['id']) == false
+  })
+
+  if (in_progress_uploads.length > 0) { result = [] }
 EOS
 end
 

--- a/cost/oracle/oracle_cbi/oracle_cbi.pt
+++ b/cost/oracle/oracle_cbi/oracle_cbi.pt
@@ -164,7 +164,7 @@ script "js_broken_bill_uploads", type: "javascript" do
       })
     }
 
-    return broken_files
+    return broken_files && bill_upload['status'] == 'in-progress'
   })
 EOS
 end


### PR DESCRIPTION
### Description

If a file upload were to fail for some reason, such as the policy engine running out of memory or a network issue, that individual file would remain in an "in-progress" status indefinitely. This would result in the policy never being able to successfully commit the bill upload as a whole, resulting in the policy stalling out.

This is a fix for the issue. If such a broken file upload is found, the policy will simply abort the bill upload and create a new one, starting the entire process over.

### Link to Example Applied Policy

This policy has been tested in a client environment that was experiencing the issue this update fixes and has been confirmed to work as expected.

### Contribution Check List

- [X] New functionality includes testing.
- [ ] ~New functionality has been documented in the README if applicable~ (Not applicable)
- [X] New functionality has been documented in CHANGELOG.MD
