### PR TITLE
POL-955 Azure Long Running Instances Fix

### DIFF
--- a/operational/azure/azure_long_running_instances/CHANGELOG.md
+++ b/operational/azure/azure_long_running_instances/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v4.2
 
 - Fixed error where policy would sometimes report on stopped instances
+- Fixed minor language error in incident output
 
 ## v4.1
 

--- a/operational/azure/azure_long_running_instances/CHANGELOG.md
+++ b/operational/azure/azure_long_running_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.2
+
+- Fixed error where policy would sometimes report on stopped instances
+
 ## v4.1
 
 - Added `Operating System` incident field.

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
@@ -303,7 +303,6 @@ datasource "ds_azure_instances" do
       field "platform", jmes_path(col_item, "properties.storageProfile.osDisk.osType")
       field "resourceType", jmes_path(col_item, "properties.hardwareProfile.vmSize")
       field "provisioningState", jmes_path(col_item, "properties.provisioningState")
-      field "statuses", jmes_path(col_item, "properties.instanceView.statuses")
       field "tags", jmes_path(col_item, "tags")
       field "subscriptionId",val(iter_item, "id")
       field "subscriptionName",val(iter_item, "name")
@@ -311,17 +310,51 @@ datasource "ds_azure_instances" do
   end
 end
 
+datasource "ds_azure_instance_statuses" do
+  iterate $ds_azure_subscriptions_filtered
+  request do
+    auth $auth_azure
+    pagination $pagination_azure
+    host $param_azure_endpoint
+    path join(["/subscriptions/", val(iter_item, "id"), "/providers/Microsoft.Compute/virtualMachines"])
+    query "api-version", "2023-07-01"
+    query "statusOnly", "true"
+    header "User-Agent", "RS Policies"
+    # Ignore status 400, 403, and 404 which can be returned in certain (legacy) types of Azure Subscriptions
+    ignore_status [400, 403, 404]
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "value[*]") do
+      field "resourceId", jmes_path(col_item, "id")
+      field "statuses", jmes_path(col_item, "properties.instanceView.statuses")
+    end
+  end
+end
+
 datasource "ds_azure_instances_running" do
-  run_script $js_azure_instances_running, $ds_azure_instances
+  run_script $js_azure_instances_running, $ds_azure_instances, $ds_azure_instance_statuses
 end
 
 script "js_azure_instances_running", type: "javascript" do
-  parameters "ds_azure_instances"
+  parameters "ds_azure_instances", "ds_azure_instance_statuses"
   result "result"
   code <<-EOS
+  status_object = {}
+
+  _.each(ds_azure_instance_statuses, function(instance) {
+    id = instance['resourceId']
+    status_object[id] = instance['statuses']
+  })
+
   result = _.filter(ds_azure_instances, function(instance) {
-    codes = _.pluck(instance['statuses'], 'code')
-    return instance['provisioningState'] == 'Succeeded' && _.contains(codes, "PowerState/running")
+    id = instance['resourceId']
+    statuses = status_object[id]
+
+    codes = []
+    if (typeof(statuses) == 'object') { codes = _.pluck(statuses, 'code') }
+
+    return _.contains(codes, "ProvisioningState/succeeded") && _.contains(codes, "PowerState/running")
   })
 EOS
 end
@@ -623,7 +656,7 @@ script "js_long_running_instances_incident", type: "javascript" do
   if (param_minimum_age > 1) { day_noun = "days" }
 
   has_verb = "has"
-  if (long_instances_total > 1) { day_noun = "have" }
+  if (long_instances_total > 1) { has_verb = "have" }
 
   findings = [
     "Out of ", instances_total, " Azure virtual ", instance_noun, " analyzed, ",

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
@@ -312,7 +312,7 @@ datasource "ds_azure_instances" do
 end
 
 datasource "ds_azure_instances_running" do
-  run_script $js_azure_instances_tag_running, $ds_azure_instances
+  run_script $js_azure_instances_running, $ds_azure_instances
 end
 
 script "js_azure_instances_running", type: "javascript" do

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
@@ -7,7 +7,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.1",
+  version: "4.2",
   provider: "Azure",
   service: "Compute",
   policy_set: "Long Running Instances"
@@ -302,6 +302,8 @@ datasource "ds_azure_instances" do
       field "timeCreated", jmes_path(col_item, "properties.timeCreated")
       field "platform", jmes_path(col_item, "properties.storageProfile.osDisk.osType")
       field "resourceType", jmes_path(col_item, "properties.hardwareProfile.vmSize")
+      field "provisioningState", jmes_path(col_item, "properties.provisioningState")
+      field "statuses", jmes_path(col_item, "properties.instanceView.statuses")
       field "tags", jmes_path(col_item, "tags")
       field "subscriptionId",val(iter_item, "id")
       field "subscriptionName",val(iter_item, "name")
@@ -309,16 +311,31 @@ datasource "ds_azure_instances" do
   end
 end
 
+datasource "ds_azure_instances_running" do
+  run_script $js_azure_instances_tag_running, $ds_azure_instances
+end
+
+script "js_azure_instances_running", type: "javascript" do
+  parameters "ds_azure_instances"
+  result "result"
+  code <<-EOS
+  result = _.filter(ds_azure_instances, function(instance) {
+    codes = _.pluck(instance['statuses'], 'code')
+    return instance['provisioningState'] == 'Succeeded' && _.contains(codes, "PowerState/running")
+  })
+EOS
+end
+
 datasource "ds_azure_instances_tag_filtered" do
-  run_script $js_azure_instances_tag_filtered, $ds_azure_instances, $param_exclusion_tags
+  run_script $js_azure_instances_tag_filtered, $ds_azure_instances_running, $param_exclusion_tags
 end
 
 script "js_azure_instances_tag_filtered", type: "javascript" do
-  parameters "ds_azure_instances", "param_exclusion_tags"
+  parameters "ds_azure_instances_running", "param_exclusion_tags"
   result "result"
   code <<-EOS
   if (param_exclusion_tags.length > 0) {
-    result = _.reject(ds_azure_instances, function(instance) {
+    result = _.reject(ds_azure_instances_running, function(instance) {
       instance_tags = []
 
       if (typeof(instance['tags']) == 'object') {
@@ -339,7 +356,7 @@ script "js_azure_instances_tag_filtered", type: "javascript" do
       return exclude_instance
     })
   } else {
-    result = ds_azure_instances
+    result = ds_azure_instances_running
   }
 EOS
 end

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "4.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 


### PR DESCRIPTION
### Description

This policy incorrectly reports on stopped instances when it should only report running instances. This PR is to fix this issue. It also fixes a minor language error in the detailed template of the incident output.

### Link to Example Applied Policy

https://app.flexera.com/orgs/27018/automation/applied-policies/projects/116186?policyId=6537cd34e947000001d934e5

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
