### PR TITLE
POL-944 Fix Azure Savings Realized for new Azure EA Connections

### DIFF
--- a/cost/azure/savings_realized/CHANGELOG.md
+++ b/cost/azure/savings_realized/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Incident subject is now the name of the applied policy
 - Policy metadata updated to better categorize the policy
-- Policy now reports Savings Plan and Spot Instance savings information if using new EA bill connection
 - Additional corrections around retrieving cost data on orgs using new EA bill connection
 - Streamlined code for better readability and faster execution
 

--- a/cost/azure/savings_realized/CHANGELOG.md
+++ b/cost/azure/savings_realized/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.6
+
+- Additional corrections around retrieving cost data on orgs using newer Azure bill connections
+
 ## v3.5
 
 - Policy incident no longer includes extraneous information about date and time in `Month` field

--- a/cost/azure/savings_realized/CHANGELOG.md
+++ b/cost/azure/savings_realized/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Incident subject is now the name of the applied policy
 - Policy metadata updated to better categorize the policy
 - Additional corrections around retrieving cost data on orgs using newer Azure bill connections
+- Streamlined code for better readability and faster execution
 
 ## v3.5
 

--- a/cost/azure/savings_realized/CHANGELOG.md
+++ b/cost/azure/savings_realized/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v3.6
 
+- Incident subject is now the name of the applied policy
 - Additional corrections around retrieving cost data on orgs using newer Azure bill connections
 
 ## v3.5

--- a/cost/azure/savings_realized/CHANGELOG.md
+++ b/cost/azure/savings_realized/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v3.6
 
 - Incident subject is now the name of the applied policy
+- Policy metadata updated to better categorize the policy
 - Additional corrections around retrieving cost data on orgs using newer Azure bill connections
 
 ## v3.5

--- a/cost/azure/savings_realized/CHANGELOG.md
+++ b/cost/azure/savings_realized/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Incident subject is now the name of the applied policy
 - Policy metadata updated to better categorize the policy
-- Additional corrections around retrieving cost data on orgs using newer Azure bill connections
+- Policy now reports Savings Plan and Spot Instance savings information if using new EA bill connection
+- Additional corrections around retrieving cost data on orgs using new EA bill connection
 - Streamlined code for better readability and faster execution
 
 ## v3.5

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -3,14 +3,14 @@ rs_pt_ver 20180301
 type "policy"
 short_description "This policy calculates savings realized by Reserved Instance purchases for Azure. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/savings_realized/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
-default_frequency "monthly"
-severity "low"
 category "Cost"
+severity "low"
+default_frequency "monthly"
 info(
-  version: "3.5",
-  provider: "Flexera",
-  service: "All",
-  policy_set: "N/A"
+  version: "3.6",
+  provider: "Azure",
+  service: "Compute",
+  policy_set: "Savings Realized"
 )
 
 ###############################################################################
@@ -19,17 +19,23 @@ info(
 
 parameter "param_email" do
   type "list"
+  category "Policy Settings"
   label "Email addresses"
+  description "A list of email addresses to notify."
+  default []
 end
 
 parameter "param_billing_centers" do
-  label "Billing Center Name"
-  description "List of Billing Center Names to check Savings Realized for. Leave blank for whole Organization view."
   type "list"
+  category "Policy Settings"
+  label "Billing Center Name"
+  description "List of Billing Center Names/IDs to check Savings Realized for. Leave blank for whole Organization view."
+  default []
 end
 
 parameter "param_period_start" do
   type "string"
+  category "Policy Settings"
   label "Period Start Date"
   description 'The starting month of the historical data to analyze (in YYYY-MM format e.g., "2021-10")'
   allowed_pattern /20[2-9][0-9]-[0-1][0-9]/
@@ -37,6 +43,7 @@ end
 
 parameter "param_period_end" do
   type "string"
+  category "Policy Settings"
   label "Period End Date"
   description "The ending month of the historical data to analyze (in YYYY-MM format)"
   allowed_pattern /20[2-9][0-9]-[0-1][0-9]/
@@ -44,6 +51,7 @@ end
 
 parameter "param_chart_type" do
   type "string"
+  category "Policy Settings"
   label "Chart Type"
   description "The type of bar chart to view savings realized data by"
   allowed_values "Grouped Bar Chart", "Stacked Bar Chart"
@@ -56,42 +64,136 @@ end
 
 credentials "auth_flexera" do
   schemes "oauth2"
-  label "flexera"
+  label "Flexera"
   description "Select Flexera One OAuth2 credentials"
   tags "provider=flexera"
 end
 
 ###############################################################################
-# Datasources and Scripts
+# Datasources & Scripts
 ###############################################################################
 
-#GET BILLING CENTERS FOR ORG
-datasource "ds_billing_centers" do
+# Get applied policy metadata for use later
+datasource "ds_applied_policy" do
   request do
     auth $auth_flexera
-    host rs_optima_host
-    path join(["/analytics/orgs/",rs_org_id,"/billing_centers"])
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    header "Api-Version", "1.0"
+  end
+end
+
+# Get region-specific Flexera API endpoints
+datasource "ds_flexera_api_hosts" do
+  run_script $js_flexera_api_hosts, rs_optima_host
+end
+
+script "js_flexera_api_hosts", type: "javascript" do
+  parameters "rs_optima_host"
+  result "result"
+  code <<-EOS
+  host_table = {
+    "api.optima.flexeraeng.com": {
+      flexera: "api.flexera.com",
+      fsm: "api.fsm.flexeraeng.com"
+    },
+    "api.optima-eu.flexeraeng.com": {
+      flexera: "api.flexera.eu",
+      fsm: "api.fsm-eu.flexeraeng.com"
+    },
+    "api.optima-au.flexeraeng.com": {
+      flexera: "api.flexera.au",
+      fsm: "api.fsm-au.flexeraeng.com"
+    }
+  }
+
+  result = host_table[rs_optima_host]
+EOS
+end
+
+# Get a list of active bill connections
+datasource "ds_bill_connections" do
+  request do
+    auth $auth_flexera
+    host val($ds_flexera_api_hosts, 'flexera')
+    path join(["/finops-onboarding/v1/orgs/", rs_org_id, "/bill-connects"])
     header "Api-Version", "1.0"
     header "User-Agent", "RS Policies"
-    query "view", "allocation_table"
   end
   result do
     encoding "json"
-    collect jmes_path(response,"[*]") do
-      field "href", jmes_path(col_item,"href")
-      field "id", jmes_path(col_item,"id")
-      field "name", jmes_path(col_item,"name")
-      field "parent_id", jmes_path(col_item,"parent_id")
-      field "ancestor_ids", jmes_path(col_item,"ancestor_ids")
-      field "allocation_table", jmes_path(col_item,"allocation_table")
+    collect jmes_path(response, "values[*]") do
+      field "id", jmes_path(col_item, "id")
+      field "kind", jmes_path(col_item, "kind")
     end
   end
 end
 
-#GET RESERVED INSTANCE COSTS
-datasource "ds_ri_aggregated_costs" do
+# Filter out old Azure EA connections and new Azure EA connections
+datasource "ds_bill_connections_old" do
+  run_script $js_bill_connections_filter, $ds_bill_connections, "finops:bill-connect-azure-ea"
+end
+
+datasource "ds_bill_connections_new" do
+  run_script $js_bill_connections_filter, $ds_bill_connections, "finops:bill-connect-cbi-oi-azure-ea"
+end
+
+script "js_bill_connections_filter", type:"javascript" do
+  parameters "ds_bill_connections", "filter_value"
+  result "result"
+  code <<-EOS
+  result = _.filter(ds_bill_connections, function(connection) {
+    return connection['kind'] == filter_value
+  })
+EOS
+end
+
+datasource "ds_billing_centers" do
   request do
-    run_script $js_get_ri_aggregated_costs, $ds_billing_centers, $param_period_start, $param_period_end, $param_billing_centers, rs_org_id, rs_optima_host
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/analytics/orgs/", rs_org_id, "/billing_centers"])
+    header "Api-Version", "1.0"
+    header "User-Agent", "RS Policies"
+    query "view", "allocation_table"
+    ignore_status [403]
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "href", jmes_path(col_item, "href")
+      field "id", jmes_path(col_item, "id")
+      field "name", jmes_path(col_item, "name")
+      field "parent_id", jmes_path(col_item, "parent_id")
+    end
+  end
+end
+
+datasource "ds_filtered_bcs" do
+  run_script $js_filtered_bcs, $ds_billing_centers, $param_billing_centers
+end
+
+script "js_filtered_bcs", type: "javascript" do
+  parameters "ds_billing_centers", "param_billing_centers"
+  result "result"
+  code <<-EOS
+  if (param_billing_centers.length == 0) {
+    filtered_bcs = _.filter(ds_billing_centers, function(bc) {
+      return bc['parent_id'] == null || bc['parent_id'] == undefined
+    })
+  } else {
+    filtered_bcs = _.filter(ds_billing_centers, function(bc) {
+      return _.contains(param_billing_centers, bc['id']) || _.contains(param_billing_centers, bc['name']) || _.contains(param_billing_centers, bc['name'].toLowerCase()) || _.contains(param_billing_centers, bc['name'].toUpperCase())
+    })
+  }
+
+  result = _.compact(_.pluck(filtered_bcs, 'id'))
+EOS
+end
+
+datasource "ds_ri_aggregated_costs_old" do
+  request do
+    run_script $js_get_aggregated_costs, $ds_bill_connections_old, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "ri_old"
   end
   result do
     encoding "json"
@@ -106,27 +208,79 @@ datasource "ds_ri_aggregated_costs" do
   end
 end
 
-script "js_get_ri_aggregated_costs", type: "javascript" do
-  parameters "ds_billing_centers", "start_date", "end_date", "param_billing_centers", "org_id", "optima_host"
+datasource "ds_ri_aggregated_costs_new" do
+  request do
+    run_script $js_get_aggregated_costs, $ds_bill_connections_new, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "ri_new"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "rows") do
+      field "instance_type", jmes_path(col_item, "dimensions.instance_type")
+      field "region", jmes_path(col_item, "dimensions.region")
+      field "usage_unit", jmes_path(col_item, "dimensions.usage_unit")
+      field "usage_amount", jmes_path(col_item, "metrics.usage_amount")
+      field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
+      field "month", jmes_path(col_item, "timestamp")
+    end
+  end
+end
+
+datasource "ds_base_aggregated_costs_old" do
+  request do
+    run_script $js_get_aggregated_costs, $ds_bill_connections_old, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "base_old"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "rows") do
+      field "instance_type", jmes_path(col_item, "dimensions.instance_type")
+      field "region", jmes_path(col_item, "dimensions.region")
+      field "usage_unit", jmes_path(col_item, "dimensions.usage_unit")
+      field "usage_amount", jmes_path(col_item, "metrics.usage_amount")
+      field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
+      field "month", jmes_path(col_item, "timestamp")
+    end
+  end
+end
+
+datasource "ds_base_aggregated_costs_new" do
+  request do
+    run_script $js_get_aggregated_costs, $ds_bill_connections_new, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "base_new"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "rows") do
+      field "instance_type", jmes_path(col_item, "dimensions.instance_type")
+      field "region", jmes_path(col_item, "dimensions.region")
+      field "usage_unit", jmes_path(col_item, "dimensions.usage_unit")
+      field "usage_amount", jmes_path(col_item, "metrics.usage_amount")
+      field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
+      field "month", jmes_path(col_item, "timestamp")
+    end
+  end
+end
+
+script "js_get_aggregated_costs", type: "javascript" do
+  parameters "bill_connections", "ds_filtered_bcs", "start_date", "end_date", "org_id", "optima_host", "connection_type"
   result "request"
   code <<-EOS
+  bill_source_expressions = []
 
-  //Get billing centers. If user specifies no billing centers, retrieve all top level billing centers. Else get array of billing centers that match the names stated in BC param
-  var billing_center_ids = []
-  if (param_billing_centers.length === 0){
-    var top_billing_centers = _.reject(ds_billing_centers, function(bc){ return bc.parent_id != null });
-    billing_center_ids = _.map(top_billing_centers, function(value, key){ return value.id });
-  } else {
-    billing_center_names = _.map(param_billing_centers, function(name){ return name.toLowerCase(); });
-    billing_center_ids = _.compact(_.map(ds_billing_centers, function(value){ if(_.contains(billing_center_names, value.name.toLowerCase())){return value.id} }));
-  }
+  _.each(bill_connections, function(item) {
+    bill_source_expressions.push({
+      "dimension": "bill_source",
+      "type": "equal",
+      "value": item['id']
+    })
+  })
 
