### PR TITLE
FOPTS-2328 Low Account Usage Policy: add account ID to incident details

### DIFF
--- a/cost/low_account_usage/CHANGELOG.md
+++ b/cost/low_account_usage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.4
+
+- Added `Account ID` incident field.
+
 ## v2.3
 
 - Added filters to API calls to reduce response body lenght.

--- a/cost/low_account_usage/low_account_usage.pt
+++ b/cost/low_account_usage/low_account_usage.pt
@@ -8,7 +8,7 @@ category "Cost"
 default_frequency "daily"
 tenancy "single"
 info(
-  version: "2.3",
+  version: "2.4",
   provider: "Flexera Optima",
   service: "",
   policy_set: ""
@@ -90,6 +90,7 @@ datasource "ds_new_bc_costs" do
       field "vendor_account_name", jmes_path(col_item,"dimensions.vendor_account_name")
       field "cost_amortized_unblended_adj", jmes_path(col_item,"metrics.cost_amortized_blended_adj")
       field "id", jmes_path(col_item,"dimensions.billing_center_id")
+      field "accountID", jmes_path(col_item,"dimensions.vendor_account")
     end
   end
 end
@@ -134,7 +135,7 @@ script "js_new_costs_request", type: "javascript" do
       host: rs_optima_host,
       path: "/bill-analysis/orgs/" + org_id + "/costs/aggregated",
       body_fields: {
-        "dimensions": ["billing_center_id","vendor","vendor_account_name"],
+        "dimensions": ["billing_center_id","vendor","vendor_account_name","vendor_account"],
         "granularity": "day",
         "metrics": ['cost_amortized_blended_adj'],
         "billing_center_ids": billing_center_ids,
@@ -146,7 +147,7 @@ script "js_new_costs_request", type: "javascript" do
             "dimension": "service",
             "type": "equal",
             "value": "APNFee"
-          }      
+          }
         }
       },
       headers: {
@@ -194,6 +195,7 @@ script "js_format_costs", type: "javascript" do
       new_sum: nbc.cost_amortized_unblended_adj,
       vendor: nbc.vendor,
       vendor_account_name: nbc.vendor_account_name,
+      accountID: nbc.accountID
     })
   })
 
@@ -212,6 +214,7 @@ script "js_format_costs", type: "javascript" do
         vendor: group[0].vendor,
         vendor_account_name: group[0].vendor_account_name,
         run_rate: parseFloat(runrate).toFixed(2)
+        accountID: group[0].accountID
     }
   });
 
@@ -219,7 +222,7 @@ script "js_format_costs", type: "javascript" do
     if (parseFloat(result.run_rate) <= param_threshold && parseFloat(result.run_rate) >= param_minimum_savings_threshold) {
       return result;
     }
-  }) 
+  })
 
   var formatted_data = _(checked_results).chain().sortBy(function(result) {
     return result.vendor_account_name;
@@ -253,6 +256,9 @@ policy "policy_budget_alert" do
       end
       field "vendor" do
         label "Vendor"
+      end
+      field "accountID" do
+        label "Account ID"
       end
       field "vendor_account_name" do
         label "Account Name"

--- a/cost/low_account_usage/low_account_usage.pt
+++ b/cost/low_account_usage/low_account_usage.pt
@@ -251,9 +251,6 @@ policy "policy_budget_alert" do
     check eq(size(data), 0)
     export do
       resource_level true
-      field "accountID" do
-        label "Account ID"
-      end
       field "name" do
         label "Billing Center Name"
       end


### PR DESCRIPTION
### Description

Customers want account ID to be provided in the incident details for Low Account Usage policy

### Issues Resolved

[FOPTS-2328 Jira](https://flexera.atlassian.net/browse/FOPTS-2328)

### Link to Example Applied Policy

[Low Account Usage - Policy template applied](https://app.flexera.com/orgs/1105/automation/applied-policies/projects/60073?policyId=65332b9755d35d0001a84227)

### Contribution Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
