### PR TITLE
feat: add param for AWS Pricing API Endpoint

### DIFF
--- a/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.4
+
+- Added parameter to override the AWS Pricing API Endpoint
+
 ## v4.3
 
 - Corrected API issue when executing policy in APAC

--- a/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.3",
+  version: "4.4",
   provider: "AWS",
   service: "Compute",
   policy_set: "Inefficient Disk Usage",
@@ -41,6 +41,15 @@ parameter "param_min_savings" do
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
   default 0
+end
+
+parameter "param_pricing_api_endpoint" do
+  type "string"
+  category "Policy Settings"
+  label "AWS Pricing API Endpoint"
+  description "See AWS Docs for more details: https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/using-price-list-query-api.html#price-list-query-api-endpoints"
+  allowed_values "api.pricing.us-east-1.amazonaws.com", "api.pricing.eu-central-1.amazonaws.com", "api.pricing.ap-south-1.amazonaws.com"
+  default "api.pricing.us-east-1.amazonaws.com"
 end
 
 parameter "param_regions_allow_or_deny" do
@@ -490,23 +499,23 @@ end
 
 datasource "ds_gp2_prices" do
   request do
-    run_script $js_volume_prices, "gp2"
+    run_script $js_volume_prices, $param_pricing_api_endpoint, "gp2"
   end
 end
 
 datasource "ds_gp3_prices" do
   request do
-    run_script $js_volume_prices, "gp3"
+    run_script $js_volume_prices, $param_pricing_api_endpoint, "gp3"
   end
 end
 
 script "js_volume_prices", type: "javascript" do
-  parameters "volumeApiName"
+  parameters "param_pricing_api_endpoint", "volumeApiName"
   result "request"
   code <<-EOS
   var request = {
     "auth": "auth_aws",
-    "host": "api.pricing.us-east-1.amazonaws.com",
+    "host": param_pricing_api_endpoint,
     "verb": "POST",
     "path": "/",
     "headers": {

--- a/cost/aws/unused_ip_addresses/CHANGELOG.md
+++ b/cost/aws/unused_ip_addresses/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.7
+
+- Added parameter to override the AWS Pricing API Endpoint
+
 ## v6.6
 
 - Corrected API issue when executing policy in APAC

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "6.6",
+  version: "6.7",
   provider: "AWS",
   service: "Compute",
   policy_set: "Unused IP Addresses",
@@ -42,6 +42,15 @@ parameter "param_days_unattached" do
   default 30
   min_value 0
   max_value 90
+end
+
+parameter "param_pricing_api_endpoint" do
+  type "string"
+  category "Policy Settings"
+  label "AWS Pricing API Endpoint"
+  description "See AWS Docs for more details: https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/using-price-list-query-api.html#price-list-query-api-endpoints"
+  allowed_values "api.pricing.us-east-1.amazonaws.com", "api.pricing.eu-central-1.amazonaws.com", "api.pricing.ap-south-1.amazonaws.com"
+  default "api.pricing.us-east-1.amazonaws.com"
 end
 
 parameter "param_regions_allow_or_deny" do
@@ -582,7 +591,7 @@ datasource "ds_ip_address_prices" do
   request do
     auth $auth_aws
     pagination $pagination_aws_products
-    host "api.pricing.us-east-1.amazonaws.com"
+    host $param_pricing_api_endpoint
     verb "POST"
     path "/"
     header "Content-Type", "application/x-amz-json-1.1"


### PR DESCRIPTION
### Description

Added parameter to override the AWS Pricing API Endpoint.

This will enable us to change the API endpoint being used by the Policy Template in case a customer is using an AWS Service Control Policy to deny `us-east-1` which we previously had hard-coded.

### Link to Example Applied Policy

https://app.flexera.com/orgs/35917/automation/applied-policies/projects/137860?noIndex=1&policyId=655bbca055d35d0001a8c051

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
