### PR TITLE
FOPTS-1899 Turbonomic Rightsize Virtual Machines Recommendations do not have "resourceType" incident field

### DIFF
--- a/cost/turbonomics/scale_virtual_machines_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/aws/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5
+
+- Added `Resource Type` incident field.
+
 ## v0.4
 
 - Added `RI Coverage` incident field.

--- a/cost/turbonomics/scale_virtual_machines_recommendations/aws/turbonomics_scale_virtual_machines.pt
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/aws/turbonomics_scale_virtual_machines.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.4",
+  version: "0.5",
   provider: "AWS",
   source: "Turbonomic",
   service: "Compute",
@@ -88,7 +88,7 @@ datasource "ds_get_turbonomic_recommendations" do
       field "resourceGroup", jmes_path(col_item, "target.aspects.cloudAspect.resourceGroup.displayName")
       field "resourceName", jmes_path(col_item, "target.displayName")
       field "region", jmes_path(col_item, "currentLocation.displayName")
-      field "resourceType", jmes_path(col_item, "currentEntity.displayName")
+      field "currentResourceType", jmes_path(col_item, "currentEntity.displayName")
       field "newResourceType", jmes_path(col_item, "newEntity.displayName")
       field "provider", jmes_path(col_item, "target.discoveredBy.type")
       field "details", jmes_path(col_item, "details")
@@ -319,6 +319,7 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
         vm.savings = (Math.round(vm.savings * 730 * 1000 * (vm.uptime/100)) / 1000)
         monthlySavings = monthlySavings + vm.savings
         vm.url = "https://" + param_turbonomic_endpoint + "/app/index.html#/view/main/action/" + vm.urlUUID
+        vm.resourceType = vm.currentResourceType
         instances.push(vm)
       }
     })
@@ -344,7 +345,7 @@ script "js_get_stats", type: "javascript" do
           {"name": "NetThroughput", "groupBy": ["key", "percentile"]}
         ],
         "startDate": startDate.getTime(),
