### PR TITLE
POL-745 SaaS Manager - Unsanctioned Spend Revamp

### DIFF
--- a/saas/fsm/unsanctioned_spend/CHANGELOG.md
+++ b/saas/fsm/unsanctioned_spend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v3.0
+
+- Added support for APAC API endpoint
+- Policy now uses and requires a general Flexera One credential
+- Incident summary now includes applied policy name
+- General code cleanup and normalization
+
 ## v2.6
 
 - Replaced references `github.com/rightscale/policy_templates` and `github.com/flexera/policy_templates` with `github.com/flexera-public/policy_templates`

--- a/saas/fsm/unsanctioned_spend/CHANGELOG.md
+++ b/saas/fsm/unsanctioned_spend/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added support for APAC API endpoint
 - Policy now uses and requires a general Flexera One credential
 - Incident summary now includes applied policy name
+- `Expense Sum` and `Currency` are now separate incident fields
 - General code cleanup and normalization
 
 ## v2.6

--- a/saas/fsm/unsanctioned_spend/README.md
+++ b/saas/fsm/unsanctioned_spend/README.md
@@ -1,6 +1,6 @@
 # SaaS Manager - Unsanctioned Spend
 
-## What it does
+## What It Does
 
 This policy will create an incident when Flexera SaaS Manager identifies unsanctioned spend on SaaS applications.
 
@@ -15,24 +15,17 @@ This policy integrates with the Flexera SaaS Manager API to retrieve the expense
 
 This policy has the following input parameters required when launching the policy.
 
+- *Email Addresses* - Email addresses of the recipients you wish to notify.
 - *Unsanctioned Application Names* - List of SaaS Application names that the policy will target for identifying unsanctioned spend. Note: if left blank, the policy will detect all unsanctioned spend.
 - *Number of Days Back* - Any unsanctioned expenses discovered during this time period will raise an incident.
