### PR TITLE
FOPTS-2380 Modify S3 Object Policy template to prevent tag calls if user don't input tags

### DIFF
--- a/cost/aws/object_storage_optimization/CHANGELOG.md
+++ b/cost/aws/object_storage_optimization/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## v3.2
 
-- Added a filter to the S3 Objects that will be moved to deeper or glacier storage class.
+- Optimized policy code to speed up execution.
+- Tags for objects are not requested if the parameter Tag exclude is empty.
 - Added a new parameter `Bucket List`.
 
 ## v3.1

--- a/cost/aws/object_storage_optimization/CHANGELOG.md
+++ b/cost/aws/object_storage_optimization/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## v3.2
 
-- Added a filter to the s3objects that will be moved to deeper or glacier storage class
-- Added a new parameter `Bucket list`
+- Added a filter to the S3 Objects that will be moved to deeper or glacier storage class.
+- Added a new parameter `Bucket list`.
 
 ## v3.1
 

--- a/cost/aws/object_storage_optimization/CHANGELOG.md
+++ b/cost/aws/object_storage_optimization/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v3.2
 
 - Added a filter to the s3objects that will be moved to deeper or glacier storage class
+- Added a new parameter `Bucket list`
 
 ## v3.1
 

--- a/cost/aws/object_storage_optimization/CHANGELOG.md
+++ b/cost/aws/object_storage_optimization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2
+
+- Added a filter to the s3objects that will be moved to deeper or glacier storage class
+
 ## v3.1
 
 - Updated description of `Account Number` parameter

--- a/cost/aws/object_storage_optimization/CHANGELOG.md
+++ b/cost/aws/object_storage_optimization/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v3.2
 
 - Optimized policy code to speed up execution.
-- Tags for objects are not requested if the parameter Tag exclude is empty.
+- Tags for objects are not requested if the parameter `Exclude Tag` is empty.
 - Added a new parameter `Bucket List`.
 
 ## v3.1

--- a/cost/aws/object_storage_optimization/CHANGELOG.md
+++ b/cost/aws/object_storage_optimization/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v3.2
 
 - Added a filter to the S3 Objects that will be moved to deeper or glacier storage class.
-- Added a new parameter `Bucket list`.
+- Added a new parameter `Bucket List`.
 
 ## v3.1
 

--- a/cost/aws/object_storage_optimization/README.md
+++ b/cost/aws/object_storage_optimization/README.md
@@ -16,6 +16,7 @@ This policy has the following input parameters required when launching the polic
 - *Email addresses to notify* - Email addresses of the recipients you wish to notify when new incidents are created
 - *Days since last modified to move to Glacier* - Move to glacier after days last modified - leave blank to skip moving
 - *Days since last modified to move to Deep Archive* - Move to glacier deep archive after days last modified- leave blank to skip moving
+- *Bucket list* - List Buckets to pointing them.
 - *Exclude Tag* - List of tags that will exclude s3 objects from being evaluated by this policy. Multiple tags are evaluated as an 'OR' condition. Tag keys or key/value pairs can be listed. Example: 'test,env=dev'
 - *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).
 - *Account Number* - The Account number for use with the AWS STS Cross Account Role. Leave blank when using AWS IAM Access key and secret. It only needs to be passed when the desired AWS account is different than the one associated with the Flexera One credential. [more](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1123608)

--- a/cost/aws/object_storage_optimization/README.md
+++ b/cost/aws/object_storage_optimization/README.md
@@ -16,7 +16,7 @@ This policy has the following input parameters required when launching the polic
 - *Email addresses to notify* - Email addresses of the recipients you wish to notify when new incidents are created
 - *Days since last modified to move to Glacier* - Move to glacier after days last modified - leave blank to skip moving
 - *Days since last modified to move to Deep Archive* - Move to glacier deep archive after days last modified- leave blank to skip moving
-- *Bucket list* - List Buckets to pointing them.
+- *Bucket list* - A list of S3 buckets to assess objects in. Leave blank to assess all buckets.
 - *Exclude Tag* - List of tags that will exclude s3 objects from being evaluated by this policy. Multiple tags are evaluated as an 'OR' condition. Tag keys or key/value pairs can be listed. Example: 'test,env=dev'
 - *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).
 - *Account Number* - The Account number for use with the AWS STS Cross Account Role. Leave blank when using AWS IAM Access key and secret. It only needs to be passed when the desired AWS account is different than the one associated with the Flexera One credential. [more](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1123608)

--- a/cost/aws/object_storage_optimization/README.md
+++ b/cost/aws/object_storage_optimization/README.md
@@ -16,7 +16,7 @@ This policy has the following input parameters required when launching the polic
 - *Email addresses to notify* - Email addresses of the recipients you wish to notify when new incidents are created
 - *Days since last modified to move to Glacier* - Move to glacier after days last modified - leave blank to skip moving
 - *Days since last modified to move to Deep Archive* - Move to glacier deep archive after days last modified- leave blank to skip moving
