### PR TITLE
feat: Add Policy Template Source parameter on Meta Parent Policy

### DIFF
--- a/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent_meta_parent.pt
+++ b/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_allowed_regions_allow_or_deny" do
   type "string"
@@ -142,7 +150,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -190,8 +198,9 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -201,7 +210,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "AWS EC2 Instances not running FlexNet Inventory Agent" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "AWS EC2 Instances not running FlexNet Inventory Agent" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "AWS EC2 Instances not running FlexNet Inventory Agent")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -461,7 +489,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -474,9 +502,16 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_aws_accounts", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_aws_accounts", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
 
   max_actions = 50;
 
@@ -520,8 +555,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_aws_account_id = cur.aws_account_id.replace(/['"]+/g, '');
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current account id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_aws_account_id) ) {
@@ -547,7 +582,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/compliance/aws/long_stopped_instances/aws_long_stopped_instances_meta_parent.pt
+++ b/compliance/aws/long_stopped_instances/aws_long_stopped_instances_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_allowed_regions_allow_or_deny" do
   type "string"
@@ -141,7 +149,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -189,8 +197,9 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -200,7 +209,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "AWS Long-stopped Instances" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "AWS Long-stopped Instances" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "AWS Long-stopped Instances")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -460,7 +488,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -473,9 +501,16 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_aws_accounts", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_aws_accounts", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
 
   max_actions = 50;
 
@@ -519,8 +554,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_aws_account_id = cur.aws_account_id.replace(/['"]+/g, '');
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current account id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_aws_account_id) ) {
@@ -546,7 +581,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
+++ b/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -147,7 +155,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -195,8 +203,8 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -206,7 +214,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "Azure Instances not running FlexNet Inventory Agent" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "Azure Instances not running FlexNet Inventory Agent" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "Azure Instances not running FlexNet Inventory Agent")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -466,7 +493,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -479,9 +506,17 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
   max_actions = 50;
 
   grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
@@ -524,8 +559,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_subscriptionID = cur.subscriptionID;
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current subscription id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_subscriptionID) ) {
@@ -549,7 +584,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
+++ b/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_avg_cpu" do
   type "number"
@@ -189,7 +197,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -237,8 +245,9 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -248,7 +257,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "AWS Idle Compute Instances" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "AWS Idle Compute Instances" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "AWS Idle Compute Instances")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -508,7 +536,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -521,9 +549,16 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_aws_accounts", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_aws_accounts", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
 
   max_actions = 50;
 
@@ -567,8 +602,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_aws_account_id = cur.aws_account_id.replace(/['"]+/g, '');
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current account id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_aws_account_id) ) {
@@ -594,7 +629,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_glacier_days" do
   type "string"
@@ -131,7 +139,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -179,8 +187,9 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -190,7 +199,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "AWS Object Storage Optimization" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "AWS Object Storage Optimization" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "AWS Object Storage Optimization")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -450,7 +478,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -463,9 +491,16 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_aws_accounts", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_aws_accounts", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
 
   max_actions = 50;
 
@@ -509,8 +544,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_aws_account_id = cur.aws_account_id.replace(/['"]+/g, '');
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current account id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_aws_account_id) ) {
@@ -536,7 +571,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_snapshot_age" do
   type "number"
@@ -195,7 +203,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -243,8 +251,9 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -254,7 +263,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "AWS Old Snapshots" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "AWS Old Snapshots" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "AWS Old Snapshots")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -514,7 +542,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -527,9 +555,16 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_aws_accounts", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_aws_accounts", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
 
   max_actions = 50;
 
@@ -573,8 +608,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_aws_account_id = cur.aws_account_id.replace(/['"]+/g, '');
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current account id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_aws_account_id) ) {
@@ -600,7 +635,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_min_savings" do
   type "number"
@@ -151,7 +159,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -199,8 +207,9 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -210,7 +219,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "AWS Rightsize EBS Volumes" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "AWS Rightsize EBS Volumes" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "AWS Rightsize EBS Volumes")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -470,7 +498,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -483,9 +511,16 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_aws_accounts", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_aws_accounts", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
 
   max_actions = 50;
 
