### PR TITLE
POL-745 SaaS Manager - Unsanctioned Applications with Existing Contract Revamp

### DIFF
--- a/saas/fsm/unsanctioned_apps_with_contract/CHANGELOG.md
+++ b/saas/fsm/unsanctioned_apps_with_contract/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added support for APAC API endpoint
 - Policy now uses and requires a general Flexera One credential
 - Incident summary now includes applied policy name
+- `Currency` is now a separate incident field
 - General code cleanup and normalization
 
 ## v2.5

--- a/saas/fsm/unsanctioned_apps_with_contract/CHANGELOG.md
+++ b/saas/fsm/unsanctioned_apps_with_contract/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v3.0
+
+- Added support for APAC API endpoint
+- Policy now uses and requires a general Flexera One credential
+- Incident summary now includes applied policy name
+- General code cleanup and normalization
+
 ## v2.5
 
 - Replaced references `github.com/rightscale/policy_templates` and `github.com/flexera/policy_templates` with `github.com/flexera-public/policy_templates`

--- a/saas/fsm/unsanctioned_apps_with_contract/README.md
+++ b/saas/fsm/unsanctioned_apps_with_contract/README.md
@@ -1,6 +1,6 @@
 # SaaS Manager - Unsanctioned Applications with Existing Contract
 
-## What it does
+## What It Does
 
 This policy will create an incident when Flexera SaaS Manager identifies unsanctioned SaaS purchases for managed applications under an existing license contract.
 
@@ -15,22 +15,15 @@ This policy integrates with the Flexera SaaS Manager API to retrieve managed Saa
 
 This policy has the following input parameters required when launching the policy.
 