-- *Bucket list* - A list of S3 buckets to assess objects in. Leave blank to assess all buckets.
+- *Bucket List* - A list of S3 buckets to assess objects in. Leave blank to assess all buckets.
 - *Exclude Tag* - List of tags that will exclude s3 objects from being evaluated by this policy. Multiple tags are evaluated as an 'OR' condition. Tag keys or key/value pairs can be listed. Example: 'test,env=dev'
 - *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).
 - *Account Number* - The Account number for use with the AWS STS Cross Account Role. Leave blank when using AWS IAM Access key and secret. It only needs to be passed when the desired AWS account is different than the one associated with the Flexera One credential. [more](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1123608)

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
@@ -49,6 +49,12 @@ parameter "param_exclude_tags" do
   description "List of tags that will exclude s3 objects from being evaluated by this policy. Multiple tags are evaluated as an 'OR' condition. Tag keys or key/value pairs can be listed. Example: 'test,env=dev'"
 end
 
+parameter "param_bucket_list" do
+  type "list"
+  label "Bucket input list"
+  description "List the buckets that you wish to include"
+end
+
 parameter "param_automatic_action" do
   type "list"
   label "Automatic Actions"
@@ -149,32 +155,59 @@ datasource "ds_aws_buckets_with_region" do
 end
 
 datasource "ds_aws_sanitized_buckets" do
-  run_script $js_parse_buckets, $ds_aws_buckets_with_region
+  run_script $js_parse_buckets, $ds_aws_buckets_with_region, $param_bucket_list
 end
 
 script "js_parse_buckets", type: "javascript" do
-  parameters "buckets"
+  parameters "buckets", "param_bucket_list"
   result "results"
   code <<-EOS
     results = []
-    for ( i = 0; i < buckets.length; i++ ) {
-      if ( !buckets[i]["region"] ){
-        results.push({
-          "bucket_name": buckets[i]["bucket_name"],
-          "bucket_creation_date": buckets[i]["bucket_creation_date"],
-          "region": "us-east-1",
-          "host": "s3.amazonaws.com",
-          "tagKeyValue": ""
-        })
-      }else{
-        if(buckets[i]["region"] == "EU" ) { buckets[i]["region"] = "eu-west-1" }
-        results.push({
-          "bucket_name": buckets[i]["bucket_name"],
-          "bucket_creation_date": buckets[i]["bucket_creation_date"],
-          "region": buckets[i]["region"],
-          "host": "s3-" + buckets[i]["region"] + ".amazonaws.com",
-          "tagKeyValue": ""
-        })
+    if (param_bucket_list.length > 0){
+      _.each(buckets, function (bucket, i) {
+        _.each(param_bucket_list, function (user_bucket) {
+          if (bucket.bucket_name === user_bucket){
+            if ( !buckets[i]["region"] ){
+              results.push({
+                "bucket_name": buckets[i]["bucket_name"],
+                "bucket_creation_date": buckets[i]["bucket_creation_date"],
+                "region": "us-east-1",
+                "host": "s3.amazonaws.com",
+                "tagKeyValue": ""
+              })
+            }else{
+              if(buckets[i]["region"] == "EU" ) { buckets[i]["region"] = "eu-west-1" }
+              results.push({
+                "bucket_name": buckets[i]["bucket_name"],
+                "bucket_creation_date": buckets[i]["bucket_creation_date"],
+                "region": buckets[i]["region"],
+                "host": "s3-" + buckets[i]["region"] + ".amazonaws.com",
+                "tagKeyValue": ""
+              })
+            }
+          }
+        });
+      });
+    }else{
+      for ( i = 0; i < buckets.length; i++ ) {
+        if ( !buckets[i]["region"] ){
+          results.push({
+            "bucket_name": buckets[i]["bucket_name"],
+            "bucket_creation_date": buckets[i]["bucket_creation_date"],
+            "region": "us-east-1",
+            "host": "s3.amazonaws.com",
+            "tagKeyValue": ""
+          })
+        }else{
+          if(buckets[i]["region"] == "EU" ) { buckets[i]["region"] = "eu-west-1" }
+          results.push({
+            "bucket_name": buckets[i]["bucket_name"],
+            "bucket_creation_date": buckets[i]["bucket_creation_date"],
+            "region": buckets[i]["region"],
+            "host": "s3-" + buckets[i]["region"] + ".amazonaws.com",
+            "tagKeyValue": ""
+          })
+        }
       }
     }
   EOS
@@ -207,19 +240,14 @@ datasource "ds_aws_list_s3_objects" do
 end
 
 datasource "ds_only_last_modified_objects" do
-  run_script $js_only_last_modified_objects, $ds_aws_list_s3_objects, $param_deep_archive_days, $param_glacier_days, $param_exclude_tags
+  run_script $js_only_last_modified_objects, $ds_aws_list_s3_objects, $param_deep_archive_days, $param_glacier_days
 end
 
 script "js_only_last_modified_objects", type: "javascript" do
-  parameters "ds_aws_list_s3_objects", "param_deep_archive_days", "param_glacier_days", "param_exclude_tags"
+  parameters "ds_aws_list_s3_objects", "param_deep_archive_days", "param_glacier_days"
   result "results"
   code <<-EOS
     results = []
-    var param_exclude_tags_lower=[];
-    for(var i=0; i < param_exclude_tags.length; i++){
-      param_exclude_tags_lower[i]=param_exclude_tags[i].toString().toLowerCase();
-    }
-
     var glacier_date = new Date();
     var deep_archive_date = new Date();
     var glacier_days_to_move = parseInt(param_glacier_days,10);
@@ -270,6 +298,7 @@ script "js_only_last_modified_objects", type: "javascript" do
       }
     });
     results = _.sortBy(results, 'region');
