### PR TITLE
POL-959 Deprecate Idle Usage Reduction Policies

### DIFF
--- a/cost/aws/idle_compute_instances/CHANGELOG.md
+++ b/cost/aws/idle_compute_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.5
+
+- Deprecated: This policy is no longer being updated. Please see policy README for more information.
+
 ## v5.4
 
 - Updated description of `Account Number` parameter

--- a/cost/aws/idle_compute_instances/README.md
+++ b/cost/aws/idle_compute_instances/README.md
@@ -1,5 +1,11 @@
 # AWS Idle Compute Instances Policy
 
+## Deprecated
+
+This policy is no longer being updated. The [AWS Rightsize EC2 Instances](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/rightsize_ec2_instances/) policy now includes this functionality and is the recommended policy for getting idle compute recommendations.
+
+## What It Does
+
 This Policy Template checks for idle instance in AWS EC2 and then terminates them upon approval.
 
 ## Prerequisites

--- a/cost/aws/idle_compute_instances/idle_compute_instances.pt
+++ b/cost/aws/idle_compute_instances/idle_compute_instances.pt
@@ -1,7 +1,7 @@
 name "AWS Idle Compute Instances"
 rs_pt_ver 20180301
 type "policy"
-short_description "**Deprecated: This policy is no longer being updated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/idle_compute_instances/) for more details**  Check for instances that are idle for the last 30 days and terminates them after approval. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/idle_compute_instances/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "**Deprecated: This policy is no longer being updated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/idle_compute_instances/) for more details.**  Check for instances that are idle for the last 30 days and terminates them after approval. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/idle_compute_instances/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 severity "low"
 category "Cost"

--- a/cost/aws/idle_compute_instances/idle_compute_instances.pt
+++ b/cost/aws/idle_compute_instances/idle_compute_instances.pt
@@ -1,13 +1,13 @@
 name "AWS Idle Compute Instances"
 rs_pt_ver 20180301
 type "policy"
-short_description "Check for instances that are idle for the last 30 days and terminates them after approval. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/idle_compute_instances/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "**Deprecated: This policy is no longer being updated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/idle_compute_instances/) for more details**  Check for instances that are idle for the last 30 days and terminates them after approval. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/idle_compute_instances/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "5.4",
+  version: "5.5",
   provider: "AWS",
   service: "Compute",
   policy_set: "Idle Compute Instances",

--- a/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
+++ b/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "5.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 

--- a/cost/azure/idle_compute_instances/CHANGELOG.md
+++ b/cost/azure/idle_compute_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.3
+
+- Deprecated: This policy is no longer being updated. Please see policy README for more information.
+
 ## v5.2
 
 - Corrected issue with policy, tags were being sent in an unsupported format

--- a/cost/azure/idle_compute_instances/README.md
+++ b/cost/azure/idle_compute_instances/README.md
@@ -1,5 +1,9 @@
 # Azure Idle Compute Instances
 
+## Deprecated
+
+This policy is no longer being updated. The [Azure Rightsize Compute Instances](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/rightsize_compute_instances/) policy now includes this functionality and is the recommended policy for getting idle compute recommendations.
+
 ## What it does
 
 This policy checks all the instances in the Azure Subscription for the average CPU usage over the last 30 days. If the usage is less than the user provided CPU percentage threshold then the virtual machines are recommended for deletion, and the user is emailed.

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
@@ -1,7 +1,7 @@
 name "Azure Idle Compute Instances"
 rs_pt_ver 20180301
 type "policy"
-short_description "**Deprecated: This policy is no longer being updated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/idle_compute_instances/) for more details**  Checks for instances that are idle for the last 30 days and terminates them after approval. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/idle_compute_instances/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "**Deprecated: This policy is no longer being updated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/idle_compute_instances/) for more details.**  Checks for instances that are idle for the last 30 days and terminates them after approval. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/idle_compute_instances/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 category "Cost"
 severity "low"

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
@@ -1,13 +1,13 @@
 name "Azure Idle Compute Instances"
 rs_pt_ver 20180301
 type "policy"
-short_description "Checks for instances that are idle for the last 30 days and terminates them after approval. \n See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/idle_compute_instances/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "**Deprecated: This policy is no longer being updated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/idle_compute_instances/) for more details**  Checks for instances that are idle for the last 30 days and terminates them after approval. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/idle_compute_instances/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "5.2",
+  version: "5.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "Idle Compute Instances",

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "5.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 

--- a/cost/azure/unused_sql_databases/CHANGELOG.md
+++ b/cost/azure/unused_sql_databases/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.2
+
+- Deprecated: This policy is no longer being updated. Please see policy README for more information.
+
 ## v5.1
 
 - Corrected issue with policy not retrieving cost data on orgs using newer Azure bill connections

--- a/cost/azure/unused_sql_databases/README.md
+++ b/cost/azure/unused_sql_databases/README.md
@@ -1,5 +1,9 @@
 # Azure Unused SQL Databases
 
