### PR TITLE
fix: name `AWS Ensure IAM Users Receive Permissions Only Through Groups`

### DIFF
--- a/security/aws/iam_users_perms_via_groups_only/iam_users_perms_via_groups_only.pt
+++ b/security/aws/iam_users_perms_via_groups_only/iam_users_perms_via_groups_only.pt
@@ -1,4 +1,4 @@
-name "AWS IAM Ensure One Active Key Per IAM User"
+name "AWS Ensure IAM Users Receive Permissions Only Through Groups"
 rs_pt_ver 20180301
 type "policy"
 short_description "Report if any IAM users have policies assigned directly instead of through groups. \n See the [README](https://github.com/flexera-public/policy_templates/tree/master/security/aws/iam_users_perms_via_groups_only) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."


### PR DESCRIPTION
### Description

We have 2 PTs with same name.. that should never happen.  Looks like this one was incorrectly named