+    console.log(results)
   EOS
 end
 
@@ -300,6 +329,7 @@ datasource "ds_aws_list_s3_objects_with_tags" do
       field "last_modified", val(iter_item, "last_modified")
       field "object_size", val(iter_item, "object_size")
       field "host", val(iter_item, "host")
+      field "modify_storage_class_to", val(iter_item, "modify_storage_class_to")
     end
   end
 end
@@ -320,6 +350,7 @@ script "js_aws_filtered_s3_objects", type: "javascript" do
     }
 
     _.each(ds_aws_list_s3_objects_with_tags, function(s3Object){
+      console.log(s3Object)
       var tags = s3Object['tags'];
       var isTagMatched=false
       var tagKeyValue=""
@@ -345,7 +376,7 @@ script "js_aws_filtered_s3_objects", type: "javascript" do
           "object_key": s3Object["object_key"],
           "storage_class": s3Object["storage_class"],
           "last_modified": s3Object["last_modified"],
-          "modify_storage_class_to": modify_storage_class_to,
+          "modify_storage_class_to": s3Object["modify_storage_class_to"],
           "object_size": s3Object["object_size"],
           "tagKeyValue":(tagKeyValue.slice(2))
         });

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
@@ -52,7 +52,8 @@ end
 parameter "param_bucket_list" do
   type "list"
   label "Bucket list"
-  description "List only the buckets that you wish to evaluate"
+  description "A list of S3 buckets to assess objects in. Leave blank to assess all buckets."
+  default []
 end
 
 parameter "param_automatic_action" do
@@ -163,53 +164,33 @@ script "js_parse_buckets", type: "javascript" do
   result "results"
   code <<-EOS
     results = []
-    if (param_bucket_list.length > 0){
-      _.each(buckets, function (bucket, i) {
-        _.each(param_bucket_list, function (user_bucket) {
-          if (bucket.bucket_name === user_bucket){
-            if ( !buckets[i]["region"] ){
-              results.push({
-                "bucket_name": buckets[i]["bucket_name"],
-                "bucket_creation_date": buckets[i]["bucket_creation_date"],
-                "region": "us-east-1",
-                "host": "s3.amazonaws.com",
-                "tagKeyValue": ""
-              })
-            }else{
-              if(buckets[i]["region"] == "EU" ) { buckets[i]["region"] = "eu-west-1" }
-              results.push({
-                "bucket_name": buckets[i]["bucket_name"],
-                "bucket_creation_date": buckets[i]["bucket_creation_date"],
-                "region": buckets[i]["region"],
-                "host": "s3-" + buckets[i]["region"] + ".amazonaws.com",
-                "tagKeyValue": ""
-              })
-            }
-          }
-        });
-      });
-    }else{
-      for ( i = 0; i < buckets.length; i++ ) {
-        if ( !buckets[i]["region"] ){
-          results.push({
-            "bucket_name": buckets[i]["bucket_name"],
-            "bucket_creation_date": buckets[i]["bucket_creation_date"],
-            "region": "us-east-1",
-            "host": "s3.amazonaws.com",
-            "tagKeyValue": ""
-          })
-        }else{
-          if(buckets[i]["region"] == "EU" ) { buckets[i]["region"] = "eu-west-1" }
-          results.push({
-            "bucket_name": buckets[i]["bucket_name"],
-            "bucket_creation_date": buckets[i]["bucket_creation_date"],
-            "region": buckets[i]["region"],
-            "host": "s3-" + buckets[i]["region"] + ".amazonaws.com",
-            "tagKeyValue": ""
-          })
-        }
-      }
+    bucket_list = []
+    if (param_bucket_list.length > 0) {
+      bucket_list = _.filter(buckets, function(bucket){ return _.contains(param_bucket_list, bucket.bucket_name)})
+    } else {
+      bucket_list = buckets
     }
+
+    _.each(bucket_list, function (bucket, i) {
+      if ( !bucket["region"] ){
+        results.push({
+          "bucket_name": bucket["bucket_name"],
+          "bucket_creation_date": bucket["bucket_creation_date"],
+          "region": "us-east-1",
+          "host": "s3.amazonaws.com",
+          "tagKeyValue": ""
+        })
+      }else{
+        if(bucket["region"] == "EU" ) { bucket["region"] = "eu-west-1" }
+        results.push({
+          "bucket_name": bucket["bucket_name"],
+          "bucket_creation_date": bucket["bucket_creation_date"],
+          "region": bucket["region"],
+          "host": "s3-" + bucket["region"] + ".amazonaws.com",
+          "tagKeyValue": ""
+        })
+      }
+    });
   EOS
 end
 
@@ -298,7 +279,6 @@ script "js_only_last_modified_objects", type: "javascript" do
       }
     });
     results = _.sortBy(results, 'region');
-    console.log(results)
   EOS
 end
 
