### PR TITLE
fix: convert nil values to empty string ""

### DIFF
--- a/tools/readme_policy_table_of_contents/generate_readme_policy_table_of_contents.rb
+++ b/tools/readme_policy_table_of_contents/generate_readme_policy_table_of_contents.rb
@@ -31,10 +31,20 @@ if (pt_files.length != 0)
 
     # Construct the policy hash with just the info we need for the output
     p = {file: file, name: pp.parsed_name, category: pp.parsed_category, provider: pp.parsed_info[:provider], service: pp.parsed_info[:service], policy_set: pp.parsed_info[:policy_set], recommendation_type: pp.parsed_info[:recommendation_type]}
+
+    ## Check that all keys/values are not nil
+    p.each do |key, value|
+      if value.nil? then p[key] = "" end
+    end
+
+    # Check if the pt_stats counters have been initialized yet
+    # If not, initialize them with count starting at 0
     if pt_stats[:categories][p[:category]].nil? then pt_stats[:categories][p[:category]] = 0 end
     if pt_stats[:providers][p[:provider]].nil? then pt_stats[:providers][p[:provider]] = 0 end
     if pt_stats[:services][p[:service]].nil? then pt_stats[:services][p[:service]] = 0 end
     if pt_stats[:policy_sets][p[:policy_set]].nil? then pt_stats[:policy_sets][p[:policy_set]] = 0 end
+
+    # Increment the stats for the policy
     pt_stats[:categories][p[:category]] += 1
     pt_stats[:providers][p[:provider]] += 1
     pt_stats[:services][p[:service]] += 1


### PR DESCRIPTION
### Description

Fixes generate readme script by adding a step to convert any `nil` values from the parsed policy template into an empty string (`""`)

### Issues Resolved

Fixes broken workflow.  Example: https://github.com/flexera-public/policy_templates/actions/runs/6950317788