+## Deprecated
+
+This policy is no longer being updated. The [Azure Rightsize SQL Databases](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/rightsize_sql_instances/) policy now includes this functionality and is the recommended policy for getting unused SQL recommendations.
+
 ## What it does
 
 This Policy template checks for Azure SQL Databases that are unused by reviewing the DB connections and delete them after user approval.

--- a/cost/azure/unused_sql_databases/azure_unused_sql_databases.pt
+++ b/cost/azure/unused_sql_databases/azure_unused_sql_databases.pt
@@ -1,13 +1,13 @@
 name "Azure Unused SQL Databases"
 rs_pt_ver 20180301
 type "policy"
-short_description "Check for database services that have no connections and decommissions them after approval. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/unused_sql_databases/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "**Deprecated: This policy is no longer being updated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/unused_sql_databases/) for more details**  Check for database services that have no connections and decommissions them after approval. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/unused_sql_databases/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "5.1",
+  version: "5.2",
   provider: "Azure",
   service: "SQL",
   policy_set: "Unused Database Services",

--- a/cost/azure/unused_sql_databases/azure_unused_sql_databases.pt
+++ b/cost/azure/unused_sql_databases/azure_unused_sql_databases.pt
@@ -1,7 +1,7 @@
 name "Azure Unused SQL Databases"
 rs_pt_ver 20180301
 type "policy"
-short_description "**Deprecated: This policy is no longer being updated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/unused_sql_databases/) for more details**  Check for database services that have no connections and decommissions them after approval. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/unused_sql_databases/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "**Deprecated: This policy is no longer being updated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/unused_sql_databases/) for more details.**  Check for database services that have no connections and decommissions them after approval. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/unused_sql_databases/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 severity "low"
 category "Cost"

--- a/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
+++ b/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "5.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 

--- a/cost/google/idle_vm_recommendations/CHANGELOG.md
+++ b/cost/google/idle_vm_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.12
+
+- Deprecated: This policy is no longer being updated. Please see policy README for more information.
+
 ## v2.11
 
 - Updated policy README file with a deeper explanation of how the GCP recommender works and the roles required to use it.

--- a/cost/google/idle_vm_recommendations/README.md
+++ b/cost/google/idle_vm_recommendations/README.md
@@ -1,5 +1,9 @@
 # Google Idle VM Recommender
 
+## Deprecated
+
+This policy is no longer being updated. The [Google Rightsize VM Recommender](https://github.com/flexera-public/policy_templates/tree/master/cost/google/rightsize_vm_recommendations) policy now includes this functionality and is the recommended policy for getting idle VM recommendations.
+
 ## What it does
 
 This Policy finds Idle Virtual Machine Recommendations and reports when it finds them. You can then delete the idle instances

--- a/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
+++ b/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
@@ -1,7 +1,7 @@
 name "Google Idle VM Recommender"
 rs_pt_ver 20180301
 type "policy"
-short_description "**Deprecated: This policy is no longer being updated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/cost/google/idle_vm_recommendations) for more details**  This Policy finds Google Idle VM Recommendations and reports when it finds them. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/google/idle_vm_recommendations) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "**Deprecated: This policy is no longer being updated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/cost/google/idle_vm_recommendations) for more details.**  This Policy finds Google Idle VM Recommendations and reports when it finds them. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/google/idle_vm_recommendations) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 category "Cost"
 severity "low"
 default_frequency "daily"

--- a/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
+++ b/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
@@ -1,12 +1,12 @@
 name "Google Idle VM Recommender"
 rs_pt_ver 20180301
 type "policy"
-short_description "This Policy finds Google Idle VM Recommendations and reports when it finds them. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/google/idle_vm_recommendations) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "**Deprecated: This policy is no longer being updated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/cost/google/idle_vm_recommendations) for more details**  This Policy finds Google Idle VM Recommendations and reports when it finds them. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/google/idle_vm_recommendations) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.11",
+  version: "2.12",
   provider:"Google",
   service: "Compute",
   policy_set: "Idle Compute Instances",
@@ -541,7 +541,7 @@ policy "policy_recommendations" do
       field "lookBackPeriod" do
         label "Lookback Period In Days"
         path "lookBackPeriodInDays"
-      end 
+      end
       field "region" do
         label "Zone"
         path "zone"


### PR DESCRIPTION
### Description

The following policies should be flagged as deprecated, as their functionality is now included in other policies:

AWS Idle Compute Instances (functionality is now part of AWS Rightsize EC2 Instances)
Azure Idle Compute Instances (functionality is now part of Azure Rightsize Compute Instances)
Azure Unused SQL Databases (functionality is now part of Azure Rightsize SQL Databases)
Google Idle VM Recommender (functionality is now part of Google Rightsize VM Recommender)

This change does *not* remove the policies from the catalog or impact the functionality of existing meta policies that customers may be using. It simply directs users to the more updated and correct policies when browsing the catalog.

### Link to Example Applied Policy

N/A. These changes don't impact policy execution.

### Contribution Check List

- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