@@ -350,7 +330,6 @@ script "js_aws_filtered_s3_objects", type: "javascript" do
     }
 
     _.each(ds_aws_list_s3_objects_with_tags, function(s3Object){
-      console.log(s3Object)
       var tags = s3Object['tags'];
       var isTagMatched=false
       var tagKeyValue=""

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
@@ -211,7 +211,7 @@ datasource "ds_only_last_modified_objects" do
 end
 
 script "js_only_last_modified_objects", type: "javascript" do
-  parameters "ds_aws_list_s3_objects", "param_deep_archive_days", "param_glacier_days", "param_exclude_tags",
+  parameters "ds_aws_list_s3_objects", "param_deep_archive_days", "param_glacier_days", "param_exclude_tags"
   result "results"
   code <<-EOS
     results = []

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
@@ -231,12 +231,12 @@ script "js_only_last_modified_objects", type: "javascript" do
   code <<-EOS
     var results = {
       "require_tags": [],
-      "without_tags": [],
-      "param_tags": param_exclude_tags
+      "without_tags": []
     }
-    var tagg = false
+
+    var arr = results.without_tags
     if (param_exclude_tags.length > 0){
-      tagg = true
+      arr = results.require_tags
     }
 
     var glacier_date = new Date();
@@ -274,8 +274,7 @@ script "js_only_last_modified_objects", type: "javascript" do
           }
         }
         if(modify_storage_class_to.length > 0){
-          if (tagg) {
-            results.require_tags.push({
+          var result = {
               "bucket_name": s3Object["bucket_name"],
               "region":s3Object["region"],
               "bucket_creation_date": s3Object["bucket_creation_date"],
@@ -285,21 +284,8 @@ script "js_only_last_modified_objects", type: "javascript" do
               "last_modified": s3Object["last_modified"],
               "modify_storage_class_to": modify_storage_class_to,
               "object_size": s3Object["object_size"]
-            });
-          }else{
-            results.without_tags.push({
-              "bucket_name": s3Object["bucket_name"],
-              "region":s3Object["region"],
-              "bucket_creation_date": s3Object["bucket_creation_date"],
-              "host": s3Object["host"],
-              "object_key": s3Object["object_key"],
-              "storage_class": s3Object["storage_class"],
-              "last_modified": s3Object["last_modified"],
-              "modify_storage_class_to": modify_storage_class_to,
-              "object_size": s3Object["object_size"]
-            });
           }
-
+          arr.push(result);
         }
       }
     });
@@ -329,18 +315,6 @@ script "js_without_tags", type: "javascript" do
   result "results"
   code <<-EOS
     results = s3objects.without_tags
-  EOS
-end
-
-datasource "ds_param_tags" do
-  run_script $js_param_tags, $ds_only_last_modified_objects
-end
-
-script "js_param_tags", type: "javascript" do
-  parameters "s3objects"
-  result "results"
-  code <<-EOS
-    results = s3objects.param_tags
   EOS
 end
 
@@ -377,19 +351,19 @@ datasource "ds_aws_list_s3_objects_with_tags" do
 end
 
 datasource "ds_aws_filtered_s3_objects" do
-  run_script $js_aws_filtered_s3_objects, $ds_aws_list_s3_objects_with_tags, $param_exclude_tags, $ds_get_caller_identity, $ds_without_tags, $ds_param_tags
+  run_script $js_aws_filtered_s3_objects, $ds_aws_list_s3_objects_with_tags, $param_exclude_tags, $ds_get_caller_identity, $ds_without_tags
 end
 
 #Process the response data, check for the tags and generate a list of s3 objects
 script "js_aws_filtered_s3_objects", type: "javascript" do
-  parameters "ds_aws_list_s3_objects_with_tags", "param_exclude_tags", "ds_get_caller_identity", "ds_without_tags", "ds_param_tags"
+  parameters "ds_aws_list_s3_objects_with_tags", "param_exclude_tags", "ds_get_caller_identity", "ds_without_tags"
   result "results"
   code <<-EOS
     results = [];
     var param_exclude_tags_lower=[];
