### PR TITLE
POL-925 AWS Policies: Update Service Metadata from EC2 to Compute

### DIFF
--- a/compliance/aws/disallowed_regions/CHANGELOG.md
+++ b/compliance/aws/disallowed_regions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1
+
+- Changed service metadata to "Compute" to ensure proper incident scraping
+
 ## v3.0
 
 - Added parameter to enable Allow or Deny filtering by user entered regions

--- a/compliance/aws/disallowed_regions/aws_disallowed_regions.pt
+++ b/compliance/aws/disallowed_regions/aws_disallowed_regions.pt
@@ -7,9 +7,9 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "3.0",
+  version: "3.1",
   provider: "AWS",
-  service: "EC2",
+  service: "Compute",
   policy_set: "Disallowed Regions"
 )
 

--- a/compliance/aws/instances_without_fnm_agent/CHANGELOG.md
+++ b/compliance/aws/instances_without_fnm_agent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.2
+
+- Changed service metadata to "Compute" to ensure proper incident scraping
+
 ## v4.1
 
 - Added logic required for "Meta Policy" use-cases

--- a/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent.pt
+++ b/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent.pt
@@ -7,9 +7,9 @@ severity "medium"
 category "Compliance"
 default_frequency "weekly"
 info(
-  version: "4.1",
+  version: "4.2",
   provider: "AWS",
-  service: "EC2",
+  service: "Compute",
   policy_set: "Instances not running FlexNet Inventory Agent"
 )
 

--- a/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent_meta_parent.pt
+++ b/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "4.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 

--- a/compliance/aws/long_stopped_instances/CHANGELOG.md
+++ b/compliance/aws/long_stopped_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.1
+
+- Changed service metadata to "Compute" to ensure proper incident scraping
+
 ## v4.0
 
 - Added logic required for "Meta Policy" use-cases

--- a/compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt
+++ b/compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt
@@ -7,9 +7,9 @@ category "Compliance"
 default_frequency "15 minutes"
 severity "low"
 info(
-  version: "4.0",
+  version: "4.1",
   provider: "AWS",
-  service: "EC2",
+  service: "Compute",
   policy_set: "Long Stopped Instances"
 )
 

--- a/compliance/aws/long_stopped_instances/aws_long_stopped_instances_meta_parent.pt
+++ b/compliance/aws/long_stopped_instances/aws_long_stopped_instances_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 

--- a/cost/aws/burstable_instance_cloudwatch_credit_utilization/CHANGELOG.md
+++ b/cost/aws/burstable_instance_cloudwatch_credit_utilization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1
+
+- Changed service metadata to "Compute" to ensure proper incident scraping
+
 ## v3.0
 
 - Added parameter to enable Allow or Deny filtering by user entered regions

--- a/cost/aws/burstable_instance_cloudwatch_credit_utilization/aws_burstable_instance_cloudwatch_credit_utilization.pt
+++ b/cost/aws/burstable_instance_cloudwatch_credit_utilization/aws_burstable_instance_cloudwatch_credit_utilization.pt
@@ -7,9 +7,9 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "3.0",
+  version: "3.1",
   provider: "AWS",
-  service: "EC2",
+  service: "Compute",
   policy_set: ""
 )
 

--- a/cost/aws/idle_compute_instances/CHANGELOG.md
+++ b/cost/aws/idle_compute_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.3
+
+- Changed service metadata to "Compute" to ensure proper incident scraping
+
 ## v5.2
 
 - Fixed output of `Tags` incident field

--- a/cost/aws/idle_compute_instances/idle_compute_instances.pt
+++ b/cost/aws/idle_compute_instances/idle_compute_instances.pt
@@ -7,9 +7,9 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "5.1",
+  version: "5.3",
   provider: "AWS",
-  service: "EC2",
+  service: "Compute",
   policy_set: "Idle Compute Instances",
   recommendation_type: "Usage Reduction"
 )

--- a/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
+++ b/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "5.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 

--- a/cost/aws/instance_cloudwatch_utilization/CHANGELOG.md
+++ b/cost/aws/instance_cloudwatch_utilization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1
+
+- Changed service metadata to "Compute" to ensure proper incident scraping
+
 ## v3.0
 
 - Added parameter to enable Allow or Deny filtering by user entered regions

--- a/cost/aws/instance_cloudwatch_utilization/aws_instance_cloudwatch_utilization.pt
+++ b/cost/aws/instance_cloudwatch_utilization/aws_instance_cloudwatch_utilization.pt
@@ -7,9 +7,9 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "3.0",
+  version: "3.1",
   provider: "AWS",
-  service: "EC2",
+  service: "Compute",
   policy_set: "Inefficient Instance Usage"
 )
 