-        "endDate": endDate.getTime()     
+        "endDate": endDate.getTime()
       },
       headers: {
         "Content-Type": "application/json"
@@ -404,6 +405,7 @@ script "js_filtered_stats", type: "javascript" do
   }
   _.each(ds_filtered_turbonomic_recommendations, function (instance, index) {
     monthlySavings = monthlySavings + instance.savings
+    ds_filtered_turbonomic_recommendations[index].resourceType = instance.resourceType
     _.each(ds_get_stats, function (stats) {
       if (instance.targetUUID == stats.uuid) {
         ds_filtered_turbonomic_recommendations[index] = getStats(ds_filtered_turbonomic_recommendations[index], stats, "CURRENT")
@@ -448,6 +450,9 @@ EOS
       field "resourceName" do
         label "Resource Name"
       end
+      field "resourceType" do
+        label "Resource Type"
+      end
       field "savingsCurrency" do
         label "Savings Currency"
       end
@@ -460,7 +465,7 @@ EOS
       field "uptime" do
         label "Virtual Machine Uptime Percentage"
       end
-      field "resourceType" do
+      field "currentResourceType" do
         label "Current Compute Tier"
       end
       field "newResourceType" do

--- a/cost/turbonomics/scale_virtual_machines_recommendations/azure/CHANGELOG.md
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/azure/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5
+
+- Added `Resource Type` incident field.
+
 ## v0.4
 
 - Renamed `Created Time` incident field to `Recommendation Created Time`.

--- a/cost/turbonomics/scale_virtual_machines_recommendations/azure/turbonomics_scale_virtual_machines.pt
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/azure/turbonomics_scale_virtual_machines.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.4",
+  version: "0.5",
   provider: "Azure",
   source: "Turbonomic",
   service: "Compute",
@@ -88,7 +88,7 @@ datasource "ds_get_turbonomics_recommendations" do
       field "resourceGroup", jmes_path(col_item, "target.aspects.cloudAspect.resourceGroup.displayName")
       field "resourceName", jmes_path(col_item, "target.displayName")
       field "region", jmes_path(col_item, "currentLocation.displayName")
-      field "resourceType", jmes_path(col_item, "currentEntity.displayName")
+      field "currentResourceType", jmes_path(col_item, "currentEntity.displayName")
       field "newResourceType", jmes_path(col_item, "newEntity.displayName")
       field "provider", jmes_path(col_item, "target.discoveredBy.type")
       field "details", jmes_path(col_item, "details")
@@ -319,6 +319,7 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
         vm.savings = (Math.round(vm.savings * 730 * 1000 * (vm.uptime/100)) / 1000)
         monthlySavings = monthlySavings + vm.savings
         vm.url = "https://"+ turbonomic_endpoint + "/app/index.html#/view/main/action/" + vm.uuid
+        vm.resourceType = vm.currentResourceType
         instances.push(vm)
       }
     })
@@ -466,6 +467,9 @@ policy "pol_turbonomics_scale_vms" do
       field "resourceName" do
         label "Resource Name"
       end
+      field "resourceType" do
+        label "Resource Type"
+      end
       field "savingsCurrency" do
         label "Savings Currency"
       end
@@ -483,7 +487,6 @@ policy "pol_turbonomics_scale_vms" do
       end
       field "currentResourceType" do
         label "Current Compute Tier"
-        path "resourceType"
       end
       field "newResourceType" do
         label "New Compute Tier"

--- a/cost/turbonomics/scale_virtual_machines_recommendations/gcp/CHANGELOG.md
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/gcp/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6
+
+- Added `Resource Type` incident field.
+
 ## v0.5
 
 - Added `RI Coverage` incident field.

--- a/cost/turbonomics/scale_virtual_machines_recommendations/gcp/turbonomics_scale_virtual_machines.pt
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/gcp/turbonomics_scale_virtual_machines.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.5",
+  version: "0.6",
   provider: "Google",
   source: "Turbonomic",
   service: "Compute",
@@ -88,7 +88,7 @@ datasource "ds_get_turbonomic_recommendations" do
       field "resourceGroup", jmes_path(col_item, "target.aspects.cloudAspect.resourceGroup.displayName")
       field "resourceName", jmes_path(col_item, "target.displayName")
       field "region", jmes_path(col_item, "currentLocation.displayName")
-      field "resourceType", jmes_path(col_item, "currentEntity.displayName")
+      field "currentResourceType", jmes_path(col_item, "currentEntity.displayName")
       field "newResourceType", jmes_path(col_item, "newEntity.displayName")
       field "provider", jmes_path(col_item, "target.discoveredBy.type")
       field "details", jmes_path(col_item, "details")
@@ -319,6 +319,7 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
         vm.savings = (Math.round(vm.savings * 730 * 1000 * (vm.uptime/100)) / 1000)
         monthlySavings = monthlySavings + vm.savings
         vm.url = "https://" + param_turbonomic_endpoint + "/app/index.html#/view/main/action/" + vm.urlUUID
+        vm.resourceType = vm.currentResourceType
         instances.push(vm)
       }
     })
@@ -406,6 +407,7 @@ script "js_filtered_stats", type: "javascript" do
   }
   _.each(ds_filtered_turbonomic_recommendations, function (instance, index) {
     monthlySavings = monthlySavings + instance.savings
+    ds_filtered_turbonomic_recommendations[index].resourceType = instance.resourceType
     _.each(ds_get_stats, function (stats) {
       if (instance.targetUUID == stats.uuid) {
         ds_filtered_turbonomic_recommendations[index] = getStats(ds_filtered_turbonomic_recommendations[index], stats, "CURRENT")
@@ -450,6 +452,9 @@ EOS
       field "resourceName" do
         label "Resource Name"
       end
+      field "resourceType" do
+        label "Resource Type"
+      end
       field "savingsCurrency" do
         label "Savings Currency"
       end
@@ -464,7 +469,6 @@ EOS
       end
       field "currentResourceType" do
         label "Current Compute Tier"
-        path "resourceType"
       end
       field "newResourceType" do
         label "New Compute Tier"


### PR DESCRIPTION
### Description

Turbonomic Rightsize Virtual Machines Recommendations for all three cloud providers now have resourceType incident field

### Issues Resolved

https://flexera.atlassian.net/browse/FOPTS-1899

### Link to Example Applied Policy

https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/60073?policyId=6513e37dd80db500016d6d2a
https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/60073?policyId=6513e1e74e39ab00016cbf66
https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/60073?policyId=6513d79b4e39ab00016cbf64

<img width="635" alt="image" src="https://github.com/flexera-public/policy_templates/assets/22282464/4063c3ab-d578-4040-8214-fc974e9a6368">

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