-    if (ds_param_tags.length > 0) {
-      for(var i=0; i < ds_param_tags.length; i++){
-        param_exclude_tags_lower[i]=ds_param_tags[i].toString().toLowerCase();
+    if (param_exclude_tags.length > 0) {
+      for(var i=0; i < param_exclude_tags.length; i++){
+        param_exclude_tags_lower[i]=param_exclude_tags[i].toString().toLowerCase();
       }
     }
 

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "3.1",
+  version: "3.2",
   provider: "AWS",
   service: "S3",
   policy_set: "Object Store Optimization"
@@ -91,7 +91,7 @@ pagination "s3_objects_pagination" do
 end
 
 ###############################################################################
-# Datasources
+# Datasources & Scripts
 ###############################################################################
 
 #https://docs.aws.amazon.com/AmazonS3/latest/API/RESTServiceGET.html
@@ -149,74 +149,8 @@ datasource "ds_aws_buckets_with_region" do
 end
 
 datasource "ds_aws_sanitized_buckets" do
-  run_script $js_parse_buckets, $ds_aws_buckets_with_region
+  run_script $js_parse_buckets, $ds_aws_buckets_with_region, $param_bucket_list
 end
-
-#https://docs.aws.amazon.com/AmazonS3/latest/API/v2-RESTBucketGET.html
-datasource "ds_aws_list_s3_objects" do
-  iterate $ds_aws_sanitized_buckets
-  request do
-    auth $auth_aws
-    pagination $s3_objects_pagination
-    verb "GET"
-    host val(iter_item, "host")
-    path join(["/", val(iter_item, "bucket_name"),"/"])
-    query "list-type", "2"
-  end
-  result do
-    encoding "xml"
-    collect xpath(response, "//ListBucketResult/Contents", "array") do
-      field "bucket_name", val(iter_item, "bucket_name")
-      field "region", val(iter_item, "region")
-      field "bucket_creation_date", val(iter_item, "bucket_creation_date")
-      field "object_key", xpath(col_item,"Key")
-      field "storage_class", xpath(col_item,"StorageClass")
-      field "last_modified", xpath(col_item,"LastModified")
-      field "object_size", xpath(col_item,"Size")
-      field "host", val(iter_item, "host")
-    end
-  end
-end
-
-#https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGETtagging.html
-datasource "ds_aws_list_s3_objects_with_tags" do
-  iterate $ds_aws_list_s3_objects
-  request do
-    auth $auth_aws
-    verb "GET"
-    host val(iter_item, "host")
-    path join(["/", val(iter_item, "bucket_name"),"/", val(iter_item, "object_key")])
-    query "tagging", ""
-  end
-  result do
-    encoding "xml"
-    collect xpath(response, "//Tagging/TagSet", "array") do
-      field "tags" do
-        collect xpath(col_item, "Tag") do
-          field "tagKey", xpath(col_item, "Key")
-          field "tagValue", xpath(col_item, "Value")
-        end
-      end
-      field "bucket_name", val(iter_item, "bucket_name")
-      field "region", val(iter_item, "region")
-      field "bucket_creation_date", val(iter_item, "bucket_creation_date")
-      field "object_key", val(iter_item, "object_key")
-      field "storage_class", val(iter_item, "storage_class")
-      field "last_modified", val(iter_item, "last_modified")
-      field "object_size", val(iter_item, "object_size")
-      field "host", val(iter_item, "host")
-    end
-  end
-end
-
-datasource "ds_aws_filtered_s3_objects" do
-  run_script $js_aws_filtered_s3_objects, $ds_aws_list_s3_objects_with_tags, $param_exclude_tags, $param_glacier_days, $param_deep_archive_days, $ds_get_caller_identity
-end
-
-
-###############################################################################
-# Scripts
-###############################################################################
 
 script "js_parse_buckets", type: "javascript" do
   parameters "buckets"
@@ -246,16 +180,46 @@ script "js_parse_buckets", type: "javascript" do
   EOS
 end
 
-#Process the response data, check for the tags and generate a list of s3 objects
-script "js_aws_filtered_s3_objects", type: "javascript" do
-  parameters "ds_aws_list_s3_objects_with_tags", "param_exclude_tags", "param_glacier_days", "param_deep_archive_days", "ds_get_caller_identity"
+#https://docs.aws.amazon.com/AmazonS3/latest/API/v2-RESTBucketGET.html
+datasource "ds_aws_list_s3_objects" do
+  iterate $ds_aws_sanitized_buckets
+  request do
+    auth $auth_aws
+    pagination $s3_objects_pagination
+    verb "GET"
+    host val(iter_item, "host")
+    path join(["/", val(iter_item, "bucket_name"),"/"])
+    query "list-type", "2"
+  end
+  result do
+    encoding "xml"
+    collect xpath(response, "//ListBucketResult/Contents", "array") do
+      field "bucket_name", val(iter_item, "bucket_name")
+      field "region", val(iter_item, "region")
+      field "bucket_creation_date", val(iter_item, "bucket_creation_date")
+      field "object_key", xpath(col_item,"Key")
+      field "storage_class", xpath(col_item,"StorageClass")
+      field "last_modified", xpath(col_item,"LastModified")
+      field "object_size", xpath(col_item,"Size")
+      field "host", val(iter_item, "host")
+    end
+  end
+end
+
+datasource "ds_only_last_modified_objects" do
+  run_script $js_only_last_modified_objects, $ds_aws_list_s3_objects, $param_deep_archive_days, $param_glacier_days, $param_exclude_tags
+end
+
+script "js_only_last_modified_objects", type: "javascript" do
+  parameters "ds_aws_list_s3_objects", "param_exclude_tags", "param_glacier_days", "param_deep_archive_days"
   result "results"
   code <<-EOS
-    results = [];
+    results = []
     var param_exclude_tags_lower=[];
     for(var i=0; i < param_exclude_tags.length; i++){
       param_exclude_tags_lower[i]=param_exclude_tags[i].toString().toLowerCase();
     }
+
     var glacier_date = new Date();
     var deep_archive_date = new Date();
     var glacier_days_to_move = parseInt(param_glacier_days,10);
@@ -265,23 +229,8 @@ script "js_aws_filtered_s3_objects", type: "javascript" do
     glacier_date = (new Date(glacier_date)).setHours(23, 59, 59, 999);
     deep_archive_date =(new Date(deep_archive_date)).setHours(23, 59, 59, 999);
 
-    _.each(ds_aws_list_s3_objects_with_tags, function(s3Object){
-      var tags = s3Object['tags'];
-      var isTagMatched=false
-      var tagKeyValue=""
-      for(var k=0; k < tags.length; k++){
-        tag = tags[k]
-        //Check, if the tag present in entered param_exclude_tags, ignore the S3 object if the tag matches/present.
-        if((param_exclude_tags_lower.indexOf((tag['tagKey']).toLowerCase()) !== -1) || (param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1)){
-          isTagMatched = true;
-        }
-        if((tag['tagValue']).length > 0){
-          tagKeyValue = tagKeyValue + ', '+ tag['tagKey']+'='+tag['tagValue']
-        }else{
-          tagKeyValue = tagKeyValue + ', '+ tag['tagKey']
-        }
-      }
-      if(!isTagMatched && s3Object.storage_class !== "GLACIER" && s3Object.storage_class !== "DEEP_ARCHIVE"){
+    _.each(ds_aws_list_s3_objects, function (s3Object) {
+      if (s3Object.storage_class !== "GLACIER" && s3Object.storage_class !== "DEEP_ARCHIVE"){
         var last_modified_date = (new Date(s3Object["last_modified"])).setHours(23, 59, 59, 999);
         var modify_storage_class_to="";
         if(param_glacier_days.length > 0 && param_deep_archive_days.length == 0 &&  last_modified_date <= glacier_date){
@@ -307,7 +256,6 @@ script "js_aws_filtered_s3_objects", type: "javascript" do
         }
         if(modify_storage_class_to.length > 0){
           results.push({
-            "accountId": ds_get_caller_identity[0]['account'],
             "bucket_name": s3Object["bucket_name"],
             "region":s3Object["region"],
             "bucket_creation_date": s3Object["bucket_creation_date"],
@@ -316,10 +264,91 @@ script "js_aws_filtered_s3_objects", type: "javascript" do
             "storage_class": s3Object["storage_class"],
             "last_modified": s3Object["last_modified"],
             "modify_storage_class_to": modify_storage_class_to,
-            "object_size": s3Object["object_size"],
-            "tagKeyValue":(tagKeyValue.slice(2))
+            "object_size": s3Object["object_size"]
           });
         }
+      }
+    });
+    results = _.sortBy(results, 'region');
+  EOS
+end
+
+#https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGETtagging.html
+datasource "ds_aws_list_s3_objects_with_tags" do
+  iterate $ds_only_last_modified_objects
+  request do
+    auth $auth_aws
+    verb "GET"
+    host val(iter_item, "host")
+    path join(["/", val(iter_item, "bucket_name"),"/", val(iter_item, "object_key")])
+    query "tagging", ""
+  end
+  result do
+    encoding "xml"
+    collect xpath(response, "//Tagging/TagSet", "array") do
+      field "tags" do
+        collect xpath(col_item, "Tag") do
+          field "tagKey", xpath(col_item, "Key")
+          field "tagValue", xpath(col_item, "Value")
+        end
+      end
+      field "bucket_name", val(iter_item, "bucket_name")
+      field "region", val(iter_item, "region")
+      field "bucket_creation_date", val(iter_item, "bucket_creation_date")
+      field "object_key", val(iter_item, "object_key")
+      field "storage_class", val(iter_item, "storage_class")
+      field "last_modified", val(iter_item, "last_modified")
+      field "object_size", val(iter_item, "object_size")
+      field "host", val(iter_item, "host")
+    end
+  end
+end
+
+datasource "ds_aws_filtered_s3_objects" do
+  run_script $js_aws_filtered_s3_objects, $ds_aws_list_s3_objects_with_tags, $param_exclude_tags, $ds_get_caller_identity
+end
+
+#Process the response data, check for the tags and generate a list of s3 objects
+script "js_aws_filtered_s3_objects", type: "javascript" do
+  parameters "ds_aws_list_s3_objects_with_tags", "param_exclude_tags", "ds_get_caller_identity"
+  result "results"
+  code <<-EOS
+    results = [];
+    var param_exclude_tags_lower=[];
+    for(var i=0; i < param_exclude_tags.length; i++){
+      param_exclude_tags_lower[i]=param_exclude_tags[i].toString().toLowerCase();
+    }
+
+    _.each(ds_aws_list_s3_objects_with_tags, function(s3Object){
+      var tags = s3Object['tags'];
+      var isTagMatched=false
+      var tagKeyValue=""
+      for(var k=0; k < tags.length; k++){
+        tag = tags[k]
+        //Check, if the tag present in entered param_exclude_tags, ignore the S3 object if the tag matches/present.
+        if((param_exclude_tags_lower.indexOf((tag['tagKey']).toLowerCase()) !== -1) || (param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1)){
+          isTagMatched = true;
+        }
+        if((tag['tagValue']).length > 0){
+          tagKeyValue = tagKeyValue + ', '+ tag['tagKey']+'='+tag['tagValue']
+        }else{
+          tagKeyValue = tagKeyValue + ', '+ tag['tagKey']
+        }
+      }
+      if(!isTagMatched){
+        results.push({
+          "accountId": ds_get_caller_identity[0]['account'],
+          "bucket_name": s3Object["bucket_name"],
+          "region":s3Object["region"],
+          "bucket_creation_date": s3Object["bucket_creation_date"],
+          "host": s3Object["host"],
+          "object_key": s3Object["object_key"],
+          "storage_class": s3Object["storage_class"],
+          "last_modified": s3Object["last_modified"],
+          "modify_storage_class_to": modify_storage_class_to,
+          "object_size": s3Object["object_size"],
+          "tagKeyValue":(tagKeyValue.slice(2))
+        });
       }
     });
     results = _.sortBy(results, 'region');

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
@@ -361,10 +361,9 @@ script "js_aws_filtered_s3_objects", type: "javascript" do
   code <<-EOS
     results = [];
     var param_exclude_tags_lower=[];
-    if (param_exclude_tags.length > 0) {
-      for(var i=0; i < param_exclude_tags.length; i++){
-        param_exclude_tags_lower[i]=param_exclude_tags[i].toString().toLowerCase();
-      }
+
+    for(var i=0; i < param_exclude_tags.length; i++){
+      param_exclude_tags_lower[i]=param_exclude_tags[i].toString().toLowerCase();
     }
 
     _.each(ds_aws_list_s3_objects_with_tags, function(s3Object){
@@ -399,6 +398,7 @@ script "js_aws_filtered_s3_objects", type: "javascript" do
         });
       }
     });
+
     _.each(ds_without_tags, function(s3Object){
       results.push({
         "accountId": ds_get_caller_identity[0]['account'],
@@ -414,6 +414,7 @@ script "js_aws_filtered_s3_objects", type: "javascript" do
         "tagKeyValue": ""
       });
     });
+
     results = _.sortBy(results, 'region');
   EOS
 end

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
@@ -211,7 +211,7 @@ datasource "ds_only_last_modified_objects" do
 end
 
 script "js_only_last_modified_objects", type: "javascript" do
-  parameters "ds_aws_list_s3_objects", "param_exclude_tags", "param_glacier_days", "param_deep_archive_days"
+  parameters "ds_aws_list_s3_objects", "param_deep_archive_days", "param_glacier_days", "param_exclude_tags",
   result "results"
   code <<-EOS
     results = []

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
@@ -51,8 +51,8 @@ end
 
 parameter "param_bucket_list" do
   type "list"
-  label "Bucket input list"
-  description "List the buckets that you wish to include"
+  label "Bucket list"
+  description "List only the buckets that you wish to evaluate"
 end
 
 parameter "param_automatic_action" do

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
@@ -149,7 +149,7 @@ datasource "ds_aws_buckets_with_region" do
 end
 
 datasource "ds_aws_sanitized_buckets" do
-  run_script $js_parse_buckets, $ds_aws_buckets_with_region, $param_bucket_list
+  run_script $js_parse_buckets, $ds_aws_buckets_with_region
 end
 
 script "js_parse_buckets", type: "javascript" do

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
@@ -47,11 +47,12 @@ parameter "param_exclude_tags" do
   type "list"
   label "Tags to ignore"
   description "List of tags that will exclude s3 objects from being evaluated by this policy. Multiple tags are evaluated as an 'OR' condition. Tag keys or key/value pairs can be listed. Example: 'test,env=dev'"
+  default []
 end
 
 parameter "param_bucket_list" do
   type "list"
-  label "Bucket list"
+  label "Bucket List"
   description "A list of S3 buckets to assess objects in. Leave blank to assess all buckets."
   default []
 end
@@ -221,14 +222,23 @@ datasource "ds_aws_list_s3_objects" do
 end
 
 datasource "ds_only_last_modified_objects" do
-  run_script $js_only_last_modified_objects, $ds_aws_list_s3_objects, $param_deep_archive_days, $param_glacier_days
+  run_script $js_only_last_modified_objects, $ds_aws_list_s3_objects, $param_deep_archive_days, $param_glacier_days, $param_exclude_tags
 end
 
 script "js_only_last_modified_objects", type: "javascript" do
-  parameters "ds_aws_list_s3_objects", "param_deep_archive_days", "param_glacier_days"
+  parameters "ds_aws_list_s3_objects", "param_deep_archive_days", "param_glacier_days", "param_exclude_tags"
   result "results"
   code <<-EOS
-    results = []
+    var results = {
+      "require_tags": [],
+      "without_tags": [],
+      "param_tags": param_exclude_tags
+    }
+    var tagg = false
+    if (param_exclude_tags.length > 0){
+      tagg = true
+    }
+
     var glacier_date = new Date();
     var deep_archive_date = new Date();
     var glacier_days_to_move = parseInt(param_glacier_days,10);
@@ -264,27 +274,79 @@ script "js_only_last_modified_objects", type: "javascript" do
           }
         }
         if(modify_storage_class_to.length > 0){
-          results.push({
-            "bucket_name": s3Object["bucket_name"],
-            "region":s3Object["region"],
-            "bucket_creation_date": s3Object["bucket_creation_date"],
-            "host": s3Object["host"],
-            "object_key": s3Object["object_key"],
-            "storage_class": s3Object["storage_class"],
-            "last_modified": s3Object["last_modified"],
-            "modify_storage_class_to": modify_storage_class_to,
-            "object_size": s3Object["object_size"]
-          });
+          if (tagg) {
+            results.require_tags.push({
+              "bucket_name": s3Object["bucket_name"],
+              "region":s3Object["region"],
+              "bucket_creation_date": s3Object["bucket_creation_date"],
+              "host": s3Object["host"],
+              "object_key": s3Object["object_key"],
+              "storage_class": s3Object["storage_class"],
+              "last_modified": s3Object["last_modified"],
+              "modify_storage_class_to": modify_storage_class_to,
+              "object_size": s3Object["object_size"]
+            });
+          }else{
+            results.without_tags.push({
+              "bucket_name": s3Object["bucket_name"],
+              "region":s3Object["region"],
+              "bucket_creation_date": s3Object["bucket_creation_date"],
+              "host": s3Object["host"],
+              "object_key": s3Object["object_key"],
+              "storage_class": s3Object["storage_class"],
+              "last_modified": s3Object["last_modified"],
+              "modify_storage_class_to": modify_storage_class_to,
+              "object_size": s3Object["object_size"]
+            });
+          }
+
         }
       }
     });
