### PR TITLE
FOPTS-2261 Azure Long Running Instances - add OS incident field

### DIFF
--- a/operational/azure/azure_long_running_instances/CHANGELOG.md
+++ b/operational/azure/azure_long_running_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.1
+
+- Added `Operating System` incident field.
+
 ## v4.0
 
 - Several parameters altered to be more descriptive and human-readable

--- a/operational/azure/azure_long_running_instances/CHANGELOG.md
+++ b/operational/azure/azure_long_running_instances/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v4.1
 
 - Added `Operating System` incident field.
+- Renamed field from `osType` to `platform`
 
 ## v4.0
 

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
@@ -623,7 +623,7 @@ script "js_long_running_instances_incident", type: "javascript" do
   result.push({
     id: "",                  resourceGroup: "",     resourceKind: "",
     resourceName: "",        region: "",            statuses: "",
-    platform: "",              resourceType: "",      accountID: "",
+    platform: "",            resourceType: "",      accountID: "",
     accountName: "",         tags: "",              age: "",
     status: "",              launchTime: "",        lookbackPeriod: "",
     policy_name: "",         costCurrency: "",      cost: "",

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
@@ -7,7 +7,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.0",
+  version: "4.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Long Running Instances"
@@ -669,6 +669,9 @@ policy "pol_utilization" do
       end
       field "resourceType" do
         label "Instance Size"
+      end
+      field "osType" do
+        label "Operating System"
       end
       field "age" do
         label "Resource Age (Days)"

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
@@ -300,7 +300,7 @@ datasource "ds_azure_instances" do
       field "name", jmes_path(col_item, "name")
       field "region", jmes_path(col_item, "location")
       field "timeCreated", jmes_path(col_item, "properties.timeCreated")
-      field "osType", jmes_path(col_item, "properties.storageProfile.osDisk.osType")
+      field "platform", jmes_path(col_item, "properties.storageProfile.osDisk.osType")
       field "resourceType", jmes_path(col_item, "properties.hardwareProfile.vmSize")
       field "tags", jmes_path(col_item, "tags")
       field "subscriptionId",val(iter_item, "id")
@@ -398,7 +398,7 @@ script "js_long_running_instances", type: "javascript" do
         name: vm['name'],
         region: vm['region'],
         statuses: vm['statuses'],
-        osType: vm['osType'],
+        platform: vm['platform'],
         resourceType: vm['resourceType'],
         subscriptionId: vm['subscriptionId'],
         subscriptionName: vm['subscriptionName'],
@@ -564,7 +564,7 @@ script "js_long_running_instances_incident", type: "javascript" do
       resourceName: vm['name'],
       region: vm['region'],
       statuses: vm['statuses'],
-      osType: vm['osType'],
+      platform: vm['platform'],
       resourceType: vm['resourceType'],
       accountID: vm['subscriptionId'],
       accountName: vm['subscriptionName'],
@@ -623,7 +623,7 @@ script "js_long_running_instances_incident", type: "javascript" do
   result.push({
     id: "",                  resourceGroup: "",     resourceKind: "",
     resourceName: "",        region: "",            statuses: "",
-    osType: "",              resourceType: "",      accountID: "",
+    platform: "",              resourceType: "",      accountID: "",
     accountName: "",         tags: "",              age: "",
     status: "",              launchTime: "",        lookbackPeriod: "",
     policy_name: "",         costCurrency: "",      cost: "",
@@ -670,7 +670,7 @@ policy "pol_utilization" do
       field "resourceType" do
         label "Instance Size"
       end
-      field "osType" do
+      field "platform" do
         label "Operating System"
       end
       field "age" do

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
@@ -778,6 +778,9 @@ policy "policy_scheduled_report" do
       field "resourceType" do
         label "Instance Size"
       end
+      field "osType" do
+        label "Operating System"
+      end
       field "age" do
         label "Resource Age (Days)"
       end

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
@@ -778,7 +778,7 @@ policy "policy_scheduled_report" do
       field "resourceType" do
         label "Instance Size"
       end
-      field "osType" do
+      field "platform" do
         label "Operating System"
       end
       field "age" do


### PR DESCRIPTION
### Description

Customers would like to have operating system shown as an additional incident field.
The policy already have this information, we need to expose it in the incident.

### Issues Resolved

<!-- List any existing issues this PR resolves below -->
[FOPTS-2261 Jira](https://flexera.atlassian.net/browse/FOPTS-2261)

### Link to Example Applied Policy

[Azure Long Running Instances policy template Applied](https://app.flexera.com/orgs/1105/automation/applied-policies/projects/60073?policyId=6526fc0155d35d0001a8213a)

### Contribution Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
