### PR TITLE
POL-967 Deprecate AWS GP3 Upgradeable Volumes Policy

### DIFF
--- a/cost/aws/gp3_volume_upgrade/CHANGELOG.md
+++ b/cost/aws/gp3_volume_upgrade/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.3
+
+- Deprecated: This policy is no longer being updated. Please see policy README for more information.
+
 ## v4.2
 
 - Updated description of `Account Number` parameter

--- a/cost/aws/gp3_volume_upgrade/README.md
+++ b/cost/aws/gp3_volume_upgrade/README.md
@@ -1,12 +1,18 @@
 # AWS GP3 Upgradeable Volumes
 
-## What it does
+## Deprecated
+
+This policy is no longer being updated. The [AWS Rightsize EBS Volumes](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/rightsize_ebs_volumes/) policy should be used for these recommendations instead.
+
+Note that the above policy does not report on IO1 or IO2 volumes. These volumes are high performance volumes, so changing them to GP3 will result in a performance downgrade and may cause issues for workloads that rely on this performance.
+
+## What It Does
 
 This Policy finds GP2, IO1, or IO2 volumes in the given account and recommends them for upgrade to GP3 if that would provide savings. A Policy Incident will be created with all of volumes that fall into these criteria.
 
 Optionally, the user can specify one or more tags that if found on a volume will exclude the volume from the list.
 
-### Policy savings details
+### Policy Savings Details
 
 The policy includes the estimated savings. The estimated savings is recognized if the resource is Upgraded. It uses the AWS Pricing API to calculate the estimated savings along with the AWS Enterprise Discount Program percentage that is calculated from costs in Optima. You can also set the *AWS EDP Percentage* parameter to a non-negative number to use for the discount percentage instead. The savings are displayed in the *Estimated Monthly Savings* column. The incident detail message includes the sum of each resource *Estimated Monthly Savings* as *Total Estimated Monthly Savings*.
 

--- a/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume.pt
+++ b/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume.pt
@@ -1,12 +1,12 @@
 name "AWS GP3 Upgradeable Volumes"
 rs_pt_ver 20180301
 type "policy"
-short_description "Checks for upgradeable volumes and report them for modification. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/gp3_volume_upgrade) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "**Deprecated: This policy is no longer being updated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/gp3_volume_upgrade/) for more details.**  Checks for upgradeable volumes and report them for modification. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/gp3_volume_upgrade) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "4.2",
+  version: "4.3",
   provider: "AWS",
   service: "EBS",
   policy_set: "GP3 Volumes"

--- a/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume_meta_parent.pt
+++ b/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 


### PR DESCRIPTION
### Description

This policy is no longer being updated. The [AWS Rightsize EBS Volumes](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/rightsize_ebs_volumes/) policy should be used for these recommendations instead.

Note that, unlike the AWS Rightsize EBS Volumes policy, this policy reports on IO1 and IO2 volumes. These volumes are high performance volumes, so changing them to GP3 will result in a performance downgrade and may cause issues for workloads that rely on this performance.

Effectively, this policy was just recommending the above change without regard for actual usage data, which is a bit reckless and shouldn't be done. A future version of the AWS Rightsize EBS Volumes policy may include this functionality, but it would be alongside actual analysis of metrics to determine if the downgrade makes sense.

### Link to Example Applied Policy

N/A. Changes have no impact on functionality or policy execution.

### Contribution Check List

- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