-- *Email addresses to notify* - Email addresses of the recipients you wish to notify
-
-## Prerequisites
-
-This policy uses [credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for connecting to the cloud -- in order to apply this policy you must have a credential registered in the system that is compatible with this policy. If there are no credentials listed when you apply the policy, please contact your cloud admin and ask them to register a credential that is compatible with this policy. The information below should be consulted when creating the credential.
-
-### Credential configuration
-
-For administrators [creating and managing credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) to use with this policy, the following information is needed:
-
-Provider tag value to match this policy: `flexera_fsm`
-
-Required permissions in the provider:
-
-- Administrator, Application Administrator, Viewer, or Security Administrator in FSM
+- *Email Addresses* - Email addresses of the recipients you wish to notify
 
 ## Policy Actions
 
-- Sends an email notification
+- Send an email report
+
+## Prerequisites
+
+This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).
+
+- [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following permissions:
+  - Administrator, Application Administrator, Viewer, or Security Administrator in FSM

--- a/saas/fsm/unsanctioned_apps_with_contract/fsm-unsanctioned_with_contract.pt
+++ b/saas/fsm/unsanctioned_apps_with_contract/fsm-unsanctioned_with_contract.pt
@@ -5,64 +5,94 @@ short_description "This policy will create an incident when Flexera SaaS Manager
 long_description ""
 severity "high"
 category "SaaS Management"
-default_frequency "daily"
+default_frequency "weekly"
 info(
-  version: "2.5",
+  version: "3.0",
   provider: "Flexera SaaS Manager",
   service: "",
   policy_set: ""
 )
 
 ###############################################################################
-# User inputs
+# Parameters
 ###############################################################################
 
 parameter "param_email" do
   type "list"
-  label "Email addresses to notify"
-  description "Email addresses of the recipients you wish to notify"
+  category "Policy Settings"
+  label "Email Addresses"
+  description "Email addresses of the recipients you wish to notify when new incidents are created"
+  default []
 end
 
 ###############################################################################
 # Authentication
 ###############################################################################
 
-#authenticate with FSM
-credentials "fsm_auth" do
+credentials "auth_flexera" do
   schemes "oauth2"
-  label "FSM"
-  description "Select the FSM Resource Manager Credential from the list."
-  tags "provider=flexera_fsm"
+  label "Flexera"
+  description "Select Flexera One OAuth2 credentials"
+  tags "provider=flexera"
 end
 
 ###############################################################################
-# Datasources
+# Datasources & Scripts
 ###############################################################################
 
-datasource "ds_get_host" do
-  run_script $js_get_host, rs_governance_host
+# Get applied policy metadata for use later
+datasource "ds_applied_policy" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    header "Api-Version", "1.0"
+  end
+end
+
+datasource "ds_flexera_api_hosts" do
+  run_script $js_flexera_api_hosts, rs_optima_host
+end
+
+script "js_flexera_api_hosts", type: "javascript" do
+  parameters "rs_optima_host"
+  result "result"
+  code <<-EOS
+  host_table = {
+    "api.optima.flexeraeng.com": {
+      flexera: "api.flexera.com",
+      fsm: "api.fsm.flexeraeng.com"
+    },
+    "api.optima-eu.flexeraeng.com": {
+      flexera: "api.flexera.eu",
+      fsm: "api.fsm-eu.flexeraeng.com"
+    },
+    "api.optima-apac.flexeraeng.com": {
+      flexera: "api.flexera.au",
+      fsm: "api.fsm-apac.flexeraeng.com"
+    }
+  }
+
+  result = host_table[rs_optima_host]
+EOS
 end
 
 datasource "ds_num_products" do
-  iterate $ds_get_host
   request do
-    auth $fsm_auth
-    host val(iter_item,"host")
-    verb "GET"
-    scheme "https"
+    auth $auth_flexera
+    host val($ds_flexera_api_hosts, "fsm")
     path join(["/svc/orgs/", rs_org_id, "/managed-products"])
     header "content-type", "application/json"
   end
   result do
     encoding "json"
     field "totalItems", jmes_path(response, "totalItems")
-    field "saas_host", val(iter_item,"host")
   end
 end
 
 datasource "ds_products" do
   request do
-    run_script $js_products, $ds_num_products, rs_org_id
+    run_script $js_products, $ds_num_products, $ds_flexera_api_hosts, rs_org_id
   end
   result do
     encoding "json"
@@ -75,26 +105,39 @@ datasource "ds_products" do
   end
 end
 
+script "js_products", type: "javascript" do
+  parameters "ds_num_products", "ds_flexera_api_hosts", "rs_org_id"
+  result "request"
+  code <<-EOS
+  var request = {
+    auth: "auth_flexera",
+    host: ds_flexera_api_hosts["fsm"],
+    path: "/svc/orgs/" + rs_org_id + "/managed-products",
+    headers: { "content-type": "application/json" },
+    query_params: {
+      "pageSize": ds_num_products["totalItems"].toString(),
+      "includeInactive": "false"
+    }
+  }
+EOS
+end
+
 datasource "ds_num_unsanctioned" do
-  iterate $ds_get_host
   request do
-    auth $fsm_auth
-    host val(iter_item,"host")
-    verb "GET"
-    scheme "https"
+    auth $auth_flexera
+    host val($ds_flexera_api_hosts, "fsm")
     path join(["/svc/orgs/", rs_org_id, "/financial-discovery"])
     header "content-type", "application/json"
   end
   result do
     encoding "json"
     field "totalItems", jmes_path(response, "totalItems")
-    field "saas_host", val(iter_item,"host")
   end
 end
 
 datasource "ds_unsanctioned" do
   request do
-    run_script $js_unsanctioned, $ds_num_unsanctioned, rs_org_id
+    run_script $js_unsanctioned, $ds_num_unsanctioned, $ds_flexera_api_hosts, rs_org_id
   end
   result do
     encoding "json"
@@ -109,102 +152,52 @@ datasource "ds_unsanctioned" do
   end
 end
 
-datasource "ds_format_data" do
-  run_script $js_format_data, $ds_products, $ds_unsanctioned
-end
-
-###############################################################################
-# Scripts
-###############################################################################
-
-script "js_get_host", type: "javascript" do
-  parameters "host"
-  result "result"
-  code <<-EOS
-    var result = [];
-    if(host.indexOf(".eu") !== -1 || host.indexOf("-eu") !== -1){
-      result.push({host: "api.fsm-eu.flexeraeng.com"});
-    }else{
-      result.push({host: "api.fsm.flexeraeng.com"});
-    }
-  EOS
-end
-
-script "js_products", type: "javascript" do
-  parameters "ds_num_products", "rs_org_id"
-  result "request"
-  code <<-EOS
-  request = {
-    auth: "fsm_auth",
-    host: ds_num_products[0]["saas_host"],
-    verb: "GET",
-    scheme: "https",
-    path: "/svc/orgs/"+rs_org_id+"/managed-products",
-    headers: {
-      "content-type": "application/json"
-    },
-    query_params: {
-      "pageSize": ds_num_products[0]["totalItems"].toString(),
-      "includeInactive": "false"
-    }
-  }
-EOS
-end
-
 script "js_unsanctioned", type: "javascript" do
-  parameters "ds_num_unsanctioned", "rs_org_id"
+  parameters "ds_num_unsanctioned", "ds_flexera_api_hosts", "rs_org_id"
   result "request"
   code <<-EOS
-  request = {
-    auth: "fsm_auth",
-    host: ds_num_unsanctioned[0]["saas_host"],
-    verb: "GET",
-    scheme: "https",
-    path: "/svc/orgs/"+rs_org_id+"/financial-discovery",
-    headers: {
-      "content-type": "application/json"
-    },
-    query_params: {
-      "pageSize": ds_num_unsanctioned[0]["totalItems"].toString()
-    }
+  var request = {
+    auth: "auth_flexera",
+    host: ds_flexera_api_hosts["fsm"],
+    path: "/svc/orgs/" + rs_org_id + "/financial-discovery",
+    headers: { "content-type": "application/json" },
+    query_params: { "pageSize": ds_num_unsanctioned["totalItems"].toString() }
   }
 EOS
+end
+
+datasource "ds_format_data" do
+  run_script $js_format_data, $ds_products, $ds_unsanctioned, $ds_applied_policy
 end
 
 script "js_format_data", type: "javascript" do
-  parameters "ds_products", "ds_unsanctioned"
+  parameters "ds_products", "ds_unsanctioned", "ds_applied_policy"
   result "result"
   code <<-EOS
-  var result = [];
-  var unsanctioned_product_names = _.pluck(ds_unsanctioned, 'product');
+  result = []
+  unsanctioned_product_names = _.pluck(ds_unsanctioned, 'product')
 
-  _.each(ds_products, function(prod){
-    if (_.contains(unsanctioned_product_names, prod["application"])){
-      var expenses = _.where(ds_unsanctioned, {product: prod["application"]});
-      var latest_expense = _.max(expenses, function(expense){ return expense.latestExpenseDate; });
+  _.each(ds_products, function(prod) {
+    if (_.contains(unsanctioned_product_names, prod["application"])) {
+      expenses = _.where(ds_unsanctioned, { product: prod["application"]} )
+      latest_expense = _.max(expenses, function(expense) { return expense['latestExpenseDate'] })
+
       result.push({
         product: prod["application"],
         vendor: prod["vendor"],
-        annualCost: "$"+prod["annualCost"],
+        annualCost: "$" + prod["annualCost"],
         licensePOC: prod["pointOfContactEmail"],
-        expenseSum: "$"+latest_expense["expenseSum"],
+        expenseSum: "$" + latest_expense["expenseSum"],
         latestExpenseDate: Date(latest_expense["latestExpenseDate"]).toString(),
         expensePurchaser: latest_expense["purchaser"]
       })
     }
   })
+
+  if (result.length > 0) {
+    result[0]['policy_name'] = ds_applied_policy['name']
+  }
 EOS
-end
-
-###############################################################################
-# Escalations
-###############################################################################
-
-escalation "report_summary" do
-  automatic true
-  label "Send Email"
-  description "Send incident email"
-  email $param_email
 end
 
 ###############################################################################
@@ -212,32 +205,43 @@ end
 ###############################################################################
 
 policy "policy_fsm_unsanctioned_with_contract" do
-  validate $ds_format_data do
-      summary_template "{{ len data }} Unsanctioned SaaS Purchases with Existing Contracts"
-      export do
-        field "product" do
-          label "Application"
-        end
-        field "vendor" do
-          label "Vendor"
-        end
-        field "annualCost" do
-          label "Annual Contract Cost"
-        end
-        field "licensePOC" do
-          label "Contract Point of Contact"
-        end
-        field "expenseSum" do
-          label "Expense Cost"
-        end
-        field "latestExpenseDate" do
-          label "Latest Expense Date"
-        end
-        field "expensePurchaser" do
-          label "Expense Purchaser"
-        end
+  validate_each $ds_format_data do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Unsanctioned SaaS Purchases with Existing Contracts"
+    check eq(val(item, "product"), "")
+    escalate $esc_email
+    export do
+      field "product" do
+        label "Application"
       end
-      escalate $report_summary
-      check eq(size(data), 0)
+      field "vendor" do
+        label "Vendor"
+      end
+      field "annualCost" do
+        label "Annual Contract Cost"
+      end
+      field "licensePOC" do
+        label "Contract Point of Contact"
+      end
+      field "expenseSum" do
+        label "Expense Cost"
+      end
+      field "latestExpenseDate" do
+        label "Latest Expense Date"
+      end
+      field "expensePurchaser" do
+        label "Expense Purchaser"
+      end
+    end
   end
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
 end

--- a/saas/fsm/unsanctioned_apps_with_contract/fsm-unsanctioned_with_contract.pt
+++ b/saas/fsm/unsanctioned_apps_with_contract/fsm-unsanctioned_with_contract.pt
@@ -77,6 +77,60 @@ script "js_flexera_api_hosts", type: "javascript" do
 EOS
 end
 
+datasource "ds_currency_reference" do
+  request do
+    host "raw.githubusercontent.com"
+    path "/rightscale/policy_templates/master/cost/scheduled_reports/currency_reference.json"
+    header "User-Agent", "RS Policies"
+  end
+end
+
+datasource "ds_currency_code" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/bill-analysis/orgs/", rs_org_id, "/settings/currency_code"])
+    header "Api-Version", "0.1"
+    header "User-Agent", "RS Policies"
+    ignore_status [403]
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+    field "value", jmes_path(response, "value")
+  end
+end
+
+datasource "ds_currency" do
+  run_script $js_currency, $ds_currency_reference, $ds_currency_code
+end
+
+script "js_currency", type:"javascript" do
+  parameters "ds_currency_reference", "ds_currency_code"
+  result "result"
+  code <<-EOS
+  symbol = "$"
+  separator = ","
+
+  if (ds_currency_code['value'] != undefined) {
+    if (ds_currency_reference[ds_currency_code['value']] != undefined) {
+      symbol = ds_currency_reference[ds_currency_code['value']]['symbol']
+
+      if (ds_currency_reference[ds_currency_code['value']]['t_separator'] != undefined) {
+        separator = ds_currency_reference[ds_currency_code['value']]['t_separator']
+      } else {
+        separator = ""
+      }
+    }
+  }
+
+  result = {
+    symbol: symbol,
+    separator: separator
+  }
+EOS
+end
+
 datasource "ds_num_products" do
   request do
     auth $auth_flexera
@@ -167,11 +221,11 @@ EOS
 end
 
 datasource "ds_format_data" do
-  run_script $js_format_data, $ds_products, $ds_unsanctioned, $ds_applied_policy
+  run_script $js_format_data, $ds_products, $ds_unsanctioned, $ds_applied_policy, $ds_currency
 end
 
 script "js_format_data", type: "javascript" do
-  parameters "ds_products", "ds_unsanctioned", "ds_applied_policy"
+  parameters "ds_products", "ds_unsanctioned", "ds_applied_policy", "ds_currency"
   result "result"
   code <<-EOS
   result = []
@@ -182,21 +236,21 @@ script "js_format_data", type: "javascript" do
       expenses = _.where(ds_unsanctioned, { product: prod["application"]} )
       latest_expense = _.max(expenses, function(expense) { return expense['latestExpenseDate'] })
 
+      latestExpenseDate = new Date(latest_expense["latestExpenseDate"]).toISOString().split('T')[0]
+
       result.push({
         product: prod["application"],
         vendor: prod["vendor"],
-        annualCost: "$" + prod["annualCost"],
+        currency: ds_currency["symbol"],
+        annualCost: prod["annualCost"],
         licensePOC: prod["pointOfContactEmail"],
-        expenseSum: "$" + latest_expense["expenseSum"],
-        latestExpenseDate: Date(latest_expense["latestExpenseDate"]).toString(),
-        expensePurchaser: latest_expense["purchaser"]
+        expenseSum: latest_expense["expenseSum"],
+        latestExpenseDate: latestExpenseDate,
+        expensePurchaser: latest_expense["purchaser"],
+        policy_name: ds_applied_policy["name"]
       })
     }
   })
-
-  if (result.length > 0) {
-    result[0]['policy_name'] = ds_applied_policy['name']
-  }
 EOS
 end
 
@@ -219,11 +273,14 @@ policy "policy_fsm_unsanctioned_with_contract" do
       field "annualCost" do
         label "Annual Contract Cost"
       end
-      field "licensePOC" do
-        label "Contract Point of Contact"
-      end
       field "expenseSum" do
         label "Expense Cost"
+      end
+      field "currency" do
+        label "Currency"
+      end
+      field "licensePOC" do
+        label "Point of Contact"
       end
       field "latestExpenseDate" do
         label "Latest Expense Date"


### PR DESCRIPTION
### Description

This is part of a broader initiative to update our SaaS Manager FSM policies to use the correct API endpoints for APAC. The policy itself has also been revamped along similar lines to other policies.

Note: This policy still uses the now-deprecated internal SaaS Manager API. This is because the new API does not yet support the requests this policy needs to make to function. This functionality will be brought to the new API before the old one is decommissioned, and this policy will need to be updated again at that time.

From the CHANGELOG:

- Added support for APAC API endpoint
- Policy now uses and requires a general Flexera One credential
- Incident summary now includes applied policy name
- `Currency` is now a separate incident field
- General code cleanup and normalization

### Link to Example Applied Policy

https://app.flexera.com/orgs/27018/automation/applied-policies/projects/116186?policyId=6555266899745e00015880f1

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