-    results = _.sortBy(results, 'region');
+    results.without_tags = _.sortBy(results.without_tags, 'region');
+    results.require_tags = _.sortBy(results.require_tags, 'region');
+  EOS
+end
+
+datasource "ds_require_tags" do
+  run_script $js_require_tags, $ds_only_last_modified_objects
+end
+
+script "js_require_tags", type: "javascript" do
+  parameters "s3objects"
+  result "results"
+  code <<-EOS
+    results = s3objects.require_tags
+  EOS
+end
+
+datasource "ds_without_tags" do
+  run_script $js_without_tags, $ds_only_last_modified_objects
+end
+
+script "js_without_tags", type: "javascript" do
+  parameters "s3objects"
+  result "results"
+  code <<-EOS
+    results = s3objects.without_tags
+  EOS
+end
+
+datasource "ds_param_tags" do
+  run_script $js_param_tags, $ds_only_last_modified_objects
+end
+
+script "js_param_tags", type: "javascript" do
+  parameters "s3objects"
+  result "results"
+  code <<-EOS
+    results = s3objects.param_tags
   EOS
 end
 
 #https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGETtagging.html
 datasource "ds_aws_list_s3_objects_with_tags" do
-  iterate $ds_only_last_modified_objects
+  iterate $ds_require_tags
   request do
     auth $auth_aws
     verb "GET"
