### PR TITLE
POL-975 Google Old Snapshots Revamp / Meta Policy

### DIFF
--- a/cost/google/old_snapshots/CHANGELOG.md
+++ b/cost/google/old_snapshots/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v3.0
+
+- Several parameters altered to be more descriptive and human-readable
+- Removed deprecated "Log to CM Audit Entries" parameter
+- Added ability to filter resources by project
+- Added ability to use wildcards when filtering resources by label
+- Added additional context to incident description
+- Normalized incident export to be consistent with other policies
+- Added human-readable recommendation to incident export
+- Added additional fields to incident export
+- Streamlined code for better readability and faster execution
+
 ## v2.12
 
 - Modified `sys_log` definition to disable `rs_cm.audit_entry.create` outside Flexera NAM

--- a/cost/google/old_snapshots/CHANGELOG.md
+++ b/cost/google/old_snapshots/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added human-readable recommendation to incident export
 - Added additional fields to incident export
 - Streamlined code for better readability and faster execution
+- Policy now requires a valid Flexera One credential
 
 ## v2.12
 

--- a/cost/google/old_snapshots/README.md
+++ b/cost/google/old_snapshots/README.md
@@ -1,45 +1,56 @@
 # Google Old Snapshots
 
-## What it does
+## What It Does
 
-This Policy finds Google snapshots older than the specified days and deletes them.
+This policy finds Google snapshots older than the specified number of days and raises an incident with a list of said snapshots. Optionally, it will delete them.
+
+## Functional Details
+
+The policy makes use of the Google Cloud Compute API to obtain a list of snapshots and their ages in order to produce a list of recommendations.
 
 ## Input Parameters
 
 This policy has the following input parameters required when launching the policy.
 
-- *Email addresses* - A list of email addresses to notify
-- *Snapshot age* - The number of days since the snapshot was created.
-- *Exclusion Label List* - list of tags that a snapshot can have to exclude it from the list.
+- *Email Addresses* - A list of email addresses to notify
+- *Snapshot Age Threshold* - The number of days since the snapshot was created to consider a snapshot old.
+- *Allow/Deny Projects* - Whether to treat Allow/Deny Projects List parameter as allow or deny list. Has no effect if Allow/Deny Projects List is left empty.
+- *Allow/Deny Projects List* - Filter results by project ID/name, either only allowing this list or denying it depending on how the above parameter is set. Leave blank to consider all projects.
+- *Exclusion Labels (Key:Value)* - Google labels to ignore resources that you don't want to produce recommendations for. Use Key:Value format for specific label key/value pairs, and Key:\* format to match any resource with a particular key, regardless of value. Examples: env:production, DO_NOT_DELETE:\*
 - *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).
 
 Please note that the "Automatic Actions" parameter contains a list of action(s) that can be performed on the resources. When it is selected, the policy will automatically execute the corresponding action on the data that failed the checks, post incident generation. Please leave it blank for *manual* action.
-For example if a user selects the "Delete Snapshots" action while applying the policy, all the snapshots that didn't satisfy the policy condition will be deleted.
+For example, if a user selects the "Delete Snapshots" action while applying the policy, all old snapshots will be deleted.
 
 ## Policy Actions
 
 The following policy actions are taken on any resources found to be out of compliance.
 
 - Send an email report
-- Delete old snapshots after an approval
+- Delete old snapshots after approval
 
 ## Prerequisites
 
-This policy uses [credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for connecting to the cloud -- in order to apply this policy you must have a credential registered in the system that is compatible with this policy. If there are no credentials listed when you apply the policy, please contact your cloud admin and ask them to register a credential that is compatible with this policy. The information below should be consulted when creating the credential.
+This Policy Template requires that several APIs be enabled in your Google Cloud environment:
 
-### Credential configuration
+- [Cloud Resource Manager API](https://console.cloud.google.com/flows/enableapi?apiid=cloudresourcemanager.googleapis.com)
+- [Compute Engine API](https://console.cloud.google.com/flows/enableapi?apiid=compute.googleapis.com)
 
-For administrators [creating and managing credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) to use with this policy, the following information is needed:
+This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).
 
-Provider tag value to match this policy: `gce`
+- [**Google Cloud Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_4083446696_1121577) (*provider=gce*) which has the following:
+  - Permissions
+    - `resourcemanager.projects.get`
+    - `compute.snapshots.get`
+    - `compute.snapshots.list`
+    - `compute.snapshots.delete`*
 
-Required permissions in the provider:
+\* Only required for taking action; the policy will still function in a read-only capacity without these permissions.
 
-- The `compute.snapshots.delete` permission
-- The `compute.snapshots.list` permission
-- The `compute.snapshots.get` permission
-- The `compute.regions.list` permission
-- The `resourcemanager.projects.get` permission
+- [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
+  - `billing_center_viewer`
+
+The [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) page in the docs has detailed instructions for setting up Credentials for the most common providers.
 
 ## Supported Clouds
 

--- a/cost/google/old_snapshots/google_delete_old_snapshots.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots.pt
@@ -324,6 +324,7 @@ policy "policy_old_snapshots" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_snapshots
+    hash_exclude "message", "labels", "age"
     export do
       resource_level true
       field "accountID" do

--- a/cost/google/old_snapshots/google_delete_old_snapshots.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots.pt
@@ -271,10 +271,10 @@ script "js_google_old_snapshots", type: "javascript" do
         projectNumber: snapshot['projectNumber'],
         policy_name: ds_applied_policy['name'],
         createdAt: new Date(snapshotTime).toISOString(),
+        labels: labels.join(', '),
         lookbackPeriod: param_snapshot_age,
         recommendationDetails: recommendationDetails,
         age: age,
-        labels: labels,
         service: "Compute Engine",
         message: ''
       })

--- a/cost/google/old_snapshots/google_delete_old_snapshots.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots.pt
@@ -270,12 +270,12 @@ script "js_google_old_snapshots", type: "javascript" do
         accountName: snapshot['projectName'],
         projectNumber: snapshot['projectNumber'],
         policy_name: ds_applied_policy['name'],
-        createdAt: snapshotTime.toISOString(),
+        createdAt: new Date(snapshotTime).toISOString(),
         lookbackPeriod: param_snapshot_age,
         recommendationDetails: recommendationDetails,
         age: age,
         labels: labels,
-        service: "Cloud Storage",
+        service: "Compute Engine",
         message: ''
       })
     }

--- a/cost/google/old_snapshots/google_delete_old_snapshots.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots.pt
@@ -6,7 +6,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "2.12",
+  version: "3.0",
   provider:"Google",
   service: "Storage",
   policy_set: "Old Snapshots"