@@ -529,8 +564,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_aws_account_id = cur.aws_account_id.replace(/['"]+/g, '');
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current account id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_aws_account_id) ) {
@@ -556,7 +591,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_min_savings" do
   type "number"
@@ -219,7 +227,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -267,8 +275,9 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -278,7 +287,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "AWS Rightsize EC2 Instances" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "AWS Rightsize EC2 Instances" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "AWS Rightsize EC2 Instances")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -538,7 +566,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -551,9 +579,16 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_aws_accounts", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_aws_accounts", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
 
   max_actions = 50;
 
@@ -597,8 +632,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_aws_account_id = cur.aws_account_id.replace(/['"]+/g, '');
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current account id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_aws_account_id) ) {
@@ -624,7 +659,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_instance_type" do
   type "string"
@@ -160,7 +168,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -208,8 +216,9 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -219,7 +228,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "AWS Superseded EC2 Instances" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "AWS Superseded EC2 Instances" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "AWS Superseded EC2 Instances")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -479,7 +507,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -492,9 +520,16 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_aws_accounts", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_aws_accounts", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
 
   max_actions = 50;
 
@@ -538,8 +573,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_aws_account_id = cur.aws_account_id.replace(/['"]+/g, '');
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current account id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_aws_account_id) ) {
@@ -565,7 +600,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_days_unattached" do
   type "number"
@@ -152,7 +160,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -200,8 +208,9 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -211,7 +220,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "AWS Unused IP Addresses" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "AWS Unused IP Addresses" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "AWS Unused IP Addresses")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -471,7 +499,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -484,9 +512,16 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_aws_accounts", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_aws_accounts", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
 
   max_actions = 50;
 
@@ -530,8 +565,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_aws_account_id = cur.aws_account_id.replace(/['"]+/g, '');
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current account id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_aws_account_id) ) {
@@ -557,7 +592,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/aws/unused_rds/unused_rds_meta_parent.pt
+++ b/cost/aws/unused_rds/unused_rds_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_unusedtime" do
   type "number"
@@ -159,7 +167,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -207,8 +215,9 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -218,7 +227,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "AWS Unused RDS Instances" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "AWS Unused RDS Instances" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "AWS Unused RDS Instances")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -478,7 +506,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -491,9 +519,16 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_aws_accounts", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_aws_accounts", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
 
   max_actions = 50;
 
@@ -537,8 +572,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_aws_account_id = cur.aws_account_id.replace(/['"]+/g, '');
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current account id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_aws_account_id) ) {
@@ -564,7 +599,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_unused_days" do
   type "number"
@@ -178,7 +186,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -226,8 +234,9 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -237,7 +246,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "AWS Unused Volumes" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "AWS Unused Volumes" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "AWS Unused Volumes")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -497,7 +525,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -510,9 +538,16 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_aws_accounts", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_aws_accounts", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
 
   max_actions = 50;
 
@@ -556,8 +591,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_aws_account_id = cur.aws_account_id.replace(/['"]+/g, '');
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current account id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_aws_account_id) ) {
@@ -583,7 +618,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -170,7 +178,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -218,8 +226,8 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -229,7 +237,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "Azure Hybrid Use Benefit for Windows Server" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "Azure Hybrid Use Benefit for Windows Server" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "Azure Hybrid Use Benefit for Windows Server")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -489,7 +516,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -502,9 +529,17 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
   max_actions = 50;
 
   grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
@@ -547,8 +582,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_subscriptionID = cur.subscriptionID;
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current subscription id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_subscriptionID) ) {
@@ -572,7 +607,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -161,7 +169,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -209,8 +217,8 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -220,7 +228,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "Azure Hybrid Use Benefit for Linux Server" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "Azure Hybrid Use Benefit for Linux Server" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "Azure Hybrid Use Benefit for Linux Server")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -480,7 +507,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -493,9 +520,17 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
   max_actions = 50;
 
   grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
@@ -538,8 +573,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_subscriptionID = cur.subscriptionID;
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current subscription id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_subscriptionID) ) {
@@ -563,7 +598,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_exclusion_tag_key" do
   category "User Inputs"
@@ -140,7 +148,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -188,8 +196,8 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -199,7 +207,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "Azure Hybrid Use Benefit for SQL" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "Azure Hybrid Use Benefit for SQL" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "Azure Hybrid Use Benefit for SQL")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -459,7 +486,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -472,9 +499,17 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
   max_actions = 50;
 
   grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
