### PR TITLE
POL-974 Deprecate AWS Unused RDS Policy

### DIFF
--- a/cost/aws/unused_rds/CHANGELOG.md
+++ b/cost/aws/unused_rds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.4
+
+- Deprecated: This policy is no longer being updated. Please see policy README for more information.
+
 ## v6.3
 
 - Corrected API issue when executing policy in APAC

--- a/cost/aws/unused_rds/README.md
+++ b/cost/aws/unused_rds/README.md
@@ -1,5 +1,9 @@
 # AWS Unused RDS Instances
 
+## Deprecated
+
+This policy is no longer being updated. The [AWS Rightsize RDS Instances](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/rightsize_rds_instances/) policy now includes this functionality and is the recommended policy for getting unused RDS instance recommendations.
+
 ## What It Does
 
 This policy template checks for Unused RDS instances by reviewing CloudWatch DBconnections and terminates them after user approval.

--- a/cost/aws/unused_rds/unused_rds.pt
+++ b/cost/aws/unused_rds/unused_rds.pt
@@ -1,13 +1,13 @@
 name "AWS Unused RDS Instances"
 rs_pt_ver 20180301
 type "policy"
-short_description "Check for database services that have no connections and delete them after approval. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/unused_rds) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "**Deprecated: This policy is no longer being updated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/unused_rds/) for more details.**  Check for database services that have no connections and delete them after approval. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/unused_rds) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "6.3",
+  version: "6.4",
   provider: "AWS",
   service: "RDS",
   policy_set: "Unused Database Services",

--- a/cost/aws/unused_rds/unused_rds_meta_parent.pt
+++ b/cost/aws/unused_rds/unused_rds_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "6.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 


### PR DESCRIPTION
### Description

The AWS Unused RDS policy is being deprecated due to the Rightsize RDS policy now containing identical functionality. This is similar to what has been done with other similar policies.

### Link to Example Applied Policy

N/A. Changes do not impact policy execution.

### Contribution Check List

- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