-  var payload = {
-    "billing_center_ids": billing_center_ids,
-    "filter": {
+  // Set filters based on the type of request (RI or Base)
+  // and whether or not we're pulling costs for an old Azure EA connection or a new one
+  if (connection_type == 'ri_old') {
+    filter = {
       "type": "and",
       "expressions": [
         { "dimension": "vendor", "type": "equal", "value": "Azure" },
+        { "type": "or", "expressions": bill_source_expressions },
         {
           "type": "or",
           "expressions": [
@@ -148,72 +302,39 @@ script "js_get_ri_aggregated_costs", type: "javascript" do
           "expression": { "dimension": "instance_type", "type": "equal", "value": "None" }
         }
       ]
-    },
-    "dimensions": [
-      "instance_type",
-      "region",
-      "usage_unit"
-    ],
-    "granularity": "month",
-    "metrics": [
-      "cost_amortized_unblended_adj",
-      "usage_amount"
-    ]
-    "end_at": end_date,
-    "start_at": start_date
-  }
-
-  var request = {
-    auth: "auth_flexera",
-    host: optima_host,
-    path: "/bill-analysis/orgs/" + org_id + "/costs/aggregated",
-    verb: "POST",
-    body_fields: payload,
-    headers: {
-      "User-Agent": "RS Policies"
     }
   }
-  EOS
-end
 
-#GET BASE COSTS
-datasource "ds_base_aggregated_costs" do
-  request do
-    run_script $js_get_base_aggregated_costs, $ds_billing_centers, $param_period_start, $param_period_end, $param_billing_centers, rs_org_id, rs_optima_host
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "rows") do
-      field "instance_type", jmes_path(col_item, "dimensions.instance_type")
-      field "region", jmes_path(col_item, "dimensions.region")
-      field "usage_unit", jmes_path(col_item, "dimensions.usage_unit")
-      field "usage_amount", jmes_path(col_item, "metrics.usage_amount")
-      field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
-      field "month", jmes_path(col_item, "timestamp")
-    end
-  end
-end
-
-script "js_get_base_aggregated_costs", type: "javascript" do
-  parameters "ds_billing_centers", "start_date", "end_date", "param_billing_centers", "org_id", "optima_host"
-  result "request"
-  code <<-EOS
-
-  //Get billing centers. If user specifies no billing centers, retrieve all top level billing centers. Else get array of billing centers that match the names stated in BC param
-  var billing_center_ids = []
-  if (param_billing_centers.length === 0){
-    var top_billing_centers = _.reject(ds_billing_centers, function(bc){ return bc.parent_id != null });
-    billing_center_ids = _.map(top_billing_centers, function(value, key){ return value.id });
-  } else {
-    billing_center_names = _.map(param_billing_centers, function(name){ return name.toLowerCase(); });
-    billing_center_ids = _.compact(_.map(ds_billing_centers, function(value){ if(_.contains(billing_center_names, value.name.toLowerCase())){return value.id} }));
-  }
-
-  var payload = {
-    "billing_center_ids": billing_center_ids,
-    "filter": {
+  if (connection_type == 'ri_new') {
+    filter = {
       "type": "and",
       "expressions": [
+        { "dimension": "vendor", "type": "equal", "value": "Azure" },
+        { "type": "or", "expressions": bill_source_expressions },
+        {
+          "type": "or",
+          "expressions": [
+            {
+              "dimension": "purchase_option",
+              "type": "equal",
+              "value": "Reserved"
+            },
+            {
+              "dimension": "purchase_option",
+              "type": "equal",
+              "value": "reserved"
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  if (connection_type == 'base_old') {
+    filter = {
+      "type": "and",
+      "expressions": [
+        { "type": "or", "expressions": bill_source_expressions },
         {
           "type": "or",
           "expressions": [
@@ -267,7 +388,51 @@ script "js_get_base_aggregated_costs", type: "javascript" do
           }
         }
       ]
-    },
+    }
+  }
+
+  if (connection_type == 'base_new') {
+    filter = {
+      "type": "and",
+      "expressions": [
+        { "type": "or", "expressions": bill_source_expressions },
+        {
+          "type": "or",
+          "expressions": [
+            {
+              "dimension": "vendor",
+              "type": "equal",
+              "value": "Azure"
+            },
+            {
+              "dimension": "vendor",
+              "type": "equal",
+              "value": "azure"
+            }
+          ]
+        },
+        {
+          "type": "or",
+          "expressions": [
+            {
+              "dimension": "category",
+              "type": "equal",
+              "value": "Commitments"
+            },
+            {
+              "dimension": "category",
+              "type": "equal",
+              "value": "commitments"
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  var payload = {
+    "billing_center_ids": ds_filtered_bcs,
+    "filter": filter,
     "dimensions": [
       "instance_type",
       "region",
@@ -292,7 +457,23 @@ script "js_get_base_aggregated_costs", type: "javascript" do
       "User-Agent": "RS Policies"
     }
   }
-  EOS
+EOS
+end
+
+datasource "ds_ri_aggregated_costs" do
+  run_script $js_cost_combiner, $ds_ri_aggregated_costs_old, $ds_ri_aggregated_costs_new
+end
+
+datasource "ds_base_aggregated_costs" do
+  run_script $js_cost_combiner, $ds_base_aggregated_costs_old, $ds_base_aggregated_costs_new
+end
+
+script "js_cost_combiner", type:"javascript" do
+  parameters "ds_costs_1", "ds_costs_2"
+  result "result"
+  code <<-EOS
+  result = ds_costs_1.concat(ds_costs_2)
+EOS
 end
 
 #CALCULATE SAVINGS REALIZED (BASE COST - RI COST) FOR EACH INSTANCE TYPE, FOR EACH REGION
@@ -489,19 +670,7 @@ script "js_create_chart_data", type: "javascript" do
   if ( report.length !== 0 ){
     report[0]["chart_dimensions"] = chart
   }
-
-  EOS
-end
-
-###############################################################################
-# Escalations
-###############################################################################
-
-escalation "esc_savings_realized_report" do
-  automatic true
-  label "Send Email"
-  description "Send incident email"
-  email $param_email
+EOS
 end
 
 ###############################################################################
@@ -511,14 +680,13 @@ end
 policy "policy_purchase_option_by_inst_type_and_region" do
   validate_each $ds_chart_data do
     summary_template "Azure Savings Realized from Reservations"
-    detail_template <<-EOS
-# Savings Realized On Compute Reservations Report
-![Savings Realized On Compute Reservations Chart](https://api.image-charts-auth.flexeraeng.com/ic-function?rs_org_id={{ rs_org_id }}&rs_project_id={{ rs_project_id }}&{{ with index data 0 }}{{ .chart_dimensions.chart_data }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_size }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_type }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_image }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_title }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_y_axis }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_axis_label }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_line_style }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_line_color }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_data_scale }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_legend_size }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_legend }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_axis_format }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_legend_position }}{{ end }})
-EOS
-    escalate $esc_savings_realized_report
-    check eq(0,1)
+    detail_template <<-'EOS'
+    # Savings Realized On Compute Reservations Report
+    ![Savings Realized On Compute Reservations Chart](https://api.image-charts-auth.flexeraeng.com/ic-function?rs_org_id={{ rs_org_id }}&rs_project_id={{ rs_project_id }}&{{ with index data 0 }}{{ .chart_dimensions.chart_data }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_size }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_type }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_image }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_title }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_y_axis }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_axis_label }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_line_style }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_line_color }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_data_scale }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_legend_size }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_legend }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_axis_format }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_legend_position }}{{ end }})
+    EOS
+    check eq(0, 1)
+    escalate $esc_email
     export do
-      # no actions so resource_level can be false
       resource_level false
       field "month" do
         label "Month"
@@ -534,4 +702,15 @@ EOS
       end
     end
   end
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
 end

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -589,8 +589,6 @@ script "js_savings_realized", type: "javascript" do
       avg_base_cost_instance_hour = 0
       if (count > 0) { avg_base_cost_instance_hour = base_cost_instance_hour_total / count }
 
-      index = [type, region].join('_').toLowerCase().trim()
-
       unique_cost_instance_hours[index] = avg_base_cost_instance_hour
     })
   })
@@ -619,7 +617,7 @@ script "js_savings_realized", type: "javascript" do
 
     result.push({
       month: month,
-      savings: savings,
+      cost: savings,
       dimension: "Savings Realized On Compute Reservations"
     })
   })
@@ -659,12 +657,12 @@ script "js_chart_data", type: "javascript" do
     }
 
     if (savings_realized_ri_entry != undefined) {
-      savings_realized_ri = savings_realized_ri_entry['savings']
+      savings_realized_ri = savings_realized_ri_entry['cost']
       percentage_ri = (savings_realized_ri / (total_spend_cost + savings_realized_ri)) * 100
     }
 
     result.push({
-      "month": month,
+      "month": month.substring(0, 7),
       "total_spend": parseFloat(total_spend_cost.toFixed(2)),
       "savings_realized_ri": parseFloat(savings_realized_ri.toFixed(2)),
       "percentage_ri": parseFloat(percentage_ri.toFixed(2))
@@ -680,8 +678,7 @@ script "js_chart_data", type: "javascript" do
   chart_type = chart_table[param_chart_type]
 
   // Create chart axis labels
-  months_mapped = _.map(_.keys(savings_by_month), function(item) { return item.substring(0,7) })
-  chart_axis_labels = ("chxl=1:," + months_mapped).split(',').join('|')
+  chart_axis_labels = ("chxl=1:," + _.pluck(result, 'month')).split(',').join('|')
 
   // Create legend
   chart_legend = "chdl=" + _.uniq(_.pluck(ds_savings_realized, 'dimension')).join('|')

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -83,6 +83,70 @@ datasource "ds_applied_policy" do
   end
 end
 
+# Table to convert region names from old EA connections to the new ones
+datasource "ds_region_table" do
+  run_script $js_region_table
+end
+
+script "js_region_table", type: "javascript" do
+  result "result"
+  code <<-EOS
+  result = {
+    "AE Central": "UAE Central",
+    "AE North": "UAE North",
+    "AP East": "East Asia",
+    "AP Southeast": "Southeast Asia",
+    "AU Central": "Australia Central",
+    "AU Central 2": "Australia Central 2",
+    "AU East": "Australia East",
+    "AU Southeast": "Australia Southeast",
+    "BR South": "Brazil South",
+    "BR Southeast": "Brazil Southeast",
+    "CA Central": "Canada Central",
+    "CA East": "Canada East",
+    "CH North": "China North",
+    "CH West": "China West",
+    "DE North": "Germany North",
+    "DE West Central": "Germany West Central",
+    "EU North": "North Europe",
+    "EU West": "West Europe",
+    "FR Central": "France Central",
+    "FR South": "France South",
+    "IN Central": "Central India",
+    "IN Central Jio": "Jio India Central",
+    "IN South": "South India",
+    "IN West": "West India",
+    "IN West Jio": "Jio India West",
+    "IT North": "Italy North",
+    "JA East": "Japan East",
+    "JA West": "Japan West",
+    "KR Central": "Korea Central",
+    "KR South": "Korea South",
+    "NO East": "Norway East",
+    "NO West": "Norway West",
+    "PL Central": "Poland Central",
+    "QA Central": "Qatar Central",
+    "SE Central": "Sweden Central",
+    "SE South": "Sweden South",
+    "UK South": "UK South",
+    "UK West": "UK West",
+    "US Central": "Central US",
+    "US East": "East US",
+    "US East 2": "East US 2",
+    "US North Central": "North Central US",
+    "US South Central": "South Central US",
+    "US West": "West US",
+    "US West 2": "West US 2",
+    "US West 3": "West US 3",
+    "US West Central": "West Central US",
+    "ZA North": "South Africa North",
+    "ZA West": "South Africa West",
+    "All Regions": "All Regions",
+    "Unassigned": "Unassigned"
+  }
+EOS
+end
+
 datasource "ds_billing_centers" do
   request do
     auth $auth_flexera
@@ -381,6 +445,10 @@ script "js_get_aggregated_costs", type: "javascript" do
               { "dimension": "purchase_option", "type": "equal", "value": "savings plan" }
             ]
           }
+        },
+        {
+          "type": "not",
+          "expression": { "dimension": "instance_type", "type": "equal", "value": "None" }
         }
       ]
     }
@@ -424,18 +492,32 @@ EOS
 end
 
 datasource "ds_ri_aggregated_costs" do
-  run_script $js_cost_combiner, $ds_ri_aggregated_costs_old, $ds_ri_aggregated_costs_new
+  run_script $js_cost_combiner, $ds_ri_aggregated_costs_old, $ds_ri_aggregated_costs_new, $ds_region_table
 end
 
 datasource "ds_base_aggregated_costs" do
-  run_script $js_cost_combiner, $ds_base_aggregated_costs_old, $ds_base_aggregated_costs_new
+  run_script $js_cost_combiner, $ds_base_aggregated_costs_old, $ds_base_aggregated_costs_new, $ds_region_table
 end
 
 script "js_cost_combiner", type:"javascript" do
-  parameters "ds_costs_1", "ds_costs_2"
+  parameters "ds_costs_old", "ds_costs_new", "ds_region_table"
   result "result"
   code <<-EOS
-  result = ds_costs_1.concat(ds_costs_2)
+  result = _.map(ds_costs_old, function(cost) {
+    region = cost['region']
+    if (ds_region_table[region] != undefined) { region = ds_region_table[region] }
+
+    return {
+      instance_type: cost['instance_type'],
+      usage_unit: cost['usage_unit'],
+      usage_amount: cost['usage_amount'],
+      cost: cost['cost'],
+      month: cost['month'],
+      region: region
+    }
+  })
+
+  result = result.concat(ds_costs_new)
 EOS
 end
 
@@ -470,28 +552,38 @@ script "js_savings_realized", type: "javascript" do
 
   // Calculate base cost of instance per hour across all months
   // for each instance type/region/operating system combination
-  unique_cost_instance_hours = []
+  base_aggregated_costs = {}
+
+  _.each(ds_base_aggregated_costs, function(cost) {
+    index = [cost['instance_type'], cost['region']].join('_').toLowerCase().trim()
+
+    if (base_aggregated_costs[index] == undefined) { base_aggregated_costs[index] = [] }
+
+    base_aggregated_costs[index].push(cost)
+  })
+
+  unique_cost_instance_hours = {}
 
   _.each(instance_types, function(type) {
     _.each(regions, function(region) {
       base_cost_instance_hour_total = 0
       count = 0
 
-      _.each(ds_base_aggregated_costs, function(cost){
-        if (cost['instance_type'] == type && cost['region'] == region) {
-          base_cost_instance_hour_total += (cost['cost'] / cost['usage_amount'])
+      index = [type, region].join('_').toLowerCase().trim()
+
+      if (base_aggregated_costs[index] != undefined) {
+        _.each(base_aggregated_costs[index], function(cost) {
+          base_cost_instance_hour_total += cost['cost'] / cost['usage_amount']
           count += 1
-        }
-      })
+        })
+      }
 
       avg_base_cost_instance_hour = 0
       if (count > 0) { avg_base_cost_instance_hour = base_cost_instance_hour_total / count }
 
-      unique_cost_instance_hours.push({
-        instance_type: type,
-        region: region,
-        avg_base_cost_instance_hour: avg_base_cost_instance_hour
-      })
+      index = [type, region].join('_').toLowerCase().trim()
+
+      unique_cost_instance_hours[index] = avg_base_cost_instance_hour
     })
   })
 
@@ -499,25 +591,22 @@ script "js_savings_realized", type: "javascript" do
   savings_realized_object = {}
 
   _.each(ds_ri_aggregated_costs, function(cost) {
-    _.each(unique_cost_instance_hours, function(instance_hour) {
-      if (cost['instance_type'] == instance_hour['instance_type'] && cost['region'] == instance_hour['region']) {
-        savings_realized_per_instance_hour = instance_hour['avg_base_cost_instance_hour'] - (cost['cost'] / cost['usage_amount'])
+    index = [cost['instance_type'], cost['region']].join('_').toLowerCase().trim()
+    avg_base_cost_instance_hour = unique_cost_instance_hours[index]
 
-        savings_realized = 0
-        if (cost['cost'] > 0) {
-          savings_realized = savings_realized_per_instance_hour * cost['usage_amount']
-        }
+    if (avg_base_cost_instance_hour != undefined) {
+      savings_realized_per_instance_hour = avg_base_cost_instance_hour - (cost['cost'] / cost['usage_amount'])
+      savings_realized = savings_realized_per_instance_hour * cost['usage_amount']
 
-        if (savings_realized_object[cost['month']] == undefined) { savings_realized_object[cost['month']] = 0 }
-          savings_realized_object[cost['month']] += savings_realized
-      }
-    })
+      if (savings_realized_object[cost['month']] == undefined) { savings_realized_object[cost['month']] = 0 }
+      savings_realized_object[cost['month']] += savings_realized
+    }
   })
 
   _.each(months, function(month) {
     cost = 0
-    if (typeof(savings_realized_object[cost['month']]) == 'number') {
-      cost = savings_realized_object[cost['month']]
+    if (savings_realized_object[month] != undefined) {
+      cost = savings_realized_object[month]
     }
 
     result.push({

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -279,7 +279,6 @@ script "js_get_aggregated_costs", type: "javascript" do
     filter = {
       "type": "and",
       "expressions": [
-        { "dimension": "vendor", "type": "equal", "value": "Azure" },
         { "type": "or", "expressions": bill_source_expressions },
         {
           "type": "or",
@@ -309,7 +308,6 @@ script "js_get_aggregated_costs", type: "javascript" do
     filter = {
       "type": "and",
       "expressions": [
-        { "dimension": "vendor", "type": "equal", "value": "Azure" },
         { "type": "or", "expressions": bill_source_expressions },
         {
           "type": "or",
@@ -335,21 +333,6 @@ script "js_get_aggregated_costs", type: "javascript" do
       "type": "and",
       "expressions": [
         { "type": "or", "expressions": bill_source_expressions },
-        {
-          "type": "or",
-          "expressions": [
-            {
-              "dimension": "vendor",
-              "type": "equal",
-              "value": "Azure"
-            },
-            {
-              "dimension": "vendor",
-              "type": "equal",
-              "value": "azure"
-            }
-          ]
-        },
         {
           "type": "or",
           "expressions": [
@@ -396,21 +379,6 @@ script "js_get_aggregated_costs", type: "javascript" do
       "type": "and",
       "expressions": [
         { "type": "or", "expressions": bill_source_expressions },
-        {
-          "type": "or",
-          "expressions": [
-            {
-              "dimension": "vendor",
-              "type": "equal",
-              "value": "Azure"
-            },
-            {
-              "dimension": "vendor",
-              "type": "equal",
-              "value": "azure"
-            }
-          ]
-        },
         {
           "type": "or",
           "expressions": [

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -531,44 +531,52 @@ script "js_savings_realized", type: "javascript" do
 EOS
 end
 
-#CHART CREATION
 datasource "ds_chart_data" do
-  run_script $js_create_chart_data, $ds_savings_realized, $ds_applied_policy, $param_chart_type
+  run_script $js_chart_data, $ds_savings_realized, $ds_applied_policy, $param_chart_type
 end
 
-script "js_create_chart_data", type: "javascript" do
-  parameters "savings_realized_data", "ds_applied_policy", "param_chart_type"
-  result "report"
+script "js_chart_data", type: "javascript" do
+  parameters "ds_savings_realized", "ds_applied_policy", "param_chart_type"
+  result "result"
   code <<-EOS
-  //Get months
-  var months = _.pluck( _.uniq(savings_realized_data, function(data){ return data.month }), "month" )
+  months = _.uniq(_.pluck(ds_savings_realized, 'month'))
 
   //Create report data (Concatenate savings realized and total costs into one object/row of data)
-  var report = []
-  _.each(months, function(mo){
+  result = []
+
+  _.each(months, function(month) {
     savings_realized = 0
     total_spend = 0
-    _.each(savings_realized_data, function(data){
-      if(mo == data.month && data.dimension == "Savings Realized On Compute Reservations"){
-        savings_realized = data.cost
-      }
-      if(mo == data.month && data.dimension == "Total Actual Spend On Discountable Compute"){
-        total_spend = data.cost
-      }
+    percentage = 0
+
+    savings_realized_for_month = _.find(ds_savings_realized, function(data) {
+      return data['month'] == month && data['dimension'] == "Savings Realized On Compute Reservations"
     })
 
-    month = mo
-    report.push({
-      "month": mo.split('-')[0] + '-' + mo.split('-')[1],
+    if (typeof(savings_realized_for_month) == 'object') {
+      savings_realized = savings_realized_for_month['cost']
+    }
+
+    total_spend_for_month = _.find(ds_savings_realized, function(data) {
+      return data['month'] == month && data['dimension'] == "Total Actual Spend On Discountable Compute"
+    })
+
+    if (typeof(total_spend_for_month) == 'object') {
+      total_spend = total_spend_for_month['cost']
+    }
+
+    percentage = (savings_realized / (total_spend + savings_realized)) *100
+
+    result.push({
+      "month": month.split('-')[0] + '-' + month.split('-')[1],
       "total_spend": parseFloat(total_spend).toFixed(2),
       "savings_realized": parseFloat(savings_realized).toFixed(2),
-      "percentage": parseFloat((savings_realized/(total_spend + savings_realized))*100).toFixed(0).toString() + "%"
+      "percentage": parseFloat(percentage).toFixed(2) + "%"
     })
   })
 
   //Group data by Cost Dimension
-  group_by_dimension =
-  _.groupBy(savings_realized_data, function(data){ return data.dimension })
+  group_by_dimension = _.groupBy(ds_savings_realized, function(data) { return data.dimension })
 
   //Determine chart type
   chart_type = "cht="
@@ -578,7 +586,7 @@ script "js_create_chart_data", type: "javascript" do
   //Create chart axis labels
   chart_axis_labels =
   ("chxl=1:," +
-    _.uniq(savings_realized_data, function(sr) { return sr.month })
+    _.uniq(ds_savings_realized, function(sr) { return sr.month })
     .map(function(sr){ return sr.month.substring(0,7) })
   ).split(",").join("|")
 
@@ -593,8 +601,8 @@ script "js_create_chart_data", type: "javascript" do
 
   //calculate scale
   //chart_range = ("chxr=0," +
-  max = (Math.max.apply(Math, savings_realized_data.map(function(sr){ return sr.savings_realized }))*1.1).toFixed(2)
-  min = (Math.min.apply(Math, savings_realized_data.map(function(sr){ return sr.savings_realized }))*0.9).toFixed(2)
+  max = (Math.max.apply(Math, ds_savings_realized.map(function(sr){ return sr.savings_realized }))*1.1).toFixed(2)
+  min = (Math.min.apply(Math, ds_savings_realized.map(function(sr){ return sr.savings_realized }))*0.9).toFixed(2)
   chart_range = "chxr=0," + min + "," + max
 
   //Create chart dataset
@@ -629,9 +637,9 @@ script "js_create_chart_data", type: "javascript" do
     chart_legend_position: encodeURI("chdlp=b")
   }
 
-  if ( report.length !== 0 ){
-    report[0]["chart_dimensions"] = chart
-    report[0]["policy_name"] = ds_applied_policy['name']
+  if (result.length > 0) {
+    result[0]["chart_dimensions"] = chart
+    result[0]["policy_name"] = ds_applied_policy['name']
   }
 EOS
 end

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -439,97 +439,96 @@ script "js_cost_combiner", type:"javascript" do
 EOS
 end
 
-#CALCULATE SAVINGS REALIZED (BASE COST - RI COST) FOR EACH INSTANCE TYPE, FOR EACH REGION
 datasource "ds_savings_realized" do
-  run_script $js_get_savings_realized, $ds_ri_aggregated_costs, $ds_base_aggregated_costs
+  run_script $js_savings_realized, $ds_ri_aggregated_costs, $ds_base_aggregated_costs
 end
 
-script "js_get_savings_realized", type: "javascript" do
-  parameters "ri_costs", "base_costs"
-  result "savings_realized_data"
+script "js_savings_realized", type: "javascript" do
+  parameters "ds_ri_aggregated_costs", "ds_base_aggregated_costs"
+  result "result"
   code <<-'EOS'
-  var temp_result = []
-  var savings_realized_data = []
+  result = []
 
-  //Get list of Instance Types, Regions, Months
-  inst_type = _.pluck( _.uniq(ri_costs, function(ri){ return ri.instance_type }), "instance_type" )
-  region = _.pluck( _.uniq(ri_costs, function(ri){ return ri.region }), "region" )
-  months = _.union(
-    _.pluck( _.uniq(ri_costs, function(ri){ return ri.month }), "month" ),
-    _.pluck( _.uniq(base_costs, function(base){ return base.month }), "month" )
-  )
+  all_costs = ds_ri_aggregated_costs.concat(ds_base_aggregated_costs)
 
-  //calculate total cost for each month
-  _.each(months, function(mo){
-    total_month_cost = 0
-    _.each(ri_costs, function(ri){
-      if(ri.month == mo){ total_month_cost += ri.cost }
+  // Get list of Instance Types, Regions, Months
+  instance_types = _.uniq(_.pluck(all_costs, 'instance_type'))
+  regions = _.uniq(_.pluck(all_costs, 'region'))
+  months = _.uniq(_.pluck(all_costs, 'month'))
+
+  // Calculate total cost for each month
+  _.each(months, function(month) {
+    month_costs = _.filter(all_costs, function(cost) { return cost['month'] == month })
+    total_month_cost = _.reduce(_.pluck(month_costs, 'cost'), function(memo, num) { return memo + num }, 0)
+
+    result.push({
+      month: month,
+      cost: total_month_cost,
+      dimension: "Total Actual Spend On Discountable Compute"
     })
-    _.each(base_costs, function(base){
-      if(base.month == mo){ total_month_cost += base.cost }
-    })
-    savings_realized_data.push({ "month": mo, "cost": total_month_cost, "dimension": "Total Actual Spend On Discountable Compute" })
   })
 
-  //calculate base cost of instance per hour across all months for each instance type/region/operating system combination
-  unique_cost_inst_hrs = []
-  _.each(inst_type, function(inst){
-    _.each(region, function(rg){
-      base_cost_inst_hr_tot = 0, count = 0
-      _.each(base_costs, function(base){
-        if(base.instance_type == inst && base.region == rg){
-          base_cost_inst_hr_tot += (base.cost / base.usage_amount)
-          count ++
+  // Calculate base cost of instance per hour across all months
+  // for each instance type/region/operating system combination
+  unique_cost_instance_hours = []
+
+  _.each(instance_types, function(type) {
+    _.each(regions, function(region) {
+      base_cost_instance_hour_total = 0
+      count = 0
+
+      _.each(ds_base_aggregated_costs, function(cost){
+        if (cost['instance_type'] == type && cost['region'] == region) {
+          base_cost_instance_hour_total += (cost['cost'] / cost['usage_amount'])
+          count += 1
         }
       })
-      avg_base_cost_inst_hr = 0
-      if(count > 0){ avg_base_cost_inst_hr = base_cost_inst_hr_tot / count }
 
-      unique_cost_inst_hrs.push({
-        "instance_type": inst,
-        "region": rg,
-        "avg_base_cost_inst_hr": avg_base_cost_inst_hr
+      avg_base_cost_instance_hour = 0
+      if (count > 0) { avg_base_cost_instance_hour = base_cost_instance_hour_total / count }
+
+      unique_cost_instance_hours.push({
+        instance_type: type,
+        region: region,
+        avg_base_cost_instance_hour: avg_base_cost_instance_hour
       })
     })
   })
 
-  //apply cost_inst_hr to calculate savings realized
-  _.each(ri_costs, function(ri){
-    _.each(unique_cost_inst_hrs, function(inst_hr){
-      if (ri.instance_type == inst_hr.instance_type && ri.region == inst_hr.region && ri.operating_system == inst_hr.operating_system){
-        savings_realized_per_inst_hr = inst_hr.avg_base_cost_inst_hr - (ri.cost / ri.usage_amount)
+  // Apply cost_instance_hour to calculate savings realized
+  savings_realized_object = {}
+
+  _.each(ds_ri_aggregated_costs, function(cost) {
+    _.each(unique_cost_instance_hours, function(instance_hour) {
+      if (cost['instance_type'] == instance_hour['instance_type'] && cost['region'] == instance_hour['region']) {
+        savings_realized_per_instance_hour = instance_hour['avg_base_cost_instance_hour'] - (cost['cost'] / cost['usage_amount'])
+
         savings_realized = 0
-        if(ri.cost > 0 ){
-          savings_realized = savings_realized_per_inst_hr * ri.usage_amount
+        if (cost['cost'] > 0) {
+          savings_realized = savings_realized_per_instance_hour * cost['usage_amount']
         }
-        //console.log("On-Demand Rate: " + inst_hr.avg_base_cost_inst_hr, "Reserved Rate: " + (ri.cost/ri.usage_amount), ri.region, ri.instance_type)
 
-        temp_result.push(
-          {
-            "month": ri.month,
-            "region": ri.region,
-            "instance_type": ri.instance_type,
-            "savings_realized": savings_realized
-          }
-        )
+        if (savings_realized_object[cost['month']] == undefined) { savings_realized_object[cost['month']] = 0 }
+          savings_realized_object[cost['month']] += savings_realized
       }
     })
   })
 
-  //reduce list - aggregate SAVINGS REALIZED costs for same month
-  _.each(months, function(mo){
-    savings_realized = 0
-    _.each(temp_result, function(res){
-      if(mo == res.month){
-        savings_realized += res.savings_realized
-      }
+  _.each(months, function(month) {
+    cost = 0
+    if (typeof(savings_realized_object[cost['month']]) == 'number') {
+      cost = savings_realized_object[cost['month']]
+    }
+
+    result.push({
+      month: month,
+      cost: cost,
+      dimension: "Savings Realized On Compute Reservations"
     })
-    savings_realized_data.push({ "month": mo, "cost": savings_realized, "dimension": "Savings Realized On Compute Reservations" })
   })
 
-  //sort by month
-  savings_realized_data = _.sortBy(savings_realized_data, "month")
-  EOS
+  result = _.sortBy(result, "month")
+EOS
 end
 
 #CHART CREATION

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -192,8 +192,9 @@ EOS
 end
 
 datasource "ds_ri_aggregated_costs_old" do
+  iterate $ds_bill_connections_old
   request do
-    run_script $js_get_aggregated_costs, $ds_bill_connections_old, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "ri_old"
+    run_script $js_get_aggregated_costs, val(iter_item, 'id'), $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "ri_old"
   end
   result do
     encoding "json"
@@ -209,8 +210,9 @@ datasource "ds_ri_aggregated_costs_old" do
 end
 
 datasource "ds_ri_aggregated_costs_new" do
+  iterate $ds_bill_connections_new
   request do
-    run_script $js_get_aggregated_costs, $ds_bill_connections_new, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "ri_new"
+    run_script $js_get_aggregated_costs, val(iter_item, 'id'), $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "ri_new"
   end
   result do
     encoding "json"
@@ -226,8 +228,9 @@ datasource "ds_ri_aggregated_costs_new" do
 end
 
 datasource "ds_base_aggregated_costs_old" do
+  iterate $ds_bill_connections_old
   request do
-    run_script $js_get_aggregated_costs, $ds_bill_connections_old, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "base_old"
+    run_script $js_get_aggregated_costs, val(iter_item, 'id'), $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "base_old"
   end
   result do
     encoding "json"
@@ -243,8 +246,9 @@ datasource "ds_base_aggregated_costs_old" do
 end
 
 datasource "ds_base_aggregated_costs_new" do
+  iterate $ds_bill_connections_new
   request do
-    run_script $js_get_aggregated_costs, $ds_bill_connections_new, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "base_new"
+    run_script $js_get_aggregated_costs, val(iter_item, 'id'), $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "base_new"
   end
   result do
     encoding "json"
@@ -260,18 +264,14 @@ datasource "ds_base_aggregated_costs_new" do
 end
 
 script "js_get_aggregated_costs", type: "javascript" do
-  parameters "bill_connections", "ds_filtered_bcs", "start_date", "end_date", "org_id", "optima_host", "connection_type"
+  parameters "bill_connection_id", "ds_filtered_bcs", "start_date", "end_date", "org_id", "optima_host", "connection_type"
   result "request"
   code <<-EOS
-  bill_source_expressions = []
-
-  _.each(bill_connections, function(item) {
-    bill_source_expressions.push({
-      "dimension": "bill_source",
-      "type": "equal",
-      "value": item['id']
-    })
-  })
+  bill_source_expression = {
+    "dimension": "bill_source",
+    "type": "equal",
+    "value": bill_connection_id
+  }
 
   // Set filters based on the type of request (RI or Base)
   // and whether or not we're pulling costs for an old Azure EA connection or a new one
@@ -279,20 +279,11 @@ script "js_get_aggregated_costs", type: "javascript" do
     filter = {
       "type": "and",
       "expressions": [
-        { "type": "or", "expressions": bill_source_expressions },
         {
           "type": "or",
           "expressions": [
-            {
-              "dimension": "service",
-              "type": "equal",
-              "value": "Microsoft.Compute"
-            },
-            {
-              "dimension": "service",
-              "type": "equal",
-              "value": "microsoft.compute"
-            }
+            { "dimension": "service", "type": "equal", "value": "Microsoft.Compute" },
+            { "dimension": "service", "type": "equal", "value": "microsoft.compute" }
           ]
         },
         {
@@ -313,7 +304,8 @@ script "js_get_aggregated_costs", type: "javascript" do
         {
           "type": "not",
           "expression": { "dimension": "instance_type", "type": "equal", "value": "None" }
-        }
+        },
+        bill_source_expression
       ]
     }
   }
@@ -322,22 +314,14 @@ script "js_get_aggregated_costs", type: "javascript" do
     filter = {
       "type": "and",
       "expressions": [
-        { "type": "or", "expressions": bill_source_expressions },
         {
           "type": "or",
           "expressions": [
-            {
-              "dimension": "purchase_option",
-              "type": "equal",
-              "value": "Reserved"
-            },
-            {
-              "dimension": "purchase_option",
-              "type": "equal",
-              "value": "reserved"
-            }
+            { "dimension": "purchase_option", "type": "equal", "value": "Reserved" },
+            { "dimension": "purchase_option", "type": "equal", "value": "reserved" }
           ]
-        }
+        },
+        bill_source_expression
       ]
     }
   }
@@ -346,20 +330,11 @@ script "js_get_aggregated_costs", type: "javascript" do
     filter = {
       "type": "and",
       "expressions": [
-        { "type": "or", "expressions": bill_source_expressions },
         {
           "type": "or",
           "expressions": [
-            {
-              "dimension": "service",
-              "type": "equal",
-              "value": "Microsoft.Compute"
-            },
-            {
-              "dimension": "service",
-              "type": "equal",
-              "value": "microsoft.compute"
-            }
+            { "dimension": "service", "type": "equal", "value": "Microsoft.Compute" },
+            { "dimension": "service", "type": "equal", "value": "microsoft.compute" }
           ]
         },
         {
@@ -383,7 +358,8 @@ script "js_get_aggregated_costs", type: "javascript" do
         {
           "type": "not",
           "expression": { "dimension": "instance_type", "type": "equal", "value": "None" }
-        }
+        },
+        bill_source_expression
       ]
     }
   }
@@ -392,22 +368,14 @@ script "js_get_aggregated_costs", type: "javascript" do
     filter = {
       "type": "and",
       "expressions": [
-        { "type": "or", "expressions": bill_source_expressions },
         {
           "type": "or",
           "expressions": [
-            {
-              "dimension": "category",
-              "type": "equal",
-              "value": "Commitments"
-            },
-            {
-              "dimension": "category",
-              "type": "equal",
-              "value": "commitments"
-            }
+            { "dimension": "category", "type": "equal", "value": "Commitments" },
+            { "dimension": "category", "type": "equal", "value": "commitments" }
           ]
-        }
+        },
+        bill_source_expression
       ]
     }
   }

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -83,70 +83,6 @@ datasource "ds_applied_policy" do
   end
 end
 
-# Table to convert region names from old EA connections to the new ones
-datasource "ds_region_table" do
-  run_script $js_region_table
-end
-
-script "js_region_table", type: "javascript" do
-  result "result"
-  code <<-EOS
-  result = {
-    "AE Central": "UAE Central",
-    "AE North": "UAE North",
-    "AP East": "East Asia",
-    "AP Southeast": "Southeast Asia",
-    "AU Central": "Australia Central",
-    "AU Central 2": "Australia Central 2",
-    "AU East": "Australia East",
-    "AU Southeast": "Australia Southeast",
-    "BR South": "Brazil South",
-    "BR Southeast": "Brazil Southeast",
-    "CA Central": "Canada Central",
-    "CA East": "Canada East",
-    "CH North": "China North",
-    "CH West": "China West",
-    "DE North": "Germany North",
-    "DE West Central": "Germany West Central",
-    "EU North": "North Europe",
-    "EU West": "West Europe",
-    "FR Central": "France Central",
-    "FR South": "France South",
-    "IN Central": "Central India",
-    "IN Central Jio": "Jio India Central",
-    "IN South": "South India",
-    "IN West": "West India",
-    "IN West Jio": "Jio India West",
-    "IT North": "Italy North",
-    "JA East": "Japan East",
-    "JA West": "Japan West",
-    "KR Central": "Korea Central",
-    "KR South": "Korea South",
-    "NO East": "Norway East",
-    "NO West": "Norway West",
-    "PL Central": "Poland Central",
-    "QA Central": "Qatar Central",
-    "SE Central": "Sweden Central",
-    "SE South": "Sweden South",
-    "UK South": "UK South",
-    "UK West": "UK West",
-    "US Central": "Central US",
-    "US East": "East US",
-    "US East 2": "East US 2",
-    "US North Central": "North Central US",
-    "US South Central": "South Central US",
-    "US West": "West US",
-    "US West 2": "West US 2",
-    "US West 3": "West US 3",
-    "US West Central": "West Central US",
-    "ZA North": "South Africa North",
-    "ZA West": "South Africa West",
-    "All Regions": "All Regions",
-    "Unassigned": "Unassigned"
-  }
-EOS
-end
-
 datasource "ds_billing_centers" do
   request do
     auth $auth_flexera
@@ -189,6 +125,7 @@ script "js_filtered_bcs", type: "javascript" do
   result = _.compact(_.pluck(filtered_bcs, 'id'))
 EOS
 end
+
 
 # Gather list of bill connections from Optima data
 datasource "ds_bill_connections" do
@@ -239,10 +176,10 @@ datasource "ds_bill_connections_new" do
 end
 
 script "js_bill_connections_filter", type:"javascript" do
-  parameters "ds_bill_connections", "index"
+  parameters "bill_connections", "index"
   result "result"
   code <<-EOS
-  bill_sources = _.filter(ds_bill_connections, function(connection) {
+  bill_sources = _.filter(bill_connections, function(connection) {
     return connection['bill_source'].indexOf('azure-ea') == index
   })
 
@@ -250,9 +187,9 @@ script "js_bill_connections_filter", type:"javascript" do
 EOS
 end
 
-datasource "ds_ri_aggregated_costs_old" do
+datasource "ds_aggregated_costs_old_base" do
   request do
-    run_script $js_get_aggregated_costs, $ds_bill_connections_old, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "ri_old"
+    run_script $js_get_aggregated_costs, $ds_bill_connections_old, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "base"
   end
   result do
     encoding "json"
@@ -267,9 +204,9 @@ datasource "ds_ri_aggregated_costs_old" do
   end
 end
 
-datasource "ds_ri_aggregated_costs_new" do
+datasource "ds_aggregated_costs_old_ri" do
   request do
-    run_script $js_get_aggregated_costs, $ds_bill_connections_new, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "ri_new"
+    run_script $js_get_aggregated_costs, $ds_bill_connections_old, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "ri"
   end
   result do
     encoding "json"
@@ -284,35 +221,16 @@ datasource "ds_ri_aggregated_costs_new" do
   end
 end
 
-datasource "ds_base_aggregated_costs_old" do
+datasource "ds_aggregated_costs_new" do
   request do
-    run_script $js_get_aggregated_costs, $ds_bill_connections_old, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "base_old"
+    run_script $js_get_aggregated_costs, $ds_bill_connections_new, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "new"
   end
   result do
     encoding "json"
     collect jmes_path(response, "rows") do
-      field "instance_type", jmes_path(col_item, "dimensions.instance_type")
-      field "region", jmes_path(col_item, "dimensions.region")
-      field "usage_unit", jmes_path(col_item, "dimensions.usage_unit")
-      field "usage_amount", jmes_path(col_item, "metrics.usage_amount")
+      field "purchase_option", jmes_path(col_item, "dimensions.purchase_option")
       field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
-      field "month", jmes_path(col_item, "timestamp")
-    end
-  end
-end
-
-datasource "ds_base_aggregated_costs_new" do
-  request do
-    run_script $js_get_aggregated_costs, $ds_bill_connections_new, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "base_new"
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "rows") do
-      field "instance_type", jmes_path(col_item, "dimensions.instance_type")
-      field "region", jmes_path(col_item, "dimensions.region")
-      field "usage_unit", jmes_path(col_item, "dimensions.usage_unit")
-      field "usage_amount", jmes_path(col_item, "metrics.usage_amount")
-      field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
+      field "savings", jmes_path(col_item, "metrics.savings_rate_reduction_amortized_adj")
       field "month", jmes_path(col_item, "timestamp")
     end
   end
@@ -322,9 +240,45 @@ script "js_get_aggregated_costs", type: "javascript" do
   parameters "bill_sources", "ds_filtered_bcs", "start_date", "end_date", "org_id", "optima_host", "connection_type"
   result "request"
   code <<-EOS
-  // Set filters based on the type of request (RI or Base)
-  // and whether or not we're pulling costs for an old Azure EA connection or a new one
-  if (connection_type == 'ri_old') {
+  // Set filters based on the type of request
+  if (connection_type == 'base') {
+    filter = {
+      "type": "and",
+      "expressions": [
+        {
+          "type": "or",
+          "expressions": [
+            { "dimension": "service", "type": "equal", "value": "Microsoft.Compute" },
+            { "dimension": "service", "type": "equal", "value": "microsoft.compute" }
+          ]
+        },
+        {
+          "type": "not",
+          "expression": {
+            "type": "or",
+            "expressions": [
+              {
+                "dimension": "resource_type",
+                "type": "equal",
+                "value": "Virtual Machines-Reservation-Base VM"
+              },
+              {
+                "dimension": "resource_type",
+                "type": "equal",
+                "value": "virtual machines-reservation-base vm"
+              }
+            ]
+          }
+        },
+        {
+          "type": "not",
+          "expression": { "dimension": "instance_type", "type": "equal", "value": "None" }
+        }
+      ]
+    }
+  }
+
+  if (connection_type == 'ri') {
     filter = {
       "type": "and",
       "expressions": [
@@ -358,32 +312,17 @@ script "js_get_aggregated_costs", type: "javascript" do
     }
   }
 
-  if (connection_type == 'ri_new') {
+  if (connection_type == 'new') {
     filter = {
       "type": "and",
       "expressions": [
         {
           "type": "or",
           "expressions": [
-            { "dimension": "category", "type": "equal", "value": "Commitments" },
-            { "dimension": "category", "type": "equal", "value": "commitments" }
+            { "dimension": "vendor", "type": "equal", "value": "Azure"  },
+            { "dimension": "vendor", "type": "equal", "value": "azure"  }
           ]
         },
-        {
-          "type": "or",
-          "expressions": [
-            { "dimension": "purchase_option", "type": "equal", "value": "Reserved" },
-            { "dimension": "purchase_option", "type": "equal", "value": "reserved" }
-          ]
-        }
-      ]
-    }
-  }
-
-  if (connection_type == 'base_old') {
-    filter = {
-      "type": "and",
-      "expressions": [
         {
           "type": "or",
           "expressions": [
@@ -393,126 +332,38 @@ script "js_get_aggregated_costs", type: "javascript" do
         },
         {
           "type": "not",
-          "expression": {
-            "type": "or",
-            "expressions": [
-              {
-                "dimension": "resource_type",
-                "type": "equal",
-                "value": "Virtual Machines-Reservation-Base VM"
-              },
-              {
-                "dimension": "resource_type",
-                "type": "equal",
-                "value": "virtual machines-reservation-base vm"
-              }
-            ]
-          }
-        },
-        {
-          "type": "not",
           "expression": { "dimension": "instance_type", "type": "equal", "value": "None" }
         }
       ]
     }
   }
 
-  if (connection_type == 'base_new') {
-    filter = {
-      "type": "and",
-      "expressions": [
-        {
-          "type": "or",
-          "expressions": [
-            { "dimension": "service", "type": "equal", "value": "Microsoft.Compute" },
-            { "dimension": "service", "type": "equal", "value": "microsoft.compute" }
-          ]
-        },
-        {
-          "type": "not",
-          "expression": {
-            "type": "or",
-            "expressions": [
-              { "dimension": "purchase_option", "type": "equal", "value": "Reserved" },
-              { "dimension": "purchase_option", "type": "equal", "value": "reserved" },
-              { "dimension": "purchase_option", "type": "equal", "value": "Spot" },
-              { "dimension": "purchase_option", "type": "equal", "value": "spot" },
-              { "dimension": "purchase_option", "type": "equal", "value": "Savings Plan" },
-              { "dimension": "purchase_option", "type": "equal", "value": "savings plan" }
-            ]
-          }
-        },
-        {
-          "type": "not",
-          "expression": {
-            "type": "or",
-            "expressions": [
-              {
-                "dimension": "resource_type",
-                "type": "equal",
-                "value": "Virtual Machines-Reservation-Base VM"
-              },
-              {
-                "dimension": "resource_type",
-                "type": "equal",
-                "value": "virtual machines-reservation-base vm"
-              }
-            ]
-          }
-        },
-        {
-          "type": "not",
-          "expression": {
-            "type": "or",
-            "expressions": [
-              { "dimension": "category", "type": "equal", "value": "Commitments" },
-              { "dimension": "category", "type": "equal", "value": "commitments" }
-            ]
-          }
-        },
-        {
-          "type": "not",
-          "expression": { "dimension": "instance_type", "type": "equal", "value": "None" }
-        }
-      ]
-    }
-  }
-
-  // Ensure we're filtering our request to just the specific bill connections
-  bill_source_expressions = []
-
-  _.each(bill_sources, function(bill_source) {
-    bill_source_expressions.push({
-      "dimension": "bill_source",
-      "type": "equal",
-      "value": bill_source
-    })
+  // Ensure we're filtering our request to just the specific bill connection
+  bill_source_expressions = _.map(bill_sources, function(bill_source) {
+    return { "dimension": "bill_source", "type": "equal", "value": bill_source }
   })
 
   filter["expressions"].push({ "type": "or", "expressions": bill_source_expressions })
 
-  // Ensure we only pull Azure costs
-  filter["expressions"].push({
-    "type": "or",
-    "expressions": [
-      { "dimension": "vendor", "type": "equal", "value": "Azure"  },
-      { "dimension": "vendor", "type": "equal", "value": "azure"  }
-    ]
-  })
+  // Other options depending on whether the request is for the new EA connection type or not
+  dimensions = [ "purchase_option" ]
+
+  if (connection_type != 'new') {
+    dimensions = [ "instance_type", "region", "usage_unit" ]
+  }
+
+  metrics = [ "cost_amortized_unblended_adj", "savings_rate_reduction_amortized_adj" ]
+
+  if (connection_type != 'new') {
+    metrics = [ "cost_amortized_unblended_adj", "usage_amount" ]
+  }
 
   payload = {
     "billing_center_ids": ds_filtered_bcs,
     "filter": filter,
-    "dimensions": [
-      "instance_type",
-      "region",
-      "usage_unit"
-    ],
+    "dimensions": dimensions,
     "granularity": "month",
-    "metrics": [
-      "cost_amortized_unblended_adj",
-      "usage_amount"
-    ]
+    "metrics": metrics,
     "end_at": end_date,
     "start_at": start_date
   }
@@ -530,47 +381,18 @@ script "js_get_aggregated_costs", type: "javascript" do
 EOS
 end
 
-datasource "ds_ri_aggregated_costs" do
-  run_script $js_cost_combiner, $ds_ri_aggregated_costs_old, $ds_ri_aggregated_costs_new, $ds_region_table
-end
-
-datasource "ds_base_aggregated_costs" do
-  run_script $js_cost_combiner, $ds_base_aggregated_costs_old, $ds_base_aggregated_costs_new, $ds_region_table
-end
-
-script "js_cost_combiner", type:"javascript" do
-  parameters "ds_costs_old", "ds_costs_new", "ds_region_table"
-  result "result"
-  code <<-EOS
-  result = _.map(ds_costs_old, function(cost) {
-    region = cost['region']
-    if (ds_region_table[region] != undefined) { region = ds_region_table[region] }
-
-    return {
-      instance_type: cost['instance_type'],
-      usage_unit: cost['usage_unit'],
-      usage_amount: cost['usage_amount'],
-      cost: cost['cost'],
-      month: cost['month'],
-      region: region
-    }
-  })
-
-  result = result.concat(ds_costs_new)
-EOS
-end
-
 datasource "ds_savings_realized" do
-  run_script $js_savings_realized, $ds_ri_aggregated_costs, $ds_base_aggregated_costs
+  run_script $js_savings_realized, $ds_aggregated_costs_old_base, $ds_aggregated_costs_old_ri, $ds_aggregated_costs_new
 end
 
 script "js_savings_realized", type: "javascript" do
-  parameters "ds_ri_aggregated_costs", "ds_base_aggregated_costs"
+  parameters "ds_aggregated_costs_old_base", "ds_aggregated_costs_old_ri", "ds_aggregated_costs_new"
   result "result"
   code <<-'EOS'
   result = []
 
-  all_costs = ds_ri_aggregated_costs.concat(ds_base_aggregated_costs)
+  // Calculate and store savings data for old EA connections
+  all_costs = ds_aggregated_costs_old_ri.concat(ds_aggregated_costs_old_base)
 
   // Get list of Instance Types, Regions, Months
   instance_types = _.uniq(_.pluck(all_costs, 'instance_type'))
@@ -593,7 +415,7 @@ script "js_savings_realized", type: "javascript" do
   // for each instance type/region/operating system combination
   base_aggregated_costs = {}
 
-  _.each(ds_base_aggregated_costs, function(cost) {
+  _.each(ds_aggregated_costs_old_base, function(cost) {
     index = [cost['instance_type'], cost['region']].join('_').toLowerCase().trim()
 
     if (base_aggregated_costs[index] == undefined) { base_aggregated_costs[index] = [] }
@@ -629,7 +451,7 @@ script "js_savings_realized", type: "javascript" do
   // Apply cost_instance_hour to calculate savings realized
   savings_realized_object = {}
 
-  _.each(ds_ri_aggregated_costs, function(cost) {
+  _.each(ds_aggregated_costs_old_ri, function(cost) {
     index = [cost['instance_type'], cost['region']].join('_').toLowerCase().trim()
     avg_base_cost_instance_hour = unique_cost_instance_hours[index]
 
@@ -655,6 +477,50 @@ script "js_savings_realized", type: "javascript" do
     })
   })
 
+  // Calculate and store savings data for new EA connections
+
+  // Function for calculating total cost for each dimension
+  function cost_sum(cost_list, month, dimension_filter) {
+    dimension_table = {
+      "Reserved": "Reservations",
+      "Savings Plan": "Savings Plans",
+      "Spot": "Spot Instances"
+    }
+
+    if (dimension_filter != "All") {
+      entries = _.filter(entries, function(cost) { return cost['purchase_option'] == dimension_filter })
+      costs = _.pluck(entries, 'cost')
+      dimension_message = "Savings Realized On Compute " + dimension_table[dimension_filter]
+    } else {
+      entries = cost_list[month]
+      costs = _.pluck(entries, 'cost')
+      dimension_message = "Total Actual Spend On Discountable Compute"
+    }
+
+    total_savings = 0
+
+    if (costs.length > 0) {
+      total_savings = _.reduce(costs, function(memo, num) { return memo + num }, 0)
+    }
+
+    return {
+      "month": month,
+      "cost": total_savings,
+      "dimension": dimension_message
+    }
+  }
+
+  new_costs_by_month = _.groupBy(ds_aggregated_costs_new, 'month')
+
+  // Calculate costs for each month
+  _.each(_.keys(new_costs_by_month), function(month) {
+    result.push(cost_sum(new_costs_by_month, month, "All"))
+    result.push(cost_sum(new_costs_by_month, month, "Reserved"))
+    result.push(cost_sum(new_costs_by_month, month, "Savings Plan"))
+    result.push(cost_sum(new_costs_by_month, month, "Spot"))
+  })
+
+  // Sort by month
   result = _.sortBy(result, "month")
 EOS
 end
@@ -669,36 +535,61 @@ script "js_chart_data", type: "javascript" do
   code <<-'EOS'
   // Create report data
   result = []
-  months = _.uniq(_.pluck(ds_savings_realized, 'month'))
+  savings_by_month = _.groupBy(ds_savings_realized, 'month')
 
-  _.each(months, function(month) {
-    savings_realized = 0
-    total_spend = 0
-    percentage = 0
-
-    savings_realized_for_month = _.find(ds_savings_realized, function(data) {
-      return data['month'] == month && data['dimension'] == "Savings Realized On Compute Reservations"
+  _.each(_.keys(savings_by_month), function(month) {
+    total_spend_entry = _.find(savings_by_month[month], function(item) {
+      return item['dimension'] == "Total Actual Spend On Discountable Compute"
     })
 
-    if (typeof(savings_realized_for_month) == 'object') {
-      savings_realized = savings_realized_for_month['cost']
-    }
-
-    total_spend_for_month = _.find(ds_savings_realized, function(data) {
-      return data['month'] == month && data['dimension'] == "Total Actual Spend On Discountable Compute"
+    savings_realized_ri_entry  = _.find(savings_by_month[month], function(item) {
+      return item['dimension'] == "Savings Realized On Compute Reservations"
     })
 
-    if (typeof(total_spend_for_month) == 'object') {
-      total_spend = total_spend_for_month['cost']
+    savings_realized_sp_entry  = _.find(savings_by_month[month], function(item) {
+      return item['dimension'] == "Savings Realized On Compute Savings Plans"
+    })
+
+    savings_realized_spot_entry  = _.find(savings_by_month[month], function(item) {
+      return item['dimension'] == "Savings Realized On Compute Spot Instances"
+    })
+
+    total_spend_cost = 0
+    savings_realized_ri_cost = 0
+    savings_realized_sp_cost = 0
+    savings_realized_spot_cost = 0
+    percentage_ri = 0
+    percentage_sp = 0
+    percentage_spot = 0
+
+    if (total_spend_entry != undefined) {
+      total_spend_cost = total_spend_entry['cost']
     }
 
-    percentage = (savings_realized / (total_spend + savings_realized)) *100
+    if (savings_realized_ri_entry != undefined) {
+      savings_realized_ri_cost = savings_realized_ri_entry['cost']
+      percentage_ri = (savings_realized_ri_cost / (total_spend_cost)) * 100
+    }
+
+    if (savings_realized_sp_entry != undefined) {
+      savings_realized_sp_cost = savings_realized_sp_entry['cost']
+      percentage_sp = (savings_realized_sp_cost / total_spend_cost) * 100
+    }
+
+    if (savings_realized_spot_entry != undefined) {
+      savings_realized_spot_cost = savings_realized_spot_entry['cost']
+      percentage_spot = (savings_realized_spot_cost / total_spend_cost) * 100
+    }
 
     result.push({
-      "month": month.split('-')[0] + '-' + month.split('-')[1],
-      "total_spend": parseFloat(total_spend).toFixed(2),
-      "savings_realized": parseFloat(savings_realized).toFixed(2),
-      "percentage": parseFloat(percentage).toFixed(2) + "%"
+      "month": month,
+      "total_spend": parseFloat(total_spend_cost.toFixed(2)),
+      "savings_realized_ri": parseFloat(savings_realized_ri_cost.toFixed(2)),
+      "savings_realized_sp": parseFloat(savings_realized_sp_cost.toFixed(2)),
+      "savings_realized_spot": parseFloat(savings_realized_spot_cost.toFixed(2)),
+      "percentage_ri": parseFloat(percentage_ri.toFixed(2))
+      "percentage_sp": parseFloat(percentage_sp.toFixed(2))
+      "percentage_spot": parseFloat(percentage_spot.toFixed(2))
     })
   })
 
@@ -711,9 +602,8 @@ script "js_chart_data", type: "javascript" do
   chart_type = chart_table[param_chart_type]
 
   // Create chart axis labels
-  sr_months = _.uniq(ds_savings_realized, function(sr) { return sr['month'] })
-  sr_months_mapped = _.map(sr_months, function(sr) { return sr['month'].substring(0,7) })
-  chart_axis_labels = ("chxl=1:," + sr_months_mapped).split(',').join('|')
+  months_mapped = _.map(_.keys(savings_by_month), function(item) { return item.substring(0,7) })
+  chart_axis_labels = ("chxl=1:," + months_mapped).split(',').join('|')
 
   // Create legend
   chart_legend = "chdl=" + _.uniq(_.pluck(ds_savings_realized, 'dimension')).join('|')
@@ -725,12 +615,12 @@ script "js_chart_data", type: "javascript" do
   chart_range = "chxr=0," + min + "," + max
 
   //Create chart dataset
-  group_by_dimension = _.groupBy(ds_savings_realized, function(data) { return data['dimension'] })
+  savings_by_dimension = _.groupBy(ds_savings_realized, 'dimension')
 
   chart_data_list = []
 
-  _.each(_.keys(group_by_dimension), function(key) {
-    chart_data_list.push(_.pluck(group_by_dimension[key], 'cost').join(','))
+  _.each(_.keys(savings_by_dimension), function(key) {
+    chart_data_list.push(_.pluck(savings_by_dimension[key], 'cost').join(','))
   })
 
   chart_data = "chd=t:" + chart_data_list.join('|')
@@ -780,11 +670,23 @@ policy "policy_purchase_option_by_inst_type_and_region" do
       field "total_spend" do
         label "Total Actual Spend On Discountable Compute"
       end
-      field "savings_realized" do
+      field "savings_realized_ri" do
         label "Savings Realized On Compute Reservations"
       end
-      field "percentage" do
-        label "Savings Rate"
+      field "savings_realized_sp" do
+        label "Savings Realized On Compute Savings Plans"
+      end
+      field "savings_realized_spot" do
+        label "Savings Realized On Compute Spot Instances"
+      end
+      field "percentage_ri" do
+        label "Savings Rate (%) from Reservation Usage"
+      end
+      field "percentage_sp" do
+        label "Savings Rate (%) from Savings Plan Usage"
+      end
+      field "percentage_spot" do
+        label "Savings Rate (%) from Spot Instance Usage"
       end
     end
   end

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -295,7 +295,21 @@ script "js_get_aggregated_costs", type: "javascript" do
             }
           ]
         },
-        { "dimension": "resource_type", "type": "equal", "value": "Virtual Machines-Reservation-Base VM" },
+        {
+          "type": "or",
+          "expressions": [
+            {
+              "dimension": "resource_type",
+              "type": "equal",
+              "value": "Virtual Machines-Reservation-Base VM"
+            },
+            {
+              "dimension": "resource_type",
+              "type": "equal",
+              "value": "virtual machines-reservation-base vm"
+            }
+          ]
+        },
         {
           "type": "not",
           "expression": { "dimension": "instance_type", "type": "equal", "value": "None" }
@@ -350,10 +364,6 @@ script "js_get_aggregated_costs", type: "javascript" do
         },
         {
           "type": "not",
-          "expression": { "dimension": "instance_type", "type": "equal", "value": "None" }
-        },
-        {
-          "type": "not",
           "expression": {
             "type": "or",
             "expressions": [
@@ -369,6 +379,10 @@ script "js_get_aggregated_costs", type: "javascript" do
               }
             ]
           }
+        },
+        {
+          "type": "not",
+          "expression": { "dimension": "instance_type", "type": "equal", "value": "None" }
         }
       ]
     }

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -571,11 +571,11 @@ end
 
 #CHART CREATION
 datasource "ds_chart_data" do
-  run_script $js_create_chart_data, $ds_savings_realized, $param_chart_type
+  run_script $js_create_chart_data, $ds_savings_realized, $ds_applied_policy, $param_chart_type
 end
 
 script "js_create_chart_data", type: "javascript" do
-  parameters "savings_realized_data", "param_chart_type"
+  parameters "savings_realized_data", "ds_applied_policy", "param_chart_type"
   result "report"
   code <<-EOS
   //Get months
@@ -669,6 +669,7 @@ script "js_create_chart_data", type: "javascript" do
 
   if ( report.length !== 0 ){
     report[0]["chart_dimensions"] = chart
+    report[0]["policy_name"] = ds_applied_policy['name']
   }
 EOS
 end
@@ -679,7 +680,7 @@ end
 
 policy "policy_purchase_option_by_inst_type_and_region" do
   validate_each $ds_chart_data do
-    summary_template "Azure Savings Realized from Reservations"
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}"
     detail_template <<-'EOS'
     # Savings Realized On Compute Reservations Report
     ![Savings Realized On Compute Reservations Chart](https://api.image-charts-auth.flexeraeng.com/ic-function?rs_org_id={{ rs_org_id }}&rs_project_id={{ rs_project_id }}&{{ with index data 0 }}{{ .chart_dimensions.chart_data }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_size }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_type }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_image }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_title }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_y_axis }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_axis_label }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_line_style }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_line_color }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_data_scale }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_legend_size }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_legend }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_axis_format }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_legend_position }}{{ end }})

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -267,12 +267,6 @@ script "js_get_aggregated_costs", type: "javascript" do
   parameters "bill_connection_id", "ds_filtered_bcs", "start_date", "end_date", "org_id", "optima_host", "connection_type"
   result "request"
   code <<-EOS
-  bill_source_expression = {
-    "dimension": "bill_source",
-    "type": "equal",
-    "value": bill_connection_id
-  }
-
   // Set filters based on the type of request (RI or Base)
   // and whether or not we're pulling costs for an old Azure EA connection or a new one
   if (connection_type == 'ri_old') {
@@ -304,8 +298,7 @@ script "js_get_aggregated_costs", type: "javascript" do
         {
           "type": "not",
           "expression": { "dimension": "instance_type", "type": "equal", "value": "None" }
-        },
-        bill_source_expression
+        }
       ]
     }
   }
@@ -317,11 +310,17 @@ script "js_get_aggregated_costs", type: "javascript" do
         {
           "type": "or",
           "expressions": [
+            { "dimension": "category", "type": "equal", "value": "Commitments" },
+            { "dimension": "category", "type": "equal", "value": "commitments" }
+          ]
+        },
+        {
+          "type": "or",
+          "expressions": [
             { "dimension": "purchase_option", "type": "equal", "value": "Reserved" },
             { "dimension": "purchase_option", "type": "equal", "value": "reserved" }
           ]
-        },
-        bill_source_expression
+        }
       ]
     }
   }
@@ -358,8 +357,7 @@ script "js_get_aggregated_costs", type: "javascript" do
         {
           "type": "not",
           "expression": { "dimension": "instance_type", "type": "equal", "value": "None" }
-        },
-        bill_source_expression
+        }
       ]
     }
   }
@@ -371,14 +369,34 @@ script "js_get_aggregated_costs", type: "javascript" do
         {
           "type": "or",
           "expressions": [
-            { "dimension": "category", "type": "equal", "value": "Commitments" },
-            { "dimension": "category", "type": "equal", "value": "commitments" }
+            { "dimension": "service", "type": "equal", "value": "Microsoft.Compute" },
+            { "dimension": "service", "type": "equal", "value": "microsoft.compute" }
           ]
         },
-        bill_source_expression
+        {
+          "type": "not",
+          "expression": {
+            "type": "or",
+            "expressions": [
+              { "dimension": "purchase_option", "type": "equal", "value": "Reserved" },
+              { "dimension": "purchase_option", "type": "equal", "value": "reserved" },
+              { "dimension": "purchase_option", "type": "equal", "value": "Spot" },
+              { "dimension": "purchase_option", "type": "equal", "value": "spot" },
+              { "dimension": "purchase_option", "type": "equal", "value": "Savings Plan" },
+              { "dimension": "purchase_option", "type": "equal", "value": "savings plan" }
+            ]
+          }
+        }
       ]
     }
   }
+
+  // Ensure we're filtering our request to just the specific bill connection
+  filter["expressions"].push({
+    "dimension": "bill_source",
+    "type": "equal",
+    "value": bill_connection_id
+  })
 
   var payload = {
     "billing_center_ids": ds_filtered_bcs,

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -83,6 +83,70 @@ datasource "ds_applied_policy" do
   end
 end
 
+# Table to convert region names from old EA connections to the new ones
+datasource "ds_region_table" do
+  run_script $js_region_table
+end
+
+script "js_region_table", type: "javascript" do
+  result "result"
+  code <<-EOS
+  result = {
+    "AE Central": "UAE Central",
+    "AE North": "UAE North",
+    "AP East": "East Asia",
+    "AP Southeast": "Southeast Asia",
+    "AU Central": "Australia Central",
+    "AU Central 2": "Australia Central 2",
+    "AU East": "Australia East",
+    "AU Southeast": "Australia Southeast",
+    "BR South": "Brazil South",
+    "BR Southeast": "Brazil Southeast",
+    "CA Central": "Canada Central",
+    "CA East": "Canada East",
+    "CH North": "China North",
+    "CH West": "China West",
+    "DE North": "Germany North",
+    "DE West Central": "Germany West Central",
+    "EU North": "North Europe",
+    "EU West": "West Europe",
+    "FR Central": "France Central",
+    "FR South": "France South",
+    "IN Central": "Central India",
+    "IN Central Jio": "Jio India Central",
+    "IN South": "South India",
+    "IN West": "West India",
+    "IN West Jio": "Jio India West",
+    "IT North": "Italy North",
+    "JA East": "Japan East",
+    "JA West": "Japan West",
+    "KR Central": "Korea Central",
+    "KR South": "Korea South",
+    "NO East": "Norway East",
+    "NO West": "Norway West",
+    "PL Central": "Poland Central",
+    "QA Central": "Qatar Central",
+    "SE Central": "Sweden Central",
+    "SE South": "Sweden South",
+    "UK South": "UK South",
+    "UK West": "UK West",
+    "US Central": "Central US",
+    "US East": "East US",
+    "US East 2": "East US 2",
+    "US North Central": "North Central US",
+    "US South Central": "South Central US",
+    "US West": "West US",
+    "US West 2": "West US 2",
+    "US West 3": "West US 3",
+    "US West Central": "West Central US",
+    "ZA North": "South Africa North",
+    "ZA West": "South Africa West",
+    "All Regions": "All Regions",
+    "Unassigned": "Unassigned"
+  }
+EOS
+end
+
 datasource "ds_billing_centers" do
   request do
     auth $auth_flexera
@@ -189,7 +253,7 @@ end
 
 datasource "ds_aggregated_costs_old_base" do
   request do
-    run_script $js_get_aggregated_costs, $ds_bill_connections_old, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "base"
+    run_script $js_get_aggregated_costs, $ds_bill_connections_old, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "old_base"
   end
   result do
     encoding "json"
@@ -206,7 +270,7 @@ end
 
 datasource "ds_aggregated_costs_old_ri" do
   request do
-    run_script $js_get_aggregated_costs, $ds_bill_connections_old, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "ri"
+    run_script $js_get_aggregated_costs, $ds_bill_connections_old, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "old_ri"
   end
   result do
     encoding "json"
@@ -221,16 +285,35 @@ datasource "ds_aggregated_costs_old_ri" do
   end
 end
 
-datasource "ds_aggregated_costs_new" do
+datasource "ds_aggregated_costs_new_base" do
   request do
-    run_script $js_get_aggregated_costs, $ds_bill_connections_new, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "new"
+    run_script $js_get_aggregated_costs, $ds_bill_connections_new, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "new_base"
   end
   result do
     encoding "json"
     collect jmes_path(response, "rows") do
-      field "purchase_option", jmes_path(col_item, "dimensions.purchase_option")
+      field "instance_type", jmes_path(col_item, "dimensions.instance_type")
+      field "region", jmes_path(col_item, "dimensions.region")
+      field "usage_unit", jmes_path(col_item, "dimensions.usage_unit")
+      field "usage_amount", jmes_path(col_item, "metrics.usage_amount")
       field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
-      field "savings", jmes_path(col_item, "metrics.savings_rate_reduction_amortized_adj")
+      field "month", jmes_path(col_item, "timestamp")
+    end
+  end
+end
+
+datasource "ds_aggregated_costs_new_ri" do
+  request do
+    run_script $js_get_aggregated_costs, $ds_bill_connections_new, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "new_ri"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "rows") do
+      field "instance_type", jmes_path(col_item, "dimensions.instance_type")
+      field "region", jmes_path(col_item, "dimensions.region")
+      field "usage_unit", jmes_path(col_item, "dimensions.usage_unit")
+      field "usage_amount", jmes_path(col_item, "metrics.usage_amount")
+      field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
       field "month", jmes_path(col_item, "timestamp")
     end
   end
@@ -241,7 +324,7 @@ script "js_get_aggregated_costs", type: "javascript" do
   result "request"
   code <<-EOS
   // Set filters based on the type of request
-  if (connection_type == 'base') {
+  if (connection_type == 'old_base') {
     filter = {
       "type": "and",
       "expressions": [
@@ -278,7 +361,7 @@ script "js_get_aggregated_costs", type: "javascript" do
     }
   }
 
-  if (connection_type == 'ri') {
+  if (connection_type == 'old_ri') {
     filter = {
       "type": "and",
       "expressions": [
@@ -312,10 +395,57 @@ script "js_get_aggregated_costs", type: "javascript" do
     }
   }
 
-  if (connection_type == 'new') {
+  if (connection_type == 'new_base') {
     filter = {
       "type": "and",
       "expressions": [
+        {
+          "type": "not",
+          "expression": {
+            "type": "or",
+            "expressions": [
+              { "dimension": "purchase_option", "type": "equal", "value": "Reserved" },
+              { "dimension": "purchase_option", "type": "equal", "value": "reserved" },
+              { "dimension": "purchase_option", "type": "equal", "value": "Savings Plan" },
+              { "dimension": "purchase_option", "type": "equal", "value": "savings plan" },
+              { "dimension": "purchase_option", "type": "equal", "value": "Spot" },
+              { "dimension": "purchase_option", "type": "equal", "value": "spot" }
+            ]
+          }
+        },
+        {
+          "type": "or",
+          "expressions": [
+            { "dimension": "vendor", "type": "equal", "value": "Azure"  },
+            { "dimension": "vendor", "type": "equal", "value": "azure"  }
+          ]
+        },
+        {
+          "type": "or",
+          "expressions": [
+            { "dimension": "service", "type": "equal", "value": "Microsoft.Compute" },
+            { "dimension": "service", "type": "equal", "value": "microsoft.compute" }
+          ]
+        },
+        {
+          "type": "not",
+          "expression": { "dimension": "instance_type", "type": "equal", "value": "None" }
+        }
+      ]
+    }
+  }
+
+  if (connection_type == 'new_ri') {
+    filter = {
+      "type": "and",
+      "expressions": [
+        {
+          "type": "or",
+          "expressions": [
+            { "dimension": "purchase_option", "type": "equal", "value": "Reserved" },
+            { "dimension": "purchase_option", "type": "equal", "value": "reserved" }
+          ]
+        },
         {
           "type": "or",
           "expressions": [
@@ -345,25 +475,12 @@ script "js_get_aggregated_costs", type: "javascript" do
 
   filter["expressions"].push({ "type": "or", "expressions": bill_source_expressions })
 
-  // Other options depending on whether the request is for the new EA connection type or not
-  dimensions = [ "purchase_option" ]
-
-  if (connection_type != 'new') {
-    dimensions = [ "instance_type", "region", "usage_unit" ]
-  }
-
-  metrics = [ "cost_amortized_unblended_adj", "savings_rate_reduction_amortized_adj" ]
-
-  if (connection_type != 'new') {
-    metrics = [ "cost_amortized_unblended_adj", "usage_amount" ]
-  }
-
   payload = {
     "billing_center_ids": ds_filtered_bcs,
     "filter": filter,
-    "dimensions": dimensions,
+    "dimensions": [ "instance_type", "region", "usage_unit" ],
     "granularity": "month",
-    "metrics": metrics,
+    "metrics": [ "cost_amortized_unblended_adj", "usage_amount" ],
     "end_at": end_date,
     "start_at": start_date
   }
@@ -382,17 +499,47 @@ EOS
 end
 
 datasource "ds_savings_realized" do
-  run_script $js_savings_realized, $ds_aggregated_costs_old_base, $ds_aggregated_costs_old_ri, $ds_aggregated_costs_new
+  run_script $js_savings_realized, $ds_aggregated_costs_old_base, $ds_aggregated_costs_old_ri, $ds_aggregated_costs_new_base, $ds_aggregated_costs_new_ri, $ds_region_table
 end
 
 script "js_savings_realized", type: "javascript" do
-  parameters "ds_aggregated_costs_old_base", "ds_aggregated_costs_old_ri", "ds_aggregated_costs_new"
+  parameters "ds_aggregated_costs_old_base", "ds_aggregated_costs_old_ri", "ds_aggregated_costs_new_base", "ds_aggregated_costs_new_ri", "ds_region_table"
   result "result"
   code <<-'EOS'
   result = []
 
-  // Calculate and store savings data for old EA connections
-  all_costs = ds_aggregated_costs_old_ri.concat(ds_aggregated_costs_old_base)
+  // Convert region value for old Azure endpoint data to match new Azure endpoint for consistency
+  old_base_mapped = _.map(ds_aggregated_costs_old_base, function(cost) {
+    region = cost['region']
+    if (ds_region_table[region] != undefined) { region = ds_region_table[region] }
+
+    return {
+      instance_type: cost['instance_type'],
+      usage_unit: cost['usage_unit'],
+      usage_amount: cost['usage_amount'],
+      cost: cost['cost'],
+      month: cost['month'],
+      region: region
+    }
+  })
+
+  old_ri_mapped = _.map(ds_aggregated_costs_old_ri, function(cost) {
+    region = cost['region']
+    if (ds_region_table[region] != undefined) { region = ds_region_table[region] }
+
+    return {
+      instance_type: cost['instance_type'],
+      usage_unit: cost['usage_unit'],
+      usage_amount: cost['usage_amount'],
+      cost: cost['cost'],
+      month: cost['month'],
+      region: region
+    }
+  })
+
+  base_costs = old_base_mapped.concat(ds_aggregated_costs_new_base)
+  ri_costs = old_ri_mapped.concat(ds_aggregated_costs_new_ri)
+  all_costs = base_costs.concat(ri_costs)
 
   // Get list of Instance Types, Regions, Months
   instance_types = _.uniq(_.pluck(all_costs, 'instance_type'))
@@ -415,7 +562,7 @@ script "js_savings_realized", type: "javascript" do
   // for each instance type/region/operating system combination
   base_aggregated_costs = {}
 
-  _.each(ds_aggregated_costs_old_base, function(cost) {
+  _.each(base_costs, function(cost) {
     index = [cost['instance_type'], cost['region']].join('_').toLowerCase().trim()
 
     if (base_aggregated_costs[index] == undefined) { base_aggregated_costs[index] = [] }
@@ -451,7 +598,7 @@ script "js_savings_realized", type: "javascript" do
   // Apply cost_instance_hour to calculate savings realized
   savings_realized_object = {}
 
-  _.each(ds_aggregated_costs_old_ri, function(cost) {
+  _.each(ri_costs, function(cost) {
     index = [cost['instance_type'], cost['region']].join('_').toLowerCase().trim()
     avg_base_cost_instance_hour = unique_cost_instance_hours[index]
 
@@ -465,59 +612,16 @@ script "js_savings_realized", type: "javascript" do
   })
 
   _.each(months, function(month) {
-    cost = 0
+    savings = 0
     if (savings_realized_object[month] != undefined) {
-      cost = savings_realized_object[month]
+      savings = savings_realized_object[month]
     }
 
     result.push({
       month: month,
-      cost: cost,
+      savings: savings,
       dimension: "Savings Realized On Compute Reservations"
     })
-  })
-
-  // Calculate and store savings data for new EA connections
-
-  // Function for calculating total cost for each dimension
-  function cost_sum(cost_list, month, dimension_filter) {
-    dimension_table = {
-      "Reserved": "Reservations",
-      "Savings Plan": "Savings Plans",
-      "Spot": "Spot Instances"
-    }
-
-    if (dimension_filter != "All") {
-      entries = _.filter(entries, function(cost) { return cost['purchase_option'] == dimension_filter })
-      costs = _.pluck(entries, 'cost')
-      dimension_message = "Savings Realized On Compute " + dimension_table[dimension_filter]
-    } else {
-      entries = cost_list[month]
-      costs = _.pluck(entries, 'cost')
-      dimension_message = "Total Actual Spend On Discountable Compute"
-    }
-
-    total_savings = 0
-
-    if (costs.length > 0) {
-      total_savings = _.reduce(costs, function(memo, num) { return memo + num }, 0)
-    }
-
-    return {
-      "month": month,
-      "cost": total_savings,
-      "dimension": dimension_message
-    }
-  }
-
-  new_costs_by_month = _.groupBy(ds_aggregated_costs_new, 'month')
-
-  // Calculate costs for each month
-  _.each(_.keys(new_costs_by_month), function(month) {
-    result.push(cost_sum(new_costs_by_month, month, "All"))
-    result.push(cost_sum(new_costs_by_month, month, "Reserved"))
-    result.push(cost_sum(new_costs_by_month, month, "Savings Plan"))
-    result.push(cost_sum(new_costs_by_month, month, "Spot"))
   })
 
   // Sort by month
@@ -546,50 +650,24 @@ script "js_chart_data", type: "javascript" do
       return item['dimension'] == "Savings Realized On Compute Reservations"
     })
 
-    savings_realized_sp_entry  = _.find(savings_by_month[month], function(item) {
-      return item['dimension'] == "Savings Realized On Compute Savings Plans"
-    })
-
-    savings_realized_spot_entry  = _.find(savings_by_month[month], function(item) {
-      return item['dimension'] == "Savings Realized On Compute Spot Instances"
-    })
-
     total_spend_cost = 0
-    savings_realized_ri_cost = 0
-    savings_realized_sp_cost = 0
-    savings_realized_spot_cost = 0
+    savings_realized_ri = 0
     percentage_ri = 0
-    percentage_sp = 0
-    percentage_spot = 0
 
     if (total_spend_entry != undefined) {
       total_spend_cost = total_spend_entry['cost']
     }
 
     if (savings_realized_ri_entry != undefined) {
-      savings_realized_ri_cost = savings_realized_ri_entry['cost']
-      percentage_ri = (savings_realized_ri_cost / (total_spend_cost)) * 100
-    }
-
-    if (savings_realized_sp_entry != undefined) {
-      savings_realized_sp_cost = savings_realized_sp_entry['cost']
-      percentage_sp = (savings_realized_sp_cost / total_spend_cost) * 100
-    }
-
-    if (savings_realized_spot_entry != undefined) {
-      savings_realized_spot_cost = savings_realized_spot_entry['cost']
-      percentage_spot = (savings_realized_spot_cost / total_spend_cost) * 100
+      savings_realized_ri = savings_realized_ri_entry['savings']
+      percentage_ri = (savings_realized_ri / (total_spend_cost + savings_realized_ri)) * 100
     }
 
     result.push({
       "month": month,
       "total_spend": parseFloat(total_spend_cost.toFixed(2)),
-      "savings_realized_ri": parseFloat(savings_realized_ri_cost.toFixed(2)),
-      "savings_realized_sp": parseFloat(savings_realized_sp_cost.toFixed(2)),
-      "savings_realized_spot": parseFloat(savings_realized_spot_cost.toFixed(2)),
+      "savings_realized_ri": parseFloat(savings_realized_ri.toFixed(2)),
       "percentage_ri": parseFloat(percentage_ri.toFixed(2))
-      "percentage_sp": parseFloat(percentage_sp.toFixed(2))
-      "percentage_spot": parseFloat(percentage_spot.toFixed(2))
     })
   })
 
@@ -673,20 +751,8 @@ policy "policy_purchase_option_by_inst_type_and_region" do
       field "savings_realized_ri" do
         label "Savings Realized On Compute Reservations"
       end
-      field "savings_realized_sp" do
-        label "Savings Realized On Compute Savings Plans"
-      end
-      field "savings_realized_spot" do
-        label "Savings Realized On Compute Spot Instances"
-      end
       field "percentage_ri" do
         label "Savings Rate (%) from Reservation Usage"
-      end
-      field "percentage_sp" do
-        label "Savings Rate (%) from Savings Plan Usage"
-      end
-      field "percentage_spot" do
-        label "Savings Rate (%) from Spot Instance Usage"
       end
     end
   end

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -461,6 +461,15 @@ script "js_get_aggregated_costs", type: "javascript" do
     "value": bill_connection_id
   })
 
+  // Ensure we only pull Azure costs
+  filter["expressions"].push({
+    "type": "or",
+    "expressions": [
+      { "dimension": "vendor", "type": "equal", "value": "Azure"  },
+      { "dimension": "vendor", "type": "equal", "value": "azure"  }
+    ]
+  })
+
   payload = {
     "billing_center_ids": ds_filtered_bcs,
     "filter": filter,

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -538,11 +538,10 @@ end
 script "js_chart_data", type: "javascript" do
   parameters "ds_savings_realized", "ds_applied_policy", "param_chart_type"
   result "result"
-  code <<-EOS
-  months = _.uniq(_.pluck(ds_savings_realized, 'month'))
-
-  //Create report data (Concatenate savings realized and total costs into one object/row of data)
+  code <<-'EOS'
+  // Create report data
   result = []
+  months = _.uniq(_.pluck(ds_savings_realized, 'month'))
 
   _.each(months, function(month) {
     savings_realized = 0
@@ -575,71 +574,59 @@ script "js_chart_data", type: "javascript" do
     })
   })
 
-  //Group data by Cost Dimension
-  group_by_dimension = _.groupBy(ds_savings_realized, function(data) { return data.dimension })
-
-  //Determine chart type
-  chart_type = "cht="
-  if (param_chart_type == "Grouped Bar Chart") { chart_type += "bvg" }
-  else if (param_chart_type == "Stacked Bar Chart" ) { chart_type += "bvs" }
-
-  //Create chart axis labels
-  chart_axis_labels =
-  ("chxl=1:," +
-    _.uniq(ds_savings_realized, function(sr) { return sr.month })
-    .map(function(sr){ return sr.month.substring(0,7) })
-  ).split(",").join("|")
-
-  //Create legend
-  chart_legend = "chdl="
-  var i = 0
-  for (var key in group_by_dimension) {
-    chart_legend += key
-    i++
-    if (i < _.size(group_by_dimension)) { chart_legend += "|" }
+  // Determine chart type
+  chart_table = {
+    "Grouped Bar Chart": "cht=bvg",
+    "Stacked Bar Chart": "cht=bvs"
   }
 
-  //calculate scale
-  //chart_range = ("chxr=0," +
-  max = (Math.max.apply(Math, ds_savings_realized.map(function(sr){ return sr.savings_realized }))*1.1).toFixed(2)
-  min = (Math.min.apply(Math, ds_savings_realized.map(function(sr){ return sr.savings_realized }))*0.9).toFixed(2)
+  chart_type = chart_table[param_chart_type]
+
+  // Create chart axis labels
+  sr_months = _.uniq(ds_savings_realized, function(sr) { return sr['month'] })
+  sr_months_mapped = _.map(sr_months, function(sr) { return sr['month'].substring(0,7) })
+  chart_axis_labels = ("chxl=1:," + sr_months_mapped).split(',').join('|')
+
+  // Create legend
+  chart_legend = "chdl=" + _.uniq(_.pluck(ds_savings_realized, 'dimension')).join('|')
+
+  // Calculate scale
+  costs = _.pluck(ds_savings_realized, 'cost')
+  max = (Math.max.apply(Math, costs) * 1.1).toFixed(2)
+  min = (Math.min.apply(Math, costs) * 0.9).toFixed(2)
   chart_range = "chxr=0," + min + "," + max
 
   //Create chart dataset
-  chart_data = "chd=t:"
-  var count_1 = 0
-  _.each(group_by_dimension, function(o){
-    var count_2 = 0
-    _.each(o, function(p){
-      chart_data = chart_data + p.cost
-      count_2++
-      if (count_2 < _.size(o)){ chart_data = chart_data + "," }
-    })
-    count_1++
-    if (count_1 < _.size(group_by_dimension)){ chart_data = chart_data + "|" }
+  group_by_dimension = _.groupBy(ds_savings_realized, function(data) { return data['dimension'] })
+
+  chart_data_list = []
+
+  _.each(_.keys(group_by_dimension), function(key) {
+    chart_data_list.push(_.pluck(group_by_dimension[key], 'cost').join(','))
   })
 
-  //Whole Chart object
-  chart = {
-    chart_type: encodeURI(chart_type),
-    chart_size: encodeURI("chs=999x450"),
-    chart_data: encodeURI(chart_data),
-    chart_title: encodeURI("chtt=Savings Realized On Compute Reservations For Organization"),
-    chart_image: encodeURI("chof=.png"),
-    chart_y_axis: encodeURI("chxt=y,x"),
-    chart_axis_label: encodeURI(chart_axis_labels),
-    chart_axis_format: encodeURI("chxs=0N*cUSD0sz*|1,min40"),
-    chart_line_style: encodeURI("chls=3|3|3|3|3|3|3|3|3|3|3"),
-    chart_line_color: encodeURI("chco=1f5ab8,55b81f,198038,b28600,1192e8,009d9a,005d5d,007d79"),
-    chart_data_scale: encodeURI("chds=a"),
-    chart_legend: encodeURI(chart_legend),
-    chart_legend_size: encodeURI("chdls=000000,10"),
-    chart_legend_position: encodeURI("chdlp=b")
-  }
+  chart_data = "chd=t:" + chart_data_list.join('|')
 
+  // Whole Chart object
   if (result.length > 0) {
-    result[0]["chart_dimensions"] = chart
     result[0]["policy_name"] = ds_applied_policy['name']
+
+    result[0]["chart_dimensions"] = {
+      chart_type: encodeURI(chart_type),
+      chart_size: encodeURI("chs=999x450"),
+      chart_data: encodeURI(chart_data),
+      chart_title: encodeURI("chtt=Savings Realized On Compute Reservations For Organization"),
+      chart_image: encodeURI("chof=.png"),
+      chart_y_axis: encodeURI("chxt=y,x"),
+      chart_axis_label: encodeURI(chart_axis_labels),
+      chart_axis_format: encodeURI("chxs=0N*cUSD0sz*|1,min40"),
+      chart_line_style: encodeURI("chls=3|3|3|3|3|3|3|3|3|3|3"),
+      chart_line_color: encodeURI("chco=1f5ab8,55b81f,198038,b28600,1192e8,009d9a,005d5d,007d79"),
+      chart_data_scale: encodeURI("chds=a"),
+      chart_legend: encodeURI(chart_legend),
+      chart_legend_size: encodeURI("chdls=000000,10"),
+      chart_legend_position: encodeURI("chdlp=b")
+    }
   }
 EOS
 end

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -251,9 +251,8 @@ EOS
 end
 
 datasource "ds_ri_aggregated_costs_old" do
-  iterate $ds_bill_connections_old
   request do
-    run_script $js_get_aggregated_costs, iter_item, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "ri_old"
+    run_script $js_get_aggregated_costs, $ds_bill_connections_old, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "ri_old"
   end
   result do
     encoding "json"
@@ -269,9 +268,8 @@ datasource "ds_ri_aggregated_costs_old" do
 end
 
 datasource "ds_ri_aggregated_costs_new" do
-  iterate $ds_bill_connections_new
   request do
-    run_script $js_get_aggregated_costs, iter_item, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "ri_new"
+    run_script $js_get_aggregated_costs, $ds_bill_connections_new, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "ri_new"
   end
   result do
     encoding "json"
@@ -287,9 +285,8 @@ datasource "ds_ri_aggregated_costs_new" do
 end
 
 datasource "ds_base_aggregated_costs_old" do
-  iterate $ds_bill_connections_old
   request do
-    run_script $js_get_aggregated_costs, iter_item, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "base_old"
+    run_script $js_get_aggregated_costs, $ds_bill_connections_old, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "base_old"
   end
   result do
     encoding "json"
@@ -305,9 +302,8 @@ datasource "ds_base_aggregated_costs_old" do
 end
 
 datasource "ds_base_aggregated_costs_new" do
-  iterate $ds_bill_connections_new
   request do
-    run_script $js_get_aggregated_costs, iter_item, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "base_new"
+    run_script $js_get_aggregated_costs, $ds_bill_connections_new, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "base_new"
   end
   result do
     encoding "json"
@@ -323,7 +319,7 @@ datasource "ds_base_aggregated_costs_new" do
 end
 
 script "js_get_aggregated_costs", type: "javascript" do
-  parameters "bill_connection_id", "ds_filtered_bcs", "start_date", "end_date", "org_id", "optima_host", "connection_type"
+  parameters "bill_sources", "ds_filtered_bcs", "start_date", "end_date", "org_id", "optima_host", "connection_type"
   result "request"
   code <<-EOS
   // Set filters based on the type of request (RI or Base)
@@ -448,18 +444,52 @@ script "js_get_aggregated_costs", type: "javascript" do
         },
         {
           "type": "not",
+          "expression": {
+            "type": "or",
+            "expressions": [
+              {
+                "dimension": "resource_type",
+                "type": "equal",
+                "value": "Virtual Machines-Reservation-Base VM"
+              },
+              {
+                "dimension": "resource_type",
+                "type": "equal",
+                "value": "virtual machines-reservation-base vm"
+              }
+            ]
+          }
+        },
+        {
+          "type": "not",
+          "expression": {
+            "type": "or",
+            "expressions": [
+              { "dimension": "category", "type": "equal", "value": "Commitments" },
+              { "dimension": "category", "type": "equal", "value": "commitments" }
+            ]
+          }
+        },
+        {
+          "type": "not",
           "expression": { "dimension": "instance_type", "type": "equal", "value": "None" }
         }
       ]
     }
   }
 
-  // Ensure we're filtering our request to just the specific bill connection
-  filter["expressions"].push({
-    "dimension": "bill_source",
-    "type": "equal",
-    "value": bill_connection_id
+  // Ensure we're filtering our request to just the specific bill connections
+  bill_source_expressions = []
+
+  _.each(bill_sources, function(bill_source) {
+    bill_source_expressions.push({
+      "dimension": "bill_source",
+      "type": "equal",
+      "value": bill_source
+    })
   })
+
+  filter["expressions"].push({ "type": "or", "expressions": bill_source_expressions })
 
   // Ensure we only pull Azure costs
   filter["expressions"].push({

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -83,71 +83,6 @@ datasource "ds_applied_policy" do
   end
 end
 
-# Get region-specific Flexera API endpoints
-datasource "ds_flexera_api_hosts" do
-  run_script $js_flexera_api_hosts, rs_optima_host
-end
-
-script "js_flexera_api_hosts", type: "javascript" do
-  parameters "rs_optima_host"
-  result "result"
-  code <<-EOS
-  host_table = {
-    "api.optima.flexeraeng.com": {
-      flexera: "api.flexera.com",
-      fsm: "api.fsm.flexeraeng.com"
-    },
-    "api.optima-eu.flexeraeng.com": {
-      flexera: "api.flexera.eu",
-      fsm: "api.fsm-eu.flexeraeng.com"
-    },
-    "api.optima-au.flexeraeng.com": {
-      flexera: "api.flexera.au",
-      fsm: "api.fsm-au.flexeraeng.com"
-    }
-  }
-
-  result = host_table[rs_optima_host]
-EOS
-end
-
-# Get a list of active bill connections
-datasource "ds_bill_connections" do
-  request do
-    auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
-    path join(["/finops-onboarding/v1/orgs/", rs_org_id, "/bill-connects"])
-    header "Api-Version", "1.0"
-    header "User-Agent", "RS Policies"
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "values[*]") do
-      field "id", jmes_path(col_item, "id")
-      field "kind", jmes_path(col_item, "kind")
-    end
-  end
-end
-
-# Filter out old Azure EA connections and new Azure EA connections
-datasource "ds_bill_connections_old" do
-  run_script $js_bill_connections_filter, $ds_bill_connections, "finops:bill-connect-azure-ea"
-end
-
-datasource "ds_bill_connections_new" do
-  run_script $js_bill_connections_filter, $ds_bill_connections, "finops:bill-connect-cbi-oi-azure-ea"
-end
-
-script "js_bill_connections_filter", type:"javascript" do
-  parameters "ds_bill_connections", "filter_value"
-  result "result"
-  code <<-EOS
-  result = _.filter(ds_bill_connections, function(connection) {
-    return connection['kind'] == filter_value
-  })
-EOS
-end
-
 datasource "ds_billing_centers" do
   request do
     auth $auth_flexera
@@ -191,10 +126,70 @@ script "js_filtered_bcs", type: "javascript" do
 EOS
 end
 
+# Gather list of bill connections from Optima data
+datasource "ds_bill_connections" do
+  request do
+    run_script $js_bill_connections, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "rows") do
+      field "bill_source", jmes_path(col_item, "dimensions.bill_source")
+    end
+  end
+end
+
+script "js_bill_connections", type: "javascript" do
+  parameters "ds_filtered_bcs", "start_date","end_date", "org_id", "optima_host"
+  result "request"
+  code <<-EOS
+  payload = {
+    "billing_center_ids": ds_filtered_bcs,
+    "dimensions": [ "bill_source" ],
+    "granularity": "month",
+    "metrics": [ "cost_amortized_unblended_adj" ],
+    "end_at": end_date,
+    "start_at": start_date
+  }
+
+  var request = {
+    auth: "auth_flexera",
+    host: optima_host,
+    path: "/bill-analysis/orgs/" + org_id + "/costs/aggregated",
+    verb: "POST",
+    body_fields: payload,
+    headers: {
+      "User-Agent": "RS Policies"
+    }
+  }
+EOS
+end
+
+# Filter out old Azure EA connections and new Azure EA connections
+datasource "ds_bill_connections_old" do
+  run_script $js_bill_connections_filter, $ds_bill_connections, 0
+end
+
+datasource "ds_bill_connections_new" do
+  run_script $js_bill_connections_filter, $ds_bill_connections, 7
+end
+
+script "js_bill_connections_filter", type:"javascript" do
+  parameters "ds_bill_connections", "index"
+  result "result"
+  code <<-EOS
+  bill_sources = _.filter(ds_bill_connections, function(connection) {
+    return connection['bill_source'].indexOf('azure-ea') == index
+  })
+
+  result = _.uniq(_.compact(_.pluck(bill_sources, 'bill_source')))
+EOS
+end
+
 datasource "ds_ri_aggregated_costs_old" do
   iterate $ds_bill_connections_old
   request do
-    run_script $js_get_aggregated_costs, val(iter_item, 'id'), $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "ri_old"
+    run_script $js_get_aggregated_costs, iter_item, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "ri_old"
   end
   result do
     encoding "json"
@@ -212,7 +207,7 @@ end
 datasource "ds_ri_aggregated_costs_new" do
   iterate $ds_bill_connections_new
   request do
-    run_script $js_get_aggregated_costs, val(iter_item, 'id'), $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "ri_new"
+    run_script $js_get_aggregated_costs, iter_item, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "ri_new"
   end
   result do
     encoding "json"
@@ -230,7 +225,7 @@ end
 datasource "ds_base_aggregated_costs_old" do
   iterate $ds_bill_connections_old
   request do
-    run_script $js_get_aggregated_costs, val(iter_item, 'id'), $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "base_old"
+    run_script $js_get_aggregated_costs, iter_item, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "base_old"
   end
   result do
     encoding "json"
@@ -248,7 +243,7 @@ end
 datasource "ds_base_aggregated_costs_new" do
   iterate $ds_bill_connections_new
   request do
-    run_script $js_get_aggregated_costs, val(iter_item, 'id'), $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "base_new"
+    run_script $js_get_aggregated_costs, iter_item, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "base_new"
   end
   result do
     encoding "json"
@@ -398,7 +393,7 @@ script "js_get_aggregated_costs", type: "javascript" do
     "value": bill_connection_id
   })
 
-  var payload = {
+  payload = {
     "billing_center_ids": ds_filtered_bcs,
     "filter": filter,
     "dimensions": [


### PR DESCRIPTION
### Description

This policy did not work correctly for clients using the new Azure EA bill connect method. This corrects that issue. The policy now obtains a list of bill connections from Optima and tailors the requests to the Optima API based on which bill connections exist. The policy should now work with both old and new connections and collect costs from both if both are present.

I've done a pretty thorough investigation/testing of this in a client account, and I am confident that we are now pulling the correct data.

It's likely that this policy will be changed to use the savings value in Optima once that feature is available for Azure, but this PR will ensure the policy at least continues to work as expected for users using the new EA bill connections in the meantime.

### Link to Example Applied Policy

https://app.flexera.com/orgs/27018/automation/applied-policies/projects/116186?policyId=65426cfb99745e0001587dfe

### Contribution Check List

- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
