### PR TITLE
POL-937 Fix String bug in Azure AHUB Linux Policy

### DIFF
--- a/cost/azure/hybrid_use_benefit_linux/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit_linux/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.2
+
+- Fixed issue where policy fails if an instance lacks Image Publisher metadata
+
 ## v4.1
 
 - Fixed README link in policy metadata

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "4.1",
+  version: "4.2",
   provider: "Azure",
   service: "Compute",
   policy_set: "Hybrid Use Benefit"
@@ -310,8 +310,10 @@ script "js_ahub_recommendations", type: "javascript" do
     ahub_qualified = false
     license = null
 
-    if (vm['imagePublisher'].toLowerCase() == "suse") { license = "SLES_BYOS" }
-    if (vm['imagePublisher'].toLowerCase() == "redhat") { license = "RHEL_BYOS" }
+    if (typeof(vm['imagePublisher']) == 'string') {
+      if (vm['imagePublisher'].toLowerCase() == "suse") { license = "SLES_BYOS" }
+      if (vm['imagePublisher'].toLowerCase() == "redhat") { license = "RHEL_BYOS" }
+    }
 
     if (vm['licenseType'] == "None" || _.isUndefined(vm['licenseType'])) {
       if (license != null) { ahub_qualified = true }

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "4.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 


### PR DESCRIPTION
### Description

This update fixes a bug where policy fails if an instance lacks Image Publisher metadata. The policy now verified that imagePublisher is a string before attempting to invoke the string method toLowerCase() on it.

### Link to Example Applied Policy

https://app.flexera.com/orgs/27018/automation/applied-policies/projects/116186?policyId=6520013a99745e0001587a3d

### Contribution Check List

- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
