### PR TITLE
POL-830 AWS Rightsize EBS Volumes Revamp

### DIFF
--- a/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v3.3
 
-- Updated logic to filter out gp3 volumes from recommendations as currently unsupported.
+- Updated logic to filter out GP3 volumes from recommendations as currently unsupported.
 - Updated the data used for the policy incident to ensure a policy incident is not created when there are no recommendations
 
 ## v3.2

--- a/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v4.0
+
+- Several parameters altered to be more descriptive and human-readable
+- Added ability to only report recommendations that meet a minimum savings threshold
+- Added ability to filter resources by multiple tag key:value pairs
+- Added ability to take automated actions to upgrade GP2 volumes to GP3
+- Added additional context to incident description
+- Removed unneeded `IOPS Average %` and `Lookback Period` fields from incident export
+- Removed unneeded API calls to CloudWatch
+- Normalized incident export to be consistent with other policies
+- Added human-readable recommendation to incident export
+- Added additional fields to incident export to facilitate scraping for dashboards
+- Policy no longer raises new escalations if statistics or savings data changed but nothing else has
+- Streamlined code for better readability and faster execution
+
 ## v3.3
 
 - Updated logic to filter out GP3 volumes from recommendations as currently unsupported.

--- a/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing.pt
@@ -1,7 +1,7 @@
 name "AWS Rightsize EBS Volumes"
 rs_pt_ver 20180301
 type "policy"
-short_description "This policy finds AWS GP2 volume types and recommends them for an upgrade to GP3 if cost savings is present. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/rightsize_ebs_volumes/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "This policy finds AWS GP2 volume types and recommends them for an upgrade to GP3 if this would result in savings. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/rightsize_ebs_volumes/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 severity "low"
 category "Cost"
@@ -68,16 +68,6 @@ parameter "param_exclusion_tags" do
   type "string"
   allowed_pattern /(^$)|([\w]?)+\:([\w]?)+/
   default ""
-end
-
-parameter "param_stats_lookback" do
-  type "number"
-  category "Statistics"
-  label "Statistic Lookback Period"
-  description "How many days back to look at CloudWatch data for volumes. This value cannot be set higher than 90 because AWS does not retain metrics for longer than 90 days."
-  default 30
-  min_value 1
-  max_value 90
 end
 
 parameter "param_automatic_action" do
@@ -311,7 +301,6 @@ script "js_currency_target", type:"javascript" do
 EOS
 end
 
-
 # Branching logic:
 # This datasource returns an empty array if the target currency is USD.
 # This prevents ds_currency_conversion from running if it's not needed.
@@ -462,7 +451,6 @@ datasource "ds_volumes" do
   end
 end
 
-
 datasource "ds_volumes_tag_filtered" do
   run_script $js_volumes_tag_filtered, $ds_volumes, $param_exclusion_tags
 end
@@ -497,197 +485,6 @@ script "js_volumes_tag_filtered", type: "javascript" do
       return volume['volumeType'] != 'gp2'
     })
   }
-EOS
-end
-
-datasource "ds_volumes_read_iops_usage" do
-  iterate $ds_volumes_tag_filtered
-  request do
-    run_script $js_volumes_iops_usage, val(iter_item, "region"), val(iter_item, "volumeId"), $param_stats_lookback, "VolumeReadOps"
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "GetMetricStatisticsResponse.GetMetricStatisticsResult") do
-      field "volumeId", val(iter_item, "volumeId")
-      field "volumeType", val(iter_item, "volumeType")
-      field "encrypted", val(iter_item, "encrypted")
-      field "createTime", val(iter_item, "createTime")
-      field "iops", val(iter_item, "iops")
-      field "size", val(iter_item, "size")
-      field "status", val(iter_item, "status")
-      field "throughput", val(iter_item, "throughput")
-      field "attachmentSet", val(iter_item, "attachmentSet")
-      field "tags", val(iter_item, "tags")
-      field "region", val(iter_item, "region")
-      field "datapoints" do
-        collect jmes_path(col_item, "Datapoints[*]") do
-          field "readOpsMaximum", jmes_path(col_item, "Maximum")
-          field "readOpsAverage", jmes_path(col_item, "Average")
-          field "readOpsSampleCount", jmes_path(col_item, "SampleCount")
-          field "readOpsSum", jmes_path(col_item, "Sum")
-          field "readOpsUnit", jmes_path(col_item, "Unit")
-        end
-      end
-    end
-  end
-end
-
-datasource "ds_volumes_write_iops_usage" do
-  iterate $ds_volumes_tag_filtered
-  request do
-    run_script $js_volumes_iops_usage, val(iter_item, "region"), val(iter_item, "volumeId"), $param_stats_lookback, "VolumeWriteOps"
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "GetMetricStatisticsResponse.GetMetricStatisticsResult") do
-      field "volumeId", val(iter_item, "volumeId")
-      field "volumeType", val(iter_item, "volumeType")
-      field "encrypted", val(iter_item, "encrypted")
-      field "createTime", val(iter_item, "createTime")
-      field "iops", val(iter_item, "iops")
-      field "size", val(iter_item, "size")
-      field "status", val(iter_item, "status")
-      field "throughput", val(iter_item, "throughput")
-      field "attachmentSet", val(iter_item, "attachmentSet")
-      field "tags", val(iter_item, "tags")
-      field "region", val(iter_item, "region")
-      field "datapoints" do
-        collect jmes_path(col_item, "Datapoints[*]") do
-          field "readOpsMaximum", jmes_path(col_item, "Maximum")
-          field "readOpsAverage", jmes_path(col_item, "Average")
-          field "readOpsSampleCount", jmes_path(col_item, "SampleCount")
-          field "readOpsSum", jmes_path(col_item, "Sum")
-          field "readOpsUnit", jmes_path(col_item, "Unit")
-        end
-      end
-    end
-  end
-end
-
-script "js_volumes_iops_usage", type: "javascript" do
-  result "request"
-  parameters "region", "volumeId", "param_stats_lookback", "metricName"
-  code <<-EOS
-  end_date = new Date().toISOString()
-  start_date = new Date(new Date().setDate(new Date().getDate() - param_stats_lookback)).toISOString()
-
-  var request = {
-    "auth": "auth_aws",
-    "host": "monitoring." + region + ".amazonaws.com",
-    "verb": "GET",
-    "path": "/",
-    "headers": {
-      "User-Agent": "RS Policies",
-      "Content-Type": "application/json",
-      "x-amz-target": "GraniteServiceVersion20100801.GetMetricStatistics",
-      "Accept": "application/json",
-      "Content-Encoding": "amz-1.0"
-    },
-    "query_params": {
-      "Action": "GetMetricStatistics",
-      "Version": "2010-08-01",
-      "Namespace": "AWS/EBS"
-      "MetricName": metricName,
-      "Dimensions.member.1.Name": "VolumeId",
-      "Dimensions.member.1.Value": volumeId,
-      "StartTime": start_date,
-      "EndTime": end_date,
-      "Period": "2592000",
-      "Statistics.member.1": "Average",
-      "Statistics.member.2": "Maximum",
-      "Statistics.member.3": "SampleCount",
-      "Statistics.member.4": "Sum"
-    }
-  }
-  EOS
-end
-
-datasource "ds_volumes_combined" do
-  run_script $js_volumes_combined, $ds_volumes_read_iops_usage, $ds_volumes_write_iops_usage
-end
-
-script "js_volumes_combined", type: "javascript" do
-  parameters "ds_volumes_read_iops_usage", "ds_volumes_write_iops_usage"
-  result "result"
-  code <<-EOS
-  result = []
-  read_object = {}
-
-  _.each(ds_volumes_read_iops_usage, function(volume) {
-    read_object[volume['volumeId']] = volume
-  })
-
-  _.each(ds_volumes_write_iops_usage, function(volume) {
-    read_data = null
-    write_data = volume['datapoints']
-
-    if (typeof(read_object[volume['volumeId']]) == 'object') {
-      read_data = read_object[volume['volumeId']]['datapoints']
-    }
-
-    if (typeof(read_data) == 'object' && typeof(write_data) == 'object') {
-      iopsAverage = null
-      iopsUtilizationPercentage = null
-
-      total_read_ops = 0
-      total_write_ops = 0
-      total_read_datapoints = 0
-      total_write_datapoints = 0
-
-      _.each(read_data, function(datapoint) {
-        total_read_ops += datapoint['readOpsSum']
-        total_read_datapoints += datapoint['readOpsSampleCount']
-      })
-
-      _.each(write_data, function(datapoint) {
-        total_write_ops += datapoint['readOpsSum']
-        total_write_datapoints += datapoint['readOpsSampleCount']
-      })
-
-      if (read_data.length > 0 && write_data.length > 0) {
-        iopsAverage = parseFloat(((total_read_ops / total_readdata_points ) / 60) + ((total_write_ops / total_write_data_points) / 60).toFixed(2))
-        iopsUtilizationPercentage = parseFloat(((iops_average / (volume['iops'])) * 100).toFixed(2))
-      }
-
-      tags = []
-      volumeName = ""
-
-      if (volume['tags'] != null && volume['tags'] != undefined) {
-        _.each(volume['tags'], function(tag) {
-          tags.push([tag['key'], tag['value']].join('='))
-
-          if (tag['key'] == 'Name') { volumeName = tag['value'] }
-        })
-      }
-
-      attachmentStatus = []
-
-      _.each(volume['attachmentSet'], function(attachment) {
-        if (attachmentStatus.length != 0) { attachmentStatus.push(", ") }
-
-        attachmentStatus.push(attachment['instanceId'])
-        attachmentStatus.push("=")
-        attachmentStatus.push(attachment['attachmentStatus'])
-      })
-
-      result.push({
-        volumeId: volume['volumeId'],
-        volumeName: volumeName,
-        volumeType: volume['volumeType'],
-        encrypted: volume['encrypted'],
-        createTime: volume['createTime'],
-        iops: volume['iops'],
-        size: volume['size'],
-        status: volume['status'],
-        throughput: volume['throughput'],
-        attachmentStatus: attachmentStatus.join(''),
-        tags: tags.join(', '),
-        region: volume['region'],
-        iopsAverage: iopsAverage,
-        iopsUtilizationPercentage: iopsUtilizationPercentage
-      })
-    }
-  })
 EOS
 end
 
@@ -741,18 +538,18 @@ EOS
 end
 
 datasource "ds_volumes_with_prices" do
-  run_script $js_volumes_with_prices, $ds_volumes_combined, $ds_gp2_prices, $ds_gp3_prices, $ds_currency
+  run_script $js_volumes_with_prices, $ds_volumes_tag_filtered, $ds_gp2_prices, $ds_gp3_prices, $ds_currency
 end
 
 script "js_volumes_with_prices", type: "javascript" do
