### PR TITLE
fix: update filter to include Azure MCA

### DIFF
--- a/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
+++ b/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
@@ -270,7 +270,7 @@ script "js_make_billing_center_request", type: "javascript" do
   // Default dimensions and filter expressions required for meta parent policy
   var dimensions = ["vendor_account", "vendor_account_name"];
   var filter_expressions = [
-    { dimension: "vendor", type: "equal", value: "Azure" }
+    { dimension: "vendor", type: "substring", substring: "Azure" } // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
   ]
 
   // Append to default dimensions and filter expressions using parent policy params

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
@@ -293,7 +293,7 @@ script "js_make_billing_center_request", type: "javascript" do
   // Default dimensions and filter expressions required for meta parent policy
   var dimensions = ["vendor_account", "vendor_account_name"];
   var filter_expressions = [
-    { dimension: "vendor", type: "equal", value: "Azure" }
+    { dimension: "vendor", type: "substring", substring: "Azure" } // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
   ]
 
   // Append to default dimensions and filter expressions using parent policy params

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
@@ -284,7 +284,7 @@ script "js_make_billing_center_request", type: "javascript" do
   // Default dimensions and filter expressions required for meta parent policy
   var dimensions = ["vendor_account", "vendor_account_name"];
   var filter_expressions = [
-    { dimension: "vendor", type: "equal", value: "Azure" }
+    { dimension: "vendor", type: "substring", substring: "Azure" } // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
   ]
 
   // Append to default dimensions and filter expressions using parent policy params

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
@@ -263,7 +263,7 @@ script "js_make_billing_center_request", type: "javascript" do
   // Default dimensions and filter expressions required for meta parent policy
   var dimensions = ["vendor_account", "vendor_account_name"];
   var filter_expressions = [
-    { dimension: "vendor", type: "equal", value: "Azure" }
+    { dimension: "vendor", type: "substring", substring: "Azure" } // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
   ]
 
   // Append to default dimensions and filter expressions using parent policy params

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
@@ -280,7 +280,7 @@ script "js_make_billing_center_request", type: "javascript" do
   // Default dimensions and filter expressions required for meta parent policy
   var dimensions = ["vendor_account", "vendor_account_name"];
   var filter_expressions = [
-    { dimension: "vendor", type: "equal", value: "Azure" }
+    { dimension: "vendor", type: "substring", substring: "Azure" } // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
   ]
 
   // Append to default dimensions and filter expressions using parent policy params

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
@@ -302,7 +302,7 @@ script "js_make_billing_center_request", type: "javascript" do
   // Default dimensions and filter expressions required for meta parent policy
   var dimensions = ["vendor_account", "vendor_account_name"];
   var filter_expressions = [
-    { dimension: "vendor", type: "equal", value: "Azure" }
+    { dimension: "vendor", type: "substring", substring: "Azure" } // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
   ]
 
   // Append to default dimensions and filter expressions using parent policy params

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
@@ -362,7 +362,7 @@ script "js_make_billing_center_request", type: "javascript" do
   // Default dimensions and filter expressions required for meta parent policy
   var dimensions = ["vendor_account", "vendor_account_name"];
   var filter_expressions = [
-    { dimension: "vendor", type: "equal", value: "Azure" }
+    { dimension: "vendor", type: "substring", substring: "Azure" } // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
   ]
 
   // Append to default dimensions and filter expressions using parent policy params

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
@@ -323,7 +323,7 @@ script "js_make_billing_center_request", type: "javascript" do
   // Default dimensions and filter expressions required for meta parent policy
   var dimensions = ["vendor_account", "vendor_account_name"];
   var filter_expressions = [
-    { dimension: "vendor", type: "equal", value: "Azure" }
+    { dimension: "vendor", type: "substring", substring: "Azure" } // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
   ]
 
   // Append to default dimensions and filter expressions using parent policy params

--- a/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent.pt
+++ b/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent.pt
@@ -265,7 +265,7 @@ script "js_make_billing_center_request", type: "javascript" do
   // Default dimensions and filter expressions required for meta parent policy
   var dimensions = ["vendor_account", "vendor_account_name"];
   var filter_expressions = [
-    { dimension: "vendor", type: "equal", value: "Azure" }
+    { dimension: "vendor", type: "substring", substring: "Azure" } // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
   ]
 
   // Append to default dimensions and filter expressions using parent policy params

--- a/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
@@ -294,7 +294,7 @@ script "js_make_billing_center_request", type: "javascript" do
   // Default dimensions and filter expressions required for meta parent policy
   var dimensions = ["vendor_account", "vendor_account_name"];
   var filter_expressions = [
-    { dimension: "vendor", type: "equal", value: "Azure" }
+    { dimension: "vendor", type: "substring", substring: "Azure" } // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
   ]
 
   // Append to default dimensions and filter expressions using parent policy params

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
@@ -295,7 +295,7 @@ script "js_make_billing_center_request", type: "javascript" do
   // Default dimensions and filter expressions required for meta parent policy
   var dimensions = ["vendor_account", "vendor_account_name"];
   var filter_expressions = [
-    { dimension: "vendor", type: "equal", value: "Azure" }
+    { dimension: "vendor", type: "substring", substring: "Azure" } // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
   ]
 
   // Append to default dimensions and filter expressions using parent policy params