--- a/cost/aws/reserved_instances/compute_purchase_recommendation/CHANGELOG.md
+++ b/cost/aws/reserved_instances/compute_purchase_recommendation/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2
+
+- Changed service metadata to "Compute" to ensure proper incident scraping
+
 ## v0.1
 
 - Replaced references `github.com/rightscale/policy_templates` and `github.com/flexera/policy_templates` with `github.com/flexera-public/policy_templates`

--- a/cost/aws/reserved_instances/compute_purchase_recommendation/aws_reserved_instance_recommendations_with_purchase.pt
+++ b/cost/aws/reserved_instances/compute_purchase_recommendation/aws_reserved_instance_recommendations_with_purchase.pt
@@ -8,9 +8,9 @@ tenancy "single"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.1",
+  version: "0.2",
   provider: "AWS",
-  service: "EC2",
+  service: "Compute",
   policy_set: "Reserved Instance",
   publish: "false"
 )

--- a/cost/aws/reserved_instances/coverage/CHANGELOG.md
+++ b/cost/aws/reserved_instances/coverage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.10
+
+- Changed service metadata to "Compute" to ensure proper incident scraping
+
 ## v2.9
 
 - Replaced references `github.com/rightscale/policy_templates` and `github.com/flexera/policy_templates` with `github.com/flexera-public/policy_templates`

--- a/cost/aws/reserved_instances/coverage/reserved_instance_coverage.pt
+++ b/cost/aws/reserved_instances/coverage/reserved_instance_coverage.pt
@@ -7,9 +7,9 @@ severity "medium"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.9",
+  version: "2.10",
   provider: "AWS",
-  service: "EC2",
+  service: "Compute",
   policy_set: ""
 )
 

--- a/cost/aws/reserved_instances/recommendations/CHANGELOG.md
+++ b/cost/aws/reserved_instances/recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.20
+
+- Changed service metadata to "Compute" to ensure proper incident scraping
+
 ## v2.19
 
 - Changed internal names of several incident fields to ensure that they are properly scraped for dashboards.

--- a/cost/aws/reserved_instances/recommendations/aws_reserved_instance_recommendations.pt
+++ b/cost/aws/reserved_instances/recommendations/aws_reserved_instance_recommendations.pt
@@ -7,9 +7,9 @@ severity "medium"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.19",
+  version: "2.20",
   provider: "AWS",
-  service: "EC2",
+  service: "Compute",
   policy_set: "Reserved Instances",
   recommendation_type: "Rate Reduction"
 )

--- a/cost/aws/schedule_instance/CHANGELOG.md
+++ b/cost/aws/schedule_instance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1
+
+- Changed service metadata to "Compute" to ensure proper incident scraping
+
 ## v3.0
 
 - Added parameter to enable Allow or Deny filtering by user entered regions

--- a/cost/aws/schedule_instance/aws_schedule_instance.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance.pt
@@ -7,9 +7,9 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "3.0",
+  version: "3.1",
   provider: "AWS",
-  service: "EC2",
+  service: "Compute",
   policy_set:"Schedule Instance"
 )
 

--- a/cost/aws/unused_ip_addresses/CHANGELOG.md
+++ b/cost/aws/unused_ip_addresses/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.4
+
+- Changed service metadata to "Compute" to ensure proper incident scraping
+
 ## v6.3
 
 - Added conditional logic to only use currency conversion API when needed

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
@@ -7,9 +7,9 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "6.3",
+  version: "6.4",
   provider: "AWS",
-  service: "EC2",
+  service: "Compute",
   policy_set: "Unused IP Addresses",
   recommendation_type: "Usage Reduction"
 )

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "6.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 

--- a/operational/aws/instance_scheduled_events/CHANGELOG.md
+++ b/operational/aws/instance_scheduled_events/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1
+
+- Changed service metadata to "Compute" to ensure proper incident scraping
+
 ## v3.0
 
 - Added parameter to enable Allow or Deny filtering by user entered regions

--- a/operational/aws/instance_scheduled_events/aws_instance_scheduled_events.pt
+++ b/operational/aws/instance_scheduled_events/aws_instance_scheduled_events.pt
@@ -6,9 +6,9 @@ long_description ""
 category "Operational"
 severity "medium"
 info(
-  version: "3.0",
+  version: "3.1",
   provider: "AWS",
-  service: "EC2",
+  service: "Compute",
   policy_set: ""
 )
 


### PR DESCRIPTION
### Description

Our AWS policies are inconsistent; some specify the Service in their info block as "Compute", and some say "EC2". This PR updates all of them to "Compute" for consistency and to ensure that any scraped incident data is properly categorized alongside their equivalents in Azure/GCP/etc.

### Link to Example Applied Policy

Changes are purely to metadata and should not impact policy execution at all.

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