-- *Email addresses to notify* - Email addresses of the recipients you wish to notify.
-
-## Prerequisites
-
-This policy uses [credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for connecting to the cloud -- in order to apply this policy you must have a credential registered in the system that is compatible with this policy. If there are no credentials listed when you apply the policy, please contact your cloud admin and ask them to register a credential that is compatible with this policy. The information below should be consulted when creating the credential.
-
-### Credential configuration
-
-For administrators [creating and managing credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) to use with this policy, the following information is needed:
-
-Provider tag value to match this policy: `flexera_fsm`
-
-Required permissions in the provider:
-
-- Security Administrator or Administrator in FSM
 
 ## Policy Actions
 
-- Sends an email notification
+- Send an email report
+
+## Prerequisites
+
+This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).
+
+- [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following permissions:
+  - Administrator, Application Administrator, Viewer, or Security Administrator in FSM

--- a/saas/fsm/unsanctioned_spend/fsm-unsanctioned_spend.pt
+++ b/saas/fsm/unsanctioned_spend/fsm-unsanctioned_spend.pt
@@ -5,77 +5,109 @@ short_description "This policy will create an incident when Flexera SaaS Manager
 long_description ""
 severity "medium"
 category "SaaS Management"
-default_frequency "daily"
+default_frequency "weekly"
 info(
-  version: "2.6",
+  version: "3.0",
   provider: "Flexera SaaS Manager",
   service: "",
   policy_set: ""
 )
 
 ###############################################################################
-# User inputs
+# Parameters
 ###############################################################################
+
+parameter "param_email" do
+  type "list"
+  category "Policy Settings"
+  label "Email Addresses"
+  description "Email addresses of the recipients you wish to notify when new incidents are created"
+  default []
+end
 
 parameter "param_unsanctioned_apps" do
   type "list"
+  category "Policy Settings"
   label "Unsanctioned Application Names"
   description "List of SaaS Application names that the policy will target for identifying unsanctioned spend. Note: if left blank, the policy will detect all unsanctioned spend."
 end
 
 parameter "param_days" do
   type "number"
+  category "Policy Settings"
   label "Number of Days Back"
-  default 7
   description "Unsanctioned expenses discovered during this time period will raise an incident"
-end
-
-parameter "param_email" do
-  type "list"
-  label "Email addresses to notify"
-  description "Email addresses of the recipients you wish to notify"
+  default 7
 end
 
 ###############################################################################
 # Authentication
 ###############################################################################
 
-#authenticate with FSM
-credentials "fsm_auth" do
+credentials "auth_flexera" do
   schemes "oauth2"
-  label "FSM"
-  description "Select the FSM Resource Manager Credential from the list."
-  tags "provider=flexera_fsm"
+  label "Flexera"
+  description "Select Flexera One OAuth2 credentials"
+  tags "provider=flexera"
 end
 
 ###############################################################################
-# Datasources
+# Datasources & Scripts
 ###############################################################################
 
-datasource "ds_get_host" do
-  run_script $js_get_host, rs_governance_host
+# Get applied policy metadata for use later
+datasource "ds_applied_policy" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    header "Api-Version", "1.0"
+  end
+end
+
+datasource "ds_flexera_api_hosts" do
+  run_script $js_flexera_api_hosts, rs_optima_host
+end
+
+script "js_flexera_api_hosts", type: "javascript" do
+  parameters "rs_optima_host"
+  result "result"
+  code <<-EOS
+  host_table = {
+    "api.optima.flexeraeng.com": {
+      flexera: "api.flexera.com",
+      fsm: "api.fsm.flexeraeng.com"
+    },
+    "api.optima-eu.flexeraeng.com": {
+      flexera: "api.flexera.eu",
+      fsm: "api.fsm-eu.flexeraeng.com"
+    },
+    "api.optima-apac.flexeraeng.com": {
+      flexera: "api.flexera.au",
+      fsm: "api.fsm-apac.flexeraeng.com"
+    }
+  }
+
+  result = host_table[rs_optima_host]
+EOS
 end
 
 datasource "ds_num_expenses" do
-  iterate $ds_get_host
   request do
-    auth $fsm_auth
-    host val(iter_item,"host")
-    verb "GET"
-    scheme "https"
+    auth $auth_flexera
+    host val($ds_flexera_api_hosts, "fsm")
     path join(["/svc/orgs/", rs_org_id, "/financial-discovery"])
     header "content-type", "application/json"
   end
   result do
     encoding "json"
     field "totalItems", jmes_path(response, "totalItems")
-    field "saas_host", val(iter_item,"host")
   end
 end
 
 datasource "ds_unsanctioned" do
   request do
-    run_script $js_unsanctioned, $ds_num_expenses, rs_org_id
+    run_script $js_unsanctioned, $ds_num_expenses, $ds_flexera_api_hosts, rs_org_id
   end
   result do
     encoding "json"
@@ -94,70 +126,48 @@ datasource "ds_unsanctioned" do
   end
 end
 
-datasource "ds_cleanup_expenses" do
-  run_script $js_cleanup_expenses, $ds_unsanctioned, $param_days, $param_unsanctioned_apps
-end
-
-###############################################################################
-# Scripts
-###############################################################################
-
-script "js_get_host", type: "javascript" do
-  parameters "host"
-  result "result"
-  code <<-EOS
-    var result = [];
-    if(host.indexOf(".eu") !== -1 || host.indexOf("-eu") !== -1){
-      result.push({host: "api.fsm-eu.flexeraeng.com"});
-    }else{
-      result.push({host: "api.fsm.flexeraeng.com"});
-    }
-  EOS
-end
-
 script "js_unsanctioned", type: "javascript" do
-  parameters "ds_num_expenses", "rs_org_id"
+  parameters "ds_num_expenses", "ds_flexera_api_hosts", "rs_org_id"
   result "request"
   code <<-EOS
-  request = {
-    auth: "fsm_auth",
-    host: ds_num_expenses[0]["saas_host"],
-    verb: "GET",
-    scheme: "https",
-    path: "/svc/orgs/"+rs_org_id+"/financial-discovery",
-    headers: {
-      "content-type": "application/json"
-    },
-    query_params: {
-      "pageSize": ds_num_expenses[0]["totalItems"].toString()
-    }
+  var request = {
+    auth: "auth_flexera",
+    host: ds_flexera_api_hosts["fsm"],
+    path: "/svc/orgs/" + rs_org_id + "/financial-discovery",
+    headers: { "content-type": "application/json" },
+    query_params: { "pageSize": ds_num_expenses["totalItems"].toString() }
   }
 EOS
 end
 
+datasource "ds_cleanup_expenses" do
+  run_script $js_cleanup_expenses, $ds_unsanctioned, $ds_applied_policy, $param_days, $param_unsanctioned_apps
+end
+
 script "js_cleanup_expenses", type: "javascript" do
-  parameters "expenses", "param_days", "param_unsanctioned_apps"
+  parameters "ds_unsanctioned", "ds_applied_policy", "param_days", "param_unsanctioned_apps"
   result "result"
   code <<-EOS
-  var result = [];
-  var date = new Date();
-  date = date.setHours(-24 * param_days);
-  date = new Date(date);
+  result = []
+  date = new Date()
+  date = date.setHours(param_days * -24)
+  date = new Date(date)
 
   // returns date formatted as string: YYYY-mm-dd
   function getFormattedDailyDate(date) {
-    var year = date.getFullYear();
-    var month = (1 + date.getMonth()).toString();
-    month = month.length > 1 ? month : '0' + month;
-    var day = date.getDate().toString();
-    day = day.length > 1 ? day : '0' + day;
-    return year + '-' + month + '-' + day;
+    year = date.getFullYear()
+    month = (1 + date.getMonth()).toString()
+    month = month.length > 1 ? month : '0' + month
+    day = date.getDate().toString()
+    day = day.length > 1 ? day : '0' + day
+    return year + '-' + month + '-' + day
   }
 
-  _.each(expenses, function(expense){
-    var expense_date = new Date(expense["expenseDate"]);
-    if (expense_date > date){
-      if (_.contains(param_unsanctioned_apps, expense["application"]) || _.isEmpty(param_unsanctioned_apps)){
+  _.each(ds_unsanctioned, function(expense){
+    expense_date = new Date(expense["expenseDate"])
+
+    if (expense_date > date) {
+      if (_.contains(param_unsanctioned_apps, expense["application"]) || _.isEmpty(param_unsanctioned_apps)) {
         result.push({
           active: expense["active"],
           expenseSum: expense["currency"]+" "+expense["expenseSum"],
@@ -173,19 +183,12 @@ script "js_cleanup_expenses", type: "javascript" do
     }
   })
 
-  result = _.sortBy(result, 'expenseDate').reverse();
+  result = _.sortBy(result, 'expenseDate').reverse()
+
+  if (result.length > 0) {
+    result[0]['policy_name'] = ds_applied_policy['name']
+  }
 EOS
-end
-
-###############################################################################
-# Escalations
-###############################################################################
-
-escalation "report_summary" do
-  automatic true
-  label "Send Email"
-  description "Send incident email"
-  email $param_email
 end
 
 ###############################################################################
@@ -193,26 +196,37 @@ end
 ###############################################################################
 
 policy "policy_fsm_unsanctioned_spend" do
-  validate $ds_cleanup_expenses do
-      summary_template "{{ len data }} Unsanctioned Expenses Found"
-      export do
-        field "expenseDate" do
-          label "Expense Date"
-        end
-        field "expenseSum" do
-          label "Expense Sum"
-        end
-        field "vendor" do
-          label "Vendor"
-        end
-        field "application" do
-          label "Application"
-        end
-        field "purchaser_email" do
-          label "Purchaser"
-        end
+  validate_each $ds_cleanup_expenses do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Unsanctioned Expenses Found"
+    check eq(val(item, "application"), "")
+    escalate $esc_email
+    export do
+      field "expenseDate" do
+        label "Expense Date"
       end
-      escalate $report_summary
-      check eq(size(data), 0)
+      field "expenseSum" do
+        label "Expense Sum"
+      end
+      field "vendor" do
+        label "Vendor"
+      end
+      field "application" do
+        label "Application"
+      end
+      field "purchaser_email" do
+        label "Purchaser"
+      end
+    end
   end
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
 end

--- a/saas/fsm/unsanctioned_spend/fsm-unsanctioned_spend.pt
+++ b/saas/fsm/unsanctioned_spend/fsm-unsanctioned_spend.pt
@@ -116,9 +116,7 @@ datasource "ds_unsanctioned" do
       field "currency", jmes_path(col_item, "currency")
       field "expenseSum", jmes_path(col_item, "expenseSum")
       field "id", jmes_path(col_item, "id")
-      field "purchaser_email", jmes_path(col_item, "purchaser")
-      field "purchaser_firstName", jmes_path(col_item, "customerAgent.firstName")
-      field "purchaser_lastName", jmes_path(col_item, "customerAgent.lastName")
+      field "email", jmes_path(col_item, "purchaser")
       field "vendor", jmes_path(col_item, "vendor.name")
       field "application", jmes_path(col_item, "product.name")
       field "expenseDate", jmes_path(col_item, "latestExpenseDate")
@@ -153,41 +151,27 @@ script "js_cleanup_expenses", type: "javascript" do
   date = date.setHours(param_days * -24)
   date = new Date(date)
 
-  // returns date formatted as string: YYYY-mm-dd
-  function getFormattedDailyDate(date) {
-    year = date.getFullYear()
-    month = (1 + date.getMonth()).toString()
-    month = month.length > 1 ? month : '0' + month
-    day = date.getDate().toString()
-    day = day.length > 1 ? day : '0' + day
-    return year + '-' + month + '-' + day
-  }
-
   _.each(ds_unsanctioned, function(expense){
-    expense_date = new Date(expense["expenseDate"])
+    expenseDate = new Date(expense["expenseDate"])
 
-    if (expense_date > date) {
-      if (_.contains(param_unsanctioned_apps, expense["application"]) || _.isEmpty(param_unsanctioned_apps)) {
+    if (expenseDate > date) {
+      if (_.contains(param_unsanctioned_apps, expense["application"]) || param_unsanctioned_apps.length == 0) {
         result.push({
           active: expense["active"],
-          expenseSum: expense["currency"]+" "+expense["expenseSum"],
+          expenseSum: Number(expense["expenseSum"]),
+          currency: expense["currency"],
           id: expense["id"],
-          purchaser_email: expense["purchaser_email"],
-          purchaser_firstName: expense["purchaser_firstName"],
-          purchaser_lastName: expense["purchaser_lastName"],
+          email: expense["email"],
           vendor: expense["vendor"],
           application: expense["application"],
-          expenseDate: getFormattedDailyDate(expense_date)
+          expenseDate: expenseDate.toISOString().split('T')[0],
+          policy_name: ds_applied_policy["name"]
         })
       }
     }
   })
 
   result = _.sortBy(result, 'expenseDate').reverse()
-
-  if (result.length > 0) {
-    result[0]['policy_name'] = ds_applied_policy['name']
-  }
 EOS
 end
 
@@ -207,14 +191,17 @@ policy "policy_fsm_unsanctioned_spend" do
       field "expenseSum" do
         label "Expense Sum"
       end
-      field "vendor" do
-        label "Vendor"
+      field "currency" do
+        label "Currency"
       end
       field "application" do
         label "Application"
       end
-      field "purchaser_email" do
-        label "Purchaser"
+      field "vendor" do
+        label "Vendor"
+      end
+      field "email" do
+        label "Purchaser Email"
       end
     end
   end


### PR DESCRIPTION
### Description

This is part of a broader initiative to update our SaaS Manager FSM policies to use the correct API endpoints for APAC. The policy itself has also been revamped along similar lines to other policies.

Note: This policy still uses the now-deprecated internal SaaS Manager API. This is because the new API does not yet support the requests this policy needs to make to function. This functionality will be brought to the new API before the old one is decommissioned, and this policy will need to be updated again at that time.

From the CHANGELOG:

- Added support for APAC API endpoint
- Policy now uses and requires a general Flexera One credential
- Incident summary now includes applied policy name
- `Expense Sum` and `Currency` are now separate incident fields
- General code cleanup and normalization

### Link to Example Applied Policy

https://app.flexera.com/orgs/27018/automation/applied-policies/projects/116186?policyId=65551e3be947000001d9380a

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
