### PR TITLE
Updated Readme as permission "cloudwatch:GetMetricData" was missing

### DIFF
--- a/cost/aws/old_snapshots/README.md
+++ b/cost/aws/old_snapshots/README.md
@@ -75,7 +75,7 @@ This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Auto
                   "ec2:DescribeImages",
                   "ec2:DescribeSnapshots",
                   "ec2:DeregisterImage",
-                  "ec2:DeleteSnapshot"
+                  "ec2:DeleteSnapshot",
                   "rds:DescribeDBInstances",
                   "rds:DescribeDBSnapshots",
                   "rds:DescribeDBClusters",

--- a/cost/aws/unused_volumes/README.md
+++ b/cost/aws/unused_volumes/README.md
@@ -53,6 +53,7 @@ This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Auto
   - `ec2:DescribeVolumes`
   - `ec2:DescribeSnapshots`
   - `cloudwatch:GetMetricStatistics`
+  - `cloudwatch:GetMetricData`
   - `ec2:CreateTags`*
   - `ec2:CreateSnapshot`*
   - `ec2:DetachVolume`*
@@ -73,6 +74,7 @@ This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Auto
                   "ec2:DescribeVolumes",
                   "ec2:DescribeSnapshots",
                   "cloudwatch:GetMetricStatistics",
+                  "cloudwatch:GetMetricData",
                   "ec2:CreateTags",
                   "ec2:CreateSnapshot",
                   "ec2:DetachVolume",


### PR DESCRIPTION
### Description

aws_delete_unused_volumes.pt uses "pagination_aws_getmetricdata" and therefore needs the  "cloudwatch:GetMetricData" permission:

- Updated Readme as permission "cloudwatch:GetMetricData" was missing.


### Contribution Check List

- [x ] New functionality includes testing. 
 (After adding the permission the template started working)
- [x ] New functionality has been documented in the README if applicable
- [x ] New functionality has been documented in CHANGELOG.MD
