### PR TITLE
POL-927 Azure China CBI - Add ability to choose specific billing month

### DIFF
--- a/cost/azure/azure_china_cbi/CHANGELOG.md
+++ b/cost/azure/azure_china_cbi/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.1
+
+- Updated template metadata `service` and `policy_set` fields to be in line with other CBI policies.
+-	Added parameter to allow user to specify the billing period as either the current month or a specific historical month.
+-	Removed `permission` declaration as is deprecated.
+
 ## v1.0
 
 - initial release

--- a/cost/azure/azure_china_cbi/CHANGELOG.md
+++ b/cost/azure/azure_china_cbi/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## v1.1
 
 - Updated template metadata `service` and `policy_set` fields to be in line with other CBI policies.
--	Added parameter to allow user to specify the billing period as either the current month or a specific historical month.
--	Removed `permission` declaration as is deprecated.
+- Added parameter to allow user to specify the billing period as either the current month or a specific historical month.
+- Removed `permission` declaration as is deprecated.
 
 ## v1.0
 

--- a/cost/azure/azure_china_cbi/README.md
+++ b/cost/azure/azure_china_cbi/README.md
@@ -14,7 +14,9 @@ This Policy Template is used to automatically take billing data for Azure China 
 
 This policy has the following input parameters required when launching the policy.
 
-- *Enrollment ID* - Your Azure EA Enrollment ID from Azure China Billing Portal
+- *Month To Ingest* - Whether to process bills for the current month, previous month, or a specific month.
+- *Billing Period* - The year and month to process bills for in YYYY-MM format. Only relevant if Specific Month is selected for the Month To Ingest parameter. Example: 2022-09
+- *Azure Enrollment ID* - Your Azure EA Enrollment ID from Azure China Billing Portal
 - *Bill Connect ID* - Bill Connect ID created in CBI API. Example: cbi-oi-azure-china-*
 - *Email addresses* - A list of email addresses to notify
 

--- a/cost/azure/azure_china_cbi/azure_china_cbi.pt
+++ b/cost/azure/azure_china_cbi/azure_china_cbi.pt
@@ -1,4 +1,4 @@
-name "Azure China Common Bill Ingestion"
+name "Azure China Common Bill Ingestion - TEST"
 rs_pt_ver 20180301
 type "policy"
 short_description "Azure China CBI Policy. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/azure_china_cbi/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
@@ -7,20 +7,30 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "1.0",
+  version: "1.1",
   provider: "Azure China",
-  service: "N/A",
-  policy_set: "Common Bill Ingest"
+  service: "Common Bill Ingestion",
+  policy_set: "Common Bill Ingestion"
 )
 
 ###############################################################################
 # Parameters
 ###############################################################################
 
-# Need to read the Azure EA key from credentials
-permission "perm_read_creds" do
-  actions   "rs_cm.show_sensitive","rs_cm.index_sensitive"
-  resources "rs_cm.credentials"
+parameter "param_billing_period" do
+  type "string"
+  label "Month To Ingest"
+  description "Month to process bills for."
+  default "Current Month"
+  allowed_values "Current Month", "Specific Month"
+end
+
+parameter "param_specific_period" do
+  type "string"
+  label "Billing Period"
+  description "Billing period to process bills for in YYYY-MM format. Only relevant if Specific Month is selected for Month To Ingest."
+  default "2020-01"
+  allowed_pattern /^(19|20)\d\d-(0[1-9]|1[0-2])$/
 end
 
 # Could maybe get this from the EA key, but for now just ask for it
@@ -48,7 +58,7 @@ end
 # Authentication
 ###############################################################################
 
-#AUTHENTICATE WITH AZURE
+#AUTHENTICATE WITH AZURE CHINA
 credentials "azure_ea_auth" do
   schemes "api_key"
   label "Azure"
@@ -56,30 +66,37 @@ credentials "azure_ea_auth" do
   tags "provider=azure_ea_china"
 end
 
-#AUTHENTICATE WITH FLEXERA/OPTIMA
-credentials "auth_rs" do
+#AUTHENTICATE WITH FLEXERA
+credentials "auth_flexera" do
   schemes "oauth2"
   label "flexera"
   description "Select FlexeraOne OAuth2 credentials"
-  tags "provider=flexera"
+  tags "provider=Flexera"
 end
 
 ###############################################################################
 # Datasources and Scripts
 ###############################################################################
 
-#GET BILLING PERIOD
+#GET BILLING PERIOD FOR RETRIEVING BILLING DATA FROM AZURE CHINA API
 datasource "ds_billing_period" do
-  run_script $js_get_billing_period
+  run_script $js_get_billing_period, $param_billing_period, $param_specific_period
 end
 
 script "js_get_billing_period", type: "javascript" do
+  parameters "param_billing_period", "param_specific_period"
   result "result"
   code <<-EOS
-  var current_bill_date = new Date()
-  current_bill_date.setDate(current_bill_date.getDate() - 2)
-  var billing_period = current_bill_date.toISOString().split("-")[0] + "-" + current_bill_date.toISOString().split("-")[1]
-  
+  //Get Billing Period
+  var billing_period = ""
+  if (param_billing_period == "Specific Month" && param_specific_period != "") {
+    billing_period = param_specific_period
+  } else {
+    var current_bill_date = new Date()
+    current_bill_date.setDate(current_bill_date.getDate() - 2)
+    billing_period = current_bill_date.toISOString().split("-")[0] + "-" + current_bill_date.toISOString().split("-")[1]
+  }
+
   var result = { 
     "billing_period": billing_period
   }
@@ -106,7 +123,7 @@ end
 #CREATE BILL UPLOAD
 datasource "ds_bill_upload" do
   request do
-    auth $auth_rs
+    auth $auth_flexera
     verb "POST"
     host rs_optima_host
     path join(["/optima/orgs/", rs_org_id, "/billUploads"])
@@ -130,7 +147,7 @@ script "create_bill_upload_file", type: "javascript" do
   result "request"
   code <<-EOS
     var request = {
-      auth: "auth_rs",
+      auth: "auth_flexera",
       verb: "POST",
       host: optima_host,
       path: "/optima/orgs/" + org_id + "/billUploads/" + bill_upload_id + '/files/azure-china' + ds_billing_period_data.billing_period + '.csv',
@@ -154,7 +171,7 @@ script "js_cbi_commit", type: "javascript" do
   result "request"
   code <<-EOS
     var request = {
-      auth: "auth_rs",
+      auth: "auth_flexera",
       verb: "POST",
       host: optima_host,
       path: "/optima/orgs/" + org_id + "/billUploads/" + bill_upload_id + '/operations',

--- a/cost/azure/azure_china_cbi/azure_china_cbi.pt
+++ b/cost/azure/azure_china_cbi/azure_china_cbi.pt
@@ -1,4 +1,4 @@
-name "Azure China Common Bill Ingestion - TEST"
+name "Azure China Common Bill Ingestion"
 rs_pt_ver 20180301
 type "policy"
 short_description "Azure China CBI Policy. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/azure_china_cbi/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves below -->
This is a change request for adding a parameter that gives the user the ability to specify a specific month to pull billing data for,. This is useful in the interest of retrieving historical data (i.e., billing data that is not the current month)

### Issues Resolved

<!-- List any existing issues this PR resolves below -->

- Removed the `permission` declaration as it is deprecated. This fixes the issue which breaks the current policy if it is applied in a tenant from the Catalog.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->
~Testing this in a customer tenant, will update when confirmed as working~ Can confirm this policy is working as expected in customer tenant

### Contribution Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
