### PR TITLE
POL-940 Fix Pricing Info in AWS Rightsize EBS Volumes

### DIFF
--- a/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.1
+
+- Fixed issue where list prices reported in incident were inflated
+
 ## v4.0
 
 - Several parameters altered to be more descriptive and human-readable

--- a/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.0",
+  version: "4.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Inefficient Disk Usage",
@@ -565,7 +565,6 @@ script "js_volumes_with_prices", type: "javascript" do
 
   // Function to grab price on GP2 price list
   function getGP2Price(instance, priceList) {
-    hourly_cost_multiplier = 365.25 / 12 * 24
     region = instance['region']
 
     size = 0
@@ -589,12 +588,11 @@ script "js_volumes_with_prices", type: "javascript" do
       })
     }
 
-    return foundPrice * hourly_cost_multiplier
+    return foundPrice
   }
 
   // Function to grab price on GP3 price list
   function getGP3Price(instance, priceList) {
-    hourly_cost_multiplier = 365.25 / 12 * 24
     region = instance['region']
 
     size = 0
@@ -642,7 +640,7 @@ script "js_volumes_with_prices", type: "javascript" do
       })
     }
 
-    return foundPrice * hourly_cost_multiplier
+    return foundPrice
   }
 
   result = []

--- a/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 


### PR DESCRIPTION
### Description

The policy was revamped with the assumption that the AWS Price List API would report hourly pricing for EBS volumes, similar to how it reports EC2 pricing. It turns out that this API reports monthly pricing, which means the math to convert it from hourly pricing resulted in highly inflated values.

### Issues Resolved

The above described issue.

### Link to Example Applied Policy

Tested in POC environment where problem was first discovered.

### Contribution Check List

- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