@@ -517,8 +552,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_subscriptionID = cur.subscriptionID;
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current subscription id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_subscriptionID) ) {
@@ -542,7 +577,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -157,7 +165,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -205,8 +213,8 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -216,7 +224,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "Azure Idle Compute Instances" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "Azure Idle Compute Instances" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "Azure Idle Compute Instances")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -476,7 +503,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -489,9 +516,17 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
   max_actions = 50;
 
   grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
@@ -534,8 +569,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_subscriptionID = cur.subscriptionID;
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current subscription id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_subscriptionID) ) {
@@ -559,7 +594,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -179,7 +187,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -227,8 +235,8 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -238,7 +246,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "Azure Old Snapshots" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "Azure Old Snapshots" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "Azure Old Snapshots")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -498,7 +525,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -511,9 +538,17 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
   max_actions = 50;
 
   grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
@@ -556,8 +591,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_subscriptionID = cur.subscriptionID;
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current subscription id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_subscriptionID) ) {
@@ -581,7 +616,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -239,7 +247,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -287,8 +295,8 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -298,7 +306,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "Azure Rightsize Compute Instances" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "Azure Rightsize Compute Instances" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "Azure Rightsize Compute Instances")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -558,7 +585,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -571,9 +598,17 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
   max_actions = 50;
 
   grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
@@ -616,8 +651,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_subscriptionID = cur.subscriptionID;
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current subscription id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_subscriptionID) ) {
@@ -641,7 +676,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -200,7 +208,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -248,8 +256,8 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -259,7 +267,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "Azure Rightsize SQL Databases" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "Azure Rightsize SQL Databases" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "Azure Rightsize SQL Databases")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -519,7 +546,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -532,9 +559,17 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
   max_actions = 50;
 
   grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
@@ -577,8 +612,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_subscriptionID = cur.subscriptionID;
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current subscription id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_subscriptionID) ) {
@@ -602,7 +637,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent.pt
+++ b/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_exclusion_tag_key" do
   category "User Inputs"
@@ -142,7 +150,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -190,8 +198,8 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -201,7 +209,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "Azure Storage Accounts without Lifecycle Management Policies" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "Azure Storage Accounts without Lifecycle Management Policies" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "Azure Storage Accounts without Lifecycle Management Policies")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -461,7 +488,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -474,9 +501,17 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
   max_actions = 50;
 
   grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
@@ -519,8 +554,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_subscriptionID = cur.subscriptionID;
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current subscription id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_subscriptionID) ) {
@@ -544,7 +579,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -171,7 +179,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -219,8 +227,8 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -230,7 +238,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "Azure Superseded Compute Instances" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "Azure Superseded Compute Instances" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "Azure Superseded Compute Instances")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -490,7 +517,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -503,9 +530,17 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
   max_actions = 50;
 
   grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
@@ -548,8 +583,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_subscriptionID = cur.subscriptionID;
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current subscription id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_subscriptionID) ) {
@@ -573,7 +608,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -172,7 +180,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -220,8 +228,8 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -231,7 +239,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "Azure Unused IP Addresses" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "Azure Unused IP Addresses" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "Azure Unused IP Addresses")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -491,7 +518,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -504,9 +531,17 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
   max_actions = 50;
 
   grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
@@ -549,8 +584,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_subscriptionID = cur.subscriptionID;
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current subscription id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_subscriptionID) ) {
@@ -574,7 +609,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
+++ b/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_exclusion_tag_key" do
   type "string"
@@ -148,7 +156,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -196,8 +204,8 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -207,7 +215,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "Azure Unused SQL Databases" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "Azure Unused SQL Databases" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "Azure Unused SQL Databases")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -467,7 +494,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -480,9 +507,17 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
   max_actions = 50;
 
   grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
@@ -525,8 +560,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_subscriptionID = cur.subscriptionID;
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current subscription id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_subscriptionID) ) {
@@ -550,7 +585,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -208,7 +216,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -256,8 +264,8 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -267,7 +275,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "Azure Unused Volumes" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "Azure Unused Volumes" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "Azure Unused Volumes")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -527,7 +554,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -540,9 +567,17 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
   max_actions = 50;
 
   grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
