### PR TITLE
POL-745 SaaS Manager - Suspicious Users Revamp

### DIFF
--- a/saas/fsm/suspicious_users/CHANGELOG.md
+++ b/saas/fsm/suspicious_users/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v3.0
+
+- Added support for APAC API endpoint
+- Policy now uses and requires a general Flexera One credential
+- Incident summary now includes applied policy name
+- General code cleanup and normalization
+
 ## v2.6
 
 - Replaced references `github.com/rightscale/policy_templates` and `github.com/flexera/policy_templates` with `github.com/flexera-public/policy_templates`

--- a/saas/fsm/suspicious_users/README.md
+++ b/saas/fsm/suspicious_users/README.md
@@ -1,6 +1,6 @@
 # SaaS Manager - Suspicious Users
 
-## What it does
+## What It Does
 
 This policy will create an incident when Flexera SaaS Manager identifies suspicious users logging into SaaS applications.
 
@@ -15,7 +15,11 @@ This policy integrates with the Flexera SaaS Manager API to retrieve suspicious 
 
 This policy has the following input parameters required when launching the policy.
 
-- *Email addresses to notify* - Email addresses of the recipients you wish to notify
+- *Email Addresses* - Email addresses of the recipients you wish to notify
+
+## Policy Actions
+
+- Send an email report
 
 ## Prerequisites
 