@@ -315,18 +377,20 @@ datasource "ds_aws_list_s3_objects_with_tags" do
 end
 
 datasource "ds_aws_filtered_s3_objects" do
-  run_script $js_aws_filtered_s3_objects, $ds_aws_list_s3_objects_with_tags, $param_exclude_tags, $ds_get_caller_identity
+  run_script $js_aws_filtered_s3_objects, $ds_aws_list_s3_objects_with_tags, $param_exclude_tags, $ds_get_caller_identity, $ds_without_tags, $ds_param_tags
 end
 
 #Process the response data, check for the tags and generate a list of s3 objects
 script "js_aws_filtered_s3_objects", type: "javascript" do
-  parameters "ds_aws_list_s3_objects_with_tags", "param_exclude_tags", "ds_get_caller_identity"
+  parameters "ds_aws_list_s3_objects_with_tags", "param_exclude_tags", "ds_get_caller_identity", "ds_without_tags", "ds_param_tags"
   result "results"
   code <<-EOS
     results = [];
     var param_exclude_tags_lower=[];
-    for(var i=0; i < param_exclude_tags.length; i++){
-      param_exclude_tags_lower[i]=param_exclude_tags[i].toString().toLowerCase();
+    if (ds_param_tags.length > 0) {
+      for(var i=0; i < ds_param_tags.length; i++){
+        param_exclude_tags_lower[i]=ds_param_tags[i].toString().toLowerCase();
+      }
     }
 
     _.each(ds_aws_list_s3_objects_with_tags, function(s3Object){
@@ -360,6 +424,21 @@ script "js_aws_filtered_s3_objects", type: "javascript" do
           "tagKeyValue":(tagKeyValue.slice(2))
         });
       }
