### PR TITLE
POL-926 Deprecate Superseded Instances Policy

### DIFF
--- a/cost/superseded_instance/CHANGELOG.md
+++ b/cost/superseded_instance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2
+
+- Deprecated: This policy is no longer being updated. See README for more information.
+
 ## v3.1
 
 - Added check to determine if the instance has been upgraded or not

--- a/cost/superseded_instance/README.md
+++ b/cost/superseded_instance/README.md
@@ -2,7 +2,7 @@
 
 ## Deprecated
 
-This policy is no longer being updated. Please use the versions of this policy specific to the cloud environments you need recommendations for.
+This policy is no longer being updated. Please use the version of this policy specific to the cloud environment you need recommendations for.
 
 - [**AWS Superseded EC2 Instances**](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/superseded_instances)
 - [**Azure Superseded Compute Instances**](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/superseded_instances)

--- a/cost/superseded_instance/README.md
+++ b/cost/superseded_instance/README.md
@@ -1,5 +1,12 @@
 # Superseded Instances Policy Template
 
+## Deprecated
+
+This policy is no longer being updated. Please use the versions of this policy specific to the cloud environments you need recommendations for.
+
+- [**AWS Superseded EC2 Instances**](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/superseded_instances)
+- [**Azure Superseded Compute Instances**](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/superseded_instances)
+
 ## What it does
 
 The Superseded Instances Policy Template is used to monitor an account a generate a list of superseded instances. This policy supports AWS, Azure, and AzureCSP. It also allows use of AMD, and Burstable types as replacement. There are fundamental differences between this and Optima Superseded Instances recommendations.

--- a/cost/superseded_instance/superseded_instance.pt
+++ b/cost/superseded_instance/superseded_instance.pt
@@ -1,14 +1,14 @@
 name "Superseded Instances"
 rs_pt_ver 20180301
 type "policy"
-short_description "This Policy Template is used to identify instance sizes that have been superseded. \n See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/superseded_instance) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "**Deprecated: This policy is no longer being updated.**  This Policy Template is used to identify instance sizes that have been superseded. \n See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/superseded_instance) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 category "Cost"
 severity "low"
 default_frequency "daily"
 tenancy "single"
 info(
-  version: "3.1",
+  version: "3.2",
   provider: "Flexera Optima",
   service: "",
   policy_set: ""


### PR DESCRIPTION
### Description

This policy only supports AWS and Azure, which both now have cloud-specific versions of this policy with much more functionality. This PR deprecates the old cloud-neutral version of the policy and directs users to the new policies in the associated README.