-  parameters "ds_volumes_combined", "ds_gp2_prices", "ds_gp3_prices", "ds_currency"
+  parameters "ds_volumes_tag_filtered", "ds_gp2_prices", "ds_gp3_prices", "ds_currency"
   result "result"
   code <<-EOS
   // Function to convert price lists to proper JSON
   function convertPriceList(priceList) {
     convertedPriceList = {}
 
-    _.each(PriceList, function(price) {
+    _.each(priceList, function(price) {
       entry = JSON.parse(price.replace(/\\"/g,'"'))
       region = entry['product']['attributes']['regionCode']
 
@@ -852,15 +649,36 @@ script "js_volumes_with_prices", type: "javascript" do
   gp2_pricelist = convertPriceList(ds_gp2_prices['PriceList'])
   gp3_pricelist = convertPriceList(ds_gp3_prices['PriceList'])
 
-  _.each(ds_volumes_combined, function(volume) {
+  _.each(ds_volumes_tag_filtered, function(volume) {
     gp2_price = getGP2Price(volume, gp2_pricelist) * ds_currency['exchange_rate']
     gp3_price = getGP3Price(volume, gp3_pricelist) * ds_currency['exchange_rate']
     savings = gp2_price - gp3_price
 
     if (savings >= 0 && gp2_price != 0 && gp3_price != 0) {
+      tags = []
+      volumeName = ""
+
+      if (volume['tags'] != null && volume['tags'] != undefined) {
+        _.each(volume['tags'], function(tag) {
+          tags.push([tag['key'], tag['value']].join('='))
+
+          if (tag['key'] == 'Name') { volumeName = tag['value'] }
+        })
+      }
+
+      attachmentStatus = []
+
+      _.each(volume['attachmentSet'], function(attachment) {
+        if (attachmentStatus.length != 0) { attachmentStatus.push(", ") }
+
+        attachmentStatus.push(attachment['instanceId'])
+        attachmentStatus.push("=")
+        attachmentStatus.push(attachment['attachmentStatus'])
+      })
+
       result.push({
         volumeId: volume['volumeId'],
-        volumeName: volume['volumeName'],
+        volumeName: volumeName,
         volumeType: volume['volumeType'],
         encrypted: volume['encrypted'],
         createTime: volume['createTime'],
@@ -868,11 +686,9 @@ script "js_volumes_with_prices", type: "javascript" do
         size: volume['size'],
         status: volume['status'],
         throughput: volume['throughput'],
-        attachmentStatus: volume['attachmentStatus'],
-        tags: volume['tags'],
+        attachmentStatus: attachmentStatus.join(''),
+        tags: tags.join(', '),
         region: volume['region'],
-        iopsAverage: volume['iopsAverage'],
-        iopsUtilizationPercentage: volume['iopsUtilizationPercentage'],
         gp2_price: gp2_price,
         gp3_price: gp3_price,
         savings: savings,
@@ -987,11 +803,11 @@ EOS
 end
 
 datasource "ds_underutil_volumes" do
-  run_script $js_underutil_volumes, $ds_volumes_tag_filtered, $ds_volumes_with_prices, $ds_volume_costs_grouped, $ds_aws_account, $ds_currency, $ds_currency_conversion, $ds_applied_policy, $param_min_savings, $param_stats_lookback
+  run_script $js_underutil_volumes, $ds_volumes_tag_filtered, $ds_volumes_with_prices, $ds_volume_costs_grouped, $ds_aws_account, $ds_currency, $ds_currency_conversion, $ds_applied_policy, $param_min_savings
 end
 
 script "js_underutil_volumes", type: "javascript" do
-  parameters "ds_volumes_tag_filtered", "ds_volumes_with_prices", "ds_volume_costs_grouped", "ds_aws_account", "ds_currency", "ds_currency_conversion", "ds_applied_policy", "param_min_savings", "param_stats_lookback"
+  parameters "ds_volumes_tag_filtered", "ds_volumes_with_prices", "ds_volume_costs_grouped", "ds_aws_account", "ds_currency", "ds_currency_conversion", "ds_applied_policy", "param_min_savings"
   result "result"
   code <<-'EOS'
   // Used for formatting numbers to look pretty
@@ -1047,8 +863,6 @@ script "js_underutil_volumes", type: "javascript" do
         attachmentStatus: volume['attachmentStatus'],
         tags: volume['tags'],
         region: volume['region'],
-        iopsAverage: volume['iopsAverage'],
-        iopsUtilizationPercentage: volume['iopsUtilizationPercentage'],
         gp2_price: parseFloat(volume['gp2_price'].toFixed(3)),
         gp3_price: parseFloat(volume['gp3_price'].toFixed(3)),
         savings: parseFloat(volume['savings'].toFixed(3)),
@@ -1058,7 +872,6 @@ script "js_underutil_volumes", type: "javascript" do
         accountID: ds_aws_account['id'],
         accountName: ds_aws_account['name'],
         recommendationDetails: recommendationDetails,
-        lookbackPeriod: param_stats_lookback,
         policy_name: ds_applied_policy['name'],
         service: "AmazonEC2",
         total_savings: "",
@@ -1102,9 +915,8 @@ script "js_underutil_volumes", type: "javascript" do
     iopsAverage: "",         iopsUtilizationPercentage: "",    gp2_price: "",
     gp3_price: "",           savings: "",                      savingsCurrency: "",
     cost: "",                age: "",                          accountID: "",
-    accountName: "",         recommendationDetails: "",        lookbackPeriod: "",
-    policy_name: "",         service: "",                      total_savings: "",
-    message: ""
+    accountName: "",         recommendationDetails: "",        policy_name: "",
+    service: "",             total_savings: "",                message: ""
   })
 
   result[0]['total_savings'] = savings_message
@@ -1118,14 +930,15 @@ end
 
 policy "pol_underutil_volumes" do
   validate_each $ds_underutil_volumes do
-    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} AWS Underutilized EBS Volumes Found"
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} AWS Underutilized GP2 Volumes Found"
     detail_template <<-'EOS'
     **Potential Monthly Savings:** {{ with index data 0 }}{{ .total_savings }}{{ end }}
 
     {{ with index data 0 }}{{ .message }}{{ end }}
     EOS
-    escalate $esc_email
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
+    escalate $esc_email
+    hash_exclude "age", "tags", "resourceName", "savings", "savingsCurrency", "total_savings", "message", "attachmentStatus"
     export do
       resource_level true
       field "accountID" do
@@ -1161,11 +974,8 @@ policy "pol_underutil_volumes" do
       field "state" do
         label "Status"
       end
-      field "iopsAverage" do
-        label "IOPS Average %"
-      end
       field "attachmentStatus" do
-        label "Volume Attachment Status"
+        label "Attachment Status"
       end
       field "cost" do
         label "Estimated Monthly Cost"
@@ -1181,9 +991,6 @@ policy "pol_underutil_volumes" do
       end
       field "savingsCurrency" do
         label "Savings Currency"
-      end
-      field "lookbackPeriod" do
-        label "Lookback Period (Days)"
       end
       field "service" do
         label "Service"

--- a/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing.pt
@@ -1033,9 +1033,9 @@ end
 define upgrade_volumes($data) return $all_responses do
   $$all_responses = []
 
-  foreach $instance in $data do
+  foreach $volume in $data do
     sub on_error: handle_error() do
-      call upgrade_volume($instance) retrieve $upgrade_response
+      call upgrade_volume($volume) retrieve $upgrade_response
     end
   end
 
@@ -1063,13 +1063,13 @@ define upgrade_volume($volume) return $response do
     }
   )
 
-  task_label("Post AWS volume response: " + $item["resourceID"] + " " + to_json($response))
+  task_label("Post AWS volume response: " + $volume["resourceID"] + " " + to_json($response))
   $$all_responses << to_json({"req": "POST " + $upgrade_url, "resp": $response})
 
   if $response["code"] != 202 && $response["code"] != 200
-    raise "Unexpected response posting AWS volume: "+ $item["resourceID"] + " " + to_json($response)
+    raise "Unexpected response posting AWS volume: "+ $volume["resourceID"] + " " + to_json($response)
   else
-    task_label("Post AWS volume successful: " + $item["resourceID"])
+    task_label("Post AWS volume successful: " + $volume["resourceID"])
   end
 end
 

--- a/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing.pt
@@ -1031,27 +1031,23 @@ end
 
 # Core CWF function to upgrade volumes to GP3
 define upgrade_volumes($data) return $all_responses do
-  # Change "No" to "Yes" to enable CWF debug logging
-  $log_to_cm_audit_entries = "No"
-
-  $$debug = $log_to_cm_audit_entries == "Yes"
-  $$log = []
-  $all_responses = []
-  $syslog_subject = "AWS Rightsizing EBS [GP2->GP3]: "
-
-  call sys_log(join([$syslog_subject, "Identified Instances"]), to_s($data))
+  $$all_responses = []
 
   foreach $instance in $data do
-    call upgrade_volume($instance) retrieve $upgrade_response
-    $all_responses << $upgrade_response
+    sub on_error: handle_error() do
+      call upgrade_volume($instance) retrieve $upgrade_response
+    end
+  end
+
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
   end
 end
 
 # CWF function to upgrade a volume to GP3
 define upgrade_volume($volume) return $response do
-  $syslog_subject = "AWS Upgrading Volume to GP3: "
-
-  call sys_log(join([$syslog_subject, "Instance"]), to_s($volume["resourceID"]))
+  $upgrade_url = "https://ec2." + $volume['region'] + ".amazonaws.com/?Action=ModifyVolume&Version=2016-11-15&VolumeType=gp3&VolumeId=" + $volume["resourceID"]
+  task_label("POST " + $upgrade_url)
 
   $response = http_request(
     auth: $$auth_aws,
@@ -1067,42 +1063,23 @@ define upgrade_volume($volume) return $response do
     }
   )
 
-  call sys_log(join([$syslog_subject, "Responses"]), to_s($response))
+  task_label("Post AWS volume response: " + $item["resourceID"] + " " + to_json($response))
+  $$all_responses << to_json({"req": "POST " + $upgrade_url, "resp": $response})
+
+  if $response["code"] != 202 && $response["code"] != 200
+    raise "Unexpected response posting AWS volume: "+ $item["resourceID"] + " " + to_json($response)
+  else
+    task_label("Post AWS volume successful: " + $item["resourceID"])
+  end
 end
 
-# CWF function to record information to the logs
-define sys_log($subject, $detail) do
-  # Create empty errors array if doesn't already exist
+define handle_error() do
   if !$$errors
     $$errors = []
   end
-  # Check if debug is enabled
-  if $$debug
-    # Append to global $$errors
-    # This is the suggested way to capture errors
-    $$errors << "Unexpected error for " + $subject + "\n  " + to_s($detail)
-    # If Flexera NAM Zone, create audit_entries [to be deprecated]
-    # This is the legacy method for capturing errors and only supported on Flexera NAM
-    if $$rs_optima_host == "api.optima.flexeraeng.com"
-      # skip_error_and_append is used to catch error if rs_cm.audit_entries.create fails unexpectedly
-      $task_label = "Creating audit entry for " + $subject
-      sub task_label: $task, on_error: skip_error_and_append($task) do
-        rs_cm.audit_entries.create(
-          notify: "None",
-          audit_entry: {
-            auditee_href: @@account,
-            summary: $subject,
-            detail: $detail
-          }
-        )
-      end # End sub on_error
-    end # End if rs_optima_host
-  end # End if debug is enabled
-end
-
-# CWF function to handle errors
-define skip_error_and_append($subject) do
-  $$errors << "Unexpected error for " + $subject + "\n  " + to_s($_error)
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
   $_error_behavior = "skip"
 end
 

--- a/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing.pt
@@ -21,7 +21,7 @@ info(
 parameter "param_email" do
   type "list"
   category "Policy Settings"
-  label "Email addresses to notify"
+  label "Email Addresses"
   description "Email addresses of the recipients you wish to notify when new incidents are created"
   default []
 end

--- a/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing.pt
@@ -75,7 +75,7 @@ parameter "param_automatic_action" do
   category "Actions"
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
-  allowed_values ["Convert to GP3"]
+  allowed_values ["Upgrade Volumes to GP3"]
   default []
 end
 
@@ -908,15 +908,15 @@ script "js_underutil_volumes", type: "javascript" do
 
   // Dummy item to ensure the policy's check statement always executes at least once
   result.push({
-    resourceID: "",          resourceName: "",                 resourceType: "",
-    encrypted: "",           createTime: "",                   iops: "",
-    size: "",                state: "",                        throughput: "",
-    attachmentStatus: "",    tags: "",                         region: "",
-    iopsAverage: "",         iopsUtilizationPercentage: "",    gp2_price: "",
-    gp3_price: "",           savings: "",                      savingsCurrency: "",
-    cost: "",                age: "",                          accountID: "",
-    accountName: "",         recommendationDetails: "",        policy_name: "",
-    service: "",             total_savings: "",                message: ""
+    resourceID: "",          resourceName: "",    resourceType: "",
+    encrypted: "",           createTime: "",      iops: "",
+    size: "",                state: "",           throughput: "",
+    attachmentStatus: "",    tags: "",            region: "",
+    gp2_price: "",           gp3_price: "",       savings: "",
+    savingsCurrency: "",     cost: "",            age: "",
+    accountID: "",           accountName: "",     recommendationDetails: "",
+    policy_name: "",         service: "",         total_savings: "",
+    message: ""
   })
 
   result[0]['total_savings'] = savings_message
@@ -938,6 +938,7 @@ policy "pol_underutil_volumes" do
     EOS
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
+    escalate $esc_upgrade_volumes
     hash_exclude "age", "tags", "resourceName", "savings", "savingsCurrency", "total_savings", "message", "attachmentStatus"
     export do
       resource_level true
@@ -973,6 +974,9 @@ policy "pol_underutil_volumes" do
       end
       field "state" do
         label "Status"
+      end
+      field "iops" do
+        label "IOPS"
       end
       field "attachmentStatus" do
         label "Attachment Status"
@@ -1012,6 +1016,94 @@ escalation "esc_email" do
   label "Send Email"
   description "Send incident email"
   email $param_email
+end
+
+escalation "esc_upgrade_volumes" do
+  automatic contains($param_automatic_action, "Upgrade Volumes to GP3")
+  label "Upgrade Volumes to GP3"
+  description "Approval to upgrade all selected volumes to GP3"
+  run "upgrade_volumes", data
+end
+
+###############################################################################
+# Cloud Workflow
+###############################################################################
+
+# Core CWF function to upgrade volumes to GP3
+define upgrade_volumes($data) return $all_responses do
+  # Change "No" to "Yes" to enable CWF debug logging
+  $log_to_cm_audit_entries = "No"
+
+  $$debug = $log_to_cm_audit_entries == "Yes"
+  $$log = []
+  $all_responses = []
+  $syslog_subject = "AWS Rightsizing EBS [GP2->GP3]: "
+
+  call sys_log(join([$syslog_subject, "Identified Instances"]), to_s($data))
+
+  foreach $instance in $data do
+    call upgrade_volume($instance) retrieve $upgrade_response
+    $all_responses << $upgrade_response
+  end
+end
+
+# CWF function to upgrade a volume to GP3
+define upgrade_volume($volume) return $response do
+  $syslog_subject = "AWS Upgrading Volume to GP3: "
+
+  call sys_log(join([$syslog_subject, "Instance"]), to_s($volume["resourceID"]))
+
+  $response = http_request(
+    auth: $$auth_aws,
+    https: true,
+    verb: "post",
+    href: "/",
+    host: "ec2." + $volume['region'] + ".amazonaws.com",
+    query_strings: {
+      "Action": "ModifyVolume",
+      "Version": "2016-11-15",
+      "VolumeType": "gp3",
+      "VolumeId": $volume["resourceID"]
+    }
+  )
+
+  call sys_log(join([$syslog_subject, "Responses"]), to_s($response))
+end
+
+# CWF function to record information to the logs
+define sys_log($subject, $detail) do
+  # Create empty errors array if doesn't already exist
+  if !$$errors
+    $$errors = []
+  end
+  # Check if debug is enabled
+  if $$debug
+    # Append to global $$errors
+    # This is the suggested way to capture errors
+    $$errors << "Unexpected error for " + $subject + "\n  " + to_s($detail)
+    # If Flexera NAM Zone, create audit_entries [to be deprecated]
+    # This is the legacy method for capturing errors and only supported on Flexera NAM
+    if $$rs_optima_host == "api.optima.flexeraeng.com"
+      # skip_error_and_append is used to catch error if rs_cm.audit_entries.create fails unexpectedly
+      $task_label = "Creating audit entry for " + $subject
+      sub task_label: $task, on_error: skip_error_and_append($task) do
+        rs_cm.audit_entries.create(
+          notify: "None",
+          audit_entry: {
+            auditee_href: @@account,
+            summary: $subject,
+            detail: $detail
+          }
+        )
+      end # End sub on_error
+    end # End if rs_optima_host
+  end # End if debug is enabled
+end
+
+# CWF function to handle errors
+define skip_error_and_append($subject) do
+  $$errors << "Unexpected error for " + $subject + "\n  " + to_s($_error)
+  $_error_behavior = "skip"
 end
 
 ###############################################################################

--- a/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing.pt
@@ -9,7 +9,7 @@ default_frequency "weekly"
 info(
   version: "4.0",
   provider: "AWS",
-  service: "EC2",
+  service: "Compute",
   policy_set: "Inefficient Disk Usage",
   recommendation_type: "Usage Reduction"
 )

--- a/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing.pt
@@ -882,7 +882,10 @@ script "js_underutil_volumes", type: "javascript" do
 
   result = _.sortBy(result, function(item) { return item['savings'] * -1 })
 
-  savings_message = ds_currency['symbol'] + ' ' + formatNumber(parseFloat(total_savings).toFixed(2), ds_currency['separator'])
+  savings_message = [
+    ds_currency['symbol'], ' ',
+    formatNumber(parseFloat(total_savings).toFixed(2), ds_currency['t_separator'])
+  ].join('')
 
   total_volumes = ds_volumes_tag_filtered.length.toString()
   total_underutil_volumes = result.length.toString()

--- a/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing.pt
@@ -564,7 +564,7 @@ datasource "ds_volumes_write_iops_usage" do
   end
 end
 
-script "js_volume_iops_usage", type: "javascript" do
+script "js_volumes_iops_usage", type: "javascript" do
   result "request"
   parameters "region", "volumeId", "param_stats_lookback", "metricName"
   code <<-EOS
@@ -994,6 +994,24 @@ script "js_underutil_volumes", type: "javascript" do
   parameters "ds_volumes_tag_filtered", "ds_volumes_with_prices", "ds_volume_costs_grouped", "ds_aws_account", "ds_currency", "ds_currency_conversion", "ds_applied_policy", "param_min_savings", "param_stats_lookback"
   result "result"
   code <<-'EOS'
+  // Used for formatting numbers to look pretty
+  function formatNumber(number, separator){
+    numString = number.toString()
+    values = numString.split(".")
+    formatted_number = ''
+
+    while (values[0].length > 3) {
+      var chunk = values[0].substr(-3)
+      values[0] = values[0].substr(0, values[0].length - 3)
+      formatted_number = separator + chunk + formatted_number
+    }
+
+    if (values[0].length > 0) { formatted_number = values[0] + formatted_number }
+    if (values[1] == undefined) { return formatted_number }
+
+    return formatted_number + "." + values[1]
+  }
+
   result = []
   total_savings = 0.0
 
@@ -1009,6 +1027,12 @@ script "js_underutil_volumes", type: "javascript" do
       endDate = new Date()
       timeDifference = endDate.getTime() - startDate.getTime()
       daysDifference = (timeDifference / (1000 * 3600 * 24)).toFixed(2)
+
+      recommendationDetails = [
+        "Upgrade volume ", volume['volumeId'], " ",
+        "in AWS Account ", ds_aws_account['name'], " ",
+        "(", ds_aws_account['id'], ") from GP2 to GP3"
+      ].join('')
 
       result.push({
         resourceID: volume['volumeId'],
@@ -1033,6 +1057,7 @@ script "js_underutil_volumes", type: "javascript" do
         age: parseFloat(daysDifference),
         accountID: ds_aws_account['id'],
         accountName: ds_aws_account['name'],
+        recommendationDetails: recommendationDetails,
         lookbackPeriod: param_stats_lookback,
         policy_name: ds_applied_policy['name'],
         service: "AmazonEC2",
@@ -1041,6 +1066,49 @@ script "js_underutil_volumes", type: "javascript" do
       })
     }
   })
+
+  result = _.sortBy(result, function(item) { return item['savings'] * -1 })
+
+  savings_message = ds_currency['symbol'] + ' ' + formatNumber(parseFloat(total_savings).toFixed(2), ds_currency['separator'])
+
+  total_volumes = ds_volumes_tag_filtered.length.toString()
+  total_underutil_volumes = result.length.toString()
+  underutil_volumes_percentage = (total_underutil_volumes / total_volumes * 100).toFixed(2).toString() + '%'
+
+  volume_noun = "volume"
+  if (total_volumes > 1) { volume_noun = "volumes" }
+
+  volume_verb = "is"
+  if (total_underutil_volumes > 1) { volume_verb = "are" }
+
+  findings = [
+    "Out of ", total_volumes, " GP2 ", volume_noun, " analyzed, ",
+    total_underutil_volumes, " (", underutil_volumes_percentage,
+    ") ", volume_verb, " recommended for upgrade to GP3."
+  ].join('')
+
+  api_disclaimer = ""
+
+  if (ds_currency_conversion['to'] == undefined && ds_currency['code'] != 'USD') {
+    api_disclaimer = "\n\nPrice and savings values are in USD due to a malfunction with Flexera's internal currency conversion API. Please contact Flexera support to report this issue."
+  }
+
+  // Dummy item to ensure the policy's check statement always executes at least once
+  result.push({
+    resourceID: "",          resourceName: "",                 resourceType: "",
+    encrypted: "",           createTime: "",                   iops: "",
+    size: "",                state: "",                        throughput: "",
+    attachmentStatus: "",    tags: "",                         region: "",
+    iopsAverage: "",         iopsUtilizationPercentage: "",    gp2_price: "",
+    gp3_price: "",           savings: "",                      savingsCurrency: "",
+    cost: "",                age: "",                          accountID: "",
+    accountName: "",         recommendationDetails: "",        lookbackPeriod: "",
+    policy_name: "",         service: "",                      total_savings: "",
+    message: ""
+  })
+
+  result[0]['total_savings'] = savings_message
+  result[0]['message'] = findings + api_disclaimer
 EOS
 end
 

--- a/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing.pt
@@ -1,13 +1,13 @@
 name "AWS Rightsize EBS Volumes"
 rs_pt_ver 20180301
 type "policy"
-short_description "Checks for cost inefficient EBS volumes. This policy finds GP2 volume types and recommends them for an upgrade to GP3 if cost savings is present. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/rightsize_ebs_volumes/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "This policy finds AWS GP2 volume types and recommends them for an upgrade to GP3 if cost savings is present. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/rightsize_ebs_volumes/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.3",
+  version: "4.0",
   provider: "AWS",
   service: "EC2",
   policy_set: "Inefficient Disk Usage",
@@ -18,29 +18,50 @@ info(
 # Parameters
 ###############################################################################
 
+parameter "param_email" do
+  type "list"
+  category "Policy Settings"
+  label "Email addresses to notify"
+  description "Email addresses of the recipients you wish to notify when new incidents are created"
+  default []
+end
+
 parameter "param_aws_account_number" do
   type "string"
+  category "Policy Settings"
   label "Account Number"
   description "The account number for AWS STS Cross Account Roles."
   default ""
 end
 
-parameter "param_allowed_regions_allow_or_deny" do
+parameter "param_min_savings" do
+  type "number"
+  category "Policy Settings"
+  label "Minimum Savings Threshold"
+  description "Minimum potential savings required to generate a recommendation"
+  min_value 0
+  default 0
+end
+
+parameter "param_regions_allow_or_deny" do
   type "string"
+  category "Filters"
   label "Allow/Deny Regions"
   description "Allow or Deny entered regions. See the README for more details"
   allowed_values "Allow", "Deny"
   default "Allow"
 end
 
-parameter "param_allowed_regions" do
+parameter "param_regions_list" do
   type "list"
-  label "Regions"
+  category "Filters"
+  label "Allow/Deny Regions List"
   allowed_pattern /^([a-zA-Z-_]+-[a-zA-Z0-9-_]+-[0-9-_]+,*|)+$/
   description "A list of allowed or denied regions. See the README for more details"
+  default []
 end
 
-parameter "param_exclusion_tag_key" do
+parameter "param_exclusion_tags" do
   category "User Inputs"
   label "Exclusion Tag Key:Value"
   description "Cloud native tag to ignore instances that you don't want to consider for downsizing or termination. Format: Key:Value"
@@ -49,30 +70,41 @@ parameter "param_exclusion_tag_key" do
   default ""
 end
 
-parameter "param_email" do
+parameter "param_stats_lookback" do
+  type "number"
+  category "Statistics"
+  label "Statistic Lookback Period"
+  description "How many days back to look at CloudWatch data for volumes. This value cannot be set higher than 90 because AWS does not retain metrics for longer than 90 days."
+  default 30
+  min_value 1
+  max_value 90
+end
+
+parameter "param_automatic_action" do
   type "list"
-  label "Email addresses to notify"
-  description "Email addresses of the recipients you wish to notify when new incidents are created"
+  category "Actions"
+  label "Automatic Actions"
+  description "When this value is set, this policy will automatically take the selected action(s)"
+  allowed_values ["Convert to GP3"]
+  default []
 end
 
 ###############################################################################
 # Authentication
 ###############################################################################
 
-#AUTHENTICATE WITH AWS
 credentials "auth_aws" do
-  schemes "aws","aws_sts"
+  schemes "aws", "aws_sts"
   label "AWS"
   description "Select the AWS Credential from the list"
   tags "provider=aws"
   aws_account_number $param_aws_account_number
 end
 
-#AUTHENTICATE WITH FLEXERA/OPTIMA
 credentials "auth_flexera" do
   schemes "oauth2"
-  label "Flexera_Automation"
-  description "Select FlexeraOne OAuth2 credentials"
+  label "Flexera"
+  description "Select Flexera One OAuth2 credentials"
   tags "provider=flexera"
 end
 
@@ -80,8 +112,7 @@ end
 # Pagination
 ###############################################################################
 
-#PAGINATION FOR AWS DESCRIBE VOLUMES CALL
-pagination "aws_volumes_pagination_xml" do
+pagination "pagination_aws_volumes" do
   get_page_marker do
     body_path "//DescribeVolumesResponse/nextToken"
   end
@@ -90,8 +121,7 @@ pagination "aws_volumes_pagination_xml" do
   end
 end
 
-#PAGINATION FOR AWS PRICING API CALL
-pagination "pagination_aws_products" do
+pagination "pagination_aws_pricing" do
   get_page_marker do
     body_path "NextToken"
   end
@@ -104,7 +134,142 @@ end
 # Datasources & Scripts
 ###############################################################################
 
-#GET CURRENCY REFERENCE AND CURRENCY CODE FOR ORG
+# Get applied policy metadata for use later
+datasource "ds_applied_policy" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    header "Api-Version", "1.0"
+  end
+end
+
+# Get region-specific Flexera API endpoints
+datasource "ds_flexera_api_hosts" do
+  run_script $js_flexera_api_hosts, rs_optima_host
+end
+
+script "js_flexera_api_hosts", type: "javascript" do
+  parameters "rs_optima_host"
+  result "result"
+  code <<-EOS
+  host_table = {
+    "api.optima.flexeraeng.com": {
+      flexera: "api.flexera.com",
+      fsm: "api.fsm.flexeraeng.com"
+    },
+    "api.optima-eu.flexeraeng.com": {
+      flexera: "api.flexera.eu",
+      fsm: "api.fsm-eu.flexeraeng.com"
+    },
+    "api.optima-au.flexeraeng.com": {
+      flexera: "api.flexera.au",
+      fsm: "api.fsm-au.flexeraeng.com"
+    }
+  }
+
+  result = host_table[rs_optima_host]
+EOS
+end
+
+# Get AWS account info
+datasource "ds_cloud_vendor_accounts" do
+  request do
+    auth $auth_flexera
+    host val($ds_flexera_api_hosts, 'flexera')
+    path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "values[*]") do
+      field "id", jmes_path(col_item, "aws.accountId")
+      field "name", jmes_path(col_item, "name")
+      field "tags", jmes_path(col_item, "tags")
+    end
+  end
+end
+
+datasource "ds_get_caller_identity" do
+  request do
+    auth $auth_aws
+    verb "GET"
+    host "sts.amazonaws.com"
+    path "/"
+    header "User-Agent", "RS Policies"
+    query "Action", "GetCallerIdentity"
+    query "Version", "2011-06-15"
+  end
+  result do
+    encoding "xml"
+    collect xpath(response, "//GetCallerIdentityResponse/GetCallerIdentityResult") do
+      field "account", xpath(col_item, "Account")
+    end
+  end
+end
+
+datasource "ds_aws_account" do
+  run_script $js_aws_account, $ds_cloud_vendor_accounts, $ds_get_caller_identity
+end
+
+script "js_aws_account", type:"javascript" do
+  parameters "ds_cloud_vendor_accounts", "ds_get_caller_identity"
+  result "result"
+  code <<-EOS
+  result = _.find(ds_cloud_vendor_accounts, function(account) {
+    return account['id'] == ds_get_caller_identity[0]['account']
+  })
+
+  // This is in case the API does not return the relevant account info
+  if (result == undefined) {
+    result = {
+      id: ds_get_caller_identity[0]['account'],
+      name: "",
+      tags: {}
+    }
+  }
+EOS
+end
+
+datasource "ds_billing_centers" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/analytics/orgs/", rs_org_id, "/billing_centers"])
+    header "Api-Version", "1.0"
+    header "User-Agent", "RS Policies"
+    query "view", "allocation_table"
+    ignore_status [403]
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "href", jmes_path(col_item, "href")
+      field "id", jmes_path(col_item, "id")
+      field "name", jmes_path(col_item, "name")
+      field "parent_id", jmes_path(col_item, "parent_id")
+    end
+  end
+end
+
+# Gather top level billing center IDs for when we pull cost data
+datasource "ds_top_level_bcs" do
+  run_script $js_top_level_bcs, $ds_billing_centers
+end
+
+script "js_top_level_bcs", type: "javascript" do
+  parameters "ds_billing_centers"
+  result "result"
+  code <<-EOS
+  filtered_bcs = _.filter(ds_billing_centers, function(bc) {
+    return bc['parent_id'] == null || bc['parent_id'] == undefined
+  })
+
+  result = _.compact(_.pluck(filtered_bcs, 'id'))
+EOS
+end
+
+# Gather local currency info
 datasource "ds_currency_reference" do
   request do
     host "raw.githubusercontent.com"
@@ -129,117 +294,91 @@ datasource "ds_currency_code" do
   end
 end
 
-#GET CALLER IDENTITY TO RETURN DETAILS ABOUT IAM ROLE USED TO CALL THE OPERATION (AWS STS)
-datasource "ds_get_caller_identity" do
-  request do
-    auth $auth_aws
-    verb "GET"
-    host "sts.amazonaws.com"
-    path "/"
-    header "User-Agent", "RS Policies"
-    query "Action", "GetCallerIdentity"
-    query "Version", "2011-06-15"
-  end
-  result do
-    encoding "xml"
-    collect xpath(response, "//GetCallerIdentityResponse/GetCallerIdentityResult") do
-      field "account",xpath(col_item, "Account")
-    end
-  end
+datasource "ds_currency_target" do
+  run_script $js_currency_target, $ds_currency_reference, $ds_currency_code
 end
 
-datasource "ds_billing_centers" do
-  request do
-    auth $auth_flexera
-    host rs_optima_host
-    path join(["/analytics/orgs/", rs_org_id, "/billing_centers"])
-    header "Api-Version", "1.0"
-    header "User-Agent", "RS Policies"
-    query "view", "allocation_table"
-    ignore_status [403]
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "[*]") do
-      field "href", jmes_path(col_item, "href")
-      field "id", jmes_path(col_item, "id")
-      field "name", jmes_path(col_item, "name")
-      field "parent_id", jmes_path(col_item, "parent_id")
-    end
-  end
-end
-
-datasource "ds_top_level_billing_centers" do
-  run_script $js_top_level_bc, $ds_billing_centers
-end
-
-script "js_top_level_bc", type: "javascript" do
-  parameters "billing_centers"
-  result "filtered_billing_centers"
+script "js_currency_target", type:"javascript" do
+  parameters "ds_currency_reference", "ds_currency_code"
+  result "result"
   code <<-EOS
-  var filtered_billing_centers =
-    _.reject(billing_centers, function(bc){ return bc.parent_id != null });
+  // Default to USD if currency is not found
+  result = ds_currency_reference['USD']
+
+  if (ds_currency_code['value'] != undefined && ds_currency_reference[ds_currency_code['value']] != undefined) {
+    result = ds_currency_reference[ds_currency_code['value']]
+  }
 EOS
 end
 
-datasource "ds_account_name" do
+
+# Branching logic:
+# This datasource returns an empty array if the target currency is USD.
+# This prevents ds_currency_conversion from running if it's not needed.
+datasource "ds_conditional_currency_conversion" do
+  run_script $js_conditional_currency_conversion, $ds_currency_target
+end
+
+script "js_conditional_currency_conversion", type: "javascript" do
+  parameters "ds_currency_target"
+  result "result"
+  code <<-EOS
+  result = []
+  // Make the request only if the target currency is not USD
+  if (ds_currency_target['code'] != 'USD') {
+    result = [1]
+  }
+EOS
+end
+
+datasource "ds_currency_conversion" do
+  # Only make a request if the target currency is not USD
+  iterate $ds_conditional_currency_conversion
   request do
-    run_script $js_get_account_name, $ds_get_caller_identity, $ds_top_level_billing_centers, rs_org_id, rs_optima_host
+    host "api.xe-auth.flexeraeng.com"
+    path "/prod/{proxy+}"
+    query "from", "USD"
+    query "to", val($ds_currency_target, 'code')
+    query "amount", "1"
+    # Ignore currency conversion if API has issues
+    ignore_status [400, 404, 502]
   end
   result do
     encoding "json"
-    collect jmes_path(response, "rows[*]") do
-      field "vendor_account_name", jmes_path(col_item, "dimensions.vendor_account_name")
-    end
+    field "from", jmes_path(response, "from")
+    field "to", jmes_path(response, "to")
+    field "amount", jmes_path(response, "amount")
+    field "year", jmes_path(response, "year")
   end
 end
 
-script "js_get_account_name", type: "javascript" do
-  parameters "account_id", "billing_centers", "org", "optima_host"
-  result "request"
-  code <<-EOS
-    // returns date formatted as string: YYYY-mm-dd
-    function getFormattedDailyDate(date) {
-      var year = date.getFullYear();
-      var month = (1 + date.getMonth()).toString();
-      month = month.length > 1 ? month : '0' + month;
-      var day = date.getDate().toString();
-      day = day.length > 1 ? day : '0' + day;
-      return year + '-' + month + '-' + day;
-    }
-    var start_date = getFormattedDailyDate(new Date(new Date().setDate(new Date().getDate() - 3)));
-    var end_date = getFormattedDailyDate(new Date(new Date().setDate(new Date().getDate() - 2)));
-    var request = {
-      auth: "auth_flexera",
-      host: optima_host,
-      verb: "POST",
-      path: "/bill-analysis/orgs/" + org + "/costs/select",
-      body_fields: {
-        "dimensions": ["vendor_account_name"],
-        "granularity": "day",
-        "start_at": start_date,
-        "end_at": end_date,
-        "metrics": ["cost_nonamortized_unblended_adj"],
-        "billing_center_ids": _.compact(_.map(billing_centers, function(value){ return value.id})),
-        "limit": 1,
-        "filter": {
-          "dimension": "vendor_account",
-          "type": "equal",
-          "value": account_id[0]["account"]
-        }
-      },
-      headers: {
-        "User-Agent": "RS Policies",
-        "Api-Version": "1.0"
-      },
-      ignore_status: [400]
-    }
-  EOS
+datasource "ds_currency" do
+  run_script $js_currency, $ds_currency_target, $ds_currency_conversion
 end
 
-# GET LIST OF OPTED-IN OR OPTED-IN-NOT-REQUIRED REGIONS
-datasource "ds_regions_list" do
-  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+script "js_currency", type:"javascript" do
+  parameters "ds_currency_target", "ds_currency_conversion"
+  result "result"
+  code <<-EOS
+  result = ds_currency_target
+  result['exchange_rate'] = 1
+
+  if (ds_currency_conversion['to'] != undefined) {
+    currency_code = ds_currency_target['code']
+    current_month = parseInt(new Date().toISOString().split('-')[1])
+
+    conversion_block = _.find(ds_currency_conversion['to'][currency_code], function(item) {
+      return item['month'] == current_month
+    })
+
+    if (conversion_block != undefined) {
+      result['exchange_rate'] = conversion_block['monthlyAverage']
+    }
+  }
+EOS
+end
+
+datasource "ds_describe_regions" do
   request do
     auth $auth_aws
     verb "GET"
@@ -262,140 +401,130 @@ datasource "ds_regions_list" do
   end
 end
 
-#FILTER REGIONS LIST ON 'ALLOWED REGIONS' PARAMETER
 datasource "ds_regions" do
-  run_script $js_get_regions, $param_allowed_regions, $ds_regions_list, $param_allowed_regions_allow_or_deny
+  run_script $js_regions, $ds_describe_regions, $param_regions_list, $param_regions_allow_or_deny
 end
 
-script "js_get_regions", type:"javascript" do
-  parameters "user_entered_regions", "all_regions", "regions_allow_or_deny"
-  result "regions"
+script "js_regions", type:"javascript" do
+  parameters "ds_describe_regions", "param_regions_list", "param_regions_allow_or_deny"
+  result "result"
   code <<-EOS
-    if (_.isEmpty(user_entered_regions)) {
-      regions = all_regions;
-    } else {
-      //Filter unique regions
-      var uniqueRegions = _.uniq(user_entered_regions);
-      var all_regions_list = []
-      //Filter and remove denied regions from all_regions
-      if (regions_allow_or_deny == "Deny"){
-        var all_regions = all_regions.filter(function(obj){
-          return user_entered_regions.indexOf(obj.region) === -1;
-        });
-      }
-      all_regions.forEach(function(all_region){
-        all_regions_list.push(all_region.region)
-      })
+  allow_deny_test = { "Allow": true, "Deny": false }
 
-      //Filter valid regions
-      var valid_regions = [];
-      _.map(uniqueRegions, function(uniqueRegion){
-        if (all_regions_list.indexOf(uniqueRegion) > -1) {
-          valid_regions.push({"region": uniqueRegion})
-        }
-      })
-
-      //Throw an error if no valid regions found
-      if (_.isEmpty(valid_regions)) {
-        regions = all_regions
-      } else {
-        regions = valid_regions
-      }
-    }
-  EOS
+  if (param_regions_list.length > 0) {
+    result = _.filter(ds_describe_regions, function(item) {
+      return _.contains(param_regions_list, item['region']) == allow_deny_test[param_regions_allow_or_deny]
+    })
+  } else {
+    result = ds_describe_regions
+  }
+EOS
 end
 
-#GET LIST OF EBS VOLUMES ACROSS ALL FILTERED REGIONS
-#https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html
-datasource "ds_aws_ebs_volumes" do
+datasource "ds_volumes" do
   iterate $ds_regions
   request do
     verb "GET"
     auth $auth_aws
-    pagination $aws_volumes_pagination_xml
+    pagination $pagination_aws_volumes
     host join(["ec2.", val(iter_item, "region"), ".amazonaws.com"])
     path "/"
     query "Action", "DescribeVolumes"
     query "Version", "2016-11-15"
-    #query "Filter.1.Name", "attachment.status"
-    #query "Filter.1.Value.1", "attached"
-    #query "Filter.2.Name", "status"
-    #query "Filter.2.Value.1", "in-use"
     header "User-Agent", "RS Policies"
     header "Content-Type", "text/xml"
   end
   result do
     encoding "xml"
     collect xpath(response, "//DescribeVolumesResponse/volumeSet/item", "array") do
-      field "region",val(iter_item, "region")
       field "volumeId", xpath(col_item, "volumeId")
+      field "volumeType", xpath(col_item, "volumeType")
+      field "encrypted", xpath(col_item, "encrypted")
+      field "createTime", xpath(col_item, "createTime")
       field "iops", xpath(col_item, "iops")
       field "size", xpath(col_item, "size")
       field "status", xpath(col_item, "status")
+      field "throughput", xpath(col_item, "throughput")
       field "attachmentSet" do
         collect xpath(col_item, "attachmentSet/item", "array") do
           field "instanceId", xpath(col_item, "instanceId")
           field "attachmentStatus", xpath(col_item, "status")
         end
       end
-      field "volumeType", xpath(col_item, "volumeType")
       field "tags" do
-        collect xpath(col_item,"tagSet/item","array") do
+        collect xpath(col_item,"tagSet/item", "array") do
           field "key", xpath(col_item, "key")
           field "value", xpath(col_item, "value")
         end
       end
-      field "throughput", xpath(col_item, "throughput") #Unit: MiB/s
+      field "region", val(iter_item, "region")
     end
   end
 end
 
-#FILTER INSTANCES BY 'TAG KEY EXCLUSION' PARAMETER
-datasource "ds_filtered_volumes" do
-  run_script $js_filter_volumes, $ds_aws_ebs_volumes, $param_exclusion_tag_key
+
+datasource "ds_volumes_tag_filtered" do
+  run_script $js_volumes_tag_filtered, $ds_volumes, $param_exclusion_tags
 end
 
-script "js_filter_volumes", type: "javascript" do
+script "js_volumes_tag_filtered", type: "javascript" do
+  parameters "ds_volumes", "param_exclusion_tags"
   result "result"
-  parameters "ds_aws_ebs_volumes", "param_exclusion_tag_key"
   code <<-EOS
-    var tag_key = param_exclusion_tag_key.split(':')[0]
-    var tag_value = param_exclusion_tag_key.split(':')[1]
-    var result = []
-    _.each(ds_aws_ebs_volumes, function(vol){
-      var tags = vol.tags
-      if ( !(_.contains(_.pluck(tags, 'key'), tag_key)
-      && _.contains(_.pluck(tags, 'value'), tag_value)) ) {
-        result.push(vol)
+  if (param_exclusion_tags.length > 0) {
+    result = _.reject(ds_volumes, function(volume) {
+      volume_tags = []
+
+      if (volume['tags'] != null && volume['tags'] != undefined) {
+        _.each(volume['tags'], function(tag) {
+          volume_tags.push([tag['key'], tag['value']].join(':'))
+          volume_tags.push([tag['key'], '*'].join(':'))
+        })
       }
+
+      exclude_volume = false
+
+      _.each(param_exclusion_tags, function(exclusion_tag) {
+        if (_.contains(volume_tags, exclusion_tag)) {
+          exclude_volume = true
+        }
+      })
+
+      return exclude_volume && volume['volumeType'] != 'gp2'
     })
-  EOS
+  } else {
+    result = _.reject(ds_volumes, function(volume) {
+      return volume['volumeType'] != 'gp2'
+    })
+  }
+EOS
 end
 
-#GET EBS READ OPERATIONS (FOR IOPS) METRICS FROM CLOUDWATCH - (COULD REPLACE WITH BATCH CALL?)
-datasource "ds_cloudwatch_ebs_read_iops_usage" do
-  iterate $ds_filtered_volumes
+datasource "ds_volumes_read_iops_usage" do
+  iterate $ds_volumes_tag_filtered
   request do
-    run_script $js_get_cloudwatch_read_ops, val(iter_item, "region"), val(iter_item, "volumeId")
+    run_script $js_volumes_iops_usage, val(iter_item, "region"), val(iter_item, "volumeId"), $param_stats_lookback, "VolumeReadOps"
   end
   result do
     encoding "json"
     collect jmes_path(response, "GetMetricStatisticsResponse.GetMetricStatisticsResult") do
-      field "region", val(iter_item, "region")
       field "volumeId", val(iter_item, "volumeId")
+      field "volumeType", val(iter_item, "volumeType")
+      field "encrypted", val(iter_item, "encrypted")
+      field "createTime", val(iter_item, "createTime")
+      field "iops", val(iter_item, "iops")
       field "size", val(iter_item, "size")
       field "status", val(iter_item, "status")
-      field "volumeType", val(iter_item, "volumeType")
-      field "iops", val(iter_item, "iops")
       field "throughput", val(iter_item, "throughput")
-      field "tags", val(iter_item, "tags")
       field "attachmentSet", val(iter_item, "attachmentSet")
+      field "tags", val(iter_item, "tags")
+      field "region", val(iter_item, "region")
       field "datapoints" do
         collect jmes_path(col_item, "Datapoints[*]") do
           field "readOpsMaximum", jmes_path(col_item, "Maximum")
           field "readOpsAverage", jmes_path(col_item, "Average")
-          field "readOpsSampleCount", jmes_path(col_item, "SampleCount")  #Sample Count in this case represents Metric Granularity (1 minute in this case)
-          field "readOpsSum", jmes_path(col_item, "Sum")                  #Sum is total read ops for this period
+          field "readOpsSampleCount", jmes_path(col_item, "SampleCount")
+          field "readOpsSum", jmes_path(col_item, "Sum")
           field "readOpsUnit", jmes_path(col_item, "Unit")
         end
       end
@@ -403,82 +532,46 @@ datasource "ds_cloudwatch_ebs_read_iops_usage" do
   end
 end
 
-script "js_get_cloudwatch_read_ops", type: "javascript" do
-  result "results"
-  parameters "region", "volume_id"
-  code <<-EOS
-  var end_date = new Date().toISOString()
-  var start_date = new Date(new Date().setDate(new Date().getDate() - 30)).toISOString();
-
-  results = {
-    "auth": "auth_aws",
-    "host": "monitoring." + region + ".amazonaws.com",
-    "verb": "GET",
-    "path": "/",
-    "headers": {
-      "User-Agent": "RS Policies",
-      "Content-Type": "application/json",
-      "x-amz-target": "GraniteServiceVersion20100801.GetMetricStatistics",
-      "Accept": "application/json",
-      "Content-Encoding": "amz-1.0"
-    },
-    "query_params": {
-      "Action": "GetMetricStatistics",
-      "Version": "2010-08-01",
-      "Namespace": "AWS/EBS"
-      "MetricName": "VolumeReadOps",
-      "Dimensions.member.1.Name": "VolumeId",
-      "Dimensions.member.1.Value": volume_id,
-      "StartTime": start_date,
-      "EndTime": end_date,
-      "Period": "2592000",
-      "Statistics.member.1": "Average",
-      "Statistics.member.2": "Maximum",
-      "Statistics.member.3": "SampleCount",
-      "Statistics.member.4": "Sum"
-    }
-  }
-  EOS
-end
-
-#GET EBS WRITE OPERATIONS (FOR IOPS) METRICS FROM CLOUDWATCH - (COULD REPLACE WITH BATCH CALL?)
-datasource "ds_cloudwatch_ebs_write_iops_usage" do
-  iterate $ds_filtered_volumes
+datasource "ds_volumes_write_iops_usage" do
+  iterate $ds_volumes_tag_filtered
   request do
-    run_script $js_get_cloudwatch_write_ops, val(iter_item, "region"), val(iter_item, "volumeId")
+    run_script $js_volumes_iops_usage, val(iter_item, "region"), val(iter_item, "volumeId"), $param_stats_lookback, "VolumeWriteOps"
   end
   result do
     encoding "json"
     collect jmes_path(response, "GetMetricStatisticsResponse.GetMetricStatisticsResult") do
-      field "region", val(iter_item, "region")
       field "volumeId", val(iter_item, "volumeId")
+      field "volumeType", val(iter_item, "volumeType")
+      field "encrypted", val(iter_item, "encrypted")
+      field "createTime", val(iter_item, "createTime")
+      field "iops", val(iter_item, "iops")
       field "size", val(iter_item, "size")
       field "status", val(iter_item, "status")
-      field "volumeType", val(iter_item, "volumeType")
-      field "iops", val(iter_item, "iops")
       field "throughput", val(iter_item, "throughput")
+      field "attachmentSet", val(iter_item, "attachmentSet")
       field "tags", val(iter_item, "tags")
+      field "region", val(iter_item, "region")
       field "datapoints" do
         collect jmes_path(col_item, "Datapoints[*]") do
-          field "writeOpsMaximum", jmes_path(col_item, "Maximum")
-          field "writeOpsAverage", jmes_path(col_item, "Average")
-          field "writeOpsSampleCount", jmes_path(col_item, "SampleCount")
-          field "writeOpsSum", jmes_path(col_item, "Sum")
-          field "writeOpsUnit", jmes_path(col_item, "Unit")
+          field "readOpsMaximum", jmes_path(col_item, "Maximum")
+          field "readOpsAverage", jmes_path(col_item, "Average")
+          field "readOpsSampleCount", jmes_path(col_item, "SampleCount")
+          field "readOpsSum", jmes_path(col_item, "Sum")
+          field "readOpsUnit", jmes_path(col_item, "Unit")
         end
       end
     end
   end
 end
 
-script "js_get_cloudwatch_write_ops", type: "javascript" do
-  result "results"
-  parameters "region", "volume_id"
+script "js_volume_iops_usage", type: "javascript" do
+  result "request"
+  parameters "region", "volumeId", "param_stats_lookback", "metricName"
   code <<-EOS
-  var end_date = new Date().toISOString()
-  var start_date = new Date(new Date().setDate(new Date().getDate() - 30)).toISOString();
+  end_date = new Date().toISOString()
+  start_date = new Date(new Date().setDate(new Date().getDate() - param_stats_lookback)).toISOString()
 
-  results = {
+  var request = {
     "auth": "auth_aws",
     "host": "monitoring." + region + ".amazonaws.com",
     "verb": "GET",
@@ -494,9 +587,9 @@ script "js_get_cloudwatch_write_ops", type: "javascript" do
       "Action": "GetMetricStatistics",
       "Version": "2010-08-01",
       "Namespace": "AWS/EBS"
-      "MetricName": "VolumeWriteOps",
+      "MetricName": metricName,
       "Dimensions.member.1.Name": "VolumeId",
-      "Dimensions.member.1.Value": volume_id,
+      "Dimensions.member.1.Value": volumeId,
       "StartTime": start_date,
       "EndTime": end_date,
       "Period": "2592000",
@@ -509,122 +602,133 @@ script "js_get_cloudwatch_write_ops", type: "javascript" do
   EOS
 end
 
-#GET THROUGHPUT METRICS?
-
-#COMBINE EBS DATA WITH CLOUDWATCH DATA
-datasource "ds_combined_cloudwatch_data" do
-  run_script $js_combine_cloudwatch_data, $ds_cloudwatch_ebs_read_iops_usage, $ds_cloudwatch_ebs_write_iops_usage, $ds_account_name
+datasource "ds_volumes_combined" do
+  run_script $js_volumes_combined, $ds_volumes_read_iops_usage, $ds_volumes_write_iops_usage
 end
 
-script "js_combine_cloudwatch_data", type: "javascript" do
-  parameters "ds_cloudwatch_read_ops", "ds_cloudwatch_write_ops", "ds_account_name"
-  result "period"
+script "js_volumes_combined", type: "javascript" do
+  parameters "ds_volumes_read_iops_usage", "ds_volumes_write_iops_usage"
+  result "result"
   code <<-EOS
+  result = []
+  read_object = {}
 
-  //Get list of Volume IDs
-  var volumes = _.union( _.pluck(ds_cloudwatch_read_ops, "volumeId"), _.pluck(ds_cloudwatch_write_ops, "volumeId") )
-
-  //Calculate Average Read Ops and Average Write Ops over period
-  period = []
-
-  accountName = ""
-  if (ds_account_name[0] != null) {
-    accountName = ds_account_name[0]['vendor_account_name']
-  }
-
-  _.each(volumes, function(volume_id){
-    var total_read_ops = 0, total_read_data_points = 0
-    var total_write_ops = 0, total_write_data_points = 0
-    var data_message = []
-
-    var vol_read_data = _.find(ds_cloudwatch_read_ops, function(read_data){ return read_data.volumeId == volume_id })
-    if(vol_read_data.datapoints.length <= 0){
-      data_message.push({ "message": "No CloudWatch Read Operations data." })
-    } else {
-      _.each(vol_read_data.datapoints, function(datapoint){
-        total_read_ops += datapoint.readOpsSum
-        total_read_data_points += datapoint.readOpsSampleCount
-      })
-    }
-
-    var vol_write_data = _.find(ds_cloudwatch_write_ops, function(write_data){ return write_data.volumeId == volume_id })
-    if(vol_write_data.datapoints.length <= 0){
-      data_message.push({ "message": "No CloudWatch Write Operations data." })
-    } else {
-      _.each(vol_write_data.datapoints, function(datapoint){
-        total_write_ops += datapoint.writeOpsSum
-        total_write_data_points += datapoint.writeOpsSampleCount
-      })
-    }
-
-    var iops_average = 0
-    var iops_utilization_percentage = 0
-    if(vol_read_data.datapoints.length > 0){
-      iops_average = (( total_read_ops / total_read_data_points ) / 60) + (( total_write_ops / total_write_data_points ) / 60)
-      iops_utilization_percentage = ((iops_average / ( vol_read_data.iops )) * 100).toFixed(2)
-    }
-
-    var resourceName = "";
-    var existing_tags = []
-    _.each( vol_read_data.tags, function(tag){
-      if (tag.key == "Name") {
-        resourceName = tag.value
-      }
-      existing_tags.push(tag.key + "=" + tag.value)
-    })
-
-    //Create string for Attachment Set Statuses
-    var attachment_statuses = ""
-    _.each( vol_read_data.attachmentSet, function(attachment){
-      if( attachment_statuses == "" ){ attachment_statuses += attachment.instanceId + "=" + attachment.attachmentStatus }
-      else{ attachment_statuses += ", " + attachment.InstanceId + "=" + attachment.attachmentStatus }
-    })
-
-    //Create string for CloudWatch Read/Write Ops Data (if doesn't exist)
-    var cloudwatch_data_message = ""
-    _.each( data_message, function(data){
-      if( cloudwatch_data_message == "" ){ cloudwatch_data_message += data.message }
-      else{ cloudwatch_data_message += ", " + data.message }
-    })
-
-    period.push({
-      "accountName": accountName,
-      "volumeId": volume_id,
-      "region": vol_read_data.region,
-      "size": vol_read_data.size,
-      "status": vol_read_data.status,
-      "attachmentStatus": attachment_statuses,
-      "volumeType": vol_read_data.volumeType,
-      "iops": vol_read_data.iops,
-      "throughput": vol_read_data.throughput,
-      "iopsAverage": Math.round(iops_average*100)/100,
-      "iopsUtilizationPercentage": iops_utilization_percentage,
-      "tags": existing_tags,
-      "resourceName": resourceName,
-      "cloudwatchDataWarning": cloudwatch_data_message,
-      "lookbackPeriod": "30 days",
-    })
+  _.each(ds_volumes_read_iops_usage, function(volume) {
+    read_object[volume['volumeId']] = volume
   })
-  EOS
+
+  _.each(ds_volumes_write_iops_usage, function(volume) {
+    read_data = null
+    write_data = volume['datapoints']
+
+    if (typeof(read_object[volume['volumeId']]) == 'object') {
+      read_data = read_object[volume['volumeId']]['datapoints']
+    }
+
+    if (typeof(read_data) == 'object' && typeof(write_data) == 'object') {
+      iopsAverage = null
+      iopsUtilizationPercentage = null
+
+      total_read_ops = 0
+      total_write_ops = 0
+      total_read_datapoints = 0
+      total_write_datapoints = 0
+
+      _.each(read_data, function(datapoint) {
+        total_read_ops += datapoint['readOpsSum']
+        total_read_datapoints += datapoint['readOpsSampleCount']
+      })
+
+      _.each(write_data, function(datapoint) {
+        total_write_ops += datapoint['readOpsSum']
+        total_write_datapoints += datapoint['readOpsSampleCount']
+      })
+
+      if (read_data.length > 0 && write_data.length > 0) {
+        iopsAverage = parseFloat(((total_read_ops / total_readdata_points ) / 60) + ((total_write_ops / total_write_data_points) / 60).toFixed(2))
+        iopsUtilizationPercentage = parseFloat(((iops_average / (volume['iops'])) * 100).toFixed(2))
+      }
+
+      tags = []
+      volumeName = ""
+
+      if (volume['tags'] != null && volume['tags'] != undefined) {
+        _.each(volume['tags'], function(tag) {
+          tags.push([tag['key'], tag['value']].join('='))
+
+          if (tag['key'] == 'Name') { volumeName = tag['value'] }
+        })
+      }
+
+      attachmentStatus = []
+
+      _.each(volume['attachmentSet'], function(attachment) {
+        if (attachmentStatus.length != 0) { attachmentStatus.push(", ") }
+
+        attachmentStatus.push(attachment['instanceId'])
+        attachmentStatus.push("=")
+        attachmentStatus.push(attachment['attachmentStatus'])
+      })
+
+      result.push({
+        volumeId: volume['volumeId'],
+        volumeName: volumeName,
+        volumeType: volume['volumeType'],
+        encrypted: volume['encrypted'],
+        createTime: volume['createTime'],
+        iops: volume['iops'],
+        size: volume['size'],
+        status: volume['status'],
+        throughput: volume['throughput'],
+        attachmentStatus: attachmentStatus.join(''),
+        tags: tags.join(', '),
+        region: volume['region'],
+        iopsAverage: iopsAverage,
+        iopsUtilizationPercentage: iopsUtilizationPercentage
+      })
+    }
+  })
+EOS
 end
 
-#GET GP2 AND GP3 LIST PRICES
-datasource "ds_gp2_costs" do
+datasource "ds_gp2_prices" do
   request do
-    run_script $js_get_gp2_costs
+    run_script $js_volume_prices, "gp2"
   end
 end
 
-script "js_get_gp2_costs", type: "javascript" do
+datasource "ds_gp3_prices" do
+  request do
+    run_script $js_volume_prices, "gp3"
+  end
+end
+
+script "js_volume_prices", type: "javascript" do
+  parameters "volumeApiName"
   result "request"
   code <<-EOS
-    var body = {
+  var request = {
+    "auth": "auth_aws",
+    "host": "api.pricing.us-east-1.amazonaws.com",
+    "verb": "POST",
+    "path": "/",
+    "headers": {
+      "User-Agent": "RS Policies",
+      "Content-Type": "application/x-amz-json-1.1",
+      "x-amz-target": "AWSPriceListService.GetProducts",
+      "Accept": "application/json"
+    },
+    "body_fields": {
       "Filters": [
         {
-          "Type": "TERM_MATCH", "Field": "ServiceCode", "Value": "AmazonEC2"
+          "Type": "TERM_MATCH",
+          "Field": "ServiceCode",
+          "Value": "AmazonEC2"
         },
         {
-          "Type": "TERM_MATCH", "Field": "volumeApiName", "Value": "gp2"
+          "Type": "TERM_MATCH",
+          "Field": "volumeApiName",
+          "Value": volumeApiName
         }
       ],
       "FormatVersion": "aws_v1",
@@ -632,284 +736,324 @@ script "js_get_gp2_costs", type: "javascript" do
       "MaxResults": 100,
       "ServiceCode": "AmazonEC2"
     }
-
-    request = {
-      "auth": "auth_aws",
-      "host": "api.pricing.us-east-1.amazonaws.com",
-      "verb": "POST",
-      "path": "/",
-      "headers": {
-        "User-Agent": "RS Policies",
-        "Content-Type": "application/x-amz-json-1.1",
-        "x-amz-target": "AWSPriceListService.GetProducts",
-        "Accept": "application/json"
-      },
-      "body_fields": body
-    }
-  EOS
+  }
+EOS
 end
 
-datasource "ds_gp3_costs" do
-  request do
-    run_script $js_get_gp3_costs
-  end
+datasource "ds_volumes_with_prices" do
+  run_script $js_volumes_with_prices, $ds_volumes_combined, $ds_gp2_prices, $ds_gp3_prices, $ds_currency
 end
 
-script "js_get_gp3_costs", type: "javascript" do
-  result "request"
-  code <<-EOS
-    var body = {
-      "Filters": [
-        {
-          "Type": "TERM_MATCH", "Field": "ServiceCode", "Value": "AmazonEC2"
-        },
-        {
-          "Type": "TERM_MATCH", "Field": "volumeApiName", "Value": "gp3"
-        }
-      ],
-      "FormateVersion": "aws_v1",
-      "NextToken": null,
-      "MaxResults": 100,
-      "ServiceCode": "AmazonEC2"
-    }
-
-    request = {
-      "auth": "auth_aws",
-      "host": "api.pricing.us-east-1.amazonaws.com",
-      "verb": "POST",
-      "path": "/",
-      "headers": {
-        "User-Agent": "RS Policies",
-        "Content-Type": "application/x-amz-json-1.1",
-        "x-amz-target": "AWSPriceListService.GetProducts",
-        "Accept": "application/json"
-      },
-      "body_fields": body
-    }
-  EOS
-end
-
-#ADD PRICES TO GP2 DISKS
-datasource "ds_disk_utilization_with_costs" do
-  run_script $js_add_costs_to_disk_util_data, $ds_gp2_costs, $ds_gp3_costs, $ds_combined_cloudwatch_data
-end
-
-script "js_add_costs_to_disk_util_data", type: "javascript" do
-  parameters "ds_gp2_costs", "ds_gp3_costs", "ds_combined_cloudwatch_data"
+script "js_volumes_with_prices", type: "javascript" do
+  parameters "ds_volumes_combined", "ds_gp2_prices", "ds_gp3_prices", "ds_currency"
   result "result"
   code <<-EOS
+  // Function to convert price lists to proper JSON
+  function convertPriceList(priceList) {
+    convertedPriceList = {}
 
-    //Convert AWS's response to actual JSON
-    gp2_pricelist = []
-    _.each(ds_gp2_costs.PriceList, function(price){
-      gp2_pricelist.push( JSON.parse(price.replace(/\\"/g,'"')) )
-    })
+    _.each(PriceList, function(price) {
+      entry = JSON.parse(price.replace(/\\"/g,'"'))
+      region = entry['product']['attributes']['regionCode']
 
-    gp3_pricelist = []
-    _.each(ds_gp3_costs.PriceList, function(price){
-      gp3_pricelist.push( JSON.parse(price.replace(/\\"/g,'"')))
-    })
-
-    //Add monthly saving to volume (IF volume type is GP2) where volume type and region matches
-    _.each(ds_combined_cloudwatch_data, function(data){
-      if( data.volumeType == "gp2"){
-
-        //Matching gp2 pricing
-        var matching_gp2_pricing = _.find(gp2_pricelist, function(price){
-          return ( price.product.attributes.regionCode == data.region )
-        })
-
-        var monthly_gp2_price = 0
-        if( matching_gp2_pricing != null ){
-          var on_demand_codes = _.keys(matching_gp2_pricing.terms.OnDemand)
-          _.each(on_demand_codes, function(od){
-            var price_dimensions = _.keys(matching_gp2_pricing.terms.OnDemand[od].priceDimensions)
-            _.each(price_dimensions, function(pd){
-              var gp2_storage = 0
-              if( data.size != "" ){ gp2_storage = Number(data.size) }
-              monthly_gp2_price =
-                (gp2_storage * Number(matching_gp2_pricing.terms.OnDemand[od].priceDimensions[pd].pricePerUnit.USD))
-            })
-          })
-        }
-
-        //Matching gp3 pricing
-        var matching_gp3_pricing = _.filter(gp3_pricelist, function(price){
-          return ( price.product.attributes.regionCode == data.region )
-        })
-
-        var monthly_gp3_price = 0
-        if( matching_gp3_pricing != null ){
-          _.each(matching_gp3_pricing, function(price_type){
-
-            //Charge per IOPS
-            if(price_type.product.productFamily == "System Operation"){
-              var on_demand_codes = _.keys(price_type.terms.OnDemand)
-              _.each(on_demand_codes, function(od){
-                var price_dimensions = _.keys(price_type.terms.OnDemand[od].priceDimensions)
-                _.each(price_dimensions, function(pd){
-                  var iops = 3000
-                  if( data.iops != "" && Number(data.iops) >= 3000 ){ iops = Number(data.iops) }
-                  monthly_gp3_price +=
-                    ((iops - 3000) * Number(price_type.terms.OnDemand[od].priceDimensions[pd].pricePerUnit.USD))
-                })
-              })
-            }
-            //Charge per Provisioned Throughput (Mbps)
-            if(price_type.product.productFamily == "Provisioned Throughput"){
-              var on_demand_codes = _.keys(price_type.terms.OnDemand)
-              _.each(on_demand_codes, function(od){
-                var price_dimensions = _.keys(price_type.terms.OnDemand[od].priceDimensions)
-                _.each(price_dimensions, function(pd){
-                  var throughput = 125
-                  if( data.throughput != "" && Number(data.throughput) >= 125 ){ throughput = Number(data.throughput) }
-                  monthly_gp3_price +=
-                    ((throughput - 125) * Number(price_type.terms.OnDemand[od].priceDimensions[pd].pricePerUnit.USD))
-                })
-              })
-            }
-            //Charge per Storage (GB)
-            if(price_type.product.productFamily == "Storage"){
-              var on_demand_codes = _.keys(price_type.terms.OnDemand)
-              _.each(on_demand_codes, function(od){
-                var price_dimensions = _.keys(price_type.terms.OnDemand[od].priceDimensions)
-                _.each(price_dimensions, function(pd){
-                  var storage = 0
-                  if( data.size != "" ){ storage = Number(data.size)}
-                  monthly_gp3_price +=
-                    (storage * Number(price_type.terms.OnDemand[od].priceDimensions[pd].pricePerUnit.USD))
-                })
-              })
-            }
-          })
-        }
-
-        data["gp2Price"] = (monthly_gp2_price).toFixed(3)
-        data["gp3Price"] = (monthly_gp3_price).toFixed(3)
-        data["savings"] = (monthly_gp2_price - monthly_gp3_price).toFixed(3)
+      if (convertedPriceList[region] == undefined) {
+        convertedPriceList[region] = []
       }
+
+      convertedPriceList[region].push(entry)
     })
 
-    //Filter out gp3s OR if the savings is less than 0	
-    result = _.filter(ds_combined_cloudwatch_data, function(data){	
-      return ( data.volumeType == "gp2" || data.savings >= 0 )	
-    })
-  EOS
-end
+    return convertedPriceList
+  }
 
-#FILTER IOPS UTILIZATION PERCENTAGE AGAINST IOPS UTILIZATION PARAMETER ("param_avg_iops")
-datasource "ds_filtered_disk_utilization_data" do
-  run_script $js_filter_disk_utilization_data, $ds_disk_utilization_with_costs, $ds_currency_reference, $ds_currency_code, $ds_get_caller_identity
-end
+  // Function to grab price on GP2 price list
+  function getGP2Price(instance, priceList) {
+    hourly_cost_multiplier = 365.25 / 12 * 24
+    region = instance['region']
 
-script "js_filter_disk_utilization_data", type: "javascript" do
-  parameters "ds_disk_utilization_with_costs", "ds_currency_reference", "ds_currency_code", "ds_get_caller_identity"
-  result "result"
-  code <<-EOS
-    var data = ds_disk_utilization_with_costs
-    //Filter data on average iops parameter
-    //if( param_avg_iops > -1 ){
-    //  data = _.filter(ds_disk_utilization_with_costs, function(util_data){ return util_data.iopsUtilizationPercentage <= param_avg_iops })
-    //}
-
-    //Add Account ID
-    _.each(data, function(vol){
-      vol["accountID"] = ds_get_caller_identity[0].account
-      vol["service"] = "AmazonEC2"
-    })
-
-    //Format Number for Policy Incident Summary Template
-    function formatNumber(number, separator){
-      var numString = number.toString()
-      var values = numString.split(".")
-      var result = ''
-      while( values[0].length > 3 ){
-        var chunk = values[0].substr(-3)
-        values[0] = values[0].substr(0, values[0].length - 3)
-        result = separator + chunk + result
-      }
-      if( values[0].length > 0 ){
-        result = values[0] + result
-      }
-      if( values[1] == undefined ){
-        return result
-      }
-      return result + "." + values[1]
+    size = 0
+    if (instance['size'] != "") {
+      size = Number(instance['size'])
     }
 
-    //Format costs with currency symbol and thousands separator
-    if( ds_currency_code['value'] !== undefined ){
-      if ( ds_currency_reference[ds_currency_code['value']] !== undefined ) {
-        var cur = ds_currency_reference[ds_currency_code['value']]['symbol']
-        if( ds_currency_reference[ds_currency_code['value']]['t_separator'] !== undefined ) {
-          var separator = ds_currency_reference[ds_currency_code['value']]['t_separator']
-        } else {
-          var separator = ""
-        }
-      } else {
-        var cur = ""
-        var separator = ""
-      }
-    } else {
-      var cur = "$"
-      var separator = ","
-    }
+    foundPrice = 0.0
 
-    var savings_amount_str = _.pluck(data, "savings")
-    var savings_amount = []
-    _.each(savings_amount_str, function(sav){
-      if (sav == null || sav == undefined){
-        sav = 0
-        savings_amount.push(sav)
-      } else {
-        sav = Number(sav)
-        savings_amount.push(sav)
-      }
-    })
+    if (priceList[region] != undefined) {
+      _.each(priceList[region], function(item) {
+        on_demand_pricing = item['terms']['OnDemand']
 
-    var total_gp2_gp3_savings = _.reduce(savings_amount, function(mem, num) {
-      return mem + num
-    }, 0)
-    total_gp2_gp3_savings = cur + ' ' + formatNumber(parseFloat(total_gp2_gp3_savings).toFixed(2), separator)
-    
-    result = []
-    if (_.size(data) > 0) {
-      _.each(data, function(obj) {
-        result.push(obj)
+        _.each(_.keys(on_demand_pricing), function(odKey) {
+          price_dimensions = on_demand_pricing[odKey]['priceDimensions']
+
+          _.each(_.keys(price_dimensions), function(priceKey) {
+            foundPrice = Number(price_dimensions[priceKey]['pricePerUnit']['USD']) * size
+          })
+        })
       })
     }
 
-    // Dummy entry to ensure the check statement in validation always runs at least once
-    result.push({
-      resourceID: "",
-      message: ""
-    })
+    return foundPrice * hourly_cost_multiplier
+  }
 
-    result[0]["message"] = "The total estimated monthly savings from moving gp2 volumes to gp3 volumes is " + total_gp2_gp3_savings
-  EOS
+  // Function to grab price on GP3 price list
+  function getGP3Price(instance, priceList) {
+    hourly_cost_multiplier = 365.25 / 12 * 24
+    region = instance['region']
+
+    size = 0
+    if (instance['size'] != "") {
+      size = Number(instance['size'])
+    }
+
+    iops = 3000
+    if (instance['iops'] != "" && Number(instance['iops']) >= 3000) {
+      iops = Number(instance['iops'])
+    }
+
+    throughput = 125
+    if (instance['throughput'] != "" && Number(instance['throughput']) >= 125) {
+      throughput = Number(instance['throughput'])
+    }
+
+    foundPrice = 0.0
+
+    if (priceList[region] != undefined) {
+      _.each(priceList[region], function(item) {
+        prePrice = 0.0
+
+        on_demand_pricing = item['terms']['OnDemand']
+
+        _.each(_.keys(on_demand_pricing), function(odKey) {
+          price_dimensions = on_demand_pricing[odKey]['priceDimensions']
+
+          _.each(_.keys(price_dimensions), function(priceKey) {
+            prePrice = Number(price_dimensions[priceKey]['pricePerUnit']['USD'])
+          })
+        })
+
+        if (item['product']['productFamily'] == "System Operation") {
+          foundPrice += prePrice * (iops - 3000)
+        }
+
+        if (item['product']['productFamily'] == "Provisioned Throughput") {
+          foundPrice += prePrice * (throughput - 125)
+        }
+
+        if (item['product']['productFamily'] == "Storage") {
+          foundPrice += prePrice * size
+        }
+      })
+    }
+
+    return foundPrice * hourly_cost_multiplier
+  }
+
+  result = []
+  gp2_pricelist = convertPriceList(ds_gp2_prices['PriceList'])
+  gp3_pricelist = convertPriceList(ds_gp3_prices['PriceList'])
+
+  _.each(ds_volumes_combined, function(volume) {
+    gp2_price = getGP2Price(volume, gp2_pricelist) * ds_currency['exchange_rate']
+    gp3_price = getGP3Price(volume, gp3_pricelist) * ds_currency['exchange_rate']
+    savings = gp2_price - gp3_price
+
+    if (savings >= 0 && gp2_price != 0 && gp3_price != 0) {
+      result.push({
+        volumeId: volume['volumeId'],
+        volumeName: volume['volumeName'],
+        volumeType: volume['volumeType'],
+        encrypted: volume['encrypted'],
+        createTime: volume['createTime'],
+        iops: volume['iops'],
+        size: volume['size'],
+        status: volume['status'],
+        throughput: volume['throughput'],
+        attachmentStatus: volume['attachmentStatus'],
+        tags: volume['tags'],
+        region: volume['region'],
+        iopsAverage: volume['iopsAverage'],
+        iopsUtilizationPercentage: volume['iopsUtilizationPercentage'],
+        gp2_price: gp2_price,
+        gp3_price: gp3_price,
+        savings: savings,
+        savingsCurrency: ds_currency['symbol']
+      })
+    }
+  })
+EOS
 end
 
-###############################################################################
-# Escalations
-###############################################################################
+datasource "ds_volume_costs" do
+  request do
+    run_script $js_volume_costs, $ds_aws_account, $ds_top_level_bcs, rs_org_id, rs_optima_host
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response,"rows[*]") do
+      field "resourceId", jmes_path(col_item, "dimensions.resource_id")
+      field "resourceType", jmes_path(col_item, "dimensions.resource_type")
+      field "vendorAccountName", jmes_path(col_item, "dimensions.vendor_account_name")
+      field "adjustmentName", jmes_path(col_item, "dimensions.adjustment_name")
+      field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
+    end
+  end
+end
 
-escalation "esc_email" do
-  automatic true
-  label "Send Email"
-  description "Send incident email"
-  email $param_email
+script "js_volume_costs", type: "javascript" do
+  parameters "ds_aws_account", "ds_top_level_bcs", "rs_org_id", "rs_optima_host"
+  result "request"
+  code <<-EOS
+  end_date = new Date()
+  end_date.setDate(end_date.getDate() - 2)
+  end_date = end_date.toISOString().split('T')[0]
+
+  start_date = new Date()
+  start_date.setDate(start_date.getDate() - 3)
+  start_date = start_date.toISOString().split('T')[0]
+
+  var request = {
+    auth: "auth_flexera",
+    host: rs_optima_host,
+    verb: "POST",
+    path: "/bill-analysis/orgs/" + rs_org_id + "/costs/select",
+    body_fields: {
+      dimensions: ["resource_id", "vendor_account_name", "resource_type", "adjustment_name"],
+      granularity: "day",
+      start_at: start_date,
+      end_at: end_date,
+      metrics: ["cost_amortized_unblended_adj"],
+      billing_center_ids: ds_top_level_bcs,
+      limit: 100000,
+      "filter": {
+        "type": "and",
+        "expressions": [
+          {
+            "dimension": "service",
+            "type": "equal",
+            "value": "AmazonEC2"
+          },
+          {
+            "dimension": "resource_type",
+            "type": "equal",
+            "value": "Storage"
+          },
+          {
+            "dimension": "vendor_account",
+            "type": "equal",
+            "value": ds_aws_account['id']
+          },
+          {
+            type: "not",
+            expression: {
+              dimension: "adjustment_name",
+              type: "substring",
+              substring: "Shared"
+            }
+          }
+        ]
+      }
+    },
+    headers: {
+      'User-Agent': "RS Policies",
+      'Api-Version': "1.0"
+    },
+    ignore_status: [400]
+  }
+EOS
+end
+
+datasource "ds_volume_costs_grouped" do
+  run_script $js_volume_costs_grouped, $ds_volume_costs
+end
+
+script "js_volume_costs_grouped", type: "javascript" do
+  parameters "ds_volume_costs"
+  result "result"
+  code <<-EOS
+  // Multiple a single day's cost by the average number of days in a month.
+  // The 0.25 is to account for leap years for extra precision.
+  cost_multiplier = 365.25 / 12
+
+  // Group cost data by resourceId for later use
+  result = {}
+
+  _.each(ds_volume_costs, function(item) {
+    id = item['resourceId'].toLowerCase()
+
+    if (result[id] == undefined) { result[id] = 0.0 }
+    result[id] += item['cost'] * cost_multiplier
+  })
+EOS
+end
+
+datasource "ds_underutil_volumes" do
+  run_script $js_underutil_volumes, $ds_volumes_tag_filtered, $ds_volumes_with_prices, $ds_volume_costs_grouped, $ds_aws_account, $ds_currency, $ds_currency_conversion, $ds_applied_policy, $param_min_savings, $param_stats_lookback
+end
+
+script "js_underutil_volumes", type: "javascript" do
+  parameters "ds_volumes_tag_filtered", "ds_volumes_with_prices", "ds_volume_costs_grouped", "ds_aws_account", "ds_currency", "ds_currency_conversion", "ds_applied_policy", "param_min_savings", "param_stats_lookback"
+  result "result"
+  code <<-'EOS'
+  result = []
+  total_savings = 0.0
+
+  _.each(ds_volumes_with_prices, function(volume) {
+    if (volume['savings'] >= param_min_savings) {
+      total_savings += volume['savings']
+
+      id = volume['volumeId'].toLowerCase()
+      cost = ds_volume_costs_grouped[id]
+      if (typeof(cost) != 'number') { cost = 0.0 }
+
+      startDate = new Date(volume['createTime']) // Volume Created Date
+      endDate = new Date()
+      timeDifference = endDate.getTime() - startDate.getTime()
+      daysDifference = (timeDifference / (1000 * 3600 * 24)).toFixed(2)
+
+      result.push({
+        resourceID: volume['volumeId'],
+        resourceName: volume['volumeName'],
+        resourceType: volume['volumeType'],
+        encrypted: volume['encrypted'],
+        createTime: startDate.toISOString(),
+        iops: volume['iops'],
+        size: volume['size'],
+        state: volume['status'],
+        throughput: volume['throughput'],
+        attachmentStatus: volume['attachmentStatus'],
+        tags: volume['tags'],
+        region: volume['region'],
+        iopsAverage: volume['iopsAverage'],
+        iopsUtilizationPercentage: volume['iopsUtilizationPercentage'],
+        gp2_price: parseFloat(volume['gp2_price'].toFixed(3)),
+        gp3_price: parseFloat(volume['gp3_price'].toFixed(3)),
+        savings: parseFloat(volume['savings'].toFixed(3)),
+        savingsCurrency: volume['savingsCurrency'],
+        cost: parseFloat(cost.toFixed(3)),
+        age: parseFloat(daysDifference),
+        accountID: ds_aws_account['id'],
+        accountName: ds_aws_account['name'],
+        lookbackPeriod: param_stats_lookback,
+        policy_name: ds_applied_policy['name'],
+        service: "AmazonEC2",
+        total_savings: "",
+        message: ""
+      })
+    }
+  })
+EOS
 end
 
 ###############################################################################
 # Policy
 ###############################################################################
 
-policy "pol_utilization" do
-  validate_each $ds_filtered_disk_utilization_data do
-    summary_template <<-EOS
-    {{ rs_project_name }} (Account ID: {{ rs_project_id }}):{{ len data }} Underutilized EBS volumes
-    EOS
+policy "pol_underutil_volumes" do
+  validate_each $ds_underutil_volumes do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} AWS Underutilized EBS Volumes Found"
     detail_template <<-'EOS'
+    **Potential Monthly Savings:** {{ with index data 0 }}{{ .total_savings }}{{ end }}
+
     {{ with index data 0 }}{{ .message }}{{ end }}
     EOS
     escalate $esc_email
@@ -923,60 +1067,76 @@ policy "pol_utilization" do
         label "Account Name"
       end
       field "resourceID" do
-        label "Volume ID"
-        path "volumeId"
-      end
-      field "size" do
-        label "Volume Size (GB)"
-      end
-      field "region" do
-        label "Region"
-      end
-      field "state" do
-        label "Volume Status"
-        path "status"
-      end
-      field "attachmentStatus" do
-        label "Volume Attachment Status"
-        path "attachmentStatus"
-      end
-      field "resourceType" do
-        label "Volume Type"
-        path "volumeType"
+        label "Resource ID"
       end
       field "resourceName" do
         label "Resource Name"
       end
+      field "tags" do
+        label "Resource Tags"
+      end
+      field "age" do
+        label "Age (Days)"
+      end
+      field "recommendationDetails" do
+        label "Recommendation"
+      end
+      field "resourceType" do
+        label "Resource Type"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "size" do
+        label "Size (GB)"
+      end
+      field "state" do
+        label "Status"
+      end
       field "iopsAverage" do
         label "IOPS Average %"
       end
-      field "gp2Price" do
-        label "Monthly Cost"
+      field "attachmentStatus" do
+        label "Volume Attachment Status"
       end
-      field "gp3Price" do
-        label "Monthly Cost if moved to GP3"
+      field "cost" do
+        label "Estimated Monthly Cost"
+      end
+      field "gp2_price" do
+        label "Current Monthly List Price"
+      end
+      field "gp3_price" do
+        label "New Monthly List Price"
       end
       field "savings" do
-        label "Estimated Monthly Savings from moving to GP3"
+        label "Estimated Monthly Savings"
       end
-      field "tags" do
-        label "Tags"
+      field "savingsCurrency" do
+        label "Savings Currency"
+      end
+      field "lookbackPeriod" do
+        label "Lookback Period (Days)"
       end
       field "service" do
         label "Service"
       end
-      field "cloudwatchDataWarning" do
-        label "CloudWatch Data Warning"
-      end
-      field "lookbackPeriod" do
-        label "Lookback Period"
-      end
       field "id" do
         label "ID"
-        path "volumeId"
+        path "resourceID"
       end
     end
   end
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
 end
 
 ###############################################################################
@@ -999,7 +1159,6 @@ datasource "ds_get_policy" do
     field "id", jmes_path(response, "id")
   end
 end
-
 
 datasource "ds_parent_policy_terminated" do
   run_script $js_decide_if_self_terminate, $ds_get_policy, policy_id, meta_parent_policy_id

--- a/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "3.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 
@@ -56,22 +56,34 @@ parameter "param_policy_schedule" do
 end
 
 ## Child Policy Parameters
-parameter "param_allowed_regions_allow_or_deny" do
+parameter "param_min_savings" do
+  type "number"
+  category "Policy Settings"
+  label "Minimum Savings Threshold"
+  description "Minimum potential savings required to generate a recommendation"
+  min_value 0
+  default 0
+end
+
+parameter "param_regions_allow_or_deny" do
   type "string"
+  category "Filters"
   label "Allow/Deny Regions"
   description "Allow or Deny entered regions. See the README for more details"
   allowed_values "Allow", "Deny"
   default "Allow"
 end
 
-parameter "param_allowed_regions" do
+parameter "param_regions_list" do
   type "list"
-  label "Regions"
+  category "Filters"
+  label "Allow/Deny Regions List"
   allowed_pattern /^([a-zA-Z-_]+-[a-zA-Z0-9-_]+-[0-9-_]+,*|)+$/
   description "A list of allowed or denied regions. See the README for more details"
+  default []
 end
 
-parameter "param_exclusion_tag_key" do
+parameter "param_exclusion_tags" do
   category "User Inputs"
   label "Exclusion Tag Key:Value"
   description "Cloud native tag to ignore instances that you don't want to consider for downsizing or termination. Format: Key:Value"
@@ -80,11 +92,20 @@ parameter "param_exclusion_tag_key" do
   default ""
 end
 
+parameter "param_automatic_action" do
+  type "list"
+  category "Actions"
+  label "Automatic Actions"
+  description "When this value is set, this policy will automatically take the selected action(s)"
+  allowed_values ["Upgrade Volumes to GP3"]
+  default []
+end
+
 ###############################################################################
 # Authentication
 ###############################################################################
 credentials "auth_aws" do
-  schemes "aws","aws_sts"
+  schemes "aws", "aws_sts"
   label "AWS"
   description "Select the AWS Credential from the list"
   tags "provider=aws"
@@ -93,8 +114,8 @@ end
 
 credentials "auth_flexera" do
   schemes "oauth2"
-  label "Flexera_Automation"
-  description "Select FlexeraOne OAuth2 credentials"
+  label "Flexera"
+  description "Select Flexera One OAuth2 credentials"
   tags "provider=flexera"
 end
 
@@ -687,19 +708,19 @@ datasource "ds_child_incident_details" do
   end
 end
 
-datasource "ds_filtered_disk_utilization_data_combined_incidents" do
-  run_script $js_ds_filtered_disk_utilization_data_combined_incidents, $ds_child_incident_details
+datasource "ds_underutil_volumes_combined_incidents" do
+  run_script $js_ds_underutil_volumes_combined_incidents, $ds_child_incident_details
 end
 
-script "js_ds_filtered_disk_utilization_data_combined_incidents", type: "javascript" do
+script "js_ds_underutil_volumes_combined_incidents", type: "javascript" do
   parameters "ds_child_incident_details"
   result "result"
   code <<-EOS
   result = []
   _.each(ds_child_incident_details, function(incident) {
     s = incident["summary"];
-    // If the incident summary contains "Underutilized EBS volumes" then include it in the filter result
-    if (s.indexOf("Underutilized EBS volumes") > -1) {
+    // If the incident summary contains "AWS Underutilized GP" then include it in the filter result
+    if (s.indexOf("AWS Underutilized GP") > -1) {
       _.each(incident["violation_data"], function(violation) {
         result.push(violation);
       });
@@ -715,9 +736,9 @@ end
 # Could also just have one incident and use meta_status to determine which escalation happens
 policy "policy_scheduled_report" do
   # Consolidated Incident Check(s)
-    # Consolidated incident for Underutilized EBS volumes
-  validate $ds_filtered_disk_utilization_data_combined_incidents do
-    summary_template "Consolidated Incident: {{ len data }} Underutilized EBS volumes"
+    # Consolidated incident for AWS Underutilized GP
+  validate $ds_underutil_volumes_combined_incidents do
+    summary_template "Consolidated Incident: {{ len data }} AWS Underutilized GP"
     escalate $esc_email
     check eq(size(data), 0)
     export do
@@ -729,49 +750,55 @@ policy "policy_scheduled_report" do
         label "Account Name"
       end
       field "resourceID" do
-        label "Volume ID"
-      end
-      field "size" do
-        label "Volume Size (GB)"
-      end
-      field "region" do
-        label "Region"
-      end
-      field "state" do
-        label "Volume Status"
-      end
-      field "attachmentStatus" do
-        label "Volume Attachment Status"
-      end
-      field "resourceType" do
-        label "Volume Type"
+        label "Resource ID"
       end
       field "resourceName" do
         label "Resource Name"
       end
-      field "iopsAverage" do
-        label "IOPS Average %"
+      field "tags" do
+        label "Resource Tags"
       end
-      field "gp2Price" do
-        label "Monthly Cost"
+      field "age" do
+        label "Age (Days)"
       end
-      field "gp3Price" do
-        label "Monthly Cost if moved to GP3"
+      field "recommendationDetails" do
+        label "Recommendation"
+      end
+      field "resourceType" do
+        label "Resource Type"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "size" do
+        label "Size (GB)"
+      end
+      field "state" do
+        label "Status"
+      end
+      field "iops" do
+        label "IOPS"
+      end
+      field "attachmentStatus" do
+        label "Attachment Status"
+      end
+      field "cost" do
+        label "Estimated Monthly Cost"
+      end
+      field "gp2_price" do
+        label "Current Monthly List Price"
+      end
+      field "gp3_price" do
+        label "New Monthly List Price"
       end
       field "savings" do
-        label "Estimated Monthly Savings from moving to GP3"
+        label "Estimated Monthly Savings"
       end
-      field "tags" do
-        label "Tags"
+      field "savingsCurrency" do
+        label "Savings Currency"
       end
       field "service" do
         label "Service"
-      end
-      field "cloudwatchDataWarning" do
-        label "CloudWatch Data Warning"
-      end
-      field "lookbackPeriod" do
-        label "Lookback Period"
       end
       field "id" do
         label "ID"


### PR DESCRIPTION
### Description

This is a revamp of the AWS Rightsize EBS Volumes policy that adds new functionality and meta policy support. The most notable changes are:

- The API calls to CloudWatch, and subsequent calculations for IOPS percentage, were removed because they had no bearing on the recommendations produced and simply added unnecessary permissions requirements for the user.
- The ability to action on resources directly from the incident has been added. This functionality has been successfully tested.

From the CHANGELOG:

- Several parameters altered to be more descriptive and human-readable
- Added ability to only report recommendations that meet a minimum savings threshold
- Added ability to filter resources by multiple tag key:value pairs
- Added ability to take automated actions to upgrade GP2 volumes to GP3
- Added additional context to incident description
- Removed unneeded `IOPS Average %` and `Lookback Period` fields from incident export
- Removed unneeded API calls to CloudWatch
- Normalized incident export to be consistent with other policies
- Added human-readable recommendation to incident export
- Added additional fields to incident export to facilitate scraping for dashboards
- Policy no longer raises new escalations if statistics or savings data changed but nothing else has
- Streamlined code for better readability and faster execution

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=65157f936a972a0001e5269f

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
