### PR TITLE
POL-966 Azure Rightsize SQL Fix

### DIFF
--- a/cost/azure/rightsize_sql_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_sql_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.1
+
+- Fixed issue where policy would fail if databases were found with no SKU
+
 ## v4.0
 
 - Several parameters altered to be more descriptive and human-readable

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.0",
+  version: "4.1",
   provider: "Azure",
   service: "SQL",
   policy_set: "Rightsize Database Instances",
@@ -347,7 +347,10 @@ script "js_azure_sql_databases_system_filtered", type: "javascript" do
   result "result"
   code <<-EOS
   result = _.reject(ds_azure_sql_databases, function(db) {
-    return db['sku']['name'] == 'System'
+    sku_name = null
+    if (typeof(db['sku']) == 'object') { sku_name = db['sku']['name'] }
+
+    return sku_name == 'System' || sku_name == null || sku_name == undefined
   })
 EOS
 end

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 


### PR DESCRIPTION
### Description

If the list of databases returned by the Azure API included entries without a valid 'sku' field, the policy would error out instead of completing. This is a fix for that; such entries are now filtered entirely, since it wouldn't be possible to provide meaningful recommendations without knowing the SKU anyway.

### Link to Example Applied Policy

https://app.flexera.com/orgs/27018/automation/applied-policies/projects/116186?policyId=654d2e7e99745e0001588027

Note: The above does not raise an incident and is just to confirm the policy completes. I have also tested this in the user environment where the issue was originally reported and verified the fix does work as intended.

### Contribution Check List

- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