@@ -18,44 +18,60 @@ info(
 
 parameter "param_email" do
   type "list"
-  label "Email addresses to notify"
-  description "Email addresses of the recipients you wish to notify when new incidents are created"
+  category "Policy Settings"
+  label "Email Addresses"
+  description "A list of email addresses to notify."
+  default []
 end
 
 parameter "param_snapshot_age" do
-  label "Snapshot Age"
-  description "The number of days since the snapshot was created"
   type "number"
+  category "Policy Settings"
+  label "Snapshot Age Threshold"
+  default 30
+  description "The number of days since the snapshot was created to consider a snapshot old."
+  min_value 1
 end
 
-parameter "param_exclusion_tags" do
-  label "Exclusion Label List"
-  description "Cloud native label to ignore snapshots. Format: Key:Value"
+parameter "param_projects_allow_or_deny" do
+  type "string"
+  category "Filters"
+  label "Allow/Deny Projects"
+  description "Allow or Deny entered Projects. See the README for more details."
+  allowed_values "Allow", "Deny"
+  default "Allow"
+end
+
+parameter "param_projects_list" do
   type "list"
-  allowed_pattern /(^$)|([\w]?)+\:([\w]?)+/
+  category "Filters"
+  label "Allow/Deny Projects List"
+  description "A list of allowed or denied Subscription IDs/names. See the README for more details."
+  default []
+end
+
+parameter "param_exclusion_labels" do
+  type "list"
+  category "Filters"
+  label "Exclusion Labels (Key:Value)"
+  description "Cloud native labels to ignore resources that you don't want to produce recommendations for. Use Key:Value format for specific label key/value pairs, and Key:* format to match any resource with a particular key, regardless of value. Examples: env:production, DO_NOT_DELETE:*"
+  allowed_pattern /(^$)|[\w]*\:.*/
+  default []
 end
 
 parameter "param_automatic_action" do
   type "list"
+  category "Actions"
   label "Automatic Actions"
-  description "When this value is set, this policy will automatically take the selected action(s)"
+  description "When this value is set, this policy will automatically take the selected action."
   allowed_values ["Delete Snapshots"]
   default []
-end
-
-parameter "param_log_to_cm_audit_entries" do
-  type "string"
-  label "Log to CM Audit Entries"
-  description "Boolean for whether or not to log any debugging information from actions to CM Audit Entries, this should be left set to No on Flexera EU"
-  default "No"
-  allowed_values "Yes", "No"
 end
 
 ###############################################################################
 # Authentication
 ###############################################################################
 
-# authenticate with Google
 credentials "auth_google" do
   schemes "oauth2"
   label "Google"
@@ -63,11 +79,18 @@ credentials "auth_google" do
   tags "provider=gce"
 end
 
+credentials "auth_flexera" do
+  schemes "oauth2"
+  label "Flexera"
+  description "Select Flexera One OAuth2 credentials"
+  tags "provider=flexera"
+end
+
 ###############################################################################
 # Pagination
 ###############################################################################
 
-pagination "google_pagination" do
+pagination "pagination_google" do
   get_page_marker do
     body_path "nextPageToken"
   end
@@ -80,99 +103,183 @@ end
 # Datasources
 ###############################################################################
 
-#get all google project
-datasource "ds_google_project" do
+# Get applied policy metadata for use later
+datasource "ds_applied_policy" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    header "Api-Version", "1.0"
+  end
+end
+
+datasource "ds_google_projects" do
   request do
     auth $auth_google
-    pagination $google_pagination
+    pagination $pagination_google
     host "cloudresourcemanager.googleapis.com"
     path "/v1/projects/"
+    query "filter", "(lifecycleState:ACTIVE)"
+    # Header X-Meta-Flexera has no affect on datasource query, but is required for Meta Policies
+    # Forces `ds_is_deleted` datasource to run first during policy execution
+    header "Meta-Flexera", val($ds_is_deleted, "path")
   end
   result do
     encoding "json"
     collect jmes_path(response, "projects[*]") do
-      field "projectNumber", jmes_path(col_item,"projectNumber")
-      field "projectId", jmes_path(col_item,"projectId")
+      field "number", jmes_path(col_item, "projectNumber")
+      field "id", jmes_path(col_item, "projectId")
+      field "name", jmes_path(col_item, "name")
     end
   end
 end
 
-datasource "ds_snapshots" do
-  iterate $ds_google_project
+datasource "ds_google_projects_filtered" do
+  run_script $js_google_projects_filtered, $ds_google_projects, $param_projects_allow_or_deny, $param_projects_list
+end
+
+script "js_google_projects_filtered", type: "javascript" do
+  parameters "ds_google_projects", "param_projects_allow_or_deny", "param_projects_list"
+  result "result"
+  code <<-EOS
+  if (param_projects_list.length > 0) {
+    result = _.filter(ds_google_projects, function(project) {
+      include_project = _.contains(param_projects_list, project['id']) || _.contains(param_projects_list, project['name']) || _.contains(param_projects_list, project['number'])
+
+      if (param_projects_allow_or_deny == "Deny") {
+        include_project = !include_project
+      }
+
+      return include_project
+    })
+  } else {
+    result = ds_google_projects
+  }
+EOS
+end
+
+datasource "ds_google_snapshots" do
+  iterate $ds_google_projects_filtered
   request do
     auth $auth_google
-    pagination $google_pagination
+    pagination $pagination_google
     host "compute.googleapis.com"
-    path join(["/compute/v1/projects/",val(iter_item,"projectId"),"/global/snapshots"])
-    query "filter","status=READY"
-    ignore_status [403,404]
+    path join(["/compute/v1/projects/", val(iter_item, "id"), "/global/snapshots"])
+    query "filter", "status=READY"
+    ignore_status [403, 404]
   end
   result do
     encoding "json"
     collect jmes_path(response, "items[*]") do
-      field "projectId", val(iter_item, "projectId")
-      field "creationTimestamp", jmes_path(col_item,"creationTimestamp")
+      field "architecture", jmes_path(col_item, "architecture")
+      field "creationTimestamp", jmes_path(col_item, "creationTimestamp")
       field "diskSizeGb", jmes_path(col_item, "diskSizeGb")
       field "labels", jmes_path(col_item, "labels")
-      field "id", jmes_path(col_item,"name")
-      field "selfLink", jmes_path(col_item,"selfLink")
+      field "id", jmes_path(col_item, "id")
+      field "kind", jmes_path(col_item, "kind")
+      field "name", jmes_path(col_item, "name")
+      field "selfLink", jmes_path(col_item, "selfLink")
+      field "snapshotType", jmes_path(col_item, "snapshotType")
+      field "sourceDisk", jmes_path(col_item, "sourceDisk")
+      field "sourceDiskId", jmes_path(col_item, "sourceDiskId")
       field "status", jmes_path(col_item, "status")
+      field "projectId", val(iter_item, "id")
+      field "projectName", val(iter_item, "name")
+      field "projectNumber", val(iter_item, "number")
     end
   end
 end
 
-datasource "ds_filtered_snapshots" do
-  run_script $js_filter_snapshots, $ds_snapshots, $param_exclusion_tags
+datasource "ds_google_snapshots_label_filtered" do
+  run_script $js_google_snapshots_label_filtered, $ds_google_snapshots, $param_exclusion_labels
 end
 
-###############################################################################
-# Scripts
-###############################################################################
-script "js_filter_snapshots", type: "javascript" do
-  parameters "ds_snapshots", "param_exclusion_tags"
-  result "filtered_snapshots"
-  code <<-EOF
-  var filtered_snapshots = _.filter(ds_snapshots, function(snapshot){
-    var count = 0
-    _.each(param_exclusion_tags, function(tag)
-      {
-        tag_key = tag.split(':')[0]
-        tag_value = tag.split(':')[1]
-        if (snapshot.labels != null && snapshot.labels !== undefined && snapshot.labels[tag_key] != null && snapshot.labels[tag_key] !== undefined){
-          if (snapshot.labels[tag_key] == tag_value){
-            count = 1
-          }
-        }
-      }
-    )
-    if (count == 0){
-      if (snapshot.id != null) {
-        var labelsList = "";
-        for(var prop in snapshot.labels){
-          labelsList = labelsList + prop+" : "+snapshot.labels[prop]+", ";
-        }
-        if(labelsList.length > 0){
-          snapshot.labels = labelsList.substring(0, labelsList.length - 2);
-        }
-        return snapshot
-      }
-    }
-  }
-)
+script "js_google_snapshots_label_filtered", type: "javascript" do
+  parameters "ds_google_snapshots", "param_exclusion_labels"
+  result "result"
+  code <<-EOS
+  if (param_exclusion_labels.length > 0) {
+    result = _.reject(ds_google_snapshots, function(snapshot) {
+      snapshot_labels = []
 
-var now = new Date()
-var one_day=1000*60*60*24
-_.each(filtered_snapshots, function(snapshot){
-  var creation_time = new Date(snapshot.creationTimestamp)
-  var difference = now.getTime() - creation_time.getTime()
-  var days_old=(difference/one_day).toFixed(0)
-  snapshot["days_old"] = days_old
-}
-)
-var filtered_snapshots = _.sortBy(filtered_snapshots, "projectId")
-var filtered_snapshots = _.sortBy(filtered_snapshots, "id")
-var filtered_snapshots = _.sortBy(filtered_snapshots, "days_old")
-EOF
+      if (typeof(snapshot['labels']) == 'object') {
+        _.each(Object.keys(snapshot['labels']), function(key) {
+          snapshot_labels.push([key, ":", snapshot['labels'][key]].join(''))
+          snapshot_labels.push([key, ":*"].join(''))
+        })
+      }
+
+      exclude_snapshot = false
+
+      _.each(param_exclusion_labels, function(exclusion_label) {
+        if (_.contains(snapshot_labels, exclusion_label)) {
+          exclude_snapshot = true
+        }
+      })
+
+      return exclude_snapshot
+    })
+  } else {
+    result = ds_google_snapshots
+  }
+EOS
+end
+
+datasource "ds_google_old_snapshots" do
+  run_script $js_google_old_snapshots, $ds_google_snapshots_label_filtered, $ds_applied_policy, $param_snapshot_age
+end
+
+script "js_google_old_snapshots", type: "javascript" do
+  parameters "ds_google_snapshots_label_filtered", "ds_applied_policy", "param_snapshot_age"
+  result "result"
+  code <<-EOS
+  result = []
+
+  _.each(ds_google_snapshots_label_filtered, function(snapshot) {
+    labels = []
+
+    if (typeof(snapshot['labels']) == 'object') {
+      _.each(Object.keys(snapshot['labels']), function(key) {
+        labels.push([key, "=", snapshot['labels'][key]].join(''))
+      })
+    }
+
+    snapshotTime = Date.parse(snapshot['creationTimestamp'])
+    age = Math.round((new Date().getTime() - new Date(snapshotTime).getTime()) / (1000 * 3600 * 24))
+
+    if (age > param_snapshot_age) {
+      recommendationDetails = [
+        "Delete Google snapshot ", snapshot["name"], " ",
+        "in Google Project ", snapshot["projectName"],
+        " (", snapshot["projectId"], ")"
+      ].join('')
+
+      result.push({
+        architecture: snapshot['architecture'],
+        creationTimestamp: snapshot['creationTimestamp'],
+        size: snapshot['diskSizeGb'],
+        resourceID: snapshot['id'],
+        kind: snapshot['kind'],
+        resourceName: snapshot['name'],
+        selfLink: snapshot['selfLink'],
+        snapshotType: snapshot['snapshotType'],
+        sourceDisk: snapshot['sourceDisk'],
+        sourceDiskId: snapshot['sourceDiskId'],
+        status: snapshot['status'],
+        accountID: snapshot['projectId'],
+        accountName: snapshot['projectName'],
+        projectNumber: snapshot['projectNumber'],
+        policy_name: ds_applied_policy['name'],
+        lookbackPeriod: param_snapshot_age,
+        recommendationDetails: recommendationDetails,
+        age: age,
+        labels: labels,
+        service: "Cloud Storage",
+        message: ''
+      })
+    }
+  })
+EOS
 end
 
 ###############################################################################
@@ -180,38 +287,56 @@ end
 ###############################################################################
 
 policy "policy_old_snapshots" do
-  validate_each $ds_filtered_snapshots do
-    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} rows containing Old Snapshots"
-    check le(to_n(val(item, "days_old")), $param_snapshot_age)
+  validate_each $ds_google_old_snapshots do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Google Old Snapshots Found"
+    check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
     escalate $esc_email