@@ -585,8 +620,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_subscriptionID = cur.subscriptionID;
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current subscription id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_subscriptionID) ) {
@@ -610,7 +645,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations_meta_parent.pt
+++ b/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_min_savings" do
   type "number"
@@ -162,7 +170,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -210,8 +218,8 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -221,7 +229,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "Google Idle Cloud SQL Instance Recommender" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "Google Idle Cloud SQL Instance Recommender" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "Google Idle Cloud SQL Instance Recommender")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -481,7 +508,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_google_projects, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_google_projects, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -494,9 +521,17 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_google_projects", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_google_projects", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
   max_actions = 50;
 
   grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
@@ -539,8 +574,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_projectID = cur.projectID;
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.projectName + " (" + cur_projectID + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Google Project **" + cur.projectName +"** (`" + cur_projectID + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.projectName + " (" + cur_projectID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Google Project **" + cur.projectName +"** (`" + cur_projectID + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current Project ID
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_projectID) ) {
@@ -564,7 +599,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/google/cud_recommendations/google_committed_use_discount_recommendations_meta_parent.pt
+++ b/cost/google/cud_recommendations/google_committed_use_discount_recommendations_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_min_savings" do
   type "number"
@@ -162,7 +170,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -210,8 +218,8 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -221,7 +229,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "Google Committed Use Discount Recommender" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "Google Committed Use Discount Recommender" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "Google Committed Use Discount Recommender")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -481,7 +508,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_google_projects, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_google_projects, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -494,9 +521,17 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_google_projects", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_google_projects", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
   max_actions = 50;
 
   grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
@@ -539,8 +574,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_projectID = cur.projectID;
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.projectName + " (" + cur_projectID + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Google Project **" + cur.projectName +"** (`" + cur_projectID + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.projectName + " (" + cur_projectID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Google Project **" + cur.projectName +"** (`" + cur_projectID + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current Project ID
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_projectID) ) {
@@ -564,7 +599,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_min_savings" do
   type "number"
@@ -162,7 +170,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -210,8 +218,8 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -221,7 +229,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "Google Idle IP Address Recommender" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "Google Idle IP Address Recommender" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "Google Idle IP Address Recommender")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -481,7 +508,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_google_projects, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_google_projects, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -494,9 +521,17 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_google_projects", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_google_projects", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
   max_actions = 50;
 
   grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
@@ -539,8 +574,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_projectID = cur.projectID;
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.projectName + " (" + cur_projectID + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Google Project **" + cur.projectName +"** (`" + cur_projectID + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.projectName + " (" + cur_projectID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Google Project **" + cur.projectName +"** (`" + cur_projectID + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current Project ID
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_projectID) ) {
@@ -564,7 +599,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_min_savings" do
   type "number"
@@ -169,7 +177,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -217,8 +225,8 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -228,7 +236,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "Google Idle Persistent Disk Recommender" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "Google Idle Persistent Disk Recommender" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "Google Idle Persistent Disk Recommender")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -488,7 +515,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_google_projects, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_google_projects, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -501,9 +528,17 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_google_projects", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_google_projects", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
   max_actions = 50;
 
   grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
@@ -546,8 +581,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_projectID = cur.projectID;
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.projectName + " (" + cur_projectID + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Google Project **" + cur.projectName +"** (`" + cur_projectID + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.projectName + " (" + cur_projectID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Google Project **" + cur.projectName +"** (`" + cur_projectID + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current Project ID
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_projectID) ) {
@@ -571,7 +606,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
+++ b/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_min_savings" do
   type "number"
@@ -171,7 +179,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -219,8 +227,8 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -230,7 +238,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "Google Rightsize VM Recommender" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "Google Rightsize VM Recommender" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "Google Rightsize VM Recommender")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -490,7 +517,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_google_projects, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_google_projects, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -503,9 +530,17 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_google_projects", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_google_projects", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
   max_actions = 50;
 
   grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
