### PR TITLE
POL-907 Fix AWS Permission Version in READMEs

### DIFF
--- a/README_GUIDELINE.md
+++ b/README_GUIDELINE.md
@@ -165,7 +165,7 @@ Required permissions in the provider:
 
 `` ```javascript
 {
-    "Version": "2012-06-01",
+    "Version": "2012-10-17",
     "Statement":[{
     "Effect":"Allow",
     "Action":[

--- a/cost/aws/object_storage_optimization/README.md
+++ b/cost/aws/object_storage_optimization/README.md
@@ -40,7 +40,7 @@ This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Auto
 
   ```json
   {
-    "Version": "2006-03-01",
+    "Version": "2012-10-17",
     "Statement":[
       {
         "Effect":"Allow",

--- a/cost/aws/s3_bucket_size/README.md
+++ b/cost/aws/s3_bucket_size/README.md
@@ -51,7 +51,7 @@ Required permissions in the provider:
 }
 
 {
-  "Version": "2006-03-01",
+  "Version": "2012-10-17",
   "Statement": [
     {
       "Effect": "Allow",


### PR DESCRIPTION
### Description

A small number of policy READMEs use invalid version numbers in their JSON examples for AWS permission policies. This updates them to instead use 2012-10-17, which is the latest valid version number.

### Link to Example Applied Policy

N/A. This is just a documentation update.

### Contribution Check List

- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
