### PR TITLE
POL-957 AWS Rightsize EC2 CloudWatch Fix

### DIFF
--- a/cost/aws/rightsize_ec2_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_ec2_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.3
+
+- Fixed issue with gathering and interpreting CloudWatch metrics
+
 ## v4.2
 
 - Updated description of `Account Number` parameter

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.2",
+  version: "4.3",
   provider: "AWS",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -593,7 +593,7 @@ script "js_cloudwatch_queries", type: "javascript" do
               "MetricName": mem_metricname,
               "Dimensions": dimensions
             },
-            "Period": 2592000,
+            "Period": lookback,
             "Stat": stat
           },
           "ReturnData": true
@@ -608,11 +608,11 @@ end
 
 # Combine queries into 500 item blocks so we can make bulk requests to Cloudwatch
 datasource "ds_instances_requests" do
-  run_script $js_instances_requests, $ds_cloudwatch_queries
+  run_script $js_instances_requests, $ds_cloudwatch_queries, $param_stats_lookback
 end
 
 script "js_instances_requests", type: "javascript" do
-  parameters "queries"
+  parameters "queries", "param_stats_lookback"
   result "result"
   code <<-EOS
   // Organize the queries into discrete requests to send in.
@@ -620,8 +620,16 @@ script "js_instances_requests", type: "javascript" do
   result = []
   query_block_size = 500
 
-  end_date = parseInt(new Date().getTime() / 1000)
-  start_date = parseInt(new Date(new Date().setDate(new Date().getDate() - 30)).getTime() / 1000)
+  // Round down to beginning of the hour to avoid getting multiple values
+  // from CloudWatch due to how the data is sliced
+  end_date = new Date()
+  end_date.setMinutes(0, 0, 0)
+  end_date = parseInt(end_date.getTime() / 1000)
+
+  start_date = new Date()
+  start_date.setDate(start_date.getDate() - param_stats_lookback)
+  start_date.setMinutes(0, 0, 0)
+  start_date = parseInt(start_date.getTime() / 1000)
 
   _.each(Object.keys(queries), function(region) {
     for (i = 0; i < queries[region].length; i += query_block_size) {
@@ -703,7 +711,11 @@ script "js_cloudwatch_data_sorted", type: "javascript" do
     region = item['region']
     instance_name = item['id'].split('_')[0] + '-' + item['id'].split('_')[1]
     metric = item['id'].split('_')[2]
-    value = item['values'][0]
+
+    // Grabbing item 0 SHOULD be safe because we should only get one result.
+    // Just in case AWS slices the data weirdly and returns 2 results, we make
+    // sure we grab the last item every time, which contains the actual data we need.
+    value = item['values'][item['values'].length - 1]
 
     if (result[region] == undefined) { result[region] = {} }
     if (result[region][instance_name] == undefined) { result[region][instance_name] = {} }

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances.pt
@@ -712,7 +712,7 @@ script "js_cloudwatch_data_sorted", type: "javascript" do
     instance_name = item['id'].split('_')[0] + '-' + item['id'].split('_')[1]
     metric = item['id'].split('_')[2]
 
-    // Grabbing item 0 SHOULD be safe because we should only get one result.
+    // Grabbing index 0 SHOULD be safe because we should only get one result.
     // Just in case AWS slices the data weirdly and returns 2 results, we make
     // sure we grab the last item every time, which contains the actual data we need.
     value = item['values'][item['values'].length - 1]

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 


### PR DESCRIPTION
### Description

This fixes several issues with how CloudWatch data is pulled that would occasionally cause incorrect results. Specifically, the date range we pull data for is now rounded down to the nearest hour. This is to ensure that the range is neatly sliced by the period we specify so that we only get one result back from CloudWatch for each metric.

Previously, it would sometimes imperfectly slice the data, giving us two results, the first being for less than an hour of time and the second being the number we actually needed, but when this happened, the policy grabbed the first number instead. As a backup, just in case somehow the above doesn't work, the policy now grabs the last item in the list of values instead of just grabbing [0] every time.

Additionally, I spotted a couple of issues where the lookback period was not being correctly used to adjust our request to the amount of days the user specified. Those have been fixed as well.

### Link to Example Applied Policy

https://app.flexera.com/orgs/27018/automation/applied-policies/projects/116186?policyId=653bb85099745e0001587d81

### Contribution Check List

- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