@@ -548,8 +583,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_projectID = cur.projectID;
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.projectName + " (" + cur_projectID + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Google Project **" + cur.projectName +"** (`" + cur_projectID + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.projectName + " (" + cur_projectID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Google Project **" + cur.projectName +"** (`" + cur_projectID + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current Project ID
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_projectID) ) {
@@ -573,7 +608,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate_meta_parent.pt
+++ b/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_allowed_regions_allow_or_deny" do
   type "string"
@@ -133,7 +141,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -181,8 +189,9 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -192,7 +201,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "AWS Lambda Functions with high error rate" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "AWS Lambda Functions with high error rate" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "AWS Lambda Functions with high error rate")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -452,7 +480,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -465,9 +493,16 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_aws_accounts", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_aws_accounts", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
 
   max_actions = 50;
 
@@ -511,8 +546,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_aws_account_id = cur.aws_account_id.replace(/['"]+/g, '');
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current account id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_aws_account_id) ) {
@@ -538,7 +573,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
+++ b/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_regions_allow_or_deny" do
   type "string"
@@ -151,7 +159,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -199,8 +207,9 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -210,7 +219,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "AWS Long Running Instances" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "AWS Long Running Instances" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "AWS Long Running Instances")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -470,7 +498,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -483,9 +511,16 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_aws_accounts", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_aws_accounts", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
 
   max_actions = 50;
 
@@ -529,8 +564,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_aws_account_id = cur.aws_account_id.replace(/['"]+/g, '');
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current account id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_aws_account_id) ) {
@@ -556,7 +591,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
+++ b/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -138,7 +146,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -186,8 +194,8 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -197,7 +205,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "Expiring Azure Certificates" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "Expiring Azure Certificates" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "Expiring Azure Certificates")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -457,7 +484,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -470,9 +497,17 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
   max_actions = 50;
 
   grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
@@ -515,8 +550,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_subscriptionID = cur.subscriptionID;
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current subscription id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_subscriptionID) ) {
@@ -540,7 +575,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -171,7 +179,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -219,8 +227,8 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -230,7 +238,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "Azure Long Running Instances" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "Azure Long Running Instances" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "Azure Long Running Instances")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -490,7 +517,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -503,9 +530,17 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
   max_actions = 50;
 
   grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
@@ -548,8 +583,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_subscriptionID = cur.subscriptionID;
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current subscription id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_subscriptionID) ) {
@@ -573,7 +608,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
+++ b/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -125,7 +133,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -173,8 +181,8 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -184,7 +192,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "Azure Tag Cardinality Report" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "Azure Tag Cardinality Report" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "Azure Tag Cardinality Report")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -444,7 +471,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -457,9 +484,17 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
   max_actions = 50;
 
   grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
@@ -502,8 +537,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_subscriptionID = cur.subscriptionID;
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current subscription id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_subscriptionID) ) {
@@ -527,7 +562,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent.pt
+++ b/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -132,7 +140,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -180,8 +188,8 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -191,7 +199,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "Azure VMs Not Using Managed Disks" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "Azure VMs Not Using Managed Disks" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "Azure VMs Not Using Managed Disks")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -451,7 +478,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -464,9 +491,17 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
   max_actions = 50;
 
   grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
@@ -509,8 +544,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_subscriptionID = cur.subscriptionID;
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current subscription id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_subscriptionID) ) {
@@ -534,7 +569,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances_meta_parent.pt
+++ b/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances_meta_parent.pt
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 parameter "param_allowed_regions_allow_or_deny" do
   type "string"
@@ -134,7 +142,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -182,8 +190,9 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -193,7 +202,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "AWS Publicly Accessible RDS Instances" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "AWS Publicly Accessible RDS Instances" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "AWS Publicly Accessible RDS Instances")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -453,7 +481,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -466,9 +494,16 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_aws_accounts", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_aws_accounts", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
 
   max_actions = 50;
 
@@ -512,8 +547,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_aws_account_id = cur.aws_account_id.replace(/['"]+/g, '');
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current account id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_aws_account_id) ) {
@@ -539,7 +574,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 __PLACEHOLDER_FOR_CHILD_POLICY_PARAMETERS_BLOCKS__
 
@@ -95,7 +103,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -143,8 +151,9 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -154,7 +163,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "__PLACEHOLDER_FOR_CHILD_POLICY_NAME__" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "__PLACEHOLDER_FOR_CHILD_POLICY_NAME__" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "__PLACEHOLDER_FOR_CHILD_POLICY_NAME__")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -414,7 +442,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -427,9 +455,16 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_aws_accounts", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_aws_accounts", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
 
   max_actions = 50;
 