-    escalate $esc_approve_delete_snapshots
+    escalate $esc_delete_snapshots
     export do
       resource_level true
-      field "projectId" do
+      field "accountID" do
         label "Project ID"
       end
-      field "id" do
-        label "Name"
+      field "accountName" do
+        label "Project Name"
       end
-      field "days_old" do
-        label "Age In Days"
+      field "projectNumber" do
+        label "Project Number"
       end
-      field "diskSizeGb" do
-        label "Size"
+      field "resourceID" do
+        label "Resource ID"
+      end
+      field "resourceName" do
+        label "Resource Name"
       end
       field "labels" do
-        label "Labels"
+        label "Resource Labels"
+      end
+      field "age" do
+        label "Age In Days"
+      end
+      field "size" do
+        label "Size (GB)"
+      end
+      field "recommendationDetails" do
+        label "Recommendation"
       end
       field "status" do
         label "Status"
       end
+      field "service" do
+        label "Service"
+      end
       field "selfLink" do
         label "Self Link"
+      end
+      field "id" do
+        label "ID"
+        path "resourceID"
       end
     end
   end
 end
-
 
 ###############################################################################
 # Escalations
@@ -224,75 +349,150 @@ escalation "esc_email" do
   email $param_email
 end
 
-escalation "esc_approve_delete_snapshots" do
+escalation "esc_delete_snapshots" do
   automatic contains($param_automatic_action, "Delete Snapshots")
   label "Delete Snapshots"
   description "Approval to delete all selected snapshots"
-  run "delete_snapshots", data, $param_log_to_cm_audit_entries, rs_optima_host
+  run "delete_snapshots", data
 end
 
 ###############################################################################
 # Cloud Workflow
 ###############################################################################
 
-define delete_snapshots($data,$param_log_to_cm_audit_entries, $$rs_optima_host) return $all_responses do
-  $$debug = $param_log_to_cm_audit_entries == "Yes"
-  $all_responses = []
-  $syslog_subject = "Google Old Snapshots: "
-  call sys_log(join([$syslog_subject, "Google Snapshot"]),to_s($data))
-  foreach $item in $data do
-    sub on_error: handle_error($response) do
-      $response = http_delete(
-        url: $item["selfLink"],
-        auth: $$auth_google,
-        headers: {
-          "cache-control": "no-cache",
-          "content-type": "application/json"
-        }
-      )
-      $all_responses << $response
+define delete_snapshots($data) return $all_responses do
+  $$all_responses = []
+
+  foreach $snapshot in $data do
+    sub on_error: handle_error() do
+      call delete_snapshot($snapshot) retrieve $delete_response
     end
   end
-  call sys_log(join([$syslog_subject, "Responses"]),to_s($all_responses))
+
+  if inspect($$errors) != "null"
+    raise join($$errors, "\n")
+  end
 end
 
-define handle_error($response) do
-  $status_code = $response["code"]
-  $syslog_subject = "Google Snapshot Deletion Error: "
-  call sys_log(join([$syslog_subject, $status_code]),to_s($response))
-  $_error_behavior = "skip"
+define delete_snapshot($snapshot) return $response do
+  task_label("DELETE " + $snapshot['selfLink'])
+
+  $response = http_delete(
+    url: $snapshot['selfLink'],
+    auth: $$auth_google,
+    headers: {
+      "cache-control": "no-cache",
+      "content-type": "application/json"
+    }
+  )
+
+  task_label("Delete Google Snapshot response: " + $snapshot["resourceName"] + " " + to_json($response))
+  $$all_responses << to_json({"req": "DELETE " + $snapshot["selfLink"], "resp": $response})
+
+  if $response["code"] != 204 && $response["code"] != 202 && $response["code"] != 200
+    raise "Unexpected response deleting Google Snapshot: "+ $snapshot["resourceName"] + " " + to_json($response)
+  else
+    task_label("Delete Google Snapshot successful: " + $snapshot["resourceName"])
+  end
 end
 
-define sys_log($subject, $detail) do
-  # Create empty errors array if doesn't already exist
+define handle_error() do
   if !$$errors
     $$errors = []
   end
-  # Check if debug is enabled
-  if $$debug
-    # Append to global $$errors
-    # This is the suggested way to capture errors
-    $$errors << "Unexpected error for " + $subject + "\n  " + to_s($detail)
-    # If Flexera NAM Zone, create audit_entries [to be deprecated]
-    # This is the legacy method for capturing errors and only supported on Flexera NAM
-    if $$rs_optima_host == "api.optima.flexeraeng.com"
-      # skip_error_and_append is used to catch error if rs_cm.audit_entries.create fails unexpectedly
-      $task_label = "Creating audit entry for " + $subject
-      sub task_label: $task, on_error: skip_error_and_append($task) do
-        rs_cm.audit_entries.create(
-          notify: "None",
-          audit_entry: {
-            auditee_href: @@account,
-            summary: $subject,
-            detail: $detail
-          }
-        )
-      end # End sub on_error
-    end # End if rs_optima_host
-  end # End if debug is enabled
+
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
-define skip_error_and_append($subject) do
-  $$errors << "Unexpected error for " + $subject + "\n  " + to_s($_error)
-  $_error_behavior = "skip"
+###############################################################################
+# Meta Policy [alpha]
+# Not intended to be modified or used by policy developers
+###############################################################################
+
+# If the meta_parent_policy_id is not set it will evaluate to an empty string and we will look for the policy itself,
+# if it is set we will look for the parent policy.
+datasource "ds_get_policy" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    ignore_status [404]
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", switch(ne(meta_parent_policy_id,""), meta_parent_policy_id, policy_id) ])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+  end
+end
+
+datasource "ds_parent_policy_terminated" do
+  run_script $js_decide_if_self_terminate, $ds_get_policy, policy_id, meta_parent_policy_id
+end
+
+# If the policy was applied by a meta_parent_policy we confirm it exists if it doesn't we confirm we are deleting
+# This information is used in two places:
+# - determining whether or not we make a delete call
+# - determining if we should create an incident (we don't want to create an incident on the run where we terminate)
+script "js_decide_if_self_terminate", type: "javascript" do
+  parameters "found", "self_policy_id", "meta_parent_policy_id"
+  result "result"
+  code <<-EOS
+  var result
+  if (meta_parent_policy_id != "" && found.id == undefined) {
+    result = true
+  } else {
+    result = false
+  }
+  EOS
+end
+
+# Two potentials ways to set this up:
+# - this way and make a unneeded 'get' request when not deleting
+# - make the delete request an interate and have it iterate over an empty array when not deleting and an array with one item when deleting
+script "js_make_terminate_request", type: "javascript" do
+  parameters "should_delete", "policy_id", "rs_project_id", "rs_governance_host"
+  result "request"
+  code <<-EOS
+
+  var request = {
+    auth:  'auth_flexera',
+    host: rs_governance_host,
+    path: "/api/governance/projects/" + rs_project_id + "/applied_policies/" + policy_id,
+    headers: {
+      "API-Version": "1.0",
+      "Content-Type":"application/json"
+    },
+  }
+
+  if (should_delete) {
+    request.verb = 'DELETE'
+  }
+  EOS
+end
+
+datasource "ds_terminate_self" do
+  request do
+    run_script $js_make_terminate_request, $ds_parent_policy_terminated, policy_id, rs_project_id, rs_governance_host
+  end
+end
+
+datasource "ds_is_deleted" do
+  run_script $js_check_deleted, $ds_terminate_self
+end
+
+# This is just a way to have the check delete request connect to the farthest leaf from policy.
+# We want the delete check to the first thing the policy does to avoid the policy erroring before it can decide whether or not it needs to self terminate
+# Example a customer deletes a credential and then terminates the parent policy. We still want the children to self terminate
+# The only way I could see this not happening is if the user who applied the parent_meta_policy was offboarded or lost policy access, the policies who are impersonating the user
+# would not have access to self-terminate
+# It may be useful for the backend to enable a mass terminate at some point for all meta_child_policies associated with an id.
+script "js_check_deleted", type: "javascript" do
+  parameters "response"
+  result "result"
+  code <<-EOS
+  result = {"path":"/"}
+  EOS
 end