+    });
+    _.each(ds_without_tags, function(s3Object){
+      results.push({
+        "accountId": ds_get_caller_identity[0]['account'],
+        "bucket_name": s3Object["bucket_name"],
+        "region":s3Object["region"],
+        "bucket_creation_date": s3Object["bucket_creation_date"],
+        "host": s3Object["host"],
+        "object_key": s3Object["object_key"],
+        "storage_class": s3Object["storage_class"],
+        "last_modified": s3Object["last_modified"],
+        "modify_storage_class_to": s3Object["modify_storage_class_to"],
+        "object_size": s3Object["object_size"],
+        "tagKeyValue": ""
+      });
     });
     results = _.sortBy(results, 'region');
   EOS

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
@@ -77,7 +77,8 @@ end
 parameter "param_bucket_list" do
   type "list"
   label "Bucket list"
-  description "List only the buckets that you wish to evaluate"
+  description "A list of S3 buckets to assess objects in. Leave blank to assess all buckets."
+  default []
 end
 
 parameter "param_automatic_action" do

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "3.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
@@ -74,6 +74,12 @@ parameter "param_exclude_tags" do
   description "List of tags that will exclude s3 objects from being evaluated by this policy. Multiple tags are evaluated as an 'OR' condition. Tag keys or key/value pairs can be listed. Example: 'test,env=dev'"
 end
 
+parameter "param_bucket_list" do
+  type "list"
+  label "Bucket list"
+  description "List only the buckets that you wish to evaluate"
+end
+
 parameter "param_automatic_action" do
   type "list"
   label "Automatic Actions"

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
@@ -76,7 +76,7 @@ end
 
 parameter "param_bucket_list" do
   type "list"
-  label "Bucket list"
+  label "Bucket List"
   description "A list of S3 buckets to assess objects in. Leave blank to assess all buckets."
   default []
 end


### PR DESCRIPTION
### Description

Modify temporally a bucket list to prevent timeout from large buckets, and revert that changes once successfully results

Additionally, if user did specify exclude tags, retrieve tags only for objects we will be raising incident for, instead of making calls for all discovered objects

### Issues Resolved

[FOPTS-2380](https://flexera.atlassian.net/browse/FOPTS-2380)

### Link to Example Applied Policy
[Applied policy with all buckets](https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/60073?policyId=654b49063411070001af400a)

### Contribution Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
