### PR TITLE
feat: Meta Policy Consolidated Incident Actions

### DIFF
--- a/compliance/aws/disallowed_regions/aws_disallowed_regions_meta_parent.pt
+++ b/compliance/aws/disallowed_regions/aws_disallowed_regions_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -743,6 +745,7 @@ script "js_ds_list_aws_instances_combined_incidents", type: "javascript" do
     // If the incident summary contains "in Disallowed regions" then include it in the filter result
     if (s.indexOf("in Disallowed regions") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -761,6 +764,7 @@ policy "policy_scheduled_report" do
   validate $ds_list_aws_instances_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} in Disallowed regions"
     escalate $esc_email
+    escalate $esc_terminate_instances_disallowed_region
     check eq(size(data), 0)
     export do
       resource_level true
@@ -778,6 +782,9 @@ policy "policy_scheduled_report" do
       end
       field "tagKeyValue" do
         label "Tags"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -882,6 +889,160 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Delete Instances
+escalation "esc_terminate_instances_disallowed_region" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Instances"
+  description "Delete instances found in disallowd regions."
+  run "esc_terminate_instances_disallowed_region", data, rs_governance_host, rs_project_id
+end
+define esc_terminate_instances_disallowed_region($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Instances")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/compliance/aws/disallowed_regions/aws_disallowed_regions_meta_parent.pt
+++ b/compliance/aws/disallowed_regions/aws_disallowed_regions_meta_parent.pt
@@ -754,6 +754,18 @@ EOS
 end
 
 
+# Escalation for Delete Instances
+escalation "esc_terminate_instances_disallowed_region" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Instances"
+  description "Delete instances found in disallowd regions."
+  run "esc_terminate_instances_disallowed_region", data, rs_governance_host, rs_project_id
+end
+define esc_terminate_instances_disallowed_region($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Instances")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -889,17 +901,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Delete Instances
-escalation "esc_terminate_instances_disallowed_region" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Delete Instances"
-  description "Delete instances found in disallowd regions."
-  run "esc_terminate_instances_disallowed_region", data, rs_governance_host, rs_project_id
-end
-define esc_terminate_instances_disallowed_region($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Delete Instances")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/compliance/aws/ecs_unused/aws_unused_ecs_clusters.pt
+++ b/compliance/aws/ecs_unused/aws_unused_ecs_clusters.pt
@@ -56,6 +56,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Delete Clusters"]
+  default []
 end
 
 

--- a/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent_meta_parent.pt
+++ b/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent_meta_parent.pt
@@ -759,6 +759,8 @@ EOS
 end
 
 
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -895,7 +897,6 @@ EOS
     check eq(size(data),0)
   end
 end
-
 
 # Begin Shared Functions for Child Actions from Consolidated Incident
 define groupByIncidentID($data) return $incidents do

--- a/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent_meta_parent.pt
+++ b/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -745,9 +747,10 @@ script "js_ds_formatted_instances_combined_incidents", type: "javascript" do
   result = []
   _.each(ds_child_incident_details, function(incident) {
     s = incident["summary"];
-    // If the incident summary contains "instances missing in FlexNet Manager" then include it in the filter result
-    if (s.indexOf("instances missing in FlexNet Manager") > -1) {
+    // If the incident summary contains "EC2 instances missing in FlexNet Manager" then include it in the filter result
+    if (s.indexOf("EC2 instances missing in FlexNet Manager") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -762,10 +765,11 @@ end
 # Could also just have one incident and use meta_status to determine which escalation happens
 policy "policy_scheduled_report" do
   # Consolidated Incident Check(s)
-    # Consolidated incident for instances missing in FlexNet Manager
+    # Consolidated incident for EC2 instances missing in FlexNet Manager
   validate $ds_formatted_instances_combined_incidents do
-    summary_template "Consolidated Incident: {{ len data }} instances missing in FlexNet Manager"
+    summary_template "Consolidated Incident: {{ len data }} EC2 instances missing in FlexNet Manager"
     escalate $esc_email
+    
     check eq(size(data), 0)
     export do
       resource_level true
@@ -783,6 +787,9 @@ policy "policy_scheduled_report" do
       end
       field "tags" do
         label "Tags"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -887,6 +894,150 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt
+++ b/compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt
@@ -64,6 +64,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Terminate Instances"]
+  default []
 end
 
 

--- a/compliance/aws/long_stopped_instances/aws_long_stopped_instances_meta_parent.pt
+++ b/compliance/aws/long_stopped_instances/aws_long_stopped_instances_meta_parent.pt
@@ -99,6 +99,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Terminate Instances"]
+  default []
 end
 
 ###############################################################################

--- a/compliance/aws/long_stopped_instances/aws_long_stopped_instances_meta_parent.pt
+++ b/compliance/aws/long_stopped_instances/aws_long_stopped_instances_meta_parent.pt
@@ -758,6 +758,18 @@ EOS
 end
 
 
+# Escalation for Terminate Instances
+escalation "esc_terminate_stopped_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Terminate Instances"
+  description "Terminate selected instances"
+  run "esc_terminate_stopped_instances", data, rs_governance_host, rs_project_id
+end
+define esc_terminate_stopped_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instances")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -891,17 +903,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Terminate Instances
-escalation "esc_terminate_stopped_instances" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Terminate Instances"
-  description "Terminate selected instances"
-  run "esc_terminate_stopped_instances", data, rs_governance_host, rs_project_id
-end
-define esc_terminate_stopped_instances($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instances")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/compliance/aws/long_stopped_instances/aws_long_stopped_instances_meta_parent.pt
+++ b/compliance/aws/long_stopped_instances/aws_long_stopped_instances_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -747,6 +749,7 @@ script "js_ds_list_aws_instances_combined_incidents", type: "javascript" do
     // If the incident summary contains "AWS Instances Stopped for Over" then include it in the filter result
     if (s.indexOf("AWS Instances Stopped for Over") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -765,6 +768,8 @@ policy "policy_scheduled_report" do
   validate $ds_list_aws_instances_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} AWS Instances Stopped for Over"
     escalate $esc_email
+    escalate $esc_report_stopped_instances
+    escalate $esc_terminate_stopped_instances
     check eq(size(data), 0)
     export do
       resource_level true
@@ -779,6 +784,9 @@ policy "policy_scheduled_report" do
       end
       field "tagKeyValue" do
         label "Tags"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -883,6 +891,160 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Terminate Instances
+escalation "esc_terminate_stopped_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Terminate Instances"
+  description "Terminate selected instances"
+  run "esc_terminate_stopped_instances", data, rs_governance_host, rs_project_id
+end
+define esc_terminate_stopped_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instances")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry_meta_parent.pt
+++ b/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry_meta_parent.pt
@@ -776,6 +776,8 @@ EOS
 end
 
 
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -945,7 +947,6 @@ EOS
     check eq(size(data),0)
   end
 end
-
 
 # Begin Shared Functions for Child Actions from Consolidated Incident
 define groupByIncidentID($data) return $incidents do

--- a/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry_meta_parent.pt
+++ b/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -762,9 +764,10 @@ script "js_ds_ahub_incident_combined_incidents", type: "javascript" do
   result = []
   _.each(ds_child_incident_details, function(incident) {
     s = incident["summary"];
-    // If the incident summary contains "with index data" then include it in the filter result
-    if (s.indexOf("with index data") > -1) {
+    // If the incident summary contains "with index data 0" then include it in the filter result
+    if (s.indexOf("with index data 0") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -779,10 +782,11 @@ end
 # Could also just have one incident and use meta_status to determine which escalation happens
 policy "policy_scheduled_report" do
   # Consolidated Incident Check(s)
-    # Consolidated incident for with index data
+    # Consolidated incident for with index data 0
   validate $ds_ahub_incident_combined_incidents do
-    summary_template "Consolidated Incident: {{ len data }} with index data"
+    summary_template "Consolidated Incident: {{ len data }} with index data 0"
     escalate $esc_email
+    
     check eq(size(data), 0)
     export do
       resource_level true
@@ -833,6 +837,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "ID"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -937,6 +944,150 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/compliance/azure/azure_disallowed_regions/azure_disallowed_regions.pt
+++ b/compliance/azure/azure_disallowed_regions/azure_disallowed_regions.pt
@@ -46,6 +46,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Terminate Instances"]
+  default []
 end
 
 ###############################################################################

--- a/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent.pt
+++ b/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent.pt
@@ -84,6 +84,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Terminate Instances"]
+  default []
 end
 
 ###############################################################################

--- a/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent.pt
+++ b/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent.pt
@@ -752,6 +752,18 @@ EOS
 end
 
 
+# Escalation for Delete Resource
+escalation "delete_resources" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Resource"
+  description "Delete the selected instance"
+  run "delete_resources", data, rs_governance_host, rs_project_id
+end
+define delete_resources($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Resource")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -887,17 +899,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Delete Resource
-escalation "delete_resources" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Delete Resource"
-  description "Delete the selected instance"
-  run "delete_resources", data, rs_governance_host, rs_project_id
-end
-define delete_resources($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Delete Resource")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent.pt
+++ b/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -741,6 +743,7 @@ script "js_filtered_resources_combined_incidents", type: "javascript" do
     // If the incident summary contains "Azure Resources out of compliance" then include it in the filter result
     if (s.indexOf("Azure Resources out of compliance") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -759,6 +762,7 @@ policy "policy_scheduled_report" do
   validate $filtered_resources_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Azure Resources out of compliance"
     escalate $esc_email
+    escalate $delete_resources
     check eq(size(data), 0)
     export do
       resource_level true
@@ -776,6 +780,9 @@ policy "policy_scheduled_report" do
       end
       field "managedBy" do
         label "Managed By"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -880,6 +887,160 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Delete Resource
+escalation "delete_resources" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Resource"
+  description "Delete the selected instance"
+  run "delete_resources", data, rs_governance_host, rs_project_id
+end
+define delete_resources($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Resource")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/compliance/azure/azure_long_stopped_instances/long_stopped_instances_azure.pt
+++ b/compliance/azure/azure_long_stopped_instances/long_stopped_instances_azure.pt
@@ -47,6 +47,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Terminate Instances"]
+  default []
 end
 
 ###############################################################################

--- a/compliance/azure/azure_long_stopped_instances/long_stopped_instances_azure_meta_parent.pt
+++ b/compliance/azure/azure_long_stopped_instances/long_stopped_instances_azure_meta_parent.pt
@@ -84,6 +84,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Terminate Instances"]
+  default []
 end
 
 ###############################################################################

--- a/compliance/azure/azure_long_stopped_instances/long_stopped_instances_azure_meta_parent.pt
+++ b/compliance/azure/azure_long_stopped_instances/long_stopped_instances_azure_meta_parent.pt
@@ -752,6 +752,18 @@ EOS
 end
 
 
+# Escalation for Delete Resource
+escalation "delete_resources" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Resource"
+  description "Delete the selected instance"
+  run "delete_resources", data, rs_governance_host, rs_project_id
+end
+define delete_resources($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Resource")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -893,17 +905,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Delete Resource
-escalation "delete_resources" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Delete Resource"
-  description "Delete the selected instance"
-  run "delete_resources", data, rs_governance_host, rs_project_id
-end
-define delete_resources($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Delete Resource")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/compliance/azure/azure_long_stopped_instances/long_stopped_instances_azure_meta_parent.pt
+++ b/compliance/azure/azure_long_stopped_instances/long_stopped_instances_azure_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -741,6 +743,7 @@ script "js_ds_filtered_resources_combined_incidents", type: "javascript" do
     // If the incident summary contains "Azure VMs in Stopped State for Over" then include it in the filter result
     if (s.indexOf("Azure VMs in Stopped State for Over") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -759,6 +762,7 @@ policy "policy_scheduled_report" do
   validate $ds_filtered_resources_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Azure VMs in Stopped State for Over"
     escalate $esc_email
+    escalate $delete_resources
     check eq(size(data), 0)
     export do
       resource_level true
@@ -782,6 +786,9 @@ policy "policy_scheduled_report" do
       end
       field "subscriptionId" do
         label "Subscription ID"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -886,6 +893,160 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Delete Resource
+escalation "delete_resources" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Resource"
+  description "Delete the selected instance"
+  run "delete_resources", data, rs_governance_host, rs_project_id
+end
+define delete_resources($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Resource")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
+++ b/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
@@ -761,6 +761,8 @@ EOS
 end
 
 
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -903,7 +905,6 @@ EOS
     check eq(size(data),0)
   end
 end
-
 
 # Begin Shared Functions for Child Actions from Consolidated Incident
 define groupByIncidentID($data) return $incidents do

--- a/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
+++ b/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -750,6 +752,7 @@ script "js_ds_formatted_instances_combined_incidents", type: "javascript" do
     // If the incident summary contains "is missing in FlexNet Manager" then include it in the filter result
     if (s.indexOf("is missing in FlexNet Manager") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -768,6 +771,7 @@ policy "policy_scheduled_report" do
   validate $ds_formatted_instances_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} is missing in FlexNet Manager"
     escalate $esc_email
+    escalate $report_instances
     check eq(size(data), 0)
     export do
       resource_level true
@@ -791,6 +795,9 @@ policy "policy_scheduled_report" do
       end
       field "tags" do
         label "Tags"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -895,6 +902,150 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/compliance/disallowed_images/disallowed_cloud_images.pt
+++ b/compliance/disallowed_images/disallowed_cloud_images.pt
@@ -48,6 +48,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Terminate Instances"]
+  default []
 end
 
 ###############################################################################

--- a/compliance/github/repository_branch_protection/repository_branch_protection.pt
+++ b/compliance/github/repository_branch_protection/repository_branch_protection.pt
@@ -58,6 +58,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Protect Branches"]
+  default []
 end
 
 credentials "auth_github" do

--- a/compliance/google/long_stopped_instances/google_long_stopped_instances.pt
+++ b/compliance/google/long_stopped_instances/google_long_stopped_instances.pt
@@ -40,6 +40,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Terminate Instances"]
+  default []
 end
 
 ###############################################################################

--- a/compliance/tags/azure_rg_tags/azure_resource_group_tags.pt
+++ b/compliance/tags/azure_rg_tags/azure_resource_group_tags.pt
@@ -59,6 +59,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Tag Resources"]
+  default []
 end
 
 ###############################################################################

--- a/compliance/tags/tag_checker/tag_checker.pt
+++ b/compliance/tags/tag_checker/tag_checker.pt
@@ -54,6 +54,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Tag Resources"]
+  default []
 end
 
 # Retrieve all clouds

--- a/compliance/unapproved_instance_types/unapproved_instance_types.pt
+++ b/compliance/unapproved_instance_types/unapproved_instance_types.pt
@@ -48,6 +48,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Stop Instances"]
+  default []
 end
 
 ###############################################################################

--- a/cost/aws/burstable_instance_cloudwatch_credit_utilization/aws_burstable_instance_cloudwatch_credit_utilization.pt
+++ b/cost/aws/burstable_instance_cloudwatch_credit_utilization/aws_burstable_instance_cloudwatch_credit_utilization.pt
@@ -81,6 +81,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Resize Instances"]
+  default []
 end
 
 ###############################################################################

--- a/cost/aws/elb/clb_unused/aws_delete_unused_clb.pt
+++ b/cost/aws/elb/clb_unused/aws_delete_unused_clb.pt
@@ -58,6 +58,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Delete Load balancers"]
+  default []
 end
 
 parameter "param_log_to_cm_audit_entries" do

--- a/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume_meta_parent.pt
+++ b/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume_meta_parent.pt
@@ -770,6 +770,8 @@ EOS
 end
 
 
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -927,7 +929,6 @@ EOS
     check eq(size(data),0)
   end
 end
-
 
 # Begin Shared Functions for Child Actions from Consolidated Incident
 define groupByIncidentID($data) return $incidents do

--- a/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume_meta_parent.pt
+++ b/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -759,6 +761,7 @@ script "js_ds_volume_cost_mapping_combined_incidents", type: "javascript" do
     // If the incident summary contains "Upgradeable Volumes Found" then include it in the filter result
     if (s.indexOf("Upgradeable Volumes Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -777,6 +780,7 @@ policy "policy_scheduled_report" do
   validate $ds_volume_cost_mapping_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Upgradeable Volumes Found"
     escalate $esc_email
+    escalate $report_volumes
     check eq(size(data), 0)
     export do
       resource_level true
@@ -815,6 +819,9 @@ policy "policy_scheduled_report" do
       end
       field "discount_calculated" do
         label "AWS EDP was Calculated"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -919,6 +926,150 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
+++ b/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
@@ -806,6 +806,18 @@ EOS
 end
 
 
+# Escalation for Terminate Instances
+escalation "esc_terminate_resources" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Terminate Instances"
+  description "Approval to terminate all selected instances"
+  run "esc_terminate_resources", data, rs_governance_host, rs_project_id
+end
+define esc_terminate_resources($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instances")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -1019,17 +1031,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Terminate Instances
-escalation "esc_terminate_resources" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Terminate Instances"
-  description "Approval to terminate all selected instances"
-  run "esc_terminate_resources", data, rs_governance_host, rs_project_id
-end
-define esc_terminate_resources($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instances")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
+++ b/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -792,9 +794,10 @@ script "js_ds_idle_instances_combined_incidents", type: "javascript" do
   result = []
   _.each(ds_child_incident_details, function(incident) {
     s = incident["summary"];
-    // If the incident summary contains "Instances Found" then include it in the filter result
-    if (s.indexOf("Instances Found") > -1) {
+    // If the incident summary contains "Idle AWS EC2 Instances Found" then include it in the filter result
+    if (s.indexOf("Idle AWS EC2 Instances Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -809,10 +812,11 @@ end
 # Could also just have one incident and use meta_status to determine which escalation happens
 policy "policy_scheduled_report" do
   # Consolidated Incident Check(s)
-    # Consolidated incident for Instances Found
+    # Consolidated incident for Idle AWS EC2 Instances Found
   validate $ds_idle_instances_combined_incidents do
-    summary_template "Consolidated Incident: {{ len data }} Instances Found"
+    summary_template "Consolidated Incident: {{ len data }} Idle AWS EC2 Instances Found"
     escalate $esc_email
+    escalate $esc_terminate_resources
     check eq(size(data), 0)
     export do
       resource_level true
@@ -908,6 +912,9 @@ policy "policy_scheduled_report" do
       end
       field "thresholdType" do
         label "Threshold Type"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -1012,6 +1019,160 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Terminate Instances
+escalation "esc_terminate_resources" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Terminate Instances"
+  description "Approval to terminate all selected instances"
+  run "esc_terminate_resources", data, rs_governance_host, rs_project_id
+end
+define esc_terminate_resources($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instances")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/aws/instance_cloudwatch_utilization/aws_instance_cloudwatch_utilization.pt
+++ b/cost/aws/instance_cloudwatch_utilization/aws_instance_cloudwatch_utilization.pt
@@ -77,6 +77,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Downsize Instances"]
+  default []
 end
 
 parameter "param_log_to_cm_audit_entries" do

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
@@ -62,6 +62,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Update S3 Objects Class"]
+  default []
 end
 
 

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
@@ -756,6 +756,29 @@ EOS
 end
 
 
+# Escalation for Approve S3 Object Storage Class Change
+escalation "esc_modify_s3_object_storage_class_approval" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Approve S3 Object Storage Class Change"
+  description "Approve selected S3 object storage class change"
+  run "esc_modify_s3_object_storage_class_approval", data, rs_governance_host, rs_project_id
+end
+define esc_modify_s3_object_storage_class_approval($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Approve S3 Object Storage Class Change")
+end
+
+# Escalation for Delete S3 Objects
+escalation "esc_delete_s3_objects_approval" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete S3 Objects"
+  description "Delete selected S3 objects"
+  run "esc_delete_s3_objects_approval", data, rs_governance_host, rs_project_id
+end
+define esc_delete_s3_objects_approval($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete S3 Objects")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -905,28 +928,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Approve S3 Object Storage Class Change
-escalation "esc_modify_s3_object_storage_class_approval" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Approve S3 Object Storage Class Change"
-  description "Approve selected S3 object storage class change"
-  run "esc_modify_s3_object_storage_class_approval", data, rs_governance_host, rs_project_id
-end
-define esc_modify_s3_object_storage_class_approval($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Approve S3 Object Storage Class Change")
-end
-
-# Escalation for Delete S3 Objects
-escalation "esc_delete_s3_objects_approval" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Delete S3 Objects"
-  description "Delete selected S3 objects"
-  run "esc_delete_s3_objects_approval", data, rs_governance_host, rs_project_id
-end
-define esc_delete_s3_objects_approval($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Delete S3 Objects")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
@@ -97,6 +97,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Update S3 Objects Class"]
+  default []
 end
 
 ###############################################################################

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -745,6 +747,7 @@ script "js_ds_aws_filtered_s3_objects_combined_incidents", type: "javascript" do
     // If the incident summary contains "Opportunities for AWS Object Storage Optimization" then include it in the filter result
     if (s.indexOf("Opportunities for AWS Object Storage Optimization") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -763,6 +766,9 @@ policy "policy_scheduled_report" do
   validate $ds_aws_filtered_s3_objects_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Opportunities for AWS Object Storage Optimization"
     escalate $esc_email
+    escalate $esc_report_s3_Objects_list
+    escalate $esc_modify_s3_object_storage_class_approval
+    escalate $esc_delete_s3_objects_approval
     check eq(size(data), 0)
     export do
       resource_level true
@@ -792,6 +798,9 @@ policy "policy_scheduled_report" do
       end
       field "host" do
         label "Host"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -896,6 +905,171 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Approve S3 Object Storage Class Change
+escalation "esc_modify_s3_object_storage_class_approval" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Approve S3 Object Storage Class Change"
+  description "Approve selected S3 object storage class change"
+  run "esc_modify_s3_object_storage_class_approval", data, rs_governance_host, rs_project_id
+end
+define esc_modify_s3_object_storage_class_approval($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Approve S3 Object Storage Class Change")
+end
+
+# Escalation for Delete S3 Objects
+escalation "esc_delete_s3_objects_approval" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete S3 Objects"
+  description "Delete selected S3 objects"
+  run "esc_delete_s3_objects_approval", data, rs_governance_host, rs_project_id
+end
+define esc_delete_s3_objects_approval($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete S3 Objects")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
@@ -812,6 +812,18 @@ EOS
 end
 
 
+# Escalation for Delete Snapshots
+escalation "esc_delete_snapshot" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Snapshots"
+  description "Approval to delete all selected snapshots"
+  run "esc_delete_snapshot", data, rs_governance_host, rs_project_id
+end
+define esc_delete_snapshot($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Snapshots")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -998,17 +1010,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Delete Snapshots
-escalation "esc_delete_snapshot" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Delete Snapshots"
-  description "Approval to delete all selected snapshots"
-  run "esc_delete_snapshot", data, rs_governance_host, rs_project_id
-end
-define esc_delete_snapshot($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Delete Snapshots")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -801,6 +803,7 @@ script "js_ds_snapshots_cost_mapping_combined_incidents", type: "javascript" do
     // If the incident summary contains "AWS Old Snapshots Found" then include it in the filter result
     if (s.indexOf("AWS Old Snapshots Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -819,6 +822,7 @@ policy "policy_scheduled_report" do
   validate $ds_snapshots_cost_mapping_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} AWS Old Snapshots Found"
     escalate $esc_email
+    escalate $esc_delete_snapshot
     check eq(size(data), 0)
     export do
       resource_level true
@@ -887,6 +891,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "ID"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -991,6 +998,160 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Delete Snapshots
+escalation "esc_delete_snapshot" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Snapshots"
+  description "Approval to delete all selected snapshots"
+  run "esc_delete_snapshot", data, rs_governance_host, rs_project_id
+end
+define esc_delete_snapshot($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Snapshots")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/aws/rds_instance_cloudwatch_utilization/rds_instance_cloudwatch_utilization.pt
+++ b/cost/aws/rds_instance_cloudwatch_utilization/rds_instance_cloudwatch_utilization.pt
@@ -75,6 +75,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Resize Instances"]
+  default []
 end
 
 parameter "param_log_to_cm_audit_entries" do

--- a/cost/aws/rds_instance_cloudwatch_utilization/rds_instance_cloudwatch_utilization_meta_parent.pt
+++ b/cost/aws/rds_instance_cloudwatch_utilization/rds_instance_cloudwatch_utilization_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -766,6 +768,7 @@ script "js_ds_filtered_results_combined_incidents", type: "javascript" do
     // If the incident summary contains "AWS RDS instances with inefficient utilization" then include it in the filter result
     if (s.indexOf("AWS RDS instances with inefficient utilization") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -784,6 +787,7 @@ policy "policy_scheduled_report" do
   validate $ds_filtered_results_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} AWS RDS instances with inefficient utilization"
     escalate $esc_email
+    escalate $resize_instances
     check eq(size(data), 0)
     export do
       resource_level true
@@ -825,6 +829,9 @@ policy "policy_scheduled_report" do
       end
       field "threshold" do
         label "CPU Threshold"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -929,6 +936,160 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Update Instance
+escalation "resize_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Update Instance"
+  description "Approve selected RDS RightSizing"
+  run "resize_instances", data, rs_governance_host, rs_project_id
+end
+define resize_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Update Instance")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/aws/rds_instance_cloudwatch_utilization/rds_instance_cloudwatch_utilization_meta_parent.pt
+++ b/cost/aws/rds_instance_cloudwatch_utilization/rds_instance_cloudwatch_utilization_meta_parent.pt
@@ -110,6 +110,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Resize Instances"]
+  default []
 end
 
 parameter "param_log_to_cm_audit_entries" do

--- a/cost/aws/rds_instance_cloudwatch_utilization/rds_instance_cloudwatch_utilization_meta_parent.pt
+++ b/cost/aws/rds_instance_cloudwatch_utilization/rds_instance_cloudwatch_utilization_meta_parent.pt
@@ -777,6 +777,18 @@ EOS
 end
 
 
+# Escalation for Update Instance
+escalation "resize_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Update Instance"
+  description "Approve selected RDS RightSizing"
+  run "resize_instances", data, rs_governance_host, rs_project_id
+end
+define resize_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Update Instance")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -936,17 +948,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Update Instance
-escalation "resize_instances" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Update Instance"
-  description "Approve selected RDS RightSizing"
-  run "resize_instances", data, rs_governance_host, rs_project_id
-end
-define resize_instances($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Update Instance")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/aws/rds_instance_license_info/rds_instance_license_info_meta_parent.pt
+++ b/cost/aws/rds_instance_license_info/rds_instance_license_info_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -724,9 +726,10 @@ script "js_ds_filtered_results_combined_incidents", type: "javascript" do
   result = []
   _.each(ds_child_incident_details, function(incident) {
     s = incident["summary"];
-    // If the incident summary contains "with index data" then include it in the filter result
-    if (s.indexOf("with index data") > -1) {
+    // If the incident summary contains "with index data 0" then include it in the filter result
+    if (s.indexOf("with index data 0") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -741,10 +744,11 @@ end
 # Could also just have one incident and use meta_status to determine which escalation happens
 policy "policy_scheduled_report" do
   # Consolidated Incident Check(s)
-    # Consolidated incident for with index data
+    # Consolidated incident for with index data 0
   validate $ds_filtered_results_combined_incidents do
-    summary_template "Consolidated Incident: {{ len data }} with index data"
+    summary_template "Consolidated Incident: {{ len data }} with index data 0"
     escalate $esc_email
+    
     check eq(size(data), 0)
     export do
       resource_level true
@@ -774,6 +778,9 @@ policy "policy_scheduled_report" do
       end
       field "licenseModel" do
         label "License Model"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -878,6 +885,150 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/aws/rds_instance_license_info/rds_instance_license_info_meta_parent.pt
+++ b/cost/aws/rds_instance_license_info/rds_instance_license_info_meta_parent.pt
@@ -738,6 +738,8 @@ EOS
 end
 
 
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -886,7 +888,6 @@ EOS
     check eq(size(data),0)
   end
 end
-
 
 # Begin Shared Functions for Child Actions from Consolidated Incident
 define groupByIncidentID($data) return $incidents do

--- a/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -754,9 +756,10 @@ script "js_ds_underutil_volumes_combined_incidents", type: "javascript" do
   result = []
   _.each(ds_child_incident_details, function(incident) {
     s = incident["summary"];
-    // If the incident summary contains "AWS Underutilized GP" then include it in the filter result
-    if (s.indexOf("AWS Underutilized GP") > -1) {
+    // If the incident summary contains "AWS Underutilized GP2 Volumes Found" then include it in the filter result
+    if (s.indexOf("AWS Underutilized GP2 Volumes Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -771,10 +774,11 @@ end
 # Could also just have one incident and use meta_status to determine which escalation happens
 policy "policy_scheduled_report" do
   # Consolidated Incident Check(s)
-    # Consolidated incident for AWS Underutilized GP
+    # Consolidated incident for AWS Underutilized GP2 Volumes Found
   validate $ds_underutil_volumes_combined_incidents do
-    summary_template "Consolidated Incident: {{ len data }} AWS Underutilized GP"
+    summary_template "Consolidated Incident: {{ len data }} AWS Underutilized GP2 Volumes Found"
     escalate $esc_email
+    escalate $esc_upgrade_volumes
     check eq(size(data), 0)
     export do
       resource_level true
@@ -837,6 +841,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "ID"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -941,6 +948,160 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Upgrade Volumes to GP3
+escalation "esc_upgrade_volumes" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Upgrade Volumes to GP3"
+  description "Approval to upgrade all selected volumes to GP3"
+  run "esc_upgrade_volumes", data, rs_governance_host, rs_project_id
+end
+define esc_upgrade_volumes($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Upgrade Volumes to GP3")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
@@ -768,6 +768,18 @@ EOS
 end
 
 
+# Escalation for Upgrade Volumes to GP3
+escalation "esc_upgrade_volumes" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Upgrade Volumes to GP3"
+  description "Approval to upgrade all selected volumes to GP3"
+  run "esc_upgrade_volumes", data, rs_governance_host, rs_project_id
+end
+define esc_upgrade_volumes($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Upgrade Volumes to GP3")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -948,17 +960,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Upgrade Volumes to GP3
-escalation "esc_upgrade_volumes" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Upgrade Volumes to GP3"
-  description "Approval to upgrade all selected volumes to GP3"
-  run "esc_upgrade_volumes", data, rs_governance_host, rs_project_id
-end
-define esc_upgrade_volumes($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Upgrade Volumes to GP3")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
@@ -858,6 +858,40 @@ EOS
 end
 
 
+# Escalation for Downsize Instances
+escalation "esc_downsize_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Downsize Instances"
+  description "Approval to downsize all selected instances"
+  run "esc_downsize_instances", data, rs_governance_host, rs_project_id
+end
+define esc_downsize_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Downsize Instances")
+end
+
+# Escalation for Stop Instances
+escalation "esc_stop_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Stop Instances"
+  description "Approval to stop all selected instances"
+  run "esc_stop_instances", data, rs_governance_host, rs_project_id
+end
+define esc_stop_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Stop Instances")
+end
+
+# Escalation for Terminate Instances
+escalation "esc_terminate_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Terminate Instances"
+  description "Approval to terminate all selected instances"
+  run "esc_terminate_instances", data, rs_governance_host, rs_project_id
+end
+define esc_terminate_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instances")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -1182,39 +1216,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Downsize Instances
-escalation "esc_downsize_instances" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Downsize Instances"
-  description "Approval to downsize all selected instances"
-  run "esc_downsize_instances", data, rs_governance_host, rs_project_id
-end
-define esc_downsize_instances($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Downsize Instances")
-end
-
-# Escalation for Stop Instances
-escalation "esc_stop_instances" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Stop Instances"
-  description "Approval to stop all selected instances"
-  run "esc_stop_instances", data, rs_governance_host, rs_project_id
-end
-define esc_stop_instances($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Stop Instances")
-end
-
-# Escalation for Terminate Instances
-escalation "esc_terminate_instances" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Terminate Instances"
-  description "Approval to terminate all selected instances"
-  run "esc_terminate_instances", data, rs_governance_host, rs_project_id
-end
-define esc_terminate_instances($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instances")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
@@ -45,6 +45,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -823,8 +824,10 @@ script "js_ds_underutil_instances_combined_incidents", type: "javascript" do
   _.each(ds_child_incident_details, function(incident) {
     s = incident["summary"];
     // If the incident summary contains "AWS Underutilized EC" then include it in the filter result
-    if (s.indexOf("AWS Underutilized EC") > -1) {
+    console.log("s="+s);
+    if (s.toLowerCase().indexOf("aws underutilized ec2 instances found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -843,9 +846,11 @@ script "js_ds_idle_instances_combined_incidents", type: "javascript" do
   result = []
   _.each(ds_child_incident_details, function(incident) {
     s = incident["summary"];
-    // If the incident summary contains "with index data" then include it in the filter result
-    if (s.indexOf("with index data") > -1) {
+    // If the incident summary contains "aws idle ec2 instances found" then include it in the filter result
+    console.log("s="+s);
+    if (s.toLowerCase().indexOf("aws idle ec2 instances found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -862,8 +867,11 @@ policy "policy_scheduled_report" do
   # Consolidated Incident Check(s)
     # Consolidated incident for AWS Underutilized EC
   validate $ds_underutil_instances_combined_incidents do
-    summary_template "Consolidated Incident: {{ len data }} AWS Underutilized EC"
+    summary_template "Consolidated Incident: {{ len data }} AWS Underutilized EC2 Instances Found"
     escalate $esc_email
+    escalate $esc_downsize_instances_child
+    escalate $esc_stop_instances_child
+    escalate $esc_terminate_instances_child
     check eq(size(data), 0)
     export do
       resource_level true
@@ -963,13 +971,19 @@ policy "policy_scheduled_report" do
       field "id" do
         label "ID"
       end
+      field "incident_id" do
+        label "Child Incident ID"
+      end
     end
   end
 
-  # Consolidated incident for with index data
+  # Consolidated incident for AWS Idle EC2 Instances
   validate $ds_idle_instances_combined_incidents do
-    summary_template "Consolidated Incident: {{ len data }} with index data"
+    summary_template "Consolidated Incident: {{ len data }} AWS Idle EC2 Instances Found"
     escalate $esc_email
+    escalate $esc_downsize_instances_child
+    escalate $esc_stop_instances_child
+    escalate $esc_terminate_instances_child
     check eq(size(data), 0)
     export do
       resource_level true
@@ -1065,6 +1079,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "ID"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -1177,6 +1194,181 @@ escalation "esc_email" do
   label "Send Email"
   description "Send incident email"
   email $param_combined_incident_email
+end
+
+# Copied from Child Policy Template
+escalation "esc_downsize_instances_child" do
+  automatic false # Do not automatically escalate, if param is set, the child will handle automatic escalation
+  label "Downsize Instances"
+  description "Approval to downsize all selected instances"
+  run "esc_downsize_instances_child", data, rs_governance_host, rs_project_id
+end
+define esc_downsize_instances_child($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Downsize Instances")
+end
+
+escalation "esc_stop_instances_child" do
+  automatic false # Do not automatically escalate, if param is set, the child will handle automatic escalation
+  label "Stop Instances"
+  description "Approval to stop all selected instances"
+  run "esc_stop_instances_child", data, rs_governance_host, rs_project_id
+end
+define esc_stop_instances_child($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Stop Instances")
+end
+
+escalation "esc_terminate_instances_child" do
+  automatic false # Do not automatically escalate, if param is set, the child will handle automatic escalation
+  label "Terminate Instances"
+  description "Approval to terminate all selected instances"
+  run "esc_terminate_instances_child", data, rs_governance_host, rs_project_id
+end
+define esc_terminate_instances_child($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instances")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+
+      # If we encountered any errors, use `raise` to mark the CWF process as errored
+      if inspect($$errors) != "null"
+        raise join($$errors,"\n")
+      end
+
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 escalation "create_policies" do

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -823,9 +824,8 @@ script "js_ds_underutil_instances_combined_incidents", type: "javascript" do
   result = []
   _.each(ds_child_incident_details, function(incident) {
     s = incident["summary"];
-    // If the incident summary contains "AWS Underutilized EC" then include it in the filter result
-    console.log("s="+s);
-    if (s.toLowerCase().indexOf("aws underutilized ec2 instances found") > -1) {
+    // If the incident summary contains "AWS Underutilized EC2 Instances Found" then include it in the filter result
+    if (s.indexOf("AWS Underutilized EC2 Instances Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
         violation["incident_id"] = incident["id"];
         result.push(violation);
@@ -846,9 +846,8 @@ script "js_ds_idle_instances_combined_incidents", type: "javascript" do
   result = []
   _.each(ds_child_incident_details, function(incident) {
     s = incident["summary"];
-    // If the incident summary contains "aws idle ec2 instances found" then include it in the filter result
-    console.log("s="+s);
-    if (s.toLowerCase().indexOf("aws idle ec2 instances found") > -1) {
+    // If the incident summary contains "AWS Idle EC2 Instances Found" then include it in the filter result
+    if (s.indexOf("AWS Idle EC2 Instances Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
         violation["incident_id"] = incident["id"];
         result.push(violation);
@@ -865,13 +864,11 @@ end
 # Could also just have one incident and use meta_status to determine which escalation happens
 policy "policy_scheduled_report" do
   # Consolidated Incident Check(s)
-    # Consolidated incident for AWS Underutilized EC
+    # Consolidated incident for AWS Underutilized EC2 Instances Found
   validate $ds_underutil_instances_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} AWS Underutilized EC2 Instances Found"
     escalate $esc_email
-    escalate $esc_downsize_instances_child
-    escalate $esc_stop_instances_child
-    escalate $esc_terminate_instances_child
+    escalate $esc_downsize_instances
     check eq(size(data), 0)
     export do
       resource_level true
@@ -977,13 +974,12 @@ policy "policy_scheduled_report" do
     end
   end
 
-  # Consolidated incident for AWS Idle EC2 Instances
+  # Consolidated incident for AWS Idle EC2 Instances Found
   validate $ds_idle_instances_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} AWS Idle EC2 Instances Found"
     escalate $esc_email
-    escalate $esc_downsize_instances_child
-    escalate $esc_stop_instances_child
-    escalate $esc_terminate_instances_child
+    escalate $esc_stop_instances
+    escalate $esc_terminate_instances
     check eq(size(data), 0)
     export do
       resource_level true
@@ -1188,42 +1184,36 @@ EOS
   end
 end
 
-# Used only for emailing the combined child incident if so desired
-escalation "esc_email" do
-  automatic true
-  label "Send Email"
-  description "Send incident email"
-  email $param_combined_incident_email
-end
-
-# Copied from Child Policy Template
-escalation "esc_downsize_instances_child" do
-  automatic false # Do not automatically escalate, if param is set, the child will handle automatic escalation
+# Escalation for Downsize Instances
+escalation "esc_downsize_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
   label "Downsize Instances"
   description "Approval to downsize all selected instances"
-  run "esc_downsize_instances_child", data, rs_governance_host, rs_project_id
+  run "esc_downsize_instances", data, rs_governance_host, rs_project_id
 end
-define esc_downsize_instances_child($data, $governance_host, $rs_project_id) do
+define esc_downsize_instances($data, $governance_host, $rs_project_id) do
   call child_run_action($data, $governance_host, $rs_project_id, "Downsize Instances")
 end
 
-escalation "esc_stop_instances_child" do
-  automatic false # Do not automatically escalate, if param is set, the child will handle automatic escalation
+# Escalation for Stop Instances
+escalation "esc_stop_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
   label "Stop Instances"
   description "Approval to stop all selected instances"
-  run "esc_stop_instances_child", data, rs_governance_host, rs_project_id
+  run "esc_stop_instances", data, rs_governance_host, rs_project_id
 end
-define esc_stop_instances_child($data, $governance_host, $rs_project_id) do
+define esc_stop_instances($data, $governance_host, $rs_project_id) do
   call child_run_action($data, $governance_host, $rs_project_id, "Stop Instances")
 end
 
-escalation "esc_terminate_instances_child" do
-  automatic false # Do not automatically escalate, if param is set, the child will handle automatic escalation
+# Escalation for Terminate Instances
+escalation "esc_terminate_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
   label "Terminate Instances"
   description "Approval to terminate all selected instances"
-  run "esc_terminate_instances_child", data, rs_governance_host, rs_project_id
+  run "esc_terminate_instances", data, rs_governance_host, rs_project_id
 end
-define esc_terminate_instances_child($data, $governance_host, $rs_project_id) do
+define esc_terminate_instances($data, $governance_host, $rs_project_id) do
   call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instances")
 end
 
@@ -1256,6 +1246,11 @@ define child_run_action($data, $governance_host, $rs_project_id, $action_label) 
   $$debug_incidents = to_json($incidents)
 
   call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
 
   # If we made it here, all actions completed successfully
   # Celebrate Success!
@@ -1347,12 +1342,6 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id) d
           raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
         end
       end
-
-      # If we encountered any errors, use `raise` to mark the CWF process as errored
-      if inspect($$errors) != "null"
-        raise join($$errors,"\n")
-      end
-
       # If we made it here, the action completed successfully
       task_label("action_status=\""+$action_status+"\" Action completed successfully")
     end
@@ -1369,6 +1358,14 @@ define handle_error() do
   # We check for errors at the end, and raise them all together
   # Skip errors handled by this definition
   $_error_behavior = "skip"
+end
+
+# Used only for emailing the combined child incident if so desired
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_combined_incident_email
 end
 
 escalation "create_policies" do

--- a/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check_meta_parent.pt
+++ b/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -719,6 +721,7 @@ script "js_ds_combined_bucket_info_combined_incidents", type: "javascript" do
     // If the incident summary contains "Buckets found without intelligent tiering policies" then include it in the filter result
     if (s.indexOf("Buckets found without intelligent tiering policies") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -737,6 +740,7 @@ policy "policy_scheduled_report" do
   validate $ds_combined_bucket_info_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Buckets found without intelligent tiering policies"
     escalate $esc_email
+    
     check eq(size(data), 0)
     export do
       resource_level true
@@ -751,6 +755,9 @@ policy "policy_scheduled_report" do
       end
       field "tagKeyValue" do
         label "Tags"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -855,6 +862,150 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check_meta_parent.pt
+++ b/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check_meta_parent.pt
@@ -730,6 +730,8 @@ EOS
 end
 
 
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -863,7 +865,6 @@ EOS
     check eq(size(data),0)
   end
 end
-
 
 # Begin Shared Functions for Child Actions from Consolidated Incident
 define groupByIncidentID($data) return $incidents do

--- a/cost/aws/schedule_instance/aws_schedule_instance.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance.pt
@@ -57,6 +57,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Schedule Instances"]
+  default []
 end
 
 ###############################################################################

--- a/cost/aws/schedule_instance/aws_schedule_instance_meta_parent.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -740,6 +742,7 @@ script "js_ds_filter_resources_combined_incidents", type: "javascript" do
     // If the incident summary contains "Schedule Instance list" then include it in the filter result
     if (s.indexOf("Schedule Instance list") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -758,6 +761,10 @@ policy "policy_scheduled_report" do
   validate $ds_filter_resources_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Schedule Instance list"
     escalate $esc_email
+    escalate $esc_schedule_instance
+    escalate $esc_terminate_instance
+    escalate $esc_update_schedule
+    escalate $esc_delete_schedule
     check eq(size(data), 0)
     export do
       resource_level true
@@ -778,6 +785,9 @@ policy "policy_scheduled_report" do
       end
       field "tags" do
         label "Tags"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -882,6 +892,193 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Schedule
+escalation "esc_schedule_instance" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Schedule"
+  description "Stop or Start the Instance"
+  run "esc_schedule_instance", data, rs_governance_host, rs_project_id
+end
+define esc_schedule_instance($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Schedule")
+end
+
+# Escalation for Terminate Instance
+escalation "esc_terminate_instance" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Terminate Instance"
+  description "Terminate or delete the Instance"
+  run "esc_terminate_instance", data, rs_governance_host, rs_project_id
+end
+define esc_terminate_instance($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instance")
+end
+
+# Escalation for Update Schedule
+escalation "esc_update_schedule" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Update Schedule"
+  description "Update the existing schedule Tag"
+  run "esc_update_schedule", data, rs_governance_host, rs_project_id
+end
+define esc_update_schedule($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Update Schedule")
+end
+
+# Escalation for Delete Schedule
+escalation "esc_delete_schedule" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Schedule"
+  description "Delete Schedule Tag"
+  run "esc_delete_schedule", data, rs_governance_host, rs_project_id
+end
+define esc_delete_schedule($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Schedule")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/aws/schedule_instance/aws_schedule_instance_meta_parent.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance_meta_parent.pt
@@ -92,6 +92,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Schedule Instances"]
+  default []
 end
 
 ###############################################################################

--- a/cost/aws/schedule_instance/aws_schedule_instance_meta_parent.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance_meta_parent.pt
@@ -751,6 +751,51 @@ EOS
 end
 
 
+# Escalation for Schedule
+escalation "esc_schedule_instance" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Schedule"
+  description "Stop or Start the Instance"
+  run "esc_schedule_instance", data, rs_governance_host, rs_project_id
+end
+define esc_schedule_instance($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Schedule")
+end
+
+# Escalation for Terminate Instance
+escalation "esc_terminate_instance" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Terminate Instance"
+  description "Terminate or delete the Instance"
+  run "esc_terminate_instance", data, rs_governance_host, rs_project_id
+end
+define esc_terminate_instance($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instance")
+end
+
+# Escalation for Update Schedule
+escalation "esc_update_schedule" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Update Schedule"
+  description "Update the existing schedule Tag"
+  run "esc_update_schedule", data, rs_governance_host, rs_project_id
+end
+define esc_update_schedule($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Update Schedule")
+end
+
+# Escalation for Delete Schedule
+escalation "esc_delete_schedule" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Schedule"
+  description "Delete Schedule Tag"
+  run "esc_delete_schedule", data, rs_governance_host, rs_project_id
+end
+define esc_delete_schedule($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Schedule")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -892,50 +937,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Schedule
-escalation "esc_schedule_instance" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Schedule"
-  description "Stop or Start the Instance"
-  run "esc_schedule_instance", data, rs_governance_host, rs_project_id
-end
-define esc_schedule_instance($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Schedule")
-end
-
-# Escalation for Terminate Instance
-escalation "esc_terminate_instance" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Terminate Instance"
-  description "Terminate or delete the Instance"
-  run "esc_terminate_instance", data, rs_governance_host, rs_project_id
-end
-define esc_terminate_instance($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instance")
-end
-
-# Escalation for Update Schedule
-escalation "esc_update_schedule" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Update Schedule"
-  description "Update the existing schedule Tag"
-  run "esc_update_schedule", data, rs_governance_host, rs_project_id
-end
-define esc_update_schedule($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Update Schedule")
-end
-
-# Escalation for Delete Schedule
-escalation "esc_delete_schedule" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Delete Schedule"
-  description "Delete Schedule Tag"
-  run "esc_delete_schedule", data, rs_governance_host, rs_project_id
-end
-define esc_delete_schedule($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Delete Schedule")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
@@ -777,6 +777,18 @@ EOS
 end
 
 
+# Escalation for Change Instance Type
+escalation "esc_change_type" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Change Instance Type"
+  description "Approval to change instance type for all superseded EC2 instances"
+  run "esc_change_type", data, rs_governance_host, rs_project_id
+end
+define esc_change_type($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Change Instance Type")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -960,17 +972,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Change Instance Type
-escalation "esc_change_type" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Change Instance Type"
-  description "Approval to change instance type for all superseded EC2 instances"
-  run "esc_change_type", data, rs_governance_host, rs_project_id
-end
-define esc_change_type($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Change Instance Type")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -763,9 +765,10 @@ script "js_ds_superseded_instances_combined_incidents", type: "javascript" do
   result = []
   _.each(ds_child_incident_details, function(incident) {
     s = incident["summary"];
-    // If the incident summary contains "AWS Potentially Superseded EC" then include it in the filter result
-    if (s.indexOf("AWS Potentially Superseded EC") > -1) {
+    // If the incident summary contains "AWS Potentially Superseded EC2 Instances Found" then include it in the filter result
+    if (s.indexOf("AWS Potentially Superseded EC2 Instances Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -780,10 +783,11 @@ end
 # Could also just have one incident and use meta_status to determine which escalation happens
 policy "policy_scheduled_report" do
   # Consolidated Incident Check(s)
-    # Consolidated incident for AWS Potentially Superseded EC
+    # Consolidated incident for AWS Potentially Superseded EC2 Instances Found
   validate $ds_superseded_instances_combined_incidents do
-    summary_template "Consolidated Incident: {{ len data }} AWS Potentially Superseded EC"
+    summary_template "Consolidated Incident: {{ len data }} AWS Potentially Superseded EC2 Instances Found"
     escalate $esc_email
+    escalate $esc_change_type
     check eq(size(data), 0)
     export do
       resource_level true
@@ -849,6 +853,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "ID"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -953,6 +960,160 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Change Instance Type
+escalation "esc_change_type" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Change Instance Type"
+  description "Approval to change instance type for all superseded EC2 instances"
+  run "esc_change_type", data, rs_governance_host, rs_project_id
+end
+define esc_change_type($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Change Instance Type")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -778,7 +779,7 @@ policy "policy_scheduled_report" do
   validate $ds_ip_cost_mapping_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} AWS Unused IP Addresses Found"
     escalate $esc_email
-    escalate $child_esc_release_ip_address
+    escalate $esc_release_ip_address
     check eq(size(data), 0)
     export do
       resource_level true
@@ -834,7 +835,7 @@ policy "policy_scheduled_report" do
         label "ID"
       end
       field "incident_id" do
-        label "incident_id"
+        label "Child Incident ID"
       end
     end
   end
@@ -941,17 +942,18 @@ EOS
   end
 end
 
-escalation "child_esc_release_ip_address" do
-  automatic true # true always for dev only
-  label "Release IP Address"
-  description "Release IP Address"
-  run "child_esc_release_ip_address", data, rs_governance_host, rs_project_id
+# Escalation for Release Unused IP Addresses
+escalation "esc_release_ip_address" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Release Unused IP Addresses"
+  description "Approval to release all selected IP addresses"
+  run "esc_release_ip_address", data, rs_governance_host, rs_project_id
 end
-
-define child_esc_release_ip_address($data, $governance_host, $rs_project_id) do
+define esc_release_ip_address($data, $governance_host, $rs_project_id) do
   call child_run_action($data, $governance_host, $rs_project_id, "Release Unused IP Addresses")
 end
 
+# Begin Shared Functions for Child Actions from Consolidated Incident
 define groupByIncidentID($data) return $incidents do
   # Empty hash to store incidents is incident_id
   $incidents = {}
@@ -980,6 +982,11 @@ define child_run_action($data, $governance_host, $rs_project_id, $action_label) 
   $$debug_incidents = to_json($incidents)
 
   call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
 
   # If we made it here, all actions completed successfully
   # Celebrate Success!
@@ -1012,6 +1019,9 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id) d
         if $action["label"] == $action_label
           $action_id = $action["id"]
         end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
       end
       # Now we are reach to trigger the action
       $request = {
@@ -1068,17 +1078,12 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id) d
           raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
         end
       end
-
-      # If we encountered any errors, use `raise` to mark the CWF process as errored
-      if inspect($$errors) != "null"
-        raise join($$errors,"\n")
-      end
-
       # If we made it here, the action completed successfully
       task_label("action_status=\""+$action_status+"\" Action completed successfully")
     end
   end
 end
+# End Shared Functions for Child Actions from Consolidated Incident
 
 # CWF function to handle errors
 define handle_error() do

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
@@ -769,6 +769,18 @@ EOS
 end
 
 
+# Escalation for Release Unused IP Addresses
+escalation "esc_release_ip_address" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Release Unused IP Addresses"
+  description "Approval to release all selected IP addresses"
+  run "esc_release_ip_address", data, rs_governance_host, rs_project_id
+end
+define esc_release_ip_address($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Release Unused IP Addresses")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -940,17 +952,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Release Unused IP Addresses
-escalation "esc_release_ip_address" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Release Unused IP Addresses"
-  description "Approval to release all selected IP addresses"
-  run "esc_release_ip_address", data, rs_governance_host, rs_project_id
-end
-define esc_release_ip_address($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Release Unused IP Addresses")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
@@ -45,6 +45,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -758,6 +759,7 @@ script "js_ds_ip_cost_mapping_combined_incidents", type: "javascript" do
     // If the incident summary contains "AWS Unused IP Addresses Found" then include it in the filter result
     if (s.indexOf("AWS Unused IP Addresses Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -776,6 +778,7 @@ policy "policy_scheduled_report" do
   validate $ds_ip_cost_mapping_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} AWS Unused IP Addresses Found"
     escalate $esc_email
+    escalate $child_esc_release_ip_address
     check eq(size(data), 0)
     export do
       resource_level true
@@ -829,6 +832,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "ID"
+      end
+      field "incident_id" do
+        label "incident_id"
       end
     end
   end
@@ -933,6 +939,156 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+escalation "child_esc_release_ip_address" do
+  automatic true # true always for dev only
+  label "Release IP Address"
+  description "Release IP Address"
+  run "child_esc_release_ip_address", data, rs_governance_host, rs_project_id
+end
+
+define child_esc_release_ip_address($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Release Unused IP Addresses")
+end
+
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+
+      # If we encountered any errors, use `raise` to mark the CWF process as errored
+      if inspect($$errors) != "null"
+        raise join($$errors,"\n")
+      end
+
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/aws/unused_rds/unused_rds.pt
+++ b/cost/aws/unused_rds/unused_rds.pt
@@ -85,6 +85,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Terminate Instances"]
+  default []
 end
 
 ###############################################################################

--- a/cost/aws/unused_rds/unused_rds_meta_parent.pt
+++ b/cost/aws/unused_rds/unused_rds_meta_parent.pt
@@ -776,6 +776,18 @@ EOS
 end
 
 
+# Escalation for Terminate RDS Instances
+escalation "esc_terminate_rds" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Terminate RDS Instances"
+  description "Terminate selected RDS Instances"
+  run "esc_terminate_rds", data, rs_governance_host, rs_project_id
+end
+define esc_terminate_rds($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Terminate RDS Instances")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -950,17 +962,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Terminate RDS Instances
-escalation "esc_terminate_rds" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Terminate RDS Instances"
-  description "Terminate selected RDS Instances"
-  run "esc_terminate_rds", data, rs_governance_host, rs_project_id
-end
-define esc_terminate_rds($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Terminate RDS Instances")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/aws/unused_rds/unused_rds_meta_parent.pt
+++ b/cost/aws/unused_rds/unused_rds_meta_parent.pt
@@ -117,6 +117,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Terminate Instances"]
+  default []
 end
 
 ###############################################################################

--- a/cost/aws/unused_rds/unused_rds_meta_parent.pt
+++ b/cost/aws/unused_rds/unused_rds_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -765,6 +767,7 @@ script "js_ds_instance_cost_mapping_combined_incidents", type: "javascript" do
     // If the incident summary contains "AWS Unused RDS Instances Found" then include it in the filter result
     if (s.indexOf("AWS Unused RDS Instances Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -783,6 +786,7 @@ policy "policy_scheduled_report" do
   validate $ds_instance_cost_mapping_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} AWS Unused RDS Instances Found"
     escalate $esc_email
+    escalate $esc_terminate_rds
     check eq(size(data), 0)
     export do
       resource_level true
@@ -839,6 +843,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "id"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -943,6 +950,160 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Terminate RDS Instances
+escalation "esc_terminate_rds" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Terminate RDS Instances"
+  description "Terminate selected RDS Instances"
+  run "esc_terminate_rds", data, rs_governance_host, rs_project_id
+end
+define esc_terminate_rds($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Terminate RDS Instances")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -784,6 +786,7 @@ script "js_ds_volume_cost_mapping_combined_incidents", type: "javascript" do
     // If the incident summary contains "Unused Volumes Found" then include it in the filter result
     if (s.indexOf("Unused Volumes Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -802,6 +805,7 @@ policy "policy_scheduled_report" do
   validate $ds_volume_cost_mapping_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Unused Volumes Found"
     escalate $esc_email
+    escalate $esc_delete_volumes
     check eq(size(data), 0)
     export do
       resource_level true
@@ -852,6 +856,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "ID"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -956,6 +963,160 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Delete Volumes
+escalation "esc_delete_volumes" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Volumes"
+  description "Approval to terminate all selected instances"
+  run "esc_delete_volumes", data, rs_governance_host, rs_project_id
+end
+define esc_delete_volumes($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Volumes")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
@@ -795,6 +795,18 @@ EOS
 end
 
 
+# Escalation for Delete Volumes
+escalation "esc_delete_volumes" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Volumes"
+  description "Approval to terminate all selected instances"
+  run "esc_delete_volumes", data, rs_governance_host, rs_project_id
+end
+define esc_delete_volumes($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Volumes")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -963,17 +975,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Delete Volumes
-escalation "esc_delete_volumes" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Delete Volumes"
-  description "Approval to terminate all selected instances"
-  run "esc_delete_volumes", data, rs_governance_host, rs_project_id
-end
-define esc_delete_volumes($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Delete Volumes")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit.pt
@@ -93,6 +93,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action."
   allowed_values ["Apply Hybrid Use Benefit"]
+  default []
 end
 
 ###############################################################################

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
@@ -784,6 +784,18 @@ EOS
 end
 
 
+# Escalation for Apply Hybrid Use Benefit
+escalation "esc_license_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Apply Hybrid Use Benefit"
+  description "Apply Hybrid Use Benefit to the selected instances"
+  run "esc_license_instances", data, rs_governance_host, rs_project_id
+end
+define esc_license_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Apply Hybrid Use Benefit")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -961,17 +973,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Apply Hybrid Use Benefit
-escalation "esc_license_instances" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Apply Hybrid Use Benefit"
-  description "Apply Hybrid Use Benefit to the selected instances"
-  run "esc_license_instances", data, rs_governance_host, rs_project_id
-end
-define esc_license_instances($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Apply Hybrid Use Benefit")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -773,6 +775,7 @@ script "js_ds_ahub_recommendations_combined_incidents", type: "javascript" do
     // If the incident summary contains "Azure Windows Virtual Machines Without Hybrid Use Benefit Found" then include it in the filter result
     if (s.indexOf("Azure Windows Virtual Machines Without Hybrid Use Benefit Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -791,6 +794,7 @@ policy "policy_scheduled_report" do
   validate $ds_ahub_recommendations_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Azure Windows Virtual Machines Without Hybrid Use Benefit Found"
     escalate $esc_email
+    escalate $esc_license_instances
     check eq(size(data), 0)
     export do
       resource_level true
@@ -850,6 +854,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "ID"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -954,6 +961,160 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Apply Hybrid Use Benefit
+escalation "esc_license_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Apply Hybrid Use Benefit"
+  description "Apply Hybrid Use Benefit to the selected instances"
+  run "esc_license_instances", data, rs_governance_host, rs_project_id
+end
+define esc_license_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Apply Hybrid Use Benefit")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
@@ -116,6 +116,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action."
   allowed_values ["Apply Hybrid Use Benefit"]
+  default []
 end
 
 ###############################################################################

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux.pt
@@ -83,6 +83,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action."
   allowed_values ["Apply Hybrid Use Benefit"]
+  default []
 end
 
 ###############################################################################

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
@@ -107,6 +107,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action."
   allowed_values ["Apply Hybrid Use Benefit"]
+  default []
 end
 
 ###############################################################################

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -764,6 +766,7 @@ script "js_ds_ahub_recommendations_combined_incidents", type: "javascript" do
     // If the incident summary contains "Azure Linux Virtual Machines Without Hybrid Use Benefit Found" then include it in the filter result
     if (s.indexOf("Azure Linux Virtual Machines Without Hybrid Use Benefit Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -782,6 +785,7 @@ policy "policy_scheduled_report" do
   validate $ds_ahub_recommendations_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Azure Linux Virtual Machines Without Hybrid Use Benefit Found"
     escalate $esc_email
+    escalate $esc_license_instances
     check eq(size(data), 0)
     export do
       resource_level true
@@ -838,6 +842,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "ID"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -942,6 +949,160 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Apply Hybrid Use Benefit
+escalation "esc_license_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Apply Hybrid Use Benefit"
+  description "Apply Hybrid Use Benefit to the selected instances"
+  run "esc_license_instances", data, rs_governance_host, rs_project_id
+end
+define esc_license_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Apply Hybrid Use Benefit")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
@@ -775,6 +775,18 @@ EOS
 end
 
 
+# Escalation for Apply Hybrid Use Benefit
+escalation "esc_license_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Apply Hybrid Use Benefit"
+  description "Apply Hybrid Use Benefit to the selected instances"
+  run "esc_license_instances", data, rs_governance_host, rs_project_id
+end
+define esc_license_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Apply Hybrid Use Benefit")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -949,17 +961,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Apply Hybrid Use Benefit
-escalation "esc_license_instances" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Apply Hybrid Use Benefit"
-  description "Apply Hybrid Use Benefit to the selected instances"
-  run "esc_license_instances", data, rs_governance_host, rs_project_id
-end
-define esc_license_instances($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Apply Hybrid Use Benefit")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql.pt
@@ -48,6 +48,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values "Hybrid use benefit for SQL"
+  default []
 end
 
 ###############################################################################

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
@@ -754,6 +754,18 @@ EOS
 end
 
 
+# Escalation for Approve AHUB for SQL
+escalation "esc_license_sqlahub" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Approve AHUB for SQL"
+  description "Approve escalation to apply Hybrid Use Benefit for SQL"
+  run "esc_license_sqlahub", data, rs_governance_host, rs_project_id
+end
+define esc_license_sqlahub($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Approve AHUB for SQL")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -913,17 +925,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Approve AHUB for SQL
-escalation "esc_license_sqlahub" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Approve AHUB for SQL"
-  description "Approve escalation to apply Hybrid Use Benefit for SQL"
-  run "esc_license_sqlahub", data, rs_governance_host, rs_project_id
-end
-define esc_license_sqlahub($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Approve AHUB for SQL")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
@@ -86,6 +86,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values "Hybrid use benefit for SQL"
+  default []
 end
 
 ###############################################################################

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -743,6 +745,7 @@ script "js_ds_filtered_instances_combined_incidents", type: "javascript" do
     // If the incident summary contains "Instances Not Using Azure Hybrid Use Benefit for SQL" then include it in the filter result
     if (s.indexOf("Instances Not Using Azure Hybrid Use Benefit for SQL") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -761,6 +764,7 @@ policy "policy_scheduled_report" do
   validate $ds_filtered_instances_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Instances Not Using Azure Hybrid Use Benefit for SQL"
     escalate $esc_email
+    escalate $esc_license_sqlahub
     check eq(size(data), 0)
     export do
       resource_level true
@@ -802,6 +806,9 @@ policy "policy_scheduled_report" do
       end
       field "vmid" do
         label "VirtualMachineResourceId"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -906,6 +913,160 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Approve AHUB for SQL
+escalation "esc_license_sqlahub" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Approve AHUB for SQL"
+  description "Approve escalation to apply Hybrid Use Benefit for SQL"
+  run "esc_license_sqlahub", data, rs_governance_host, rs_project_id
+end
+define esc_license_sqlahub($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Approve AHUB for SQL")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances.pt
@@ -61,6 +61,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Terminate Instances"]
+  default []
 end
 
 parameter "param_log_to_cm_audit_entries" do

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
@@ -771,6 +771,18 @@ EOS
 end
 
 
+# Escalation for Terminate Instances
+escalation "esc_delete_resources" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Terminate Instances"
+  description "Approval to terminate all selected instances"
+  run "esc_delete_resources", data, rs_governance_host, rs_project_id
+end
+define esc_delete_resources($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instances")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -942,17 +954,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Terminate Instances
-escalation "esc_delete_resources" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Terminate Instances"
-  description "Approval to terminate all selected instances"
-  run "esc_delete_resources", data, rs_governance_host, rs_project_id
-end
-define esc_delete_resources($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instances")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
@@ -95,6 +95,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Terminate Instances"]
+  default []
 end
 
 parameter "param_log_to_cm_audit_entries" do

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -760,6 +762,7 @@ script "js_ds_only_instances_combined_incidents", type: "javascript" do
     // If the incident summary contains "Azure idle compute instances found" then include it in the filter result
     if (s.indexOf("Azure idle compute instances found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -778,6 +781,7 @@ policy "policy_scheduled_report" do
   validate $ds_only_instances_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Azure idle compute instances found"
     escalate $esc_email
+    escalate $esc_delete_resources
     check eq(size(data), 0)
     export do
       resource_level true
@@ -831,6 +835,9 @@ policy "policy_scheduled_report" do
       end
       field "resourceType" do
         label "Resource Type"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -935,6 +942,160 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Terminate Instances
+escalation "esc_delete_resources" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Terminate Instances"
+  description "Approval to terminate all selected instances"
+  run "esc_delete_resources", data, rs_governance_host, rs_project_id
+end
+define esc_delete_resources($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instances")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/azure/instances_log_analytics_utilization/azure_instance_log_analytics_utilization.pt
+++ b/cost/azure/instances_log_analytics_utilization/azure_instance_log_analytics_utilization.pt
@@ -67,6 +67,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Downsize Instances"]
+  default []
 end
 
 parameter "param_log_to_cm_audit_entries" do

--- a/cost/azure/object_storage_optimization/azure_object_storage_optimization.pt
+++ b/cost/azure/object_storage_optimization/azure_object_storage_optimization.pt
@@ -47,6 +47,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Modify Blob storage"]
+  default []
 end
 
 ###############################################################################

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots.pt
@@ -101,6 +101,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action."
   allowed_values ["Delete Snapshots"]
+  default []
 end
 
 ###############################################################################

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
@@ -793,6 +793,18 @@ EOS
 end
 
 
+# Escalation for Delete Snapshots
+escalation "esc_delete_snapshot" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Snapshots"
+  description "Approval to delete all selected snapshots"
+  run "esc_delete_snapshot", data, rs_governance_host, rs_project_id
+end
+define esc_delete_snapshot($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Snapshots")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -961,17 +973,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Delete Snapshots
-escalation "esc_delete_snapshot" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Delete Snapshots"
-  description "Approval to delete all selected snapshots"
-  run "esc_delete_snapshot", data, rs_governance_host, rs_project_id
-end
-define esc_delete_snapshot($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Delete Snapshots")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -782,6 +784,7 @@ script "js_ds_azure_snapshots_incident_combined_incidents", type: "javascript" d
     // If the incident summary contains "Azure Old Snapshots Found" then include it in the filter result
     if (s.indexOf("Azure Old Snapshots Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -800,6 +803,7 @@ policy "policy_scheduled_report" do
   validate $ds_azure_snapshots_incident_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Azure Old Snapshots Found"
     escalate $esc_email
+    escalate $esc_delete_snapshot
     check eq(size(data), 0)
     export do
       resource_level true
@@ -850,6 +854,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "ID"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -954,6 +961,160 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Delete Snapshots
+escalation "esc_delete_snapshot" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Snapshots"
+  description "Approval to delete all selected snapshots"
+  run "esc_delete_snapshot", data, rs_governance_host, rs_project_id
+end
+define esc_delete_snapshot($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Snapshots")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
@@ -125,6 +125,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action."
   allowed_values ["Delete Snapshots"]
+  default []
 end
 
 ###############################################################################

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -842,6 +844,7 @@ script "js_ds_underutilized_instances_combined_incidents", type: "javascript" do
     // If the incident summary contains "Azure Underutilized Virtual Machines Found" then include it in the filter result
     if (s.indexOf("Azure Underutilized Virtual Machines Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -863,6 +866,7 @@ script "js_ds_idle_instances_combined_incidents", type: "javascript" do
     // If the incident summary contains "Azure Idle Virtual Machines Found" then include it in the filter result
     if (s.indexOf("Azure Idle Virtual Machines Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -881,6 +885,7 @@ policy "policy_scheduled_report" do
   validate $ds_underutilized_instances_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Azure Underutilized Virtual Machines Found"
     escalate $esc_email
+    escalate $esc_downsize_instances
     check eq(size(data), 0)
     export do
       resource_level true
@@ -962,6 +967,9 @@ policy "policy_scheduled_report" do
       field "id" do
         label "ID"
       end
+      field "incident_id" do
+        label "Child Incident ID"
+      end
     end
   end
 
@@ -969,6 +977,7 @@ policy "policy_scheduled_report" do
   validate $ds_idle_instances_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Azure Idle Virtual Machines Found"
     escalate $esc_email
+    escalate $esc_delete_instances
     check eq(size(data), 0)
     export do
       resource_level true
@@ -1046,6 +1055,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "ID"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -1150,6 +1162,171 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Downsize Instances
+escalation "esc_downsize_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Downsize Instances"
+  description "Approval to downsize all selected instances"
+  run "esc_downsize_instances", data, rs_governance_host, rs_project_id
+end
+define esc_downsize_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Downsize Instances")
+end
+
+# Escalation for Delete Instances
+escalation "esc_delete_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Instances"
+  description "Approval to delete all selected instances"
+  run "esc_delete_instances", data, rs_governance_host, rs_project_id
+end
+define esc_delete_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Instances")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
@@ -875,6 +875,29 @@ EOS
 end
 
 
+# Escalation for Downsize Instances
+escalation "esc_downsize_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Downsize Instances"
+  description "Approval to downsize all selected instances"
+  run "esc_downsize_instances", data, rs_governance_host, rs_project_id
+end
+define esc_downsize_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Downsize Instances")
+end
+
+# Escalation for Delete Instances
+escalation "esc_delete_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Instances"
+  description "Approval to delete all selected instances"
+  run "esc_delete_instances", data, rs_governance_host, rs_project_id
+end
+define esc_delete_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Instances")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -1162,28 +1185,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Downsize Instances
-escalation "esc_downsize_instances" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Downsize Instances"
-  description "Approval to downsize all selected instances"
-  run "esc_downsize_instances", data, rs_governance_host, rs_project_id
-end
-define esc_downsize_instances($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Downsize Instances")
-end
-
-# Escalation for Delete Instances
-escalation "esc_delete_instances" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Delete Instances"
-  description "Approval to delete all selected instances"
-  run "esc_delete_instances", data, rs_governance_host, rs_project_id
-end
-define esc_delete_instances($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Delete Instances")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
@@ -836,6 +836,29 @@ EOS
 end
 
 
+# Escalation for Downsize Underutilized Instances
+escalation "esc_downsize_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Downsize Underutilized Instances"
+  description "Approval to downsize all selected underutilized instances"
+  run "esc_downsize_instances", data, rs_governance_host, rs_project_id
+end
+define esc_downsize_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Downsize Underutilized Instances")
+end
+
+# Escalation for Delete Unused Instances
+escalation "esc_delete_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Unused Instances"
+  description "Approval to delete all selected unused instances"
+  run "esc_delete_instances", data, rs_governance_host, rs_project_id
+end
+define esc_delete_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Unused Instances")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -1087,28 +1110,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Downsize Underutilized Instances
-escalation "esc_downsize_instances" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Downsize Underutilized Instances"
-  description "Approval to downsize all selected underutilized instances"
-  run "esc_downsize_instances", data, rs_governance_host, rs_project_id
-end
-define esc_downsize_instances($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Downsize Underutilized Instances")
-end
-
-# Escalation for Delete Unused Instances
-escalation "esc_delete_instances" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Delete Unused Instances"
-  description "Approval to delete all selected unused instances"
-  run "esc_delete_instances", data, rs_governance_host, rs_project_id
-end
-define esc_delete_instances($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Delete Unused Instances")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -803,6 +805,7 @@ script "js_ds_downsize_sql_incident_combined_incidents", type: "javascript" do
     // If the incident summary contains "Azure Underutilized SQL Databases Found" then include it in the filter result
     if (s.indexOf("Azure Underutilized SQL Databases Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -824,6 +827,7 @@ script "js_ds_unused_sql_incident_combined_incidents", type: "javascript" do
     // If the incident summary contains "Azure Unused SQL Databases Found" then include it in the filter result
     if (s.indexOf("Azure Unused SQL Databases Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -842,6 +846,7 @@ policy "policy_scheduled_report" do
   validate $ds_downsize_sql_incident_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Azure Underutilized SQL Databases Found"
     escalate $esc_email
+    escalate $esc_downsize_instances
     check eq(size(data), 0)
     export do
       resource_level true
@@ -908,6 +913,9 @@ policy "policy_scheduled_report" do
       field "lookbackPeriod" do
         label "Lookback Period"
       end
+      field "incident_id" do
+        label "Child Incident ID"
+      end
     end
   end
 
@@ -915,6 +923,7 @@ policy "policy_scheduled_report" do
   validate $ds_unused_sql_incident_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Azure Unused SQL Databases Found"
     escalate $esc_email
+    escalate $esc_delete_instances
     check eq(size(data), 0)
     export do
       resource_level true
@@ -971,6 +980,9 @@ policy "policy_scheduled_report" do
       end
       field "lookbackPeriod" do
         label "Lookback Period"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -1075,6 +1087,171 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Downsize Underutilized Instances
+escalation "esc_downsize_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Downsize Underutilized Instances"
+  description "Approval to downsize all selected underutilized instances"
+  run "esc_downsize_instances", data, rs_governance_host, rs_project_id
+end
+define esc_downsize_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Downsize Underutilized Instances")
+end
+
+# Escalation for Delete Unused Instances
+escalation "esc_delete_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Unused Instances"
+  description "Approval to delete all selected unused instances"
+  run "esc_delete_instances", data, rs_governance_host, rs_project_id
+end
+define esc_delete_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Unused Instances")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/azure/schedule_instance/azure_schedule_instance.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance.pt
@@ -48,6 +48,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions(s)"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Schedule Instances"]
+  default []
 end
 
 ###############################################################################

--- a/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -742,6 +744,7 @@ script "js_ds_filter_instances_combined_incidents", type: "javascript" do
     // If the incident summary contains "Azure Schedule Instance list" then include it in the filter result
     if (s.indexOf("Azure Schedule Instance list") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -760,6 +763,10 @@ policy "policy_scheduled_report" do
   validate $ds_filter_instances_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Azure Schedule Instance list"
     escalate $esc_email
+    escalate $esc_schedule_instance
+    escalate $esc_terminate_instance
+    escalate $esc_update_schedule
+    escalate $esc_delete_schedule
     check eq(size(data), 0)
     export do
       resource_level true
@@ -792,6 +799,9 @@ policy "policy_scheduled_report" do
       end
       field "tags" do
         label "Tags Object"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -896,6 +906,193 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Schedule
+escalation "esc_schedule_instance" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Schedule"
+  description "Stop or Start the Instance"
+  run "esc_schedule_instance", data, rs_governance_host, rs_project_id
+end
+define esc_schedule_instance($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Schedule")
+end
+
+# Escalation for Terminate Instance
+escalation "esc_terminate_instance" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Terminate Instance"
+  description "Terminate or delete the Instance"
+  run "esc_terminate_instance", data, rs_governance_host, rs_project_id
+end
+define esc_terminate_instance($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instance")
+end
+
+# Escalation for Update Schedule
+escalation "esc_update_schedule" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Update Schedule"
+  description "Update the existing schedule Tag"
+  run "esc_update_schedule", data, rs_governance_host, rs_project_id
+end
+define esc_update_schedule($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Update Schedule")
+end
+
+# Escalation for Delete Schedule
+escalation "esc_delete_schedule" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Schedule"
+  description "Delete Schedule Tag"
+  run "esc_delete_schedule", data, rs_governance_host, rs_project_id
+end
+define esc_delete_schedule($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Schedule")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
@@ -753,6 +753,51 @@ EOS
 end
 
 
+# Escalation for Schedule
+escalation "esc_schedule_instance" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Schedule"
+  description "Stop or Start the Instance"
+  run "esc_schedule_instance", data, rs_governance_host, rs_project_id
+end
+define esc_schedule_instance($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Schedule")
+end
+
+# Escalation for Terminate Instance
+escalation "esc_terminate_instance" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Terminate Instance"
+  description "Terminate or delete the Instance"
+  run "esc_terminate_instance", data, rs_governance_host, rs_project_id
+end
+define esc_terminate_instance($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instance")
+end
+
+# Escalation for Update Schedule
+escalation "esc_update_schedule" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Update Schedule"
+  description "Update the existing schedule Tag"
+  run "esc_update_schedule", data, rs_governance_host, rs_project_id
+end
+define esc_update_schedule($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Update Schedule")
+end
+
+# Escalation for Delete Schedule
+escalation "esc_delete_schedule" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Schedule"
+  description "Delete Schedule Tag"
+  run "esc_delete_schedule", data, rs_governance_host, rs_project_id
+end
+define esc_delete_schedule($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Schedule")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -906,50 +951,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Schedule
-escalation "esc_schedule_instance" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Schedule"
-  description "Stop or Start the Instance"
-  run "esc_schedule_instance", data, rs_governance_host, rs_project_id
-end
-define esc_schedule_instance($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Schedule")
-end
-
-# Escalation for Terminate Instance
-escalation "esc_terminate_instance" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Terminate Instance"
-  description "Terminate or delete the Instance"
-  run "esc_terminate_instance", data, rs_governance_host, rs_project_id
-end
-define esc_terminate_instance($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instance")
-end
-
-# Escalation for Update Schedule
-escalation "esc_update_schedule" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Update Schedule"
-  description "Update the existing schedule Tag"
-  run "esc_update_schedule", data, rs_governance_host, rs_project_id
-end
-define esc_update_schedule($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Update Schedule")
-end
-
-# Escalation for Delete Schedule
-escalation "esc_delete_schedule" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Delete Schedule"
-  description "Delete Schedule Tag"
-  run "esc_delete_schedule", data, rs_governance_host, rs_project_id
-end
-define esc_delete_schedule($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Delete Schedule")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
@@ -85,6 +85,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions(s)"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Schedule Instances"]
+  default []
 end
 
 ###############################################################################

--- a/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent.pt
+++ b/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -745,6 +747,7 @@ script "js_ds_merged_metrics_combined_incidents", type: "javascript" do
     // If the incident summary contains "Azure Storage Accounts without Lifecycle Policies" then include it in the filter result
     if (s.indexOf("Azure Storage Accounts without Lifecycle Policies") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -763,6 +766,7 @@ policy "policy_scheduled_report" do
   validate $ds_merged_metrics_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Azure Storage Accounts without Lifecycle Policies"
     escalate $esc_email
+    
     check eq(size(data), 0)
     export do
       resource_level true
@@ -783,6 +787,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "Id"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -887,6 +894,150 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent.pt
+++ b/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent.pt
@@ -756,6 +756,8 @@ EOS
 end
 
 
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -895,7 +897,6 @@ EOS
     check eq(size(data),0)
   end
 end
-
 
 # Begin Shared Functions for Child Actions from Consolidated Incident
 define groupByIncidentID($data) return $incidents do

--- a/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
@@ -785,6 +785,18 @@ EOS
 end
 
 
+# Escalation for Change Instance Type
+escalation "esc_change_type" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Change Instance Type"
+  description "Approval to change instance type for all superseded EC2 instances"
+  run "esc_change_type", data, rs_governance_host, rs_project_id
+end
+define esc_change_type($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Change Instance Type")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -962,17 +974,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Change Instance Type
-escalation "esc_change_type" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Change Instance Type"
-  description "Approval to change instance type for all superseded EC2 instances"
-  run "esc_change_type", data, rs_governance_host, rs_project_id
-end
-define esc_change_type($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Change Instance Type")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -774,6 +776,7 @@ script "js_ds_superseded_instances_combined_incidents", type: "javascript" do
     // If the incident summary contains "Azure Potentially Superseded Virtual Machines Found" then include it in the filter result
     if (s.indexOf("Azure Potentially Superseded Virtual Machines Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -792,6 +795,7 @@ policy "policy_scheduled_report" do
   validate $ds_superseded_instances_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Azure Potentially Superseded Virtual Machines Found"
     escalate $esc_email
+    escalate $esc_change_type
     check eq(size(data), 0)
     export do
       resource_level true
@@ -851,6 +855,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "ID"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -955,6 +962,160 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Change Instance Type
+escalation "esc_change_type" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Change Instance Type"
+  description "Approval to change instance type for all superseded EC2 instances"
+  run "esc_change_type", data, rs_governance_host, rs_project_id
+end
+define esc_change_type($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Change Instance Type")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
@@ -786,6 +786,18 @@ EOS
 end
 
 
+# Escalation for Delete IP Addresses
+escalation "esc_delete_ip_address" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete IP Addresses"
+  description "Approval to delete all selected IP addresses"
+  run "esc_delete_ip_address", data, rs_governance_host, rs_project_id
+end
+define esc_delete_ip_address($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete IP Addresses")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -954,17 +966,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Delete IP Addresses
-escalation "esc_delete_ip_address" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Delete IP Addresses"
-  description "Approval to delete all selected IP addresses"
-  run "esc_delete_ip_address", data, rs_governance_host, rs_project_id
-end
-define esc_delete_ip_address($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Delete IP Addresses")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -775,6 +777,7 @@ script "js_ds_ip_cost_mapping_combined_incidents", type: "javascript" do
     // If the incident summary contains "Azure Unused IP Addresses Found" then include it in the filter result
     if (s.indexOf("Azure Unused IP Addresses Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -793,6 +796,7 @@ policy "policy_scheduled_report" do
   validate $ds_ip_cost_mapping_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Azure Unused IP Addresses Found"
     escalate $esc_email
+    escalate $esc_delete_ip_address
     check eq(size(data), 0)
     export do
       resource_level true
@@ -843,6 +847,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "ID"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -947,6 +954,160 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Delete IP Addresses
+escalation "esc_delete_ip_address" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete IP Addresses"
+  description "Approval to delete all selected IP addresses"
+  run "esc_delete_ip_address", data, rs_governance_host, rs_project_id
+end
+define esc_delete_ip_address($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete IP Addresses")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/azure/unused_sql_databases/azure_unused_sql_databases.pt
+++ b/cost/azure/unused_sql_databases/azure_unused_sql_databases.pt
@@ -50,6 +50,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Terminate Instances"]
+  default []
 end
 
 parameter "param_log_to_cm_audit_entries" do

--- a/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
+++ b/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
@@ -762,6 +762,18 @@ EOS
 end
 
 
+# Escalation for Delete SQL databases
+escalation "esc_delete_unused_sql_databases_approval" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete SQL databases"
+  description "Deleted unused SQL Databases"
+  run "esc_delete_unused_sql_databases_approval", data, rs_governance_host, rs_project_id
+end
+define esc_delete_unused_sql_databases_approval($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete SQL databases")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -936,17 +948,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Delete SQL databases
-escalation "esc_delete_unused_sql_databases_approval" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Delete SQL databases"
-  description "Deleted unused SQL Databases"
-  run "esc_delete_unused_sql_databases_approval", data, rs_governance_host, rs_project_id
-end
-define esc_delete_unused_sql_databases_approval($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Delete SQL databases")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
+++ b/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -751,6 +753,7 @@ script "js_ds_instance_cost_mapping_combined_incidents", type: "javascript" do
     // If the incident summary contains "Unused Azure Databases Found" then include it in the filter result
     if (s.indexOf("Unused Azure Databases Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -769,6 +772,7 @@ policy "policy_scheduled_report" do
   validate $ds_instance_cost_mapping_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Unused Azure Databases Found"
     escalate $esc_email
+    escalate $esc_delete_unused_sql_databases_approval
     check eq(size(data), 0)
     export do
       resource_level true
@@ -825,6 +829,9 @@ policy "policy_scheduled_report" do
       end
       field "platform" do
         label "Platform"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -929,6 +936,160 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Delete SQL databases
+escalation "esc_delete_unused_sql_databases_approval" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete SQL databases"
+  description "Deleted unused SQL Databases"
+  run "esc_delete_unused_sql_databases_approval", data, rs_governance_host, rs_project_id
+end
+define esc_delete_unused_sql_databases_approval($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete SQL databases")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
+++ b/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
@@ -86,6 +86,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Terminate Instances"]
+  default []
 end
 
 parameter "param_log_to_cm_audit_entries" do

--- a/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
@@ -822,6 +822,18 @@ EOS
 end
 
 
+# Escalation for Delete Volumes
+escalation "esc_delete_volumes" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Volumes"
+  description "Approval to terminate all selected instances"
+  run "esc_delete_volumes", data, rs_governance_host, rs_project_id
+end
+define esc_delete_volumes($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Volumes")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -999,17 +1011,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Delete Volumes
-escalation "esc_delete_volumes" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Delete Volumes"
-  description "Approval to terminate all selected instances"
-  run "esc_delete_volumes", data, rs_governance_host, rs_project_id
-end
-define esc_delete_volumes($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Delete Volumes")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -811,6 +813,7 @@ script "js_ds_volume_cost_mapping_combined_incidents", type: "javascript" do
     // If the incident summary contains "Azure Unused Volumes Found" then include it in the filter result
     if (s.indexOf("Azure Unused Volumes Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -829,6 +832,7 @@ policy "policy_scheduled_report" do
   validate $ds_volume_cost_mapping_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Azure Unused Volumes Found"
     escalate $esc_email
+    escalate $esc_delete_volumes
     check eq(size(data), 0)
     export do
       resource_level true
@@ -888,6 +892,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "ID"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -992,6 +999,160 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Delete Volumes
+escalation "esc_delete_volumes" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Volumes"
+  description "Approval to terminate all selected instances"
+  run "esc_delete_volumes", data, rs_governance_host, rs_project_id
+end
+define esc_delete_volumes($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Volumes")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/downsize_instance/downsize_instance.pt
+++ b/cost/downsize_instance/downsize_instance.pt
@@ -60,6 +60,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Downsize Instances"]
+  default []
 end
 
 

--- a/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations_meta_parent.pt
+++ b/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Google Projects are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Google Projects [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -765,6 +767,7 @@ script "js_ds_recommendations_incident_combined_incidents", type: "javascript" d
     // If the incident summary contains "Google Idle Cloud SQL Instances Found" then include it in the filter result
     if (s.indexOf("Google Idle Cloud SQL Instances Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -783,6 +786,8 @@ policy "policy_scheduled_report" do
   validate $ds_recommendations_incident_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Google Idle Cloud SQL Instances Found"
     escalate $esc_email
+    escalate $esc_stop_instances
+    escalate $esc_delete_instances
     check eq(size(data), 0)
     export do
       resource_level true
@@ -863,6 +868,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "ID"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -967,6 +975,171 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Stop Cloud SQL Instances
+escalation "esc_stop_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Stop Cloud SQL Instances"
+  description "Approval to stop all selected Cloud SQL instances"
+  run "esc_stop_instances", data, rs_governance_host, rs_project_id
+end
+define esc_stop_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Stop Cloud SQL Instances")
+end
+
+# Escalation for Delete Cloud SQL Instances
+escalation "esc_delete_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Cloud SQL Instances"
+  description "Approval to delete all selected Cloud SQL instances"
+  run "esc_delete_instances", data, rs_governance_host, rs_project_id
+end
+define esc_delete_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Cloud SQL Instances")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations_meta_parent.pt
+++ b/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations_meta_parent.pt
@@ -776,6 +776,29 @@ EOS
 end
 
 
+# Escalation for Stop Cloud SQL Instances
+escalation "esc_stop_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Stop Cloud SQL Instances"
+  description "Approval to stop all selected Cloud SQL instances"
+  run "esc_stop_instances", data, rs_governance_host, rs_project_id
+end
+define esc_stop_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Stop Cloud SQL Instances")
+end
+
+# Escalation for Delete Cloud SQL Instances
+escalation "esc_delete_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Cloud SQL Instances"
+  description "Approval to delete all selected Cloud SQL instances"
+  run "esc_delete_instances", data, rs_governance_host, rs_project_id
+end
+define esc_delete_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Cloud SQL Instances")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -975,28 +998,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Stop Cloud SQL Instances
-escalation "esc_stop_instances" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Stop Cloud SQL Instances"
-  description "Approval to stop all selected Cloud SQL instances"
-  run "esc_stop_instances", data, rs_governance_host, rs_project_id
-end
-define esc_stop_instances($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Stop Cloud SQL Instances")
-end
-
-# Escalation for Delete Cloud SQL Instances
-escalation "esc_delete_instances" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Delete Cloud SQL Instances"
-  description "Approval to delete all selected Cloud SQL instances"
-  run "esc_delete_instances", data, rs_governance_host, rs_project_id
-end
-define esc_delete_instances($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Delete Cloud SQL Instances")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/google/cloudsql_rightsizing/google_cloudsql_rightsizing.pt
+++ b/cost/google/cloudsql_rightsizing/google_cloudsql_rightsizing.pt
@@ -54,6 +54,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Resize Instances"]
+  default []
 end
 
 parameter "param_log_to_cm_audit_entries" do

--- a/cost/google/cud_recommendations/google_committed_use_discount_recommendations_meta_parent.pt
+++ b/cost/google/cud_recommendations/google_committed_use_discount_recommendations_meta_parent.pt
@@ -776,6 +776,8 @@ EOS
 end
 
 
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -948,7 +950,6 @@ EOS
     check eq(size(data),0)
   end
 end
-
 
 # Begin Shared Functions for Child Actions from Consolidated Incident
 define groupByIncidentID($data) return $incidents do

--- a/cost/google/cud_recommendations/google_committed_use_discount_recommendations_meta_parent.pt
+++ b/cost/google/cud_recommendations/google_committed_use_discount_recommendations_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Google Projects are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Google Projects [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -765,6 +767,7 @@ script "js_ds_recommendations_incident_combined_incidents", type: "javascript" d
     // If the incident summary contains "Google Committed Use Discount Recommendations" then include it in the filter result
     if (s.indexOf("Google Committed Use Discount Recommendations") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -783,6 +786,7 @@ policy "policy_scheduled_report" do
   validate $ds_recommendations_incident_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Google Committed Use Discount Recommendations"
     escalate $esc_email
+    
     check eq(size(data), 0)
     export do
       resource_level true
@@ -836,6 +840,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "ID"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -940,6 +947,150 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/google/idle_compute_instances/google_idle_compute_instances.pt
+++ b/cost/google/idle_compute_instances/google_idle_compute_instances.pt
@@ -54,6 +54,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Terminate Instances"]
+  default []
 end
 
 parameter "param_log_to_cm_audit_entries" do

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Google Projects are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Google Projects [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -765,6 +767,7 @@ script "js_ds_recommendations_incident_combined_incidents", type: "javascript" d
     // If the incident summary contains "Google Idle IP Addresses Found" then include it in the filter result
     if (s.indexOf("Google Idle IP Addresses Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -783,6 +786,7 @@ policy "policy_scheduled_report" do
   validate $ds_recommendations_incident_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Google Idle IP Addresses Found"
     escalate $esc_email
+    escalate $esc_delete_ip_address
     check eq(size(data), 0)
     export do
       resource_level true
@@ -845,6 +849,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "ID"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -949,6 +956,160 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Delete IP Addresses
+escalation "esc_delete_ip_address" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete IP Addresses"
+  description "Approval to delete all selected IP addresses"
+  run "esc_delete_ip_address", data, rs_governance_host, rs_project_id
+end
+define esc_delete_ip_address($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete IP Addresses")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
@@ -776,6 +776,18 @@ EOS
 end
 
 
+# Escalation for Delete IP Addresses
+escalation "esc_delete_ip_address" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete IP Addresses"
+  description "Approval to delete all selected IP addresses"
+  run "esc_delete_ip_address", data, rs_governance_host, rs_project_id
+end
+define esc_delete_ip_address($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete IP Addresses")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -956,17 +968,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Delete IP Addresses
-escalation "esc_delete_ip_address" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Delete IP Addresses"
-  description "Approval to delete all selected IP addresses"
-  run "esc_delete_ip_address", data, rs_governance_host, rs_project_id
-end
-define esc_delete_ip_address($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Delete IP Addresses")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
@@ -92,6 +92,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Delete Disks"]
+  default []
 end
 
 ###############################################################################

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
@@ -115,6 +115,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Delete Disks"]
+  default []
 end
 
 ###############################################################################

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
@@ -783,6 +783,18 @@ EOS
 end
 
 
+# Escalation for Delete Disks
+escalation "esc_delete_disks" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Disks"
+  description "Approval to delete all selected disks"
+  run "esc_delete_disks", data, rs_governance_host, rs_project_id
+end
+define esc_delete_disks($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Disks")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -972,17 +984,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Delete Disks
-escalation "esc_delete_disks" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Delete Disks"
-  description "Approval to delete all selected disks"
-  run "esc_delete_disks", data, rs_governance_host, rs_project_id
-end
-define esc_delete_disks($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Delete Disks")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Google Projects are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Google Projects [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -772,6 +774,7 @@ script "js_ds_recommendations_incident_combined_incidents", type: "javascript" d
     // If the incident summary contains "Google Idle Persistent Disks Found" then include it in the filter result
     if (s.indexOf("Google Idle Persistent Disks Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -790,6 +793,7 @@ policy "policy_scheduled_report" do
   validate $ds_recommendations_incident_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Google Idle Persistent Disks Found"
     escalate $esc_email
+    escalate $esc_delete_disks
     check eq(size(data), 0)
     export do
       resource_level true
@@ -861,6 +865,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "ID"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -965,6 +972,160 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Delete Disks
+escalation "esc_delete_disks" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Disks"
+  description "Approval to delete all selected disks"
+  run "esc_delete_disks", data, rs_governance_host, rs_project_id
+end
+define esc_delete_disks($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Disks")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
+++ b/cost/google/idle_vm_recommendations/google_vm_recommendations.pt
@@ -48,6 +48,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Terminate Instances"]
+  default []
 end
 
 parameter "param_log_to_cm_audit_entries" do

--- a/cost/google/instances_stackdriver_utilization/google_instances_stackdriver_utilization.pt
+++ b/cost/google/instances_stackdriver_utilization/google_instances_stackdriver_utilization.pt
@@ -47,6 +47,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Downsize Instances"]
+  default []
 end
 
 parameter "param_log_to_cm_audit_entries" do

--- a/cost/google/object_storage_optimization/google_object_storage_optimization.pt
+++ b/cost/google/object_storage_optimization/google_object_storage_optimization.pt
@@ -46,6 +46,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Update Storage Buckets"]
+  default []
 end
 
 ###############################################################################

--- a/cost/google/old_snapshots/google_delete_old_snapshots.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots.pt
@@ -40,6 +40,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Delete Snapshots"]
+  default []
 end
 
 parameter "param_log_to_cm_audit_entries" do

--- a/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
+++ b/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Google Projects are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Google Projects [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -774,6 +776,7 @@ script "js_ds_underutil_incident_combined_incidents", type: "javascript" do
     // If the incident summary contains "Google Underutilized VM Instances Found" then include it in the filter result
     if (s.indexOf("Google Underutilized VM Instances Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -795,6 +798,7 @@ script "js_ds_idle_incident_combined_incidents", type: "javascript" do
     // If the incident summary contains "Google Idle VM Instances Found" then include it in the filter result
     if (s.indexOf("Google Idle VM Instances Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -813,6 +817,7 @@ policy "policy_scheduled_report" do
   validate $ds_underutil_incident_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Google Underutilized VM Instances Found"
     escalate $esc_email
+    escalate $esc_downsize_instances
     check eq(size(data), 0)
     export do
       resource_level true
@@ -894,6 +899,9 @@ policy "policy_scheduled_report" do
       field "id" do
         label "ID"
       end
+      field "incident_id" do
+        label "Child Incident ID"
+      end
     end
   end
 
@@ -901,6 +909,8 @@ policy "policy_scheduled_report" do
   validate $ds_idle_incident_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Google Idle VM Instances Found"
     escalate $esc_email
+    escalate $esc_stop_instances
+    escalate $esc_delete_instances
     check eq(size(data), 0)
     export do
       resource_level true
@@ -978,6 +988,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "ID"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -1082,6 +1095,182 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Downsize VM Instances
+escalation "esc_downsize_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Downsize VM Instances"
+  description "Approval to downsize all selected VM instances"
+  run "esc_downsize_instances", data, rs_governance_host, rs_project_id
+end
+define esc_downsize_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Downsize VM Instances")
+end
+
+# Escalation for Stop VM Instances
+escalation "esc_stop_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Stop VM Instances"
+  description "Approval to stop all selected VM instances"
+  run "esc_stop_instances", data, rs_governance_host, rs_project_id
+end
+define esc_stop_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Stop VM Instances")
+end
+
+# Escalation for Delete VM Instances
+escalation "esc_delete_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete VM Instances"
+  description "Approval to delete all selected VM instances"
+  run "esc_delete_instances", data, rs_governance_host, rs_project_id
+end
+define esc_delete_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete VM Instances")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
+++ b/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
@@ -807,6 +807,40 @@ EOS
 end
 
 
+# Escalation for Downsize VM Instances
+escalation "esc_downsize_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Downsize VM Instances"
+  description "Approval to downsize all selected VM instances"
+  run "esc_downsize_instances", data, rs_governance_host, rs_project_id
+end
+define esc_downsize_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Downsize VM Instances")
+end
+
+# Escalation for Stop VM Instances
+escalation "esc_stop_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Stop VM Instances"
+  description "Approval to stop all selected VM instances"
+  run "esc_stop_instances", data, rs_governance_host, rs_project_id
+end
+define esc_stop_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Stop VM Instances")
+end
+
+# Escalation for Delete VM Instances
+escalation "esc_delete_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete VM Instances"
+  description "Approval to delete all selected VM instances"
+  run "esc_delete_instances", data, rs_governance_host, rs_project_id
+end
+define esc_delete_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete VM Instances")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -1095,39 +1129,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Downsize VM Instances
-escalation "esc_downsize_instances" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Downsize VM Instances"
-  description "Approval to downsize all selected VM instances"
-  run "esc_downsize_instances", data, rs_governance_host, rs_project_id
-end
-define esc_downsize_instances($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Downsize VM Instances")
-end
-
-# Escalation for Stop VM Instances
-escalation "esc_stop_instances" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Stop VM Instances"
-  description "Approval to stop all selected VM instances"
-  run "esc_stop_instances", data, rs_governance_host, rs_project_id
-end
-define esc_stop_instances($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Stop VM Instances")
-end
-
-# Escalation for Delete VM Instances
-escalation "esc_delete_instances" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Delete VM Instances"
-  description "Approval to delete all selected VM instances"
-  run "esc_delete_instances", data, rs_governance_host, rs_project_id
-end
-define esc_delete_instances($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Delete VM Instances")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/cost/google/schedule_instance/google_schedule_instance.pt
+++ b/cost/google/schedule_instance/google_schedule_instance.pt
@@ -34,6 +34,7 @@ parameter "param_automatic_action" do
   label "Automatic Action(s)"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Schedule Instances"]
+  default []
 end
 
 ###############################################################################

--- a/cost/google/unattached_volumes/google_delete_unattached_volumes.pt
+++ b/cost/google/unattached_volumes/google_delete_unattached_volumes.pt
@@ -49,6 +49,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Delete Volumes"]
+  default []
 end
 
 parameter "param_log_to_cm_audit_entries" do

--- a/cost/google/unused_cloudsql_instances/google_unused_cloudsql_instances.pt
+++ b/cost/google/unused_cloudsql_instances/google_unused_cloudsql_instances.pt
@@ -46,6 +46,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Terminate Resource"]
+  default []
 end
 
 parameter "param_log_to_cm_audit_entries" do

--- a/cost/google/unutilized_ip_addresses/google_unutilized_ip_addresses.pt
+++ b/cost/google/unutilized_ip_addresses/google_unutilized_ip_addresses.pt
@@ -37,6 +37,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Delete IP Addresses"]
+  default []
 end
 
 parameter "param_log_to_cm_audit_entries" do

--- a/cost/rightlink_rightsize/rightlink-rightsize-add-tags.pt
+++ b/cost/rightlink_rightsize/rightlink-rightsize-add-tags.pt
@@ -40,6 +40,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Tag Instances"]
+  default []
 end
 
 auth "auth_rs", type: "rightscale"

--- a/cost/rightlink_rightsize/rightlink_rightsize.pt
+++ b/cost/rightlink_rightsize/rightlink_rightsize.pt
@@ -85,6 +85,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Re-Size Instances"]
+  default []
 end
 
 auth "auth_rs", type: "rightscale"

--- a/cost/superseded_instance_remediation/superseded_instance_remediation.pt
+++ b/cost/superseded_instance_remediation/superseded_instance_remediation.pt
@@ -63,6 +63,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Update Instances"]
+  default []
 end
 
 ###############################################################################

--- a/cost/terminate_policy/instance_terminate.pt
+++ b/cost/terminate_policy/instance_terminate.pt
@@ -50,6 +50,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Terminate Instances"]
+  default []
 end
 
 ###############################################################################

--- a/cost/unattached_addresses/unattached_addresses.pt
+++ b/cost/unattached_addresses/unattached_addresses.pt
@@ -33,6 +33,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Delete IP Addresses"]
+  default []
 end
 
 auth "auth_rs", type: "rightscale"

--- a/cost/volumes/old_snapshots/old_snapshot.pt
+++ b/cost/volumes/old_snapshots/old_snapshot.pt
@@ -45,6 +45,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Delete Snapshots"]
+  default []
 end
 
 auth "rs", type: "rightscale"

--- a/cost/volumes/unattached_volumes/uav_policy.pt
+++ b/cost/volumes/unattached_volumes/uav_policy.pt
@@ -60,6 +60,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Delete Volumes"]
+  default []
 end
 
 ###############################################################################

--- a/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate_meta_parent.pt
+++ b/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate_meta_parent.pt
@@ -750,6 +750,8 @@ EOS
 end
 
 
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -892,7 +894,6 @@ EOS
     check eq(size(data),0)
   end
 end
-
 
 # Begin Shared Functions for Child Actions from Consolidated Incident
 define groupByIncidentID($data) return $incidents do

--- a/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate_meta_parent.pt
+++ b/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -739,6 +741,7 @@ script "js_ds_merged_results_combined_incidents", type: "javascript" do
     // If the incident summary contains "AWS Functions over error percentage" then include it in the filter result
     if (s.indexOf("AWS Functions over error percentage") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -757,6 +760,7 @@ policy "policy_scheduled_report" do
   validate $ds_merged_results_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} AWS Functions over error percentage"
     escalate $esc_email
+    escalate $esc_functions_in_error
     check eq(size(data), 0)
     export do
       resource_level true
@@ -780,6 +784,9 @@ policy "policy_scheduled_report" do
       end
       field "tags" do
         label "tags"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -884,6 +891,150 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
+++ b/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -757,6 +759,7 @@ script "js_ds_long_running_instances_incident_combined_incidents", type: "javasc
     // If the incident summary contains "AWS Long Running Instances Found" then include it in the filter result
     if (s.indexOf("AWS Long Running Instances Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -775,6 +778,8 @@ policy "policy_scheduled_report" do
   validate $ds_long_running_instances_incident_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} AWS Long Running Instances Found"
     escalate $esc_email
+    escalate $esc_stop_instances
+    escalate $esc_terminate_instances
     check eq(size(data), 0)
     export do
       resource_level true
@@ -840,6 +845,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "ID"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -944,6 +952,171 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Stop Instances
+escalation "esc_stop_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Stop Instances"
+  description "Approval to stop all selected instances"
+  run "esc_stop_instances", data, rs_governance_host, rs_project_id
+end
+define esc_stop_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Stop Instances")
+end
+
+# Escalation for Terminate Instances
+escalation "esc_terminate_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Terminate Instances"
+  description "Approval to terminate all selected instances"
+  run "esc_terminate_instances", data, rs_governance_host, rs_project_id
+end
+define esc_terminate_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instances")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
+++ b/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
@@ -768,6 +768,29 @@ EOS
 end
 
 
+# Escalation for Stop Instances
+escalation "esc_stop_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Stop Instances"
+  description "Approval to stop all selected instances"
+  run "esc_stop_instances", data, rs_governance_host, rs_project_id
+end
+define esc_stop_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Stop Instances")
+end
+
+# Escalation for Terminate Instances
+escalation "esc_terminate_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Terminate Instances"
+  description "Approval to terminate all selected instances"
+  run "esc_terminate_instances", data, rs_governance_host, rs_project_id
+end
+define esc_terminate_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instances")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -952,28 +975,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Stop Instances
-escalation "esc_stop_instances" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Stop Instances"
-  description "Approval to stop all selected instances"
-  run "esc_stop_instances", data, rs_governance_host, rs_project_id
-end
-define esc_stop_instances($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Stop Instances")
-end
-
-# Escalation for Terminate Instances
-escalation "esc_terminate_instances" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Terminate Instances"
-  description "Approval to terminate all selected instances"
-  run "esc_terminate_instances", data, rs_governance_host, rs_project_id
-end
-define esc_terminate_instances($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instances")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/operational/aws/subnet_name_sync/aws_subnet_name_sync.pt
+++ b/operational/aws/subnet_name_sync/aws_subnet_name_sync.pt
@@ -65,6 +65,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Update Subnets"]
+  default []
 end
 
 ###############################################################################

--- a/operational/aws/tag_cardinality/aws_tag_cardinality_meta_parent.pt
+++ b/operational/aws/tag_cardinality/aws_tag_cardinality_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -714,6 +716,7 @@ script "js_ds_tag_report_combined_incidents", type: "javascript" do
     // If the incident summary contains "AWS Tag Cardinality Report" then include it in the filter result
     if (s.indexOf("AWS Tag Cardinality Report") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -732,6 +735,7 @@ policy "policy_scheduled_report" do
   validate $ds_tag_report_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} AWS Tag Cardinality Report"
     escalate $esc_email
+    
     check eq(size(data), 0)
     export do
       resource_level false
@@ -746,6 +750,9 @@ policy "policy_scheduled_report" do
       end
       field "value_list" do
         label "Unique Values"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -850,6 +857,150 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/operational/aws/tag_cardinality/aws_tag_cardinality_meta_parent.pt
+++ b/operational/aws/tag_cardinality/aws_tag_cardinality_meta_parent.pt
@@ -725,6 +725,8 @@ EOS
 end
 
 
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -858,7 +860,6 @@ EOS
     check eq(size(data),0)
   end
 end
-
 
 # Begin Shared Functions for Child Actions from Consolidated Incident
 define groupByIncidentID($data) return $incidents do

--- a/operational/aws/vpc_name_sync/aws_vpc_name_sync.pt
+++ b/operational/aws/vpc_name_sync/aws_vpc_name_sync.pt
@@ -33,6 +33,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Update VPC"]
+  default []
 end
 
 ###############################################################################

--- a/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
+++ b/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -741,6 +743,7 @@ script "js_ds_filtered_certificates_combined_incidents", type: "javascript" do
     // If the incident summary contains "Expired Certificates Found" then include it in the filter result
     if (s.indexOf("Expired Certificates Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -759,6 +762,7 @@ policy "policy_scheduled_report" do
   validate $ds_filtered_certificates_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Expired Certificates Found"
     escalate $esc_email
+    escalate $esc_report_bad_certs
     check eq(size(data), 0)
     export do
       resource_level true
@@ -806,6 +810,9 @@ policy "policy_scheduled_report" do
       end
       field "certStatus" do
         label "Certificate Status"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -910,6 +917,150 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
+++ b/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
@@ -752,6 +752,8 @@ EOS
 end
 
 
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -918,7 +920,6 @@ EOS
     check eq(size(data),0)
   end
 end
-
 
 # Begin Shared Functions for Child Actions from Consolidated Incident
 define groupByIncidentID($data) return $incidents do

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -774,6 +776,7 @@ script "js_ds_long_running_instances_incident_combined_incidents", type: "javasc
     // If the incident summary contains "Azure Long Running Instances Found" then include it in the filter result
     if (s.indexOf("Azure Long Running Instances Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -792,6 +795,8 @@ policy "policy_scheduled_report" do
   validate $ds_long_running_instances_incident_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Azure Long Running Instances Found"
     escalate $esc_email
+    escalate $esc_stop_instances
+    escalate $esc_terminate_instances
     check eq(size(data), 0)
     export do
       resource_level true
@@ -848,6 +853,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "ID"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -952,6 +960,171 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Stop Instances
+escalation "esc_stop_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Stop Instances"
+  description "Approval to stop all selected instances"
+  run "esc_stop_instances", data, rs_governance_host, rs_project_id
+end
+define esc_stop_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Stop Instances")
+end
+
+# Escalation for Terminate Instances
+escalation "esc_terminate_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Terminate Instances"
+  description "Approval to terminate all selected instances"
+  run "esc_terminate_instances", data, rs_governance_host, rs_project_id
+end
+define esc_terminate_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instances")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
@@ -785,6 +785,29 @@ EOS
 end
 
 
+# Escalation for Stop Instances
+escalation "esc_stop_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Stop Instances"
+  description "Approval to stop all selected instances"
+  run "esc_stop_instances", data, rs_governance_host, rs_project_id
+end
+define esc_stop_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Stop Instances")
+end
+
+# Escalation for Terminate Instances
+escalation "esc_terminate_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Terminate Instances"
+  description "Approval to terminate all selected instances"
+  run "esc_terminate_instances", data, rs_governance_host, rs_project_id
+end
+define esc_terminate_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instances")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -960,28 +983,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Stop Instances
-escalation "esc_stop_instances" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Stop Instances"
-  description "Approval to stop all selected instances"
-  run "esc_stop_instances", data, rs_governance_host, rs_project_id
-end
-define esc_stop_instances($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Stop Instances")
-end
-
-# Escalation for Terminate Instances
-escalation "esc_terminate_instances" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Terminate Instances"
-  description "Approval to terminate all selected instances"
-  run "esc_terminate_instances", data, rs_governance_host, rs_project_id
-end
-define esc_terminate_instances($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instances")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/operational/azure/sync_tags_with_optima/sync_azure_tags.pt
+++ b/operational/azure/sync_tags_with_optima/sync_azure_tags.pt
@@ -53,6 +53,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Add tags to Optima"]
+  default []
 end
 
 ###############################################################################

--- a/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
+++ b/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
@@ -739,6 +739,8 @@ EOS
 end
 
 
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -872,7 +874,6 @@ EOS
     check eq(size(data),0)
   end
 end
-
 
 # Begin Shared Functions for Child Actions from Consolidated Incident
 define groupByIncidentID($data) return $incidents do

--- a/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
+++ b/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -728,6 +730,7 @@ script "js_ds_tag_report_combined_incidents", type: "javascript" do
     // If the incident summary contains "Azure Tag Cardinality Report" then include it in the filter result
     if (s.indexOf("Azure Tag Cardinality Report") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -746,6 +749,7 @@ policy "policy_scheduled_report" do
   validate $ds_tag_report_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Azure Tag Cardinality Report"
     escalate $esc_email
+    
     check eq(size(data), 0)
     export do
       resource_level false
@@ -760,6 +764,9 @@ policy "policy_scheduled_report" do
       end
       field "value_list" do
         label "Unique Values"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -864,6 +871,150 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent.pt
+++ b/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent.pt
@@ -746,6 +746,8 @@ EOS
 end
 
 
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -894,7 +896,6 @@ EOS
     check eq(size(data),0)
   end
 end
-
 
 # Begin Shared Functions for Child Actions from Consolidated Incident
 define groupByIncidentID($data) return $incidents do

--- a/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent.pt
+++ b/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -735,6 +737,7 @@ script "js_ds_filtered_virtual_machines_combined_incidents", type: "javascript" 
     // If the incident summary contains "Azure VMs without managed disks" then include it in the filter result
     if (s.indexOf("Azure VMs without managed disks") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -753,6 +756,7 @@ policy "policy_scheduled_report" do
   validate $ds_filtered_virtual_machines_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Azure VMs without managed disks"
     escalate $esc_email
+    
     check eq(size(data), 0)
     export do
       resource_level true
@@ -782,6 +786,9 @@ policy "policy_scheduled_report" do
       end
       field "tags" do
         label "Tags"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -886,6 +893,150 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/operational/cloud_credentials/aws/aws_connection_key_rotation_policy.pt
+++ b/operational/cloud_credentials/aws/aws_connection_key_rotation_policy.pt
@@ -41,6 +41,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Update Credentials"]
+  default []
 end
 
 ###############################################################################

--- a/operational/snapshots/no_recent_snapshots.pt
+++ b/operational/snapshots/no_recent_snapshots.pt
@@ -54,6 +54,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Take Snapshots"]
+  default []
 end
 
 permission "perm_resources" do

--- a/operational/stranded_servers/stranded_servers.pt
+++ b/operational/stranded_servers/stranded_servers.pt
@@ -43,6 +43,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Terminate Instances"]
+  default []
 end
 
 ###############################################################################

--- a/operational/vmware/instance_tag_sync/instance_tag_sync.pt
+++ b/operational/vmware/instance_tag_sync/instance_tag_sync.pt
@@ -78,6 +78,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Synchronize Tags"]
+  default []
 end
 
 ###############################################################################

--- a/saas/okta/inactive_users/okta-inactive-users.pt
+++ b/saas/okta/inactive_users/okta-inactive-users.pt
@@ -36,6 +36,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Deactivate Users"]
+  default []
 end
 
 credentials "auth_okta" do

--- a/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes_meta_parent.pt
+++ b/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -733,6 +735,7 @@ script "js_ds_unencrypted_volumes_map_combined_incidents", type: "javascript" do
     // If the incident summary contains "Unencrypted Volumes Found in AWS" then include it in the filter result
     if (s.indexOf("Unencrypted Volumes Found in AWS") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -751,6 +754,7 @@ policy "policy_scheduled_report" do
   validate $ds_unencrypted_volumes_map_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Unencrypted Volumes Found in AWS"
     escalate $esc_email
+    escalate $report_unencrypted_volumes
     check eq(size(data), 0)
     export do
       resource_level true
@@ -780,6 +784,9 @@ policy "policy_scheduled_report" do
       end
       field "tagKeyValue" do
         label "TAGs"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -884,6 +891,150 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes_meta_parent.pt
+++ b/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes_meta_parent.pt
@@ -744,6 +744,8 @@ EOS
 end
 
 
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -892,7 +894,6 @@ EOS
     check eq(size(data),0)
   end
 end
-
 
 # Begin Shared Functions for Child Actions from Consolidated Incident
 define groupByIncidentID($data) return $incidents do

--- a/security/aws/loadbalancer_internet_facing/aws_internet-facing_elbs.pt
+++ b/security/aws/loadbalancer_internet_facing/aws_internet-facing_elbs.pt
@@ -56,6 +56,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Delete ELBs and ALBs"]
+  default []
 end
 
 ###############################################################################

--- a/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances.pt
+++ b/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances.pt
@@ -57,6 +57,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Update RDS Instances"]
+  default []
 end
 
 ###############################################################################

--- a/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances_meta_parent.pt
+++ b/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances_meta_parent.pt
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do
@@ -740,6 +742,7 @@ script "js_ds_rds_publicly_accessible_instance_map_combined_incidents", type: "j
     // If the incident summary contains "Publicly Accessible RDS Instances Found in AWS" then include it in the filter result
     if (s.indexOf("Publicly Accessible RDS Instances Found in AWS") > -1) {
       _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
         result.push(violation);
       });
     }
@@ -758,6 +761,9 @@ policy "policy_scheduled_report" do
   validate $ds_rds_publicly_accessible_instance_map_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Publicly Accessible RDS Instances Found in AWS"
     escalate $esc_email
+    escalate $report_publicly_accessible_RDS_instances
+    escalate $modify_publicly_accessible_RDS_instance_approval
+    escalate $delete_publicly_accessible_RDS_instances_approval
     check eq(size(data), 0)
     export do
       resource_level true
@@ -790,6 +796,9 @@ policy "policy_scheduled_report" do
       end
       field "db_cluster_identifier" do
         label "DB Cluster Identifier"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
       end
     end
   end
@@ -894,6 +903,171 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
+end
+
+# Escalation for Update Instance
+escalation "modify_publicly_accessible_RDS_instance_approval" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Update Instance"
+  description "Approve selected RDS public access rule configuration change"
+  run "modify_publicly_accessible_RDS_instance_approval", data, rs_governance_host, rs_project_id
+end
+define modify_publicly_accessible_RDS_instance_approval($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Update Instance")
+end
+
+# Escalation for Delete Instance
+escalation "delete_publicly_accessible_RDS_instances_approval" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Instance"
+  description "Delete selected publicly accessible RDS-instances"
+  run "delete_publicly_accessible_RDS_instances_approval", data, rs_governance_host, rs_project_id
+end
+define delete_publicly_accessible_RDS_instances_approval($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Instance")
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 # Used only for emailing the combined child incident if so desired

--- a/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances_meta_parent.pt
+++ b/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances_meta_parent.pt
@@ -751,6 +751,29 @@ EOS
 end
 
 
+# Escalation for Update Instance
+escalation "modify_publicly_accessible_RDS_instance_approval" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Update Instance"
+  description "Approve selected RDS public access rule configuration change"
+  run "modify_publicly_accessible_RDS_instance_approval", data, rs_governance_host, rs_project_id
+end
+define modify_publicly_accessible_RDS_instance_approval($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Update Instance")
+end
+
+# Escalation for Delete Instance
+escalation "delete_publicly_accessible_RDS_instances_approval" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Instance"
+  description "Delete selected publicly accessible RDS-instances"
+  run "delete_publicly_accessible_RDS_instances_approval", data, rs_governance_host, rs_project_id
+end
+define delete_publicly_accessible_RDS_instances_approval($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Instance")
+end
+
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -903,28 +926,6 @@ EOS
     escalate $delete_policies
     check eq(size(data),0)
   end
-end
-
-# Escalation for Update Instance
-escalation "modify_publicly_accessible_RDS_instance_approval" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Update Instance"
-  description "Approve selected RDS public access rule configuration change"
-  run "modify_publicly_accessible_RDS_instance_approval", data, rs_governance_host, rs_project_id
-end
-define modify_publicly_accessible_RDS_instance_approval($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Update Instance")
-end
-
-# Escalation for Delete Instance
-escalation "delete_publicly_accessible_RDS_instances_approval" do
-  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Delete Instance"
-  description "Delete selected publicly accessible RDS-instances"
-  run "delete_publicly_accessible_RDS_instances_approval", data, rs_governance_host, rs_project_id
-end
-define delete_publicly_accessible_RDS_instances_approval($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Delete Instance")
 end
 
 # Begin Shared Functions for Child Actions from Consolidated Incident

--- a/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances_meta_parent.pt
+++ b/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances_meta_parent.pt
@@ -92,6 +92,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Update RDS Instances"]
+  default []
 end
 
 ###############################################################################

--- a/security/aws/rds_unencrypted/aws_unencrypted_rds_instances.pt
+++ b/security/aws/rds_unencrypted/aws_unencrypted_rds_instances.pt
@@ -63,6 +63,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Delete RDS Instances"]
+  default []
 end
 
 ###############################################################################

--- a/security/aws/unencrypted_s3_buckets/aws_unencrypted_s3_buckets.pt
+++ b/security/aws/unencrypted_s3_buckets/aws_unencrypted_s3_buckets.pt
@@ -48,6 +48,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Encrypt Buckets"]
+  default []
 end
 
 ###############################################################################

--- a/security/azure/sql_publicly_accessible_managed_instance/check_for_publicly_accessible_azure_sql_managed_instance.pt
+++ b/security/azure/sql_publicly_accessible_managed_instance/check_for_publicly_accessible_azure_sql_managed_instance.pt
@@ -48,6 +48,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Disable Public endpoint"]
+  default []
 end
 
 ###############################################################################

--- a/security/security_groups/world_open_ports/security_group_rules_with_world_open_ports.pt
+++ b/security/security_groups/world_open_ports/security_group_rules_with_world_open_ports.pt
@@ -32,6 +32,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Delete Security Groups"]
+  default []
 end
 
 auth "auth_rs", type: "rightscale"

--- a/security/storage/aws/s3_buckets_without_server_access_logging/aws_s3_buckets_without_server_access_logging.pt
+++ b/security/storage/aws/s3_buckets_without_server_access_logging/aws_s3_buckets_without_server_access_logging.pt
@@ -62,6 +62,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Enable Bucket Logging"]
+  default []
 end
 
 ###############################################################################

--- a/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do

--- a/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
@@ -800,6 +800,150 @@ EOS
   end
 end
 
+__PLACEHOLDER_FOR_CONSOLIDATED_INCIDENT_ESCALATIONS__
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
+end
+
 # Used only for emailing the combined child incident if so desired
 escalation "esc_email" do
   automatic true

--- a/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
@@ -691,6 +691,8 @@ end
 
 __PLACEHOLDER_FOR_CONSOLIDATED_INCIDENT_DATASOURCES__
 
+__PLACEHOLDER_FOR_CONSOLIDATED_INCIDENT_ESCALATIONS__
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -800,7 +802,6 @@ EOS
   end
 end
 
-__PLACEHOLDER_FOR_CONSOLIDATED_INCIDENT_ESCALATIONS__
 # Begin Shared Functions for Child Actions from Consolidated Incident
 define groupByIncidentID($data) return $incidents do
   # Empty hash to store incidents is incident_id

--- a/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do

--- a/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
@@ -810,6 +810,150 @@ EOS
   end
 end
 
+__PLACEHOLDER_FOR_CONSOLIDATED_INCIDENT_ESCALATIONS__
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
+end
+
 # Used only for emailing the combined child incident if so desired
 escalation "esc_email" do
   automatic true

--- a/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
@@ -701,6 +701,8 @@ end
 
 __PLACEHOLDER_FOR_CONSOLIDATED_INCIDENT_DATASOURCES__
 
+__PLACEHOLDER_FOR_CONSOLIDATED_INCIDENT_ESCALATIONS__
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -810,7 +812,6 @@ EOS
   end
 end
 
-__PLACEHOLDER_FOR_CONSOLIDATED_INCIDENT_ESCALATIONS__
 # Begin Shared Functions for Child Actions from Consolidated Incident
 define groupByIncidentID($data) return $incidents do
   # Empty hash to store incidents is incident_id

--- a/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
@@ -34,6 +34,7 @@ parameter "param_dimension_filter_includes" do
   If no include filters are provided, then all Google Projects are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_dimension_filter_excludes" do
@@ -45,6 +46,7 @@ parameter "param_dimension_filter_excludes" do
   Can be used to exclude specific Google Projects [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
   EOS
+  default []
 end
 
 parameter "param_policy_schedule" do

--- a/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
@@ -810,6 +810,150 @@ EOS
   end
 end
 
+__PLACEHOLDER_FOR_CONSOLIDATED_INCIDENT_ESCALATIONS__
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
+end
+
 # Used only for emailing the combined child incident if so desired
 escalation "esc_email" do
   automatic true

--- a/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
@@ -701,6 +701,8 @@ end
 
 __PLACEHOLDER_FOR_CONSOLIDATED_INCIDENT_DATASOURCES__
 
+__PLACEHOLDER_FOR_CONSOLIDATED_INCIDENT_ESCALATIONS__
+
 # Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
 # Minimum of 1 incident, max of four
 # Could swap the summary to only showing running
@@ -810,7 +812,6 @@ EOS
   end
 end
 
-__PLACEHOLDER_FOR_CONSOLIDATED_INCIDENT_ESCALATIONS__
 # Begin Shared Functions for Child Actions from Consolidated Incident
 define groupByIncidentID($data) return $incidents do
   # Empty hash to store incidents is incident_id

--- a/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
+++ b/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
@@ -93,6 +93,40 @@ def compile_meta_parent_policy(file_path)
   # Get resource level
   resource_level = pt.scan(/^\s*resource_level (true|false)$/)
 
+  # Get escalations blocks
+  escalation_blocks_child = pt.scan(/escalation ".*?" do.*?^end/m)
+  escalation_blocks_parent = []
+  escalation_blocks_child.each do |escalation|
+    consolidated_incident_escalation_template = <<-EOL
+# Escalation for __PLACEHOLDER_FOR_CHILD_POLICY_ESC_LABEL__
+escalation "__PLACEHOLDER_FOR_CHILD_POLICY_ESC_ID__" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "__PLACEHOLDER_FOR_CHILD_POLICY_ESC_LABEL__"
+  description "__PLACEHOLDER_FOR_CHILD_POLICY_ESC_DESCRIPTION__"
+  run "__PLACEHOLDER_FOR_CHILD_POLICY_ESC_ID__", data, rs_governance_host, rs_project_id
+end
+define __PLACEHOLDER_FOR_CHILD_POLICY_ESC_ID__($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "__PLACEHOLDER_FOR_CHILD_POLICY_ESC_LABEL__")
+end
+    EOL
+    # Drop any escalations related to email action
+    next if escalation.include?("email")
+    # Get Escalation ID
+    esc_id = escalation.scan(/escalation "(.*?)" do/)[0][0]
+    # Get Escalation Label
+    esc_label = escalation.scan(/label "(.*?)"/)[0][0]
+    # Get Escalation Description
+    esc_description = escalation.scan(/description "(.*?)"/)[0][0]
+    # Replace the placeholders with the values from the child policy template
+    esc = consolidated_incident_escalation_template.gsub("__PLACEHOLDER_FOR_CHILD_POLICY_ESC_ID__", esc_id)
+    esc = esc.gsub("__PLACEHOLDER_FOR_CHILD_POLICY_ESC_LABEL__", esc_label)
+    esc = esc.gsub("__PLACEHOLDER_FOR_CHILD_POLICY_ESC_DESCRIPTION__", esc_description)
+    escalation_blocks_parent.push(esc)
+  end
+  # print("Escalation Blocks:\n")
+  # print(escalation_blocks_parent.join("\n---------\n"))
+  # print("\n")
+
   consolidated_incident_datasource_template = <<~EOL
   datasource "__PLACEHOLDER_FOR_CHILD_POLICY_CONSOLIDATED_INCIDENT_DATASOURCE___combined_incidents" do
     run_script $js___PLACEHOLDER_FOR_CHILD_POLICY_CONSOLIDATED_INCIDENT_DATASOURCE___combined_incidents, $ds_child_incident_details
@@ -108,6 +142,7 @@ def compile_meta_parent_policy(file_path)
       // If the incident summary contains "__PLACEHOLDER_FOR_CHILD_POLICY_RESOURCE_TYPE_NAME__" then include it in the filter result
       if (s.indexOf("__PLACEHOLDER_FOR_CHILD_POLICY_RESOURCE_TYPE_NAME__") > -1) {
         _.each(incident["violation_data"], function(violation) {
+          violation["incident_id"] = incident["id"];
           result.push(violation);
         });
       }
@@ -120,6 +155,7 @@ def compile_meta_parent_policy(file_path)
   validate $__PLACEHOLDER_FOR_CHILD_POLICY_CONSOLIDATED_INCIDENT_DATASOURCE___combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} __PLACEHOLDER_FOR_CHILD_POLICY_RESOURCE_TYPE_NAME__"
     escalate $esc_email
+    __PLACEHOLDER_FOR_CHILD_POLICY_CONSOLIDATED_INCIDENT_ESCALATIONS__
     check eq(size(data), 0)
     export do
       resource_level __PLACEHOLDER_FOR_CHILD_POLICY_CONSOLIDATED_INCIDENT_RESOURCE_LEVEL__
@@ -138,6 +174,15 @@ def compile_meta_parent_policy(file_path)
     # print("Raw Validate Block:\n")
     # print(validate_block)
     # print("\n---\n")
+    # From validate block, capture the escalate lines
+    escalations_child = validate_block.scan(/escalate \$.*\n^/)
+    escalations_parent = []
+    escalations_child.each do |escalation|
+      # Drop any escalations related to email action
+      next if escalation.include?("email")
+      escalations_parent.push(escalation)
+    end
+
     # From validate block, capture the export block
     export_block = validate_block.scan(/export.*?do.*?^  end/m)
     # print("Export Block: \n")
@@ -158,12 +203,18 @@ def compile_meta_parent_policy(file_path)
       # print(export_block)
       # print("\n---\n")
     end
+    # Append the incident_id field to the fields array
+    # This holds the child policy incident ID, and can be used for actions from the meta parent
+    incident_id = "field \"incident_id\" do\n        label \"Child Incident ID\"\n      end".strip
+    fields.push(incident_id)
 
     # From each validate block, capture the summary_template and detail_template
     summary_template = validate_block.scan(/summary_template\s+\"(.*?)\"/m)
     summary_template = validate_block.scan(/summary_template\s+<<-EOS\s+(.*?)EOS/m) if summary_template.empty?
+    # print("Summary Template:\n")
+    # print(summary_template)
     # From the summary template, capture the longest string that contains only letters and spaces
-    summary_template_search_string = summary_template[0][0].scan(/[a-zA-Z\s]+/).max_by(&:length).strip
+    summary_template_search_string = summary_template[0][0].scan(/[a-zA-Z0-9 \s]+/).max_by(&:length).strip
     # print("Summary Template Search String:\n")
     # print(summary_template_search_string)
     # print("\n------------------\n")
@@ -179,6 +230,8 @@ def compile_meta_parent_policy(file_path)
     # Replace the placeholder with the Child Policy Resource Type Name
     output_ds = output_ds.gsub("__PLACEHOLDER_FOR_CHILD_POLICY_RESOURCE_TYPE_NAME__", summary_template_search_string)
     output_incident = output_check.gsub("__PLACEHOLDER_FOR_CHILD_POLICY_RESOURCE_TYPE_NAME__", summary_template_search_string)
+    # Replace the placeholder with the Child Policy Escalations
+    output_incident = output_incident.gsub("__PLACEHOLDER_FOR_CHILD_POLICY_CONSOLIDATED_INCIDENT_ESCALATIONS__", escalations_parent.join("    ").rstrip)
     # Replace the placeholder with the Child Policy Consolidated Incident Fields
     output_ds = output_ds.gsub("__PLACEHOLDER_FOR_CHILD_POLICY_CONSOLIDATED_INCIDENT_FIELDS__", fields.join("\n"))
     # Replace the placeholder with the Child Policy Consolidated Incident Datasource Block
@@ -238,6 +291,9 @@ def compile_meta_parent_policy(file_path)
   # For each check, build the consolidated incident check and datasource
   output_pt = output_pt.gsub("__PLACEHOLDER_FOR_CONSOLIDATED_INCIDENT_CHECKS__", consolidated_incidents_checks.join("\n"))
   output_pt = output_pt.gsub("__PLACEHOLDER_FOR_CONSOLIDATED_INCIDENT_DATASOURCES__", consolidated_indidents_datasources.join("\n"))
+
+  # For each escalation, build the consolidated incident escalation
+  output_pt = output_pt.gsub("__PLACEHOLDER_FOR_CONSOLIDATED_INCIDENT_ESCALATIONS__", escalation_blocks_parent.join("\n"))
 
   # Write the output parent policy template to disk
   # The output file will be written to the same directory as the child policy template


### PR DESCRIPTION
### Description

 - Enables triggering policy escalation actions from the Meta Parent "Consolidated Incident"
 - Fixes the Incident Summary for some policies `with index 0` -> `AWS EC2 Volumes Found` ( [example](https://github.com/flexera-public/policy_templates/pull/1620/files#diff-622ba01a4d2f8338f7ab763d1d660e1b052ceaf93d800da5a71da2f93e45314fL971-R1013) )



### Link to Example Applied Policy

https://app.flexera.com/orgs/27018/automation/applied-policies/projects/116186?policyId=6553ef7099745e00015880dc
https://app.flexera.com/orgs/27018/automation/applied-policies/projects/116186?policyId=6553ef6c99745e00015880db

### Contribution Check List

- [X] New functionality includes testing.


Validated that actions work on AWS... using ARN/Credential in `586789346966` on a child policy applied for `638914988530`:
> fpt -a 116186 run aws_unused_ip_addresses_meta_parent.pt -C auth_flexera=BKaraffa-flexera-com_RefreshToken -C auth_aws=arn-aws-iam--586789346966-role-FlexeraAutomationAccessRole 'param_dimension_filter_includes=["vendor_account=638914988530"]' 'param_regions_list=["us-east-1","us-east-2","us-west-1","us-west-2"]' param_days_unattached=0 -kr

and

> fpt -a 116186 run aws_rightsize_ec2_instances_meta_parent.pt -C auth_flexera=BKaraffa-flexera-com_RefreshToken -C auth_aws=arn-aws-iam--586789346966-role-FlexeraAutomationAccessRole 'param_dimension_filter_includes=["vendor_account=638914988530"]' 'param_regions_list=["us-west-2"]' param_stats_idle_threshold_cpu_value=50 param_stats_underutil_threshold_cpu_value=100 -kr
