### PR TITLE
Google Meta Policy Parent Fix

### DIFF
--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
@@ -285,7 +285,7 @@ script "js_make_billing_center_request", type: "javascript" do
   // Default dimensions and filter expressions required for meta parent policy
   var dimensions = ["vendor_account", "vendor_account_name"];
   var filter_expressions = [
-    { dimension: "vendor", type: "equal", value: "Google" }
+    { dimension: "vendor", type: "equal", value: "GCP" }
   ]
 
   // Append to default dimensions and filter expressions using parent policy params

--- a/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
+++ b/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
@@ -294,7 +294,7 @@ script "js_make_billing_center_request", type: "javascript" do
   // Default dimensions and filter expressions required for meta parent policy
   var dimensions = ["vendor_account", "vendor_account_name"];
   var filter_expressions = [
-    { dimension: "vendor", type: "equal", value: "Google" }
+    { dimension: "vendor", type: "equal", value: "GCP" }
   ]
 
   // Append to default dimensions and filter expressions using parent policy params

--- a/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
@@ -231,7 +231,7 @@ script "js_make_billing_center_request", type: "javascript" do
   // Default dimensions and filter expressions required for meta parent policy
   var dimensions = ["vendor_account", "vendor_account_name"];
   var filter_expressions = [
-    { dimension: "vendor", type: "equal", value: "Google" }
+    { dimension: "vendor", type: "equal", value: "GCP" }
   ]
 
   // Append to default dimensions and filter expressions using parent policy params


### PR DESCRIPTION
### Description

This fixes an issue with Google meta parent policies due to the vendor name in the Optima API being "GCP" instead of "Google"