--- a/cost/google/old_snapshots/google_delete_old_snapshots.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots.pt
@@ -366,6 +366,9 @@ policy "policy_old_snapshots" do
       field "selfLink" do
         label "Self Link"
       end
+      field "lookbackPeriod" do
+        label "Snapshot Age Threshold (Days)"
+      end
       field "id" do
         label "ID"
         path "resourceID"

--- a/cost/google/old_snapshots/google_delete_old_snapshots.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots.pt
@@ -4,7 +4,7 @@ type "policy"
 short_description "Checks for snapshots older than specified number of days and, optionally, deletes them. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/google/old_snapshots) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 category "Cost"
 severity "low"
-default_frequency "daily"
+default_frequency "weekly"
 info(
   version: "3.0",
   provider:"Google",
@@ -141,7 +141,7 @@ end
 script "js_google_projects_filtered", type: "javascript" do
   parameters "ds_google_projects", "param_projects_allow_or_deny", "param_projects_list"
   result "result"
-  code <<-EOS
+  code <<-'EOS'
   if (param_projects_list.length > 0) {
     result = _.filter(ds_google_projects, function(project) {
       include_project = _.contains(param_projects_list, project['id']) || _.contains(param_projects_list, project['name']) || _.contains(param_projects_list, project['number'])
@@ -197,7 +197,7 @@ end
 script "js_google_snapshots_label_filtered", type: "javascript" do
   parameters "ds_google_snapshots", "param_exclusion_labels"
   result "result"
-  code <<-EOS
+  code <<-'EOS'
   if (param_exclusion_labels.length > 0) {
     result = _.reject(ds_google_snapshots, function(snapshot) {
       snapshot_labels = []
@@ -232,7 +232,7 @@ end
 script "js_google_old_snapshots", type: "javascript" do
   parameters "ds_google_snapshots_label_filtered", "ds_applied_policy", "param_snapshot_age"
   result "result"
-  code <<-EOS
+  code <<-'EOS'
   result = []
 
   _.each(ds_google_snapshots_label_filtered, function(snapshot) {
@@ -256,7 +256,6 @@ script "js_google_old_snapshots", type: "javascript" do
 
       result.push({
         architecture: snapshot['architecture'],
-        creationTimestamp: snapshot['creationTimestamp'],
         size: snapshot['diskSizeGb'],
         resourceID: snapshot['id'],
         kind: snapshot['kind'],
@@ -270,6 +269,7 @@ script "js_google_old_snapshots", type: "javascript" do
         accountName: snapshot['projectName'],
         projectNumber: snapshot['projectNumber'],
         policy_name: ds_applied_policy['name'],
+        createdAt: snapshotTime.toISOString(),
         lookbackPeriod: param_snapshot_age,
         recommendationDetails: recommendationDetails,
         age: age,
@@ -279,6 +279,36 @@ script "js_google_old_snapshots", type: "javascript" do
       })
     }
   })
+
+  // Message for incident output
+  total_snapshots = ds_google_snapshots_label_filtered.length.toString()
+  total_old_snapshots = result.length.toString()
+  old_snapshots_percentage = (total_old_snapshots / total_snapshots * 100).toFixed(2).toString() + '%'
+
+  days_noun = "days"
+  if (param_snapshot_age == 1) { days_noun = "day" }
+
+  findings = [
+    "Out of ", total_snapshots, " snapshots analyzed, ",
+    total_old_snapshots, " (", old_snapshots_percentage,
+    ") are older than ", param_snapshot_age, " ", days_noun, " ",
+    "and are recommended for deletion.\n\n"
+  ].join('')
+
+  disclaimer = "The above settings can be modified by editing the applied policy and changing the appropriate parameters."
+
+  result = _.sortBy(result, 'resourceName')
+  result = _.sortBy(result, 'accountID')
+
+  // Dummy item to ensure that the check statement in the policy executes at least once
+  result.push({
+    resourceID: "",
+    message: "",
+    labels: "",
+    age: ""
+  })
+
+  result[0]['message'] = findings + disclaimer
 EOS
 end
 
@@ -289,7 +319,8 @@ end
 policy "policy_old_snapshots" do
   validate_each $ds_google_old_snapshots do
     summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Google Old Snapshots Found"
-    check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
+    detail_template "{{ with index data 0 }}{{ .message }}{{ end }}"
+    check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_snapshots
     export do
@@ -311,6 +342,9 @@ policy "policy_old_snapshots" do
       end
       field "labels" do
         label "Resource Labels"
+      end
+      field "createdAt" do
+        label "Date/Time Created"
       end
       field "age" do
         label "Age (Days)"

--- a/cost/google/old_snapshots/google_delete_old_snapshots.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots.pt
@@ -9,7 +9,8 @@ info(
   version: "3.0",
   provider:"Google",
   service: "Storage",
-  policy_set: "Old Snapshots"
+  policy_set: "Old Snapshots",
+  recommendation_type: "Usage Reduction"
 )
 
 ###############################################################################

--- a/cost/google/old_snapshots/google_delete_old_snapshots.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots.pt
@@ -313,7 +313,7 @@ policy "policy_old_snapshots" do
         label "Resource Labels"
       end
       field "age" do
-        label "Age In Days"
+        label "Age (Days)"
       end
       field "size" do
         label "Size (GB)"

--- a/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
@@ -803,6 +803,9 @@ policy "policy_scheduled_report" do
       field "labels" do
         label "Resource Labels"
       end
+      field "createdAt" do
+        label "Date/Time Created"
+      end
       field "age" do
         label "Age (Days)"
       end

--- a/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
@@ -804,7 +804,7 @@ policy "policy_scheduled_report" do
         label "Resource Labels"
       end
       field "age" do
-        label "Age In Days"
+        label "Age (Days)"
       end
       field "size" do
         label "Size (GB)"

--- a/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
@@ -1,0 +1,1187 @@
+name "Google Old Snapshots Meta Parent"
+rs_pt_ver 20180301
+type "policy"
+short_description "Applies and manages \"child\" [Google Old Snapshots](https://github.com/flexera-public/policy_templates/tree/master/cost/google/old_snapshots) Policies."
+severity "low"
+category "Cost"
+tenancy "single"
+default_frequency "15 minutes"
+info(
+  provider: "Google",
+  version: "3.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  publish: "false"
+)
+
+##############################################################################
+# Parameters
+##############################################################################
+
+## Meta Parent Parameters
+## These are params specific to the meta parent policy.
+parameter "param_combined_incident_email" do
+  type "list"
+  label "Email addresses for combined incident"
+  description "A list of email addresses to notify with the consolidated child policy incident."
+  default []
+end
+
+parameter "param_dimension_filter_includes" do
+  type "list"
+  label "Dimension Include Filters"
+  description <<-EOS
+  Filters [`dimension_name=dimension_value` pairs] to determine which Google Projects returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  During each run this policy will select Google Projects who match **all** the filters defined and apply a child policy for each.
+  If no include filters are provided, then all Google Projects are included by default.
+  Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
+  EOS
+  default []
+end
+
+parameter "param_dimension_filter_excludes" do
+  type "list"
+  label "Dimension Exclude Filters"
+  description <<-EOS
+  Filters [`dimension_name=dimension_value` pairs] to determine which Google Projects returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  During each run this policy will select Google Projects who match **all** the filters defined here and excludes them from results.
+  Can be used to exclude specific Google Projects [`vendor_account=123456789012`]
+  Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
+  EOS
+  default []
+end
+
+parameter "param_policy_schedule" do
+  type "string"
+  label "Child Policy Schedule"
+  description "The interval at which the child policy checks for conditions and generates incidents."
+  default "daily"
+  allowed_values "daily", "weekly", "monthly"
+end
+
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
+## Child Policy Parameters
+parameter "param_snapshot_age" do
+  type "number"
+  category "Policy Settings"
+  label "Snapshot Age Threshold"
+  default 30
+  description "The number of days since the snapshot was created to consider a snapshot old."
+  min_value 1
+end
+
+parameter "param_exclusion_labels" do
+  type "list"
+  category "Filters"
+  label "Exclusion Labels (Key:Value)"
+  description "Cloud native labels to ignore resources that you don't want to produce recommendations for. Use Key:Value format for specific label key/value pairs, and Key:* format to match any resource with a particular key, regardless of value. Examples: env:production, DO_NOT_DELETE:*"
+  allowed_pattern /(^$)|[\w]*\:.*/
+  default []
+end
+
+parameter "param_automatic_action" do
+  type "list"
+  category "Actions"
+  label "Automatic Actions"
+  description "When this value is set, this policy will automatically take the selected action."
+  allowed_values ["Delete Snapshots"]
+  default []
+end
+
+###############################################################################
+# Authentication
+###############################################################################
+credentials "auth_google" do
+  schemes "oauth2"
+  label "Google"
+  description "Select the Google Cloud Credential from the list."
+  tags "provider=gce"
+end
+
+credentials "auth_flexera" do
+  schemes "oauth2"
+  label "Flexera"
+  description "Select Flexera One OAuth2 credentials"
+  tags "provider=flexera"
+end
+
+###############################################################################
+# Pagination
+###############################################################################
+
+pagination "pagination_google" do
+  get_page_marker do
+    body_path "nextPageToken"
+  end
+  set_page_marker do
+    query "pageToken"
+  end
+end
+
+###############################################################################
+# Datasources & Scripts
+###############################################################################
+
+# Get Applied Parent Policy Details
+datasource "ds_self_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    field "name", jmes_path(response, "name")
+    field "creator_id", jmes_path(response, "created_by.id")
+    field "credentials", jmes_path(response, "credentials")
+    field "options", jmes_path(response, "options")
+  end
+end
+
+datasource "ds_child_policy_options" do
+  run_script $js_child_policy_options, $ds_self_policy_information
+end
+
+script "js_child_policy_options", type: "javascript" do
+  parameters "ds_self_policy_information"
+  result "options"
+  code <<-EOS
+  // Filter Options that are not appropriate for Child Policy
+  var options = _.map(ds_self_policy_information.options, function(option){
+    // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+      return { "name": option.name, "value": option.value };
+    }
+  });
+  // Explicitly add param_email which is disabled/does not exist in meta parent policy
+  options.push({
+    "name": "param_email",
+    "value": []
+  });
+  EOS
+end
+
+datasource "ds_child_policy_options_map" do
+  run_script $js_child_policy_options_map, $ds_child_policy_options
+end
+
+script "js_child_policy_options_map", type: "javascript" do
+  parameters "ds_child_policy_options"
+  result "options"
+  code <<-EOS
+  function format_options_keyvalue(options) {
+    var options_keyvalue_map = {};
+    _.each(options, function(option) {
+      options_keyvalue_map[option.name] = option.value;
+    });
+    return options_keyvalue_map;
+  }
+  var options = format_options_keyvalue(ds_child_policy_options)
+  EOS
+end
+
+datasource "ds_format_self" do
+  run_script $js_format_self, $ds_self_policy_information, $ds_child_policy_options_map
+end
+
+script "js_format_self", type: "javascript" do
+  parameters "ds_self_policy_information", "ds_child_policy_options_map"
+  result "formatted"
+  code <<-EOS
+  var formatted = {
+    "name": ds_self_policy_information["name"],
+    "creator_id": ds_self_policy_information["creator_id"],
+    "credentials": ds_self_policy_information["credentials"],
+    "options": ds_child_policy_options_map
+  };
+  EOS
+end
+
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/orgs/", rs_org_id, "/published_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "Google Old Snapshots" and .created_by.email == "support@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "Google Old Snapshots")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+datasource "ds_get_billing_centers" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/analytics/orgs/",rs_org_id,"/billing_centers"])
+    header "Api-Version", "1.0"
+    header "User-Agent", "RS Policies"
+    query "view", "allocation_table"
+    ignore_status [403]
+  end
+  result do
+    encoding "json"
+    # Select the Billing Centers that have "parent_id" undefined or "" (i.e. top-level Billing Centers)
+    collect jq(response, '.[] | select(.parent_id == null)' ) do
+      field "href", jq(col_item,".href")
+      field "id", jq(col_item,".id")
+      field "name", jq(col_item,".name")
+      field "parent_id", jq(col_item,".parent_id")
+    end
+  end
+end
+
+# Get the Google projects
+datasource "ds_get_google_projects" do
+  request do
+    run_script $js_make_billing_center_request, rs_org_id, rs_optima_host, $ds_get_billing_centers, $param_dimension_filter_includes, $param_dimension_filter_excludes
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response,"rows[*]") do
+      field "projectID", jmes_path(col_item,"dimensions.vendor_account")
+      field "projectName", jmes_path(col_item,"dimensions.vendor_account_name")
+    end
+  end
+end
+
+script "js_make_billing_center_request", type: "javascript" do
+  parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
+  result "request"
+  code <<-EOS
+
+  billing_centers_formatted = []
+
+  for (x=0; x< billing_centers_unformatted.length; x++) {
+    billing_centers_formatted.push(billing_centers_unformatted[x]["id"])
+  }
+
+  finish = new Date()
+  finishFormatted = finish.toJSON().split("T")[0]
+  start = new Date()
+  start.setDate(start.getDate() - 30)
+  startFormatted = start.toJSON().split("T")[0]
+
+  // Default dimensions and filter expressions required for meta parent policy
+  var dimensions = ["vendor_account", "vendor_account_name"];
+  var filter_expressions = [
+    { dimension: "vendor", type: "equal", value: "GCP" }
+  ]
+
+  // Append to default dimensions and filter expressions using parent policy params
+  _.each(param_dimension_filter_includes, function (v) {
+    // split key=value string
+    var split = v.split("=");
+    var k = split[0];
+    var v = split[1];
+    // append to lists
+    dimensions.push(k);
+    filter_expressions.push({ dimension: k, type: "equal", value: v });
+  });
+
+  // Append to filter expressions using exclude policy params
+  _.each(param_dimension_filter_excludes, function (v) {
+    // split key=value string
+    var split = v.split("=");
+    var k = split[0];
+    var v = split[1];
+    // append to lists
+    dimensions.push(k);
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+  });
+
+  // Produces a duplicate-free version of the array
+  dimensions = _.uniq(dimensions);
+
+  var body = {
+    "dimensions": dimensions,
+    "granularity":"day",
+    "start_at": startFormatted,
+    "end_at": finishFormatted,
+    "metrics":["cost_amortized_unblended_adj"],
+    "billing_center_ids": billing_centers_formatted,
+    "filter":
+    {
+      "type": "and",
+      "expressions": filter_expressions
+    },
+    "summarized": true
+  }
+  var request = {
+    auth:  'auth_flexera',
+    host:  rs_optima_host,
+    scheme: 'https',
+    verb: 'POST',
+    path:  "/bill-analysis/orgs/"+ rs_org_id + "/costs/aggregated",
+    headers: {
+      "API-Version": "1.0",
+      "Content-Type":"application/json"
+    },
+    body: JSON.stringify(body)
+  }
+  EOS
+end
+
+# Get Child policies
+datasource "ds_get_existing_policies" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies"])
+    header "Api-Version", "1.0"
+    query "meta_parent_policy_id", policy_id
+  end
+  result do
+    collect jq(response, '.items[]?') do
+      field "name", jq(col_item, ".name")
+      field "applied_policy_id", jq(col_item, ".id")
+      field "options", jq(col_item, ".options")
+      field "updated_at", jq(col_item, ".updated_at")
+      field "status", jq(col_item, ".status")
+    end
+  end
+end
+
+# Get Child policies incidents
+datasource "ds_get_existing_policies_incidents" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/incidents"])
+    header "Api-Version", "1.0"
+    query "meta_parent_policy_id", policy_id
+  end
+  result do
+    collect jq(response, '.items[]?') do
+      field "incident_id", jq(col_item, ".id")
+      field "applied_policy_id", jq(col_item, ".applied_policy.id")
+      field "state", jq(col_item, ".state")
+      field "violation_data_count", jq(col_item, ".violation_data_count")
+      field "updated_at", jq(col_item, ".updated_at")
+      field "meta_parent_policy_id", jq(col_item, ".meta_parent_policy_id")
+    end
+  end
+end
+
+datasource "ds_format_incidents" do
+  run_script $js_format_existing_policies_incidents, $ds_get_existing_policies_incidents
+end
+
+script "js_format_existing_policies_incidents", type: "javascript" do
+  parameters "unformatted"
+  result "formatted"
+  code <<-EOS
+  formatted={}
+  for (x=0;x<unformatted.length; x++) {
+    current = unformatted[x]
+    formatted[current.applied_policy_id] = {incident_id: current.incident_id, state: current.state, violation_data_count: current.violation_data_count, updated_at: current.updated_at}
+  }
+  EOS
+end
+
+datasource "ds_format_existing_policies" do
+  run_script $js_format_existing_policies, $ds_get_existing_policies, $ds_format_incidents
+end
+
+# format
+# duplicates logic should compare updated at
+# we can validate update here when destructing the existing policy options, don't need updated at
+# format options
+script "js_format_existing_policies", type: "javascript" do
+  parameters "ds_get_existing_policies", "ds_format_incidents"
+  result "result"
+  code <<-EOS
+  function format_options_keyvalue(options) {
+    var options_keyvalue_map = {};
+    _.each(options, function(option) {
+      options_keyvalue_map[option.name] = option.value;
+    });
+    return options_keyvalue_map;
+  }
+
+  result = {}
+  formatted = {}
+  duplicates = []
+  // tracking holds all existing policies and later can be used to determine if existing policies should be deleted [i.e. if cloud subscription was removed]
+  tracking = {}
+
+  for (x=0; x<ds_get_existing_policies.length; x++) {
+    options = format_options_keyvalue(ds_get_existing_policies[x].options);
+
+    projectID=options["param_projects_list"][0]
+    if (formatted[projectID] == undefined) {
+      formatted[projectID] = {
+        "applied_policy_id":ds_get_existing_policies[x]["applied_policy_id"],
+        "applied_policy_name":ds_get_existing_policies[x]["name"],
+        "status":ds_get_existing_policies[x]["status"],
+        "updated_at":ds_get_existing_policies[x]["updated_at"],
+        "incident": ds_format_incidents[ds_get_existing_policies[x]["applied_policy_id"]],
+        "options": options
+      }
+      tracking[projectID] = false
+    } else {
+      current = formatted[projectID]
+
+      currDate = new Date(current.updated_at)
+      newDate = new Date(ds_get_existing_policies[x].updated_at)
+
+      if (currDate > newDate) {
+        duplicates.push({
+          "applied_policy_id":ds_get_existing_policies[x]["applied_policy_id"],
+          "applied_policy_name":ds_get_existing_policies[x]["name"],
+          "status":ds_get_existing_policies[x]["status"],
+          "updated_at":ds_get_existing_policies[x]["updated_at"],
+          "incident": ds_format_incidents[ds_get_existing_policies[x]["applied_policy_id"]]
+        })
+      } else {
+        duplicates.push({
+          "applied_policy_id":current["applied_policy_id"],
+          "applied_policy_name":current["applied_policy_name"],
+          "status":current["status"],
+          "updated_at":current["updated_at"],
+          "incident": current["incident"]
+        })
+        formatted[projectID] = {
+          "applied_policy_id":ds_get_existing_policies[x]["applied_policy_id"],
+          "applied_policy_name":ds_get_existing_policies[x]["name"],
+          "status":ds_get_existing_policies[x]["status"],
+          "updated_at":ds_get_existing_policies[x]["updated_at"],
+          "incident": ds_format_incidents[ds_get_existing_policies[x]["applied_policy_id"]],
+          "options": options
+        }
+
+      }
+    }
+  }
+
+  result.formatted=formatted
+  result.duplicates=duplicates
+  result.tracking=tracking
+  EOS
+end
+
+datasource "ds_take_in_parameters" do
+  run_script $js_take_in_parameters, $ds_get_google_projects, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+end
+
+# hardcode template href with id from catalog
+# catalog policies show in customer's published templates with their org id
+# "template_href": "/api/governance/orgs/" + rs_org_id + "/published_templates/62618616e3dff80001572bf0"
+# update logic: the only reason we're going to update the child policies for is changes to options
+# and only some options, email is always blank and projectID is tied to the idenity of each policy, so: new project creation, removal of project: termination
+# param_automatic_action is a list with only one action, unless the person is applying using an API and putting the same value multiple times this should either be a length of 0 or 1
+# param_log_to_cm_audit_entries is a String of Yes or No
+# param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
+# If we only want to do an update on the values changing we could sort before doing the equality check.
+script "js_take_in_parameters", type: "javascript" do
+  parameters "ds_get_google_projects", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  result "grid_and_cwf"
+  code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
+  max_actions = 50;
+
+  grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
+
+  should_keep = ds_format_existing_policies.tracking;
+
+  // Construct UI URL prefixes for policy template summary
+  ui_url_prefix = "https://" + f1_app_host + "/orgs/" + rs_org_id;
+  applied_policy_url_prefix = ui_url_prefix + "/automation/applied-policies/projects/" + rs_project_id + "?noIndex=1&policyId=";
+  incident_url_prefix       = ui_url_prefix + "/automation/incidents/projects/" + rs_project_id + "?noIndex=1&incidentId=";
+
+  function add_to_grid(ep, action) {
+    policy_status={
+      "policy_name": ep["applied_policy_name"],
+      "policy_link": applied_policy_url_prefix + ep["applied_policy_id"],
+      "meta_policy_status": action,
+      "policy_status": ep["status"],
+      "policy_last_update": ep["updated_at"],
+    };
+    if (ep.incident != null) {
+      policy_status["incident_link"] = incident_url_prefix + ep.incident.incident_id;
+      policy_status["incident_state"] = ep.incident.state;
+      policy_status["incident_violation_data_count"] = ep.incident.violation_data_count;
+      policy_status["incident_last_update"] = ep.incident.updated_at;
+    }
+    grid_and_cwf.grid.push(policy_status);
+  }
+
+  for (x=0; x<ds_format_existing_policies.duplicates.length; x++) {
+    if (grid_and_cwf.to_delete.length < max_actions) {
+      grid_and_cwf.to_delete.push({"id":ds_format_existing_policies.duplicates[x]["applied_policy_id"], "name": ds_format_existing_policies.duplicates[x]["applied_policy_name"]})
+      add_to_grid(ds_format_existing_policies.duplicates[x], "terminating")
+    } else {
+      add_to_grid(ds_format_existing_policies.duplicates[x], "to be terminated")
+    }
+  }
+
+  for (x=0; x<ds_get_google_projects.length; x++) {
+    cur = ds_get_google_projects[x];
+    cur_projectID = cur.projectID;
+
+    // Name and description do not vary between create or updates so defining them here
+    name = child_policy_information.name + ": " + cur.projectName + " (" + cur_projectID + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Google Project **" + cur.projectName +"** (`" + cur_projectID + "`).  " + child_policy_information.short_description;
+
+    // Check if child policy exists for current Project ID
+    if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_projectID) ) {
+      // Child Policy does not exist and should be created
+      console.log("Child Policy for Subscription ID: "+cur_projectID+" does not exist and should be created");
+
+      // Use the options from the parent policy in "name value" list format
+      options = _.toArray(ds_child_policy_options);
+
+      // Set param_projects_list values for this child policy
+      options.push({
+        "name": "param_projects_list",
+        "value": [cur_projectID],
+      });
+
+      if (grid_and_cwf.to_create.length < max_actions) {
+        grid_and_cwf.to_create.push({
+          "name" : name,
+          "description" : description,
+          "credentials" : ds_format_self.credentials,
+          "options" : options,
+          "frequency" : param_policy_schedule,
+          "meta_parent_policy_id": meta_parent_policy_id,
+          "template_href": child_policy_information.href
+        })
+        policy_status={
+          "policy_name": name,
+          "meta_policy_status": "creating policy",
+          "policy_status": "",
+          "policy_last_update": "",
+        }
+        grid_and_cwf.grid.push(policy_status)
+      } else {
+        policy_status={
+          "policy_name": name,
+          "meta_policy_status": "policy to be created",
+          "policy_status": "",
+          "policy_last_update": "",
+        }
+        grid_and_cwf.grid.push(policy_status)
+      }
+    } else {
+      console.log("Child Policy for "+cur_projectID+" does exist for current project ID and may need to be updated or deleted");
+      // Child Policy does exist for current project ID and may need to be updated or deleted
+      // Assume by default we should keep it and not update it
+      should_keep[cur_projectID] = true;
+      should_update = false;
+
+      // Use the options from the parent policy in "name value" list format
+      options = _.toArray(ds_child_policy_options);
+
+      // Set param_projects_list values for this child policy
+      options.push({
+        "name": "param_projects_list",
+        "value": [cur_projectID],
+      });
+
+      // Check if child policy params match parent policy params
+      _.each(ds_format_self.options, function(value, key) {
+        // If any child and parent param values do not match, mark the child policy as should_update
+        if ( !_.isEqual(value, ds_format_existing_policies["formatted"][cur_projectID]["options"][key]) ) {
+          console.log("Child Policy Param does not match Parent Policy and should be updated. "+key+" does not match "+value+"!="+ds_format_existing_policies["formatted"][cur_projectID]["options"][key]);
+          should_update = true;
+        }
+      });
+
+
+      if (should_update) {
+        // Child policy needs to be updated
+        if (grid_and_cwf.to_update.length < max_actions) {
+          // Child policy needs to be updated and is within the max_actions limit
+          console.log("Child Policy needs to be updated. ds_format_existing_policies.formatted[cur_projectID]="+JSON.stringify(ds_format_existing_policies.formatted[cur_projectID]));
+          add_to_grid(ds_format_existing_policies.formatted[cur_projectID], "updating")
+          name = ds_format_existing_policies.formatted[cur_projectID].applied_policy_name
+          // Add to_update
+          grid_and_cwf.to_update.push({
+            "applied_policy_id": ds_format_existing_policies.formatted[cur_projectID].applied_policy_id,
+            "name" : name,
+            "description" : description,
+            "credentials" : ds_format_self.credentials,
+            "options" : options,
+            "frequency" : param_policy_schedule,
+          })
+        } else {
+          // Child policy needs to be updated but is outside the max_actions limit
+          // Add to grid but do not add to to_update
+          console.log("Child Policy needs to be updated. ds_format_existing_policies.formatted[cur_projectID]="+JSON.stringify(ds_format_existing_policies.formatted[cur_projectID]));
+          add_to_grid(ds_format_existing_policies.formatted[cur_projectID], "to be updated");
+        }
+      } else {
+        // Child policy does not need to be updated
+        add_to_grid(ds_format_existing_policies.formatted[cur_projectID], "running");
+      }
+    }
+  }
+
+  console.log("Checking if policies should be deleted. "+JSON.stringify(should_keep));
+  _.each(should_keep, function(keep, account_id) {
+    console.log("Should keep "+account_id+"="+keep);
+    if (!keep) {
+      if (grid_and_cwf.to_delete.length < max_actions) {
+        grid_and_cwf.to_delete.push({"id":ds_format_existing_policies.formatted[account_id].applied_policy_id, "name": ds_format_existing_policies.formatted[account_id].applied_policy_name})
+        add_to_grid(ds_format_existing_policies.formatted[account_id], "terminating")
+      } else {
+        add_to_grid(ds_format_existing_policies.formatted[account_id], "to be terminated")
+      }
+    }
+  });
+
+  EOS
+end
+
+datasource "ds_only_grid" do
+  run_script $js_only_grid, $ds_take_in_parameters
+end
+
+script "js_only_grid", type: "javascript" do
+  parameters "results"
+  result "only_grid"
+  code <<-EOS
+    only_grid = results.grid
+  EOS
+end
+
+datasource "ds_to_create" do
+  run_script $js_only_create, $ds_take_in_parameters
+end
+
+script "js_only_create", type: "javascript" do
+  parameters "results"
+  result "only_create"
+  code <<-EOS
+    only_create = results.to_create
+  EOS
+end
+
+datasource "ds_to_update" do
+  run_script $js_only_update, $ds_take_in_parameters
+end
+
+script "js_only_update", type: "javascript" do
+  parameters "results"
+  result "only_update"
+  code <<-EOS
+    only_update = results.to_update
+  EOS
+end
+
+datasource "ds_to_delete" do
+  run_script $js_only_delete, $ds_take_in_parameters
+end
+
+script "js_only_delete", type: "javascript" do
+  parameters "results"
+  result "only_delete"
+  code <<-EOS
+    only_delete = results.to_delete
+  EOS
+end
+
+# The following datasources consolidate the child incident output into a single incident.
+# This is because it is more convenient for many users to have a single incident with all of the data.
+datasource "ds_child_incident_details" do
+  iterate $ds_get_existing_policies_incidents
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/incidents/", val(iter_item, 'incident_id')])
+    verb "GET"
+    header "User-Agent", "RS Policies"
+    header "Api-Version", "1.0"
+    query "view", "extended"
+  end
+end
+
+datasource "ds_google_old_snapshots_combined_incidents" do
+  run_script $js_ds_google_old_snapshots_combined_incidents, $ds_child_incident_details
+end
+
+script "js_ds_google_old_snapshots_combined_incidents", type: "javascript" do
+  parameters "ds_child_incident_details"
+  result "result"
+  code <<-EOS
+  result = []
+  _.each(ds_child_incident_details, function(incident) {
+    s = incident["summary"];
+    // If the incident summary contains "Google Old Snapshots Found" then include it in the filter result
+    if (s.indexOf("Google Old Snapshots Found") > -1) {
+      _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
+        result.push(violation);
+      });
+    }
+  });
+EOS
+end
+
+
+# Escalation for Delete Snapshots
+escalation "esc_delete_snapshots" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Delete Snapshots"
+  description "Approval to delete all selected snapshots"
+  run "esc_delete_snapshots", data, rs_governance_host, rs_project_id
+end
+define esc_delete_snapshots($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Snapshots")
+end
+
+
+# Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
+# Minimum of 1 incident, max of four
+# Could swap the summary to only showing running
+# Could also just have one incident and use meta_status to determine which escalation happens
+policy "policy_scheduled_report" do
+  # Consolidated Incident Check(s)
+    # Consolidated incident for Google Old Snapshots Found
+  validate $ds_google_old_snapshots_combined_incidents do
+    summary_template "Consolidated Incident: {{ len data }} Google Old Snapshots Found"
+    escalate $esc_email
+    escalate $esc_delete_snapshots
+    check eq(size(data), 0)
+    export do
+      resource_level true
+      field "accountID" do
+        label "Project ID"
+      end
+      field "accountName" do
+        label "Project Name"
+      end
+      field "projectNumber" do
+        label "Project Number"
+      end
+      field "resourceID" do
+        label "Resource ID"
+      end
+      field "resourceName" do
+        label "Resource Name"
+      end
+      field "labels" do
+        label "Resource Labels"
+      end
+      field "age" do
+        label "Age In Days"
+      end
+      field "size" do
+        label "Size (GB)"
+      end
+      field "recommendationDetails" do
+        label "Recommendation"
+      end
+      field "status" do
+        label "Status"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "selfLink" do
+        label "Self Link"
+      end
+      field "id" do
+        label "ID"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
+      end
+    end
+  end
+
+  # Status Incident Check
+  validate $ds_take_in_parameters do
+    summary_template "{{ data.parent_policy.name }}: Status of Child Policies"
+    detail_template <<-EOS
+The current status of Child Policies for **{{ data.parent_policy.name }}**:
+
+Total Child Applied Policies: {{ len data.grid }}
+
+| Applied Policy | Meta Child Policy Status | Policy Status | Policy Last Update | Incident | Incident State | Violation Count | Incident Last Update |
+| -------------- | ------------------------ | ------------- | ------------------ | -------- | -------------- | --------------- | -------------------- |
+{{ range data.grid -}}
+| {{- if .policy_link }} [{{ .policy_name }}]({{ .policy_link }}) {{ else }} {{ .policy_name }} {{- end }} | {{- if .meta_policy_status }} {{ .meta_policy_status }} {{ else }} No value {{- end }} | {{- if .policy_status }} {{ .policy_status }} {{ else }} No value {{- end }} | {{- if .policy_last_update }} {{ .policy_last_update }} {{ else }} No value {{- end }} | {{- if .incident_link }} [Incident]({{ .incident_link }}) {{ else }} No Incident {{- end }} | {{- if .incident_state }} {{ .incident_state }} {{ else }} No Incident {{- end }} | {{- if .incident_last_update }} {{ .incident_violation_data_count }} {{ else }} No Incident {{- end }} | {{- if .incident_last_update }} {{ .incident_last_update }} {{ else }} No Incident {{- end }} |
+{{ end -}}
+
+EOS
+    check false
+    # Export Table disabled for now until UI can support URL / linking
+    # Without linking the `policy_link`, `incident_link` values are not usable directly from UI
+    # export "grid" do
+    #   resource_level true
+    #   field "id" do
+    #     label "Applied Policy ID"
+    #   end
+    #   field "policy_name" do
+    #     label "Applied Policy Name"
+    #   end
+    #   field "policy_link" do
+    #     label "Applied Policy Link"
+    #   end
+    #   field "meta_policy_status" do
+    #     label "Meta Child Policy Status"
+    #   end
+    #   field "policy_status" do
+    #     label "Policy Status"
+    #   end
+    #   field "policy_last_update" do
+    #     label "Policy Last Update"
+    #   end
+    #   field "incident_link" do
+    #     label "Incident Link"
+    #   end
+    #   field "incident_state" do
+    #     label "Incident State"
+    #   end
+    #   field "incident_violation_data_count" do
+    #     label "Incident Violation Count"
+    #   end
+    #   field "incident_last_update" do
+    #     label "Incident Last Update"
+    #   end
+    # end
+  end
+
+  # Create Child Policies Incident Check
+  validate $ds_to_create do
+    summary_template "Policies being created"
+    detail_template <<-EOS
+    Policies Being Created:
+
+    | Applied Policy |
+    | --------------- |
+    {{ range data -}}
+    | {{ .name }} |
+    {{ end -}}
+    EOS
+    escalate $create_policies
+    check eq(size(data),0)
+  end
+
+  # Update Child Policies Incident Check
+  validate $ds_to_update do
+    summary_template "Policies being updated"
+    detail_template <<-EOS
+    Policies Being Updated:
+
+    | Applied Policy |
+    | --------------- |
+    {{ range data -}}
+    | {{ .name }} |
+    {{ end -}}
+    EOS
+    escalate $update_policies
+    check eq(size(data),0)
+  end
+
+  # Delete Child Policies Incident Check
+  validate $ds_to_delete do
+    summary_template "Policies being deleted"
+    detail_template <<-EOS
+    Policies being Deleted:
+
+    | Applied Policy |
+    | --------------- |
+    {{ range data -}}
+    | {{ .name }} |
+    {{ end -}}
+    EOS
+    escalate $delete_policies
+    check eq(size(data),0)
+  end
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
+end
+
+# Used only for emailing the combined child incident if so desired
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_combined_incident_email
+end
+
+escalation "create_policies" do
+  run "create_applied_policies", data, rs_governance_host, rs_project_id
+end
+
+# if name !=null
+define create_applied_policies($data, $governance_host, $rs_project_id) return $responses do
+  $responses = []
+  $$debug = []
+  $item_index = 0
+  $item_total = size($data)
+  foreach $item in $data do
+    $item_index = $item_index + 1
+    $status = to_s("("+$item_index+"/"+$item_total+")")
+    task_label($status+" Creating Applied Policy with Options: " + to_json($item["options"]))
+    $response = http_request(
+      auth: $$auth_flexera,
+      verb: "post",
+      https: true,
+      host: $governance_host,
+      href: join(["/api/governance/projects/", $rs_project_id, "/applied_policies"]),
+      headers: { "Api-Version": "1.0" },
+      body: {
+        "name": $item["name"],
+        "description": $item["description"],
+        "template_href": $item["template_href"],
+        "frequency": $item["frequency"],
+        "options": $item["options"],
+        "credentials": $item["credentials"],
+        "meta_parent_policy_id": $item["meta_parent_policy_id"]
+      }
+    )
+    $responses << $response
+    $$debug << to_json({
+      "response": $response,
+      "item": $item,
+      "governance_host": $governance_host
+    })
+  end
+end
+
+escalation "update_policies" do
+  run "update_applied_policies", data, rs_governance_host, rs_project_id
+end
+
+define update_applied_policies($data, $governance_host, $rs_project_id) return $responses do
+  $responses = []
+  $$debug = []
+  $item_index = 0
+  $item_total = size($data)
+  foreach $item in $data do
+    $item_index = $item_index + 1
+    $status = to_s("("+$item_index+"/"+$item_total+")")
+    task_label($status+" Updating Applied Policy with Options: " + to_json($item["options"]))
+    $response = http_request(
+      auth: $$auth_flexera,
+      verb: "patch",
+      https: true,
+      host: $governance_host,
+      href: join(["/api/governance/projects/", $rs_project_id, "/applied_policies/", $item["applied_policy_id"]]),
+      headers: { "Api-Version": "1.0" },
+      body: {
+        "options": $item["options"]
+      }
+    )
+    $responses << $response
+    $$debug << to_json({
+      "response": $response,
+      "item": $item,
+      "governance_host": $governance_host
+    })
+  end
+end
+
+escalation "delete_policies" do
+  run "delete_applied_policies", data, rs_governance_host, rs_project_id
+end
+
+define delete_applied_policies($data, $governance_host, $rs_project_id) return $responses do
+  $responses = []
+  $$debug = []
+  $item_index = 0
+  $item_total = size($data)
+  foreach $item in $data do
+    $item_index = $item_index + 1
+    $status = to_s("("+$item_index+"/"+$item_total+")")
+    task_label($status+" Deleting Applied Policy: " + $item["id"])
+    $response = http_request(
+      auth: $$auth_flexera,
+      verb: "delete",
+      https: true,
+      host: $governance_host,
+      href: join(["/api/governance/projects/", $rs_project_id, "/applied_policies/", $item["id"]]),
+      headers: { "Api-Version": "1.0" }
+    )
+    $responses << $response
+    $$debug << to_json({
+      "response": $response,
+      "item": $item,
+      "governance_host": $governance_host
+    })
+  end
+end

--- a/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
@@ -824,6 +824,9 @@ policy "policy_scheduled_report" do
       field "selfLink" do
         label "Self Link"
       end
+      field "lookbackPeriod" do
+        label "Snapshot Age Threshold (Days)"
+      end
       field "id" do
         label "ID"
       end

--- a/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
+++ b/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
@@ -55,7 +55,8 @@ default_child_policy_template_files = [
   "../../cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt",
   "../../cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt",
   "../../cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations.pt",
-  "../../cost/google/cud_recommendations/google_committed_use_discount_recommendations.pt"
+  "../../cost/google/cud_recommendations/google_committed_use_discount_recommendations.pt",
+  "../../cost/google/old_snapshots/google_delete_old_snapshots.pt"
 ]
 
 


### PR DESCRIPTION
### Description

This is a revamp of the Google Old Snapshots policy that also adds meta policy support for it.

Note: This policy does not report savings (identical to previous version) because we do not ingest GCP billing data at a granular enough level to obtain costs for specific resources. This policy should be updated if/when that changes.

From the CHANGELOG:

- Several parameters altered to be more descriptive and human-readable
- Removed deprecated "Log to CM Audit Entries" parameter
- Added ability to filter resources by project
- Added ability to use wildcards when filtering resources by label
- Added additional context to incident description
- Normalized incident export to be consistent with other policies
- Added human-readable recommendation to incident export
- Added additional fields to incident export
- Streamlined code for better readability and faster execution
- Policy now requires a valid Flexera One credential

### Link to Example Applied Policy

https://app.flexera.com/orgs/27018/automation/applied-policies/projects/116186?policyId=65660e9c99745e0001588323

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