@@ -25,12 +29,8 @@ This policy uses [credentials](https://docs.flexera.com/flexera/EN/Automation/Ma
 
 For administrators [creating and managing credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) to use with this policy, the following information is needed:
 
-Provider tag value to match this policy: `flexera_fsm`
+Provider tag value to match this policy: `flexera`
 
 Required permissions in the provider:
 
 - Administrator, Application Administrator, Viewer, or Security Administrator in FSM
-
-## Policy Actions
-
-- Sends an email notification

--- a/saas/fsm/suspicious_users/fsm-suspicious_users.pt
+++ b/saas/fsm/suspicious_users/fsm-suspicious_users.pt
@@ -4,42 +4,43 @@ type "policy"
 short_description "This policy will create an incident when Flexera SaaS Manager identifies suspicious users logging into SaaS applications. See the [README](https://github.com/flexera-public/policy_templates/tree/master/saas/fsm/suspicious_users/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 severity "high"
-default_frequency "daily"
+default_frequency "weekly"
 category "SaaS Management"
 info(
-  version: "2.6",
+  version: "3.0",
   provider: "Flexera SaaS Manager",
   service: "",
   policy_set: ""
 )
 
 ###############################################################################
-# User inputs
+# Parameters
 ###############################################################################
 
 parameter "param_email" do
   type "list"
-  label "Email addresses to notify"
-  description "Email addresses of the recipients you wish to notify"
+  category "Policy Settings"
+  label "Email Addresses"
+  description "Email addresses of the recipients you wish to notify when new incidents are created"
+  default []
 end
 
 ###############################################################################
 # Authentication
 ###############################################################################
 
-#authenticate with FSM
-credentials "fsm_auth" do
+credentials "auth_flexera" do
   schemes "oauth2"
-  label "FSM"
-  description "Select the FSM Resource Manager Credential from the list."
-  tags "provider=flexera_fsm"
+  label "Flexera"
+  description "Select Flexera One OAuth2 credentials"
+  tags "provider=flexera"
 end
 
 ###############################################################################
 # Pagination
 ###############################################################################
 
-pagination "pag_get_suspicious_users" do
+pagination "pagination_users_suspicious" do
   get_page_marker do
     body_path jq(response, 'if length < 1000 then null else if $marker != "" then $marker | tonumber + 1 else 2 end end')
   end
@@ -49,35 +50,51 @@ pagination "pag_get_suspicious_users" do
 end
 
 ###############################################################################
-# Datasources and Scripts
+# Datasources & Scripts
 ###############################################################################
 
-#GET HOST
-datasource "ds_get_host" do
-  run_script $js_get_host, rs_governance_host
+# Get applied policy metadata for use later
+datasource "ds_applied_policy" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    header "Api-Version", "1.0"
+  end
 end
 
-script "js_get_host", type: "javascript" do
-  parameters "rs_governance_host"
+datasource "ds_flexera_api_hosts" do
+  run_script $js_flexera_api_hosts, rs_optima_host
+end
+
+script "js_flexera_api_hosts", type: "javascript" do
+  parameters "rs_optima_host"
   result "result"
   code <<-EOS
-    var result = []
-    if(rs_governance_host.indexOf(".eu") !== -1 || rs_governance_host.indexOf("-eu") !== -1){
-      result.push({ host: "api.fsm-eu.flexeraeng.com" })
-    }else{
-      result.push({ host: "api.fsm.flexeraeng.com" })
+  host_table = {
+    "api.optima.flexeraeng.com": {
+      flexera: "api.flexera.com",
+      fsm: "api.fsm.flexeraeng.com"
+    },
+    "api.optima-eu.flexeraeng.com": {
+      flexera: "api.flexera.eu",
+      fsm: "api.fsm-eu.flexeraeng.com"
+    },
+    "api.optima-apac.flexeraeng.com": {
+      flexera: "api.flexera.au",
+      fsm: "api.fsm-apac.flexeraeng.com"
     }
-  EOS
+  }
+
+  result = host_table[rs_optima_host]
+EOS
 end
 
 datasource "ds_suspicious_users" do
-  iterate $ds_get_host
   request do
-    auth $fsm_auth
-    pagination $pag_get_suspicious_users
-    host val(iter_item,"host")
-    verb "GET"
-    scheme "https"
+    auth $auth_flexera
+    pagination $pagination_users_suspicious
+    host val($ds_flexera_api_hosts, "fsm")
     path join(["/svc/orgs/", rs_org_id, "/activity/suspicious-agents"])
     header "content-type", "application/json"
     query "page", "1"
@@ -102,39 +119,51 @@ datasource "ds_suspicious_users" do
 end
 
 datasource "ds_users_cleanup" do
-  run_script $js_users_cleanup, $ds_suspicious_users
+  run_script $js_users_cleanup, $ds_suspicious_users, $ds_applied_policy
 end
 
 script "js_users_cleanup", type: "javascript" do
-  parameters "users"
+  parameters "ds_suspicious_users", "ds_applied_policy"
   result "result"
   code <<-EOS
-    _.each(users, function(user){
-      if (user.unauthorized == true){
-        user["activity_type"] = "Unauthorized";
-      } else {
-        user["activity_type"] = "Unrecognized";
+  result = []
+
+  _.each(ds_suspicious_users, function(user) {
+    firstName = user['firstName']
+    if (typeof(firstName) != 'string') { firstName = '' }
+
+    lastName = user["lastName"]
+    if (typeof(lastName) != 'string') { lastName = '' }
+
+    activity_type = "Unrecognized"
+    if (user['unauthorized'] == true) { activity_type = "Unauthorized" }
+
+    email = user["email"]
+
+    if (typeof(email) != 'string') {
+      email = ""
+
+      if (typeof(user['uniqueId']) == 'string' && user['uniqueId'] != "(Unknown)") {
+        email = user['uniqueId']
       }
-      if (user.firstName == null){ user["firstName"] = "" }
-      if (user.lastName == null){ user["lastName"] = "" }
-      if (user.email == null){
-        if (user.uniqueId == "(Unknown)" || user.uniqueId == null){ user["email"] = "" }
-        else { user["email"] = user.uniqueId }
-      }
+    }
+
+    result.push({
+      uniqueId: user['uniqueId'],
+      managedProductName: user['managedProductName'],
+      recognized: user['recognized'],
+      unauthorized: user['unauthorized'],
+      firstName: firstName,
+      lastName: lastName,
+      activity_type: activity_type,
+      email: email
     })
-    var result = users;
-  EOS
-end
+  })
 
-###############################################################################
-# Escalations
-###############################################################################
-
-escalation "report_summary" do
-  automatic true
-  label "Send Email"
-  description "Send incident email"
-  email $param_email
+  if (result.length > 0) {
+    result[0]['policy_name'] = ds_applied_policy['name']
+  }
+EOS
 end
 
 ###############################################################################
@@ -142,8 +171,10 @@ end
 ###############################################################################
 
 policy "policy_fsm_suspicious_users" do
-  validate $ds_users_cleanup do
-    summary_template "{{ len data }} Suspicious SaaS Users Found"
+  validate_each $ds_users_cleanup do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Suspicious SaaS Users Found"
+    check eq(val(item, "uniqueId"), "")
+    escalate $esc_email
     export do
       field "lastName" do
         label "Last Name"
@@ -161,7 +192,16 @@ policy "policy_fsm_suspicious_users" do
         label "Activity Type"
       end
     end
-    escalate $report_summary
-    check eq(size(data), 0)
   end
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
 end


### PR DESCRIPTION
### Description

This is part of a broader initiative to update our SaaS Manager FSM policies to use the correct API endpoints for APAC. The policy itself has also been revamped along similar lines to other policies.

Note: This policy still uses the now-deprecated internal SaaS Manager API. This is because the new API does not yet support the requests this policy needs to make to function. This functionality will be brought to the new API before the old one is decommissioned, and this policy will need to be updated again at that time.

From the CHANGELOG:

- Added support for APAC API endpoint
- Policy now uses and requires a general Flexera One credential
- Incident summary now includes applied policy name
- General code cleanup and normalization

### Link to Example Applied Policy

https://app.flexera.com/orgs/27018/automation/applied-policies/projects/116186?policyId=65455431e947000001d936ce

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