--- a/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
+++ b/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
@@ -271,7 +271,7 @@ script "js_make_billing_center_request", type: "javascript" do
   // Default dimensions and filter expressions required for meta parent policy
   var dimensions = ["vendor_account", "vendor_account_name"];
   var filter_expressions = [
-    { dimension: "vendor", type: "equal", value: "Azure" }
+    { dimension: "vendor", type: "substring", substring: "Azure" } // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
   ]
 
   // Append to default dimensions and filter expressions using parent policy params

--- a/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
@@ -331,7 +331,7 @@ script "js_make_billing_center_request", type: "javascript" do
   // Default dimensions and filter expressions required for meta parent policy
   var dimensions = ["vendor_account", "vendor_account_name"];
   var filter_expressions = [
-    { dimension: "vendor", type: "equal", value: "Azure" }
+    { dimension: "vendor", type: "substring", substring: "Azure" } // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
   ]
 
   // Append to default dimensions and filter expressions using parent policy params

--- a/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
+++ b/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
@@ -261,7 +261,7 @@ script "js_make_billing_center_request", type: "javascript" do
   // Default dimensions and filter expressions required for meta parent policy
   var dimensions = ["vendor_account", "vendor_account_name"];
   var filter_expressions = [
-    { dimension: "vendor", type: "equal", value: "Azure" }
+    { dimension: "vendor", type: "substring", substring: "Azure" } // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
   ]
 
   // Append to default dimensions and filter expressions using parent policy params

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
@@ -294,7 +294,7 @@ script "js_make_billing_center_request", type: "javascript" do
   // Default dimensions and filter expressions required for meta parent policy
   var dimensions = ["vendor_account", "vendor_account_name"];
   var filter_expressions = [
-    { dimension: "vendor", type: "equal", value: "Azure" }
+    { dimension: "vendor", type: "substring", substring: "Azure" } // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
   ]
 
   // Append to default dimensions and filter expressions using parent policy params

--- a/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
+++ b/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
@@ -248,7 +248,7 @@ script "js_make_billing_center_request", type: "javascript" do
   // Default dimensions and filter expressions required for meta parent policy
   var dimensions = ["vendor_account", "vendor_account_name"];
   var filter_expressions = [
-    { dimension: "vendor", type: "equal", value: "Azure" }
+    { dimension: "vendor", type: "substring", substring: "Azure" } // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
   ]
 
   // Append to default dimensions and filter expressions using parent policy params

--- a/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent.pt
+++ b/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent.pt
@@ -255,7 +255,7 @@ script "js_make_billing_center_request", type: "javascript" do
   // Default dimensions and filter expressions required for meta parent policy
   var dimensions = ["vendor_account", "vendor_account_name"];
   var filter_expressions = [
-    { dimension: "vendor", type: "equal", value: "Azure" }
+    { dimension: "vendor", type: "substring", substring: "Azure" } // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
   ]
 
   // Append to default dimensions and filter expressions using parent policy params

--- a/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
@@ -231,7 +231,7 @@ script "js_make_billing_center_request", type: "javascript" do
   // Default dimensions and filter expressions required for meta parent policy
   var dimensions = ["vendor_account", "vendor_account_name"];
   var filter_expressions = [
-    {"dimension":"vendor","type":"substring","substring":"Azure"} // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
+    { dimension:"vendor", type:"substring", substring:"Azure" } // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
   ]
 
   // Append to default dimensions and filter expressions using parent policy params

--- a/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
@@ -231,7 +231,7 @@ script "js_make_billing_center_request", type: "javascript" do
   // Default dimensions and filter expressions required for meta parent policy
   var dimensions = ["vendor_account", "vendor_account_name"];
   var filter_expressions = [
-    { dimension:"vendor", type: "substring", substring: "Azure" } // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
+    { dimension: "vendor", type: "substring", substring: "Azure" } // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
   ]
 
   // Append to default dimensions and filter expressions using parent policy params

--- a/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
@@ -231,7 +231,7 @@ script "js_make_billing_center_request", type: "javascript" do
   // Default dimensions and filter expressions required for meta parent policy
   var dimensions = ["vendor_account", "vendor_account_name"];
   var filter_expressions = [
-    { dimension: "vendor", type: "equal", value: "Azure" }
+    {"dimension":"vendor","type":"substring","substring":"Azure"} // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
   ]
 
   // Append to default dimensions and filter expressions using parent policy params

--- a/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
@@ -231,7 +231,7 @@ script "js_make_billing_center_request", type: "javascript" do
   // Default dimensions and filter expressions required for meta parent policy
   var dimensions = ["vendor_account", "vendor_account_name"];
   var filter_expressions = [
-    { dimension:"vendor", type:"substring", substring:"Azure" } // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
+    { dimension:"vendor", type: "substring", substring: "Azure" } // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
   ]
 
   // Append to default dimensions and filter expressions using parent policy params


### PR DESCRIPTION
### Description

Currently Azure Meta Parent policies will not include subscriptions under an Azure MCA due to the filter.  This updates the filter to use `substring` instead of `equal` for identifying Azure Subscriptions
