### PR TITLE
POL-780 Azure Savings Realized Date Change

### DIFF
--- a/cost/azure/savings_realized/CHANGELOG.md
+++ b/cost/azure/savings_realized/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.5
+
+- Policy incident no longer includes extraneous information about date and time in `Month` field
+
 ## v3.4
 
 - Added a condition to prevent null report chart array

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -7,7 +7,7 @@ default_frequency "monthly"
 severity "low"
 category "Cost"
 info(
-  version: "3.4",
+  version: "3.5",
   provider: "Flexera",
   service: "All",
   policy_set: "N/A"
@@ -54,7 +54,6 @@ end
 # Authentication
 ###############################################################################
 
-#AUTHENTICATE WITH FLEXERA/OPTIMA
 credentials "auth_flexera" do
   schemes "oauth2"
   label "flexera"
@@ -414,8 +413,10 @@ script "js_create_chart_data", type: "javascript" do
         total_spend = data.cost
       }
     })
+
+    month = mo
     report.push({
-      "month": mo,
+      "month": mo.split('-')[0] + '-' + mo.split('-')[1],
       "total_spend": parseFloat(total_spend).toFixed(2),
       "savings_realized": parseFloat(savings_realized).toFixed(2),
       "percentage": parseFloat((savings_realized/(total_spend + savings_realized))*100).toFixed(0).toString() + "%"


### PR DESCRIPTION
### Description

The month field of this policy, despite just reporting a month, includes a full timestamp with date and time, like so: 

2023-06-01T00:00:00Z

This modification makes it so that the Month field in the incident just contains the month, like so:

2023-06

### Link to Example Applied Policy

Verified working in client account.

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