@@ -473,8 +508,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_aws_account_id = cur.aws_account_id.replace(/['"]+/g, '');
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current account id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_aws_account_id) ) {
@@ -500,7 +535,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 __PLACEHOLDER_FOR_CHILD_POLICY_PARAMETERS_BLOCKS__
 
@@ -108,7 +116,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -156,8 +164,8 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -167,7 +175,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "__PLACEHOLDER_FOR_CHILD_POLICY_NAME__" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "__PLACEHOLDER_FOR_CHILD_POLICY_NAME__" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "__PLACEHOLDER_FOR_CHILD_POLICY_NAME__")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -427,7 +454,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_azure_subscriptions, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -440,9 +467,17 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_azure_subscriptions", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
   max_actions = 50;
 
   grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
@@ -485,8 +520,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_subscriptionID = cur.subscriptionID;
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.subscriptionName + " (" + cur_subscriptionID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + cur.subscriptionName +"** (`" + cur_subscriptionID + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current subscription id
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_subscriptionID) ) {
@@ -510,7 +545,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,

--- a/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
@@ -55,6 +55,14 @@ parameter "param_policy_schedule" do
   allowed_values "daily", "weekly", "monthly"
 end
 
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
 ## Child Policy Parameters
 __PLACEHOLDER_FOR_CHILD_POLICY_PARAMETERS_BLOCKS__
 
@@ -108,7 +116,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });
@@ -156,8 +164,8 @@ script "js_format_self", type: "javascript" do
   EOS
 end
 
-# Get Child Policy Details
-datasource "ds_child_policy_information" do
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
   request do
     auth $auth_flexera
     host rs_governance_host
@@ -167,7 +175,26 @@ datasource "ds_child_policy_information" do
   result do
     encoding "json"
     # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
-    collect jq(response, '.items[] | select(.name == "__PLACEHOLDER_FOR_CHILD_POLICY_NAME__" and .created_by.email == "support@flexera.com")' ) do
+    collect jq(response, '.items[] | select(.name == "__PLACEHOLDER_FOR_CHILD_POLICY_NAME__" and .created_by.email == "BKaraffa@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "__PLACEHOLDER_FOR_CHILD_POLICY_NAME__")' ) do
       field "name", jmes_path(col_item, "name")
       field "href", jmes_path(col_item, "href")
       field "short_description", jmes_path(col_item, "short_description")
@@ -427,7 +454,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_google_projects, $ds_format_self, first($ds_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_get_google_projects, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -440,9 +467,17 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_google_projects", "ds_format_self", "ds_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_get_google_projects", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
   max_actions = 50;
 
   grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
@@ -485,8 +520,8 @@ script "js_take_in_parameters", type: "javascript" do
     cur_projectID = cur.projectID;
 
     // Name and description do not vary between create or updates so defining them here
-    name = ds_child_policy_information.name + ": " + cur.projectName + " (" + cur_projectID + ") (child policy)";
-    description = ds_child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Google Project **" + cur.projectName +"** (`" + cur_projectID + "`).  " + ds_child_policy_information.short_description;
+    name = child_policy_information.name + ": " + cur.projectName + " (" + cur_projectID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Google Project **" + cur.projectName +"** (`" + cur_projectID + "`).  " + child_policy_information.short_description;
 
     // Check if child policy exists for current Project ID
     if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_projectID) ) {
@@ -510,7 +545,7 @@ script "js_take_in_parameters", type: "javascript" do
           "options" : options,
           "frequency" : param_policy_schedule,
           "meta_parent_policy_id": meta_parent_policy_id,
-          "template_href": ds_child_policy_information.href
+          "template_href": child_policy_information.href
         })
         policy_status={
           "policy_name": name,


### PR DESCRIPTION
### Description

Adds a parameter which enables a Meta Parent Policy Template to use the uploaded Policy Template for the child instead of the Published Template.  This is primarily helpful for development, but may also be helpful for customers that use forked versions of our Child Policy Templates.

### Link to Example Applied Policy

https://app.flexera.com/orgs/27018/automation/applied-policies/projects/116186?policyId=652ed5b4e947000001d933b3
Deployed using uploaded policy template
