### PR TITLE
POL-889 AWS Open S3 Buckets Revamp / Meta

### DIFF
--- a/security/storage/aws/public_buckets/CHANGELOG.md
+++ b/security/storage/aws/public_buckets/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v3.0
+
+- Several parameters altered to be more descriptive and human-readable
+- Added ability to filter resources by region
+- Added additional context to incident description
+- Normalized incident export to be consistent with other policies
+- Added human-readable recommendation to incident export
+- Policy no longer raises new escalations if bucket owner has changed but nothing else has
+- Streamlined code for better readability and faster execution
+- Policy now requires a valid Flexera credential
+
 ## v2.8
 
 - Updated description of `Account Number` parameter

--- a/security/storage/aws/public_buckets/README.md
+++ b/security/storage/aws/public_buckets/README.md
@@ -1,51 +1,66 @@
 # AWS Open Buckets
 
-## What it does
+## What It Does
 
-This Policy Template will check your account for Amazon S3 buckets with public permission.
+This policy checks all the S3 buckets in an AWS Account for public permissions. The user is emailed a list of offending buckets.
+
+## Functional Details
+
+- The policy leverages the AWS API to retrieve a list of all S3 buckets and their ACLs.
+- The policy identifies all S3 buckets whose grantees contain the URI `http://acs.amazonaws.com/groups/global/AllUsers`
+- The recommendation provided for these S3 buckets is to remove the offending permissions.
 
 ## Input Parameters
 
 This policy has the following input parameters required when launching the policy.
 
-- *param_email* - Email addresses of the recipients you wish to notify
-- *Account Number* - The Account number for use with the AWS STS Cross Account Role. Leave blank when using AWS IAM Access key and secret. It only needs to be passed when the desired AWS account is different than the one associated with the Flexera One credential. [more](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1123608)
+- *Email Addresses* - Email addresses of the recipients you wish to notify when new incidents are created.
+- *Account Number* - The Account number for use with the AWS STS Cross Account Role. Leave blank when using AWS IAM Access key and secret. It only needs to be passed when the desired AWS account is different than the one associated with the Flexera One credential. [More information is available in our documentation.](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1123608)
+- *Allow/Deny Regions* - Whether to treat Allow/Deny Regions List parameter as allow or deny list. Has no effect if Allow/Deny Regions List is left empty.
+- *Allow/Deny Regions List* - A list of regions to allow or deny for an AWS account. Please enter the regions code if SCP is enabled. See [Available Regions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) in AWS; otherwise, the policy may fail on regions that are disabled via SCP. Leave blank to consider all the regions.
 
 ## Policy Actions
 
-The following policy actions are taken on any resources found to be out of compliance.
-
-- Send an email report
+- Sends an email notification
 
 ## Prerequisites
 
-This policy uses [credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for connecting to the cloud -- in order to apply this policy you must have a credential registered in the system that is compatible with this policy. If there are no credentials listed when you apply the policy, please contact your cloud admin and ask them to register a credential that is compatible with this policy. The information below should be consulted when creating the credential.
+This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).
 
 ### Credential configuration
 
 For administrators [creating and managing credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) to use with this policy, the following information is needed:
 
-Provider tag value to match this policy: `aws`
+- [**AWS Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1121575) (*provider=aws*) which has the following permissions:
+  - `s3:ListAllMyBuckets`
+  - `s3:GetBucketLocation`
+  - `s3:GetBucketAcl`
+  - `sts:GetCallerIdentity`
 
-Required permissions in the provider:
+  Example IAM Permission Policy:
 
-```json
-{
-  "Version": "2006-03-01",
-  "Statement": [
-    {
-      "Sid": "ListObjectsInBucket",
-      "Effect": "Allow",
-      "Action": [
-        "s3:ListAllMyBuckets",
-        "s3:GetBucketLocation",
-        "s3:GetBucketAcl"
-      ],
-      "Resource": ["arn:aws:s3:::bucket-name"]
-    }
-  ]
-}
-```
+  ```json
+  {
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "s3:ListAllMyBuckets",
+                  "s3:GetBucketLocation",
+                  "s3:GetBucketAcl",
+                  "sts:GetCallerIdentity"
+              ],
+              "Resource": "*"
+          }
+      ]
+  }
+  ```
+
+- [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
+  - `billing_center_viewer`
+
+The [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) page in the docs has detailed instructions for setting up Credentials for the most common providers.
 
 ## Supported Clouds
 
@@ -53,4 +68,4 @@ Required permissions in the provider:
 
 ## Cost
 
-This Policy Template does not launch any instances, and so does not incur any cloud costs.
+This Policy Template does not incur any cloud costs.

--- a/security/storage/aws/public_buckets/aws_public_buckets.pt
+++ b/security/storage/aws/public_buckets/aws_public_buckets.pt
@@ -1,7 +1,7 @@
-name "AWS Open Buckets"
+name "AWS Open S3 Buckets"
 rs_pt_ver 20180301
 type "policy"
-short_description "Check for buckets that are open to everyone. See the [README](https://github.com/flexera-public/policy_templates/tree/master/security/storage/aws/public_buckets) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "Check for S3 buckets that are open to everyone. See the [README](https://github.com/flexera-public/policy_templates/tree/master/security/storage/aws/public_buckets) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 severity "high"
 category "Security"
@@ -10,7 +10,7 @@ info(
   version: "3.0",
   provider: "AWS",
   service: "S3",
-  policy_set: "Open Buckets"
+  policy_set: "Open S3 Buckets"
 )
 
 ###############################################################################
@@ -282,8 +282,16 @@ datasource "ds_aws_bucket_acls" do
   result do
     encoding "xml"
     collect xpath(response, "//AccessControlPolicy", "array") do
-      field "grantee_uris", xpath(col_item, "AccessControlList/Grant/Grantee/URI", "array")
+      field "grantees" do
+        collect xpath(col_item, "AccessControlList/Grant/Grantee") do
+          field "name", xpath(col_item, "DisplayName")
+          field "email", xpath(col_item, "EmailAddress")
+          field "id", xpath(col_item, "ID")
+          field "uri", xpath(col_item, "URI")
+        end
+      end
       field "owner", xpath(col_item, "Owner/DisplayName")
+      field "owner_id", xpath(col_item, "Owner/ID")
       field "bucket_name", val(iter_item, "bucket_name")
       field "creation_date", val(iter_item, "creation_date")
       field "region", val(iter_item, "region")
@@ -315,20 +323,34 @@ script "js_aws_public_buckets", type: "javascript" do
   result "result"
   code <<-'EOS'
   open_buckets = _.filter(ds_aws_bucket_acls, function(bucket) {
-    return _.contains(bucket['grantee_uris'], "http://acs.amazonaws.com/groups/global/AllUsers")
+    uri_list = _pluck(bucket['grantees'], 'uri')
+    return _.contains(uri_list, "http://acs.amazonaws.com/groups/global/AllUsers")
   })
 
   result = _.map(open_buckets, function(bucket) {
+    recommendationDetails = [
+      "Remove public access from S3 bucket ", bucket['bucket_name'], " ",
+      "in AWS Account ", ds_aws_account['name'], " (", ds_aws_account['id'], ")"
+    ].join('')
+
+    offending_grantee = _.find(bucket['grantees'], function(grantee) {
+      return grantee['uri'] == 'http://acs.amazonaws.com/groups/global/AllUsers'
+    })
+
     return {
       id: bucket['bucket_name'],
       creation_date: bucket['creation_date'],
       region: bucket['region'],
       host: bucket['host'],
-      grantee_uris: bucket['grantee_uris'].join(' '),
       owner: bucket['owner'],
+      grantee_id: offending_grantee['id'],
+      grantee_name: offending_grantee['name'],
+      grantee_email: offending_grantee['email'],
+      grantee_uri: offending_grantee['uri'],
       policy_name: ds_applied_policy['name'],
       accountID: ds_aws_account['id'],
-      accountName: ds_aws_account['name']
+      accountName: ds_aws_account['name'],
+      recommendation: recommendationDetails
     }
   })
 
@@ -373,20 +395,26 @@ policy "pol_public_buckets" do
       field "accountName" do
         label "Account Name"
       end
-      field "region" do
-        label "Region"
-      end
       field "id" do
         label "Bucket Name"
+      end
+      field "region" do
+        label "Region"
       end
       field "creation_date" do
         label "Creation Date"
       end
-      field "grantee_uris" do
-        label "GranteeURI"
-      end
       field "owner" do
         label "Owner"
+      end
+      field "grantee_id" do
+        label "Grantee ID"
+      end
+      field "grantee_name" do
+        label "Grantee Name"
+      end
+      field "grantee_uri" do
+        label "Grantee URI"
       end
     end
   end
@@ -423,7 +451,6 @@ datasource "ds_get_policy" do
     field "id", jmes_path(response, "id")
   end
 end
-
 
 datasource "ds_parent_policy_terminated" do
   run_script $js_decide_if_self_terminate, $ds_get_policy, policy_id, meta_parent_policy_id

--- a/security/storage/aws/public_buckets/aws_public_buckets.pt
+++ b/security/storage/aws/public_buckets/aws_public_buckets.pt
@@ -407,6 +407,9 @@ policy "pol_public_buckets" do
       field "owner" do
         label "Owner"
       end
+      field "recommendationDetails" do
+        label "Recommendation"
+      end
       field "grantee_uri" do
         label "Grantee URI"
       end

--- a/security/storage/aws/public_buckets/aws_public_buckets.pt
+++ b/security/storage/aws/public_buckets/aws_public_buckets.pt
@@ -323,7 +323,7 @@ script "js_aws_public_buckets", type: "javascript" do
   result "result"
   code <<-'EOS'
   open_buckets = _.filter(ds_aws_bucket_acls, function(bucket) {
-    uri_list = _pluck(bucket['grantees'], 'uri')
+    uri_list = _.pluck(bucket['grantees'], 'uri')
     return _.contains(uri_list, "http://acs.amazonaws.com/groups/global/AllUsers")
   })
 
@@ -406,12 +406,6 @@ policy "pol_public_buckets" do
       end
       field "owner" do
         label "Owner"
-      end
-      field "grantee_id" do
-        label "Grantee ID"
-      end
-      field "grantee_name" do
-        label "Grantee Name"
       end
       field "grantee_uri" do
         label "Grantee URI"

--- a/security/storage/aws/public_buckets/aws_public_buckets.pt
+++ b/security/storage/aws/public_buckets/aws_public_buckets.pt
@@ -367,6 +367,12 @@ policy "pol_public_buckets" do
     hash_exclude "message", "owner"
     export do
       resource_level true
+      field "accountID" do
+        label "Account ID"
+      end
+      field "accountName" do
+        label "Account Name"
+      end
       field "region" do
         label "Region"
       end

--- a/security/storage/aws/public_buckets/aws_public_buckets.pt
+++ b/security/storage/aws/public_buckets/aws_public_buckets.pt
@@ -350,7 +350,7 @@ script "js_aws_public_buckets", type: "javascript" do
       policy_name: ds_applied_policy['name'],
       accountID: ds_aws_account['id'],
       accountName: ds_aws_account['name'],
-      recommendation: recommendationDetails
+      recommendationDetails: recommendationDetails
     }
   })
 

--- a/security/storage/aws/public_buckets/aws_public_buckets.pt
+++ b/security/storage/aws/public_buckets/aws_public_buckets.pt
@@ -360,7 +360,7 @@ script "js_aws_public_buckets", type: "javascript" do
   public_buckets_percentage = (total_public_buckets / total_buckets * 100).toFixed(2).toString() + '%'
 
   findings = [
-    "Out of ", total_buckets, " AWS Object Storage buckets analyzed, ",
+    "Out of ", total_buckets, " AWS S3 buckets analyzed, ",
     total_public_buckets, " (", public_buckets_percentage,
     ") are open to public access."
   ].join('')
@@ -382,7 +382,7 @@ end
 
 policy "pol_public_buckets" do
   validate_each $ds_aws_public_buckets do
-    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} AWS Public Object Storage Buckets Found"
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} AWS S3 Buckets With Public Access Found"
     detail_template "{{ with index data 0 }}{{ .message }}{{ end }}"
     check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
     escalate $esc_email

--- a/security/storage/aws/public_buckets/aws_public_buckets.pt
+++ b/security/storage/aws/public_buckets/aws_public_buckets.pt
@@ -5,22 +5,13 @@ short_description "Check for buckets that are open to everyone. See the [README]
 long_description ""
 severity "high"
 category "Security"
+default_frequency "daily"
 info(
-  version: "2.8",
+  version: "3.0",
   provider: "AWS",
   service: "S3",
   policy_set: "Open Buckets"
 )
-
-###############################################################################
-# Permissions
-###############################################################################
-
-permission "perm_read_creds" do
-  actions   "rs_cm.show_sensitive","rs_cm.index_sensitive"
-  resources "rs_cm.credentials"
-end
-
 
 ###############################################################################
 # Parameters
@@ -28,7 +19,10 @@ end
 
 parameter "param_email" do
   type "list"
-  label "Email addresses of the recipients you wish to notify"
+  category "Policy Settings"
+  label "Email addresses to notify"
+  description "Email addresses of the recipients you wish to notify when new incidents are created"
+  default []
 end
 
 parameter "param_aws_account_number" do
@@ -39,43 +33,178 @@ parameter "param_aws_account_number" do
   default ""
 end
 
+parameter "param_regions_allow_or_deny" do
+  type "string"
+  category "Filters"
+  label "Allow/Deny Regions"
+  description "Allow or Deny entered regions. See the README for more details"
+  allowed_values "Allow", "Deny"
+  default "Allow"
+end
+
+parameter "param_regions_list" do
+  type "list"
+  category "Filters"
+  label "Allow/Deny Regions List"
+  allowed_pattern /^([a-zA-Z-_]+-[a-zA-Z0-9-_]+-[0-9-_]+,*|)+$/
+  description "A list of allowed or denied regions. See the README for more details"
+  default []
+end
+
 ###############################################################################
 # Authentication
 ###############################################################################
 
-#authenticate with AWS
 credentials "auth_aws" do
-  schemes "aws","aws_sts"
+  schemes "aws", "aws_sts"
   label "AWS"
-  description "Select the AWS Credential from the list."
+  description "Select the AWS Credential from the list"
   tags "provider=aws"
   aws_account_number $param_aws_account_number
 end
 
+credentials "auth_flexera" do
+  schemes "oauth2"
+  label "Flexera"
+  description "Select Flexera One OAuth2 credentials"
+  tags "provider=flexera"
+end
+
 ###############################################################################
-# Datasources
+# Pagination
 ###############################################################################
 
-# Reference: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTServiceGET.html
-datasource "aws_buckets" do
-  # This request is not paginated
+pagination "pagination_aws" do
+  get_page_marker do
+    body_path jmes_path(response, "NextToken")
+  end
+  set_page_marker do
+    body_field "NextToken"
+  end
+end
+
+###############################################################################
+# Datasources & Scripts
+###############################################################################
+
+# Get applied policy metadata for use later
+datasource "ds_applied_policy" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    header "Api-Version", "1.0"
+  end
+end
+
+# Get region-specific Flexera API endpoints
+datasource "ds_flexera_api_hosts" do
+  run_script $js_flexera_api_hosts, rs_optima_host
+end
+
+script "js_flexera_api_hosts", type: "javascript" do
+  parameters "rs_optima_host"
+  result "result"
+  code <<-'EOS'
+  host_table = {
+    "api.optima.flexeraeng.com": {
+      flexera: "api.flexera.com",
+      fsm: "api.fsm.flexeraeng.com"
+    },
+    "api.optima-eu.flexeraeng.com": {
+      flexera: "api.flexera.eu",
+      fsm: "api.fsm-eu.flexeraeng.com"
+    },
+    "api.optima-apac.flexeraeng.com": {
+      flexera: "api.flexera.au",
+      fsm: "api.fsm-apac.flexeraeng.com"
+    }
+  }
+
+  result = host_table[rs_optima_host]
+EOS
+end
+
+# Get AWS account info
+datasource "ds_cloud_vendor_accounts" do
+  request do
+    auth $auth_flexera
+    host val($ds_flexera_api_hosts, 'flexera')
+    path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "values[*]") do
+      field "id", jmes_path(col_item, "aws.accountId")
+      field "name", jmes_path(col_item, "name")
+      field "tags", jmes_path(col_item, "tags")
+    end
+  end
+end
+
+datasource "ds_get_caller_identity" do
+  request do
+    auth $auth_aws
+    verb "GET"
+    host "sts.amazonaws.com"
+    path "/"
+    header "User-Agent", "RS Policies"
+    query "Action", "GetCallerIdentity"
+    query "Version", "2011-06-15"
+  end
+  result do
+    encoding "xml"
+    collect xpath(response, "//GetCallerIdentityResponse/GetCallerIdentityResult") do
+      field "account", xpath(col_item, "Account")
+    end
+  end
+end
+
+datasource "ds_aws_account" do
+  run_script $js_aws_account, $ds_cloud_vendor_accounts, $ds_get_caller_identity
+end
+
+script "js_aws_account", type:"javascript" do
+  parameters "ds_cloud_vendor_accounts", "ds_get_caller_identity"
+  result "result"
+  code <<-'EOS'
+  result = _.find(ds_cloud_vendor_accounts, function(account) {
+    return account['id'] == ds_get_caller_identity[0]['account']
+  })
+
+  // This is in case the API does not return the relevant account info
+  if (result == undefined) {
+    result = {
+      id: ds_get_caller_identity[0]['account'],
+      name: "",
+      tags: {}
+    }
+  }
+EOS
+end
+
+datasource "ds_aws_buckets" do
   request do
     auth $auth_aws
     host "s3.amazonaws.com"
     path "/"
     header "User-Agent", "RS Policies"
+    # Header X-Meta-Flexera has no affect on datasource query, but is required for Meta Policies
+    # Forces `ds_is_deleted` datasource to run first during policy execution
+    header "Meta-Flexera", val($ds_is_deleted, "path")
   end
   result do
     encoding "xml"
     collect xpath(response, "//ListAllMyBucketsResult/Buckets/Bucket", "array") do
-      field "bucket_name", xpath(col_item,"Name")
+      field "bucket_name", xpath(col_item, "Name")
       field "creation_date", xpath(col_item, "CreationDate")
     end
   end
 end
 
-datasource "aws_buckets_with_region" do
-  iterate $aws_buckets
+datasource "ds_aws_buckets_with_region" do
+  iterate $ds_aws_buckets
   request do
     auth $auth_aws
     host "s3-external-1.amazonaws.com"
@@ -85,104 +214,157 @@ datasource "aws_buckets_with_region" do
   end
   result do
     encoding "xml"
+    field "region", xpath(response, "//LocationConstraint")
     field "bucket_name", val(iter_item, "bucket_name")
     field "creation_date", val(iter_item, "creation_date")
-    field "region", xpath(response, "//LocationConstraint")
   end
 end
 
-datasource "aws_sanitized_buckets" do
-  run_script $parse_buckets, $aws_buckets_with_region
+datasource "ds_aws_sanitized_buckets" do
+  run_script $js_aws_sanitized_buckets, $ds_aws_buckets_with_region
 end
 
-script "parse_buckets", type: "javascript" do
-  parameters "buckets"
-  result "results"
-  code <<-EOS
-// This is the list of filtered buckets.
-results = []
-for ( i = 0; i < buckets.length; i++ ) {
-  if ( !buckets[i]["region"] ){
-    results.push(
-    {
-      "bucket_name": buckets[i]["bucket_name"],
-      "creation_date": buckets[i]["creation_date"],
-      "region": "us-east-1",
-      "host": "s3-external-1.amazonaws.com"
+script "js_aws_sanitized_buckets", type: "javascript" do
+  parameters "ds_aws_buckets_with_region"
+  result "result"
+  code <<-'EOS'
+  result = _.map(ds_aws_buckets_with_region, function(bucket) {
+    bucket_name = bucket['bucket_name']
+    creation_date = bucket['creation_date']
+    region = bucket['region']
+    host = ["s3-", bucket["region"], ".amazonaws.com"].join('')
+
+    if (region == 'EU') {
+      region = "eu-west-1"
+      host = "s3-eu-west-1.amazonaws.com"
     }
-    )
-  } else {
-    if ( buckets[i]["region"] == "EU" ) { buckets[i]["region"] = "eu-west-1" }
-    results.push(
-    {
-      "bucket_name": buckets[i]["bucket_name"],
-      "creation_date": buckets[i]["creation_date"],
-      "region": buckets[i]["region"],
-      "host": "s3-" + buckets[i]["region"] + ".amazonaws.com"
+
+    if (typeof(region) != 'string' || region == '' || region == 'us-east-1') {
+      region = "us-east-1"
+      host = "s3-external-1.amazonaws.com"
     }
-    )
-  }
-};
+
+    return {
+      bucket_name: bucket_name,
+      creation_date: creation_date,
+      region: region,
+      host: host
+    }
+  })
 EOS
 end
 
-# Reference: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETacl.html
-datasource "aws_bucket_acls" do
-  iterate $aws_sanitized_buckets
+datasource "ds_aws_buckets_region_filtered" do
+  run_script $js_aws_buckets_region_filtered, $ds_aws_sanitized_buckets, $param_regions_list, $param_regions_allow_or_deny
+end
+
+script "js_aws_buckets_region_filtered", type:"javascript" do
+  parameters "ds_aws_sanitized_buckets", "param_regions_list", "param_regions_allow_or_deny"
+  result "result"
+  code <<-'EOS'
+  allow_deny_test = { "Allow": true, "Deny": false }
+
+  if (param_regions_list.length > 0) {
+    result = _.filter(ds_aws_sanitized_buckets, function(bucket) {
+      return _.contains(param_regions_list, bucket['region']) == allow_deny_test[param_regions_allow_or_deny]
+    })
+  } else {
+    result = ds_aws_sanitized_buckets
+  }
+EOS
+end
+
+datasource "ds_aws_bucket_acls" do
+  iterate $ds_aws_buckets_region_filtered
   request do
-    run_script $aws_bucket_acl_request, val(iter_item, "bucket_name"), val(iter_item, "host")
+    run_script $js_aws_bucket_acls, val(iter_item, "bucket_name"), val(iter_item, "host")
   end
-  #request do
-  #  auth $auth_aws
-  #  host val(iter_item,"host")
-  #  path join(["/", val(iter_item, "bucket_name")])
-  #  query "acl", ""
-  #  header "User-Agent", "RS Policies"
-  #end
   result do
     encoding "xml"
     collect xpath(response, "//AccessControlPolicy", "array") do
-      field "id", val(iter_item, "bucket_name")
+      field "grantee_uris", xpath(col_item, "AccessControlList/Grant/Grantee/URI", "array")
+      field "owner", xpath(col_item, "Owner/DisplayName")
+      field "bucket_name", val(iter_item, "bucket_name")
       field "creation_date", val(iter_item, "creation_date")
       field "region", val(iter_item, "region")
-      field "grantee_uris", xpath(col_item, "AccessControlList/Grant/Grantee/URI","array")
-      field "owner", xpath(col_item, "Owner/DisplayName")
-      field "region", val(iter_item, "region")
+      field "host", val(iter_item, "host")
     end
   end
 end
 
-###############################################################################
-# Scripts
-###############################################################################
-
-script "aws_bucket_acl_request", type: "javascript" do
+script "js_aws_bucket_acls", type: "javascript" do
   parameters "bucket_name", "host"
   result "request"
-  code <<-EOS
+  code <<-'EOS'
   request = {
     auth: "auth_aws",
     host: host,
-    path: '/' + bucket_name + '/',
-    query_params: {
-      acl: ""
-    },
-    headers: {
-      "User-Agent": "RS Policies"
-    }
+    path: ["/", bucket_name, "/"].join(''),
+    headers: { "User-Agent": "RS Policies" },
+    query_params: { acl: "" }
   }
-  EOS
+EOS
+end
+
+datasource "ds_aws_public_buckets" do
+  run_script $js_aws_public_buckets, $ds_aws_bucket_acls, $ds_aws_buckets_region_filtered, $ds_aws_account, $ds_applied_policy
+end
+
+script "js_aws_public_buckets", type: "javascript" do
+  parameters "ds_aws_bucket_acls", "ds_aws_buckets_region_filtered", "ds_aws_account", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  open_buckets = _.filter(ds_aws_bucket_acls, function(bucket) {
+    return _.contains(bucket['grantee_uris'], "http://acs.amazonaws.com/groups/global/AllUsers")
+  })
+
+  result = _.map(open_buckets, function(bucket) {
+    return {
+      id: bucket['bucket_name'],
+      creation_date: bucket['creation_date'],
+      region: bucket['region'],
+      host: bucket['host'],
+      grantee_uris: bucket['grantee_uris'].join(' '),
+      owner: bucket['owner'],
+      policy_name: ds_applied_policy['name'],
+      accountID: ds_aws_account['id'],
+      accountName: ds_aws_account['name']
+    }
+  })
+
+  // Message for incident output
+  total_buckets = ds_aws_buckets_region_filtered.length.toString()
+  total_public_buckets = result.length.toString()
+  public_buckets_percentage = (total_public_buckets / total_buckets * 100).toFixed(2).toString() + '%'
+
+  findings = [
+    "Out of ", total_buckets, " AWS Object Storage buckets analyzed, ",
+    total_public_buckets, " (", public_buckets_percentage,
+    ") are open to public access."
+  ].join('')
+
+  // Dummy item to ensure that the check statement in the policy executes at least once
+  result.push({
+    id: "",             creation_date: "",    region: "",
+    host: "",           grantee_uris: "",     owner: "",
+    policy_name: "",    accountID: "",        accountName: ""
+  })
+
+  result[0]['message'] = findings
+EOS
 end
 
 ###############################################################################
 # Policy
 ###############################################################################
 
-policy "public_buckets" do
-  validate_each $aws_bucket_acls do
-    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} Public Buckets Found in AWS"
-    escalate $report_open_buckets
-    check logic_not(contains(val(item, "grantee_uris"), "http://acs.amazonaws.com/groups/global/AllUsers"))
+policy "pol_public_buckets" do
+  validate_each $ds_aws_public_buckets do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} AWS Public Object Storage Buckets Found"
+    detail_template "{{ with index data 0 }}{{ .message }}{{ end }}"
+    check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
+    escalate $esc_email
+    hash_exclude "message", "owner"
     export do
       resource_level true
       field "region" do
@@ -208,9 +390,100 @@ end
 # Escalations
 ###############################################################################
 
-escalation "report_open_buckets" do
+escalation "esc_email" do
   automatic true
   label "Send Email"
   description "Send incident email"
   email $param_email
+end
+
+###############################################################################
+# Meta Policy [alpha]
+# Not intended to be modified or used by policy developers
+###############################################################################
+
+# If the meta_parent_policy_id is not set it will evaluate to an empty string and we will look for the policy itself,
+# if it is set we will look for the parent policy.
+datasource "ds_get_policy" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    ignore_status [404]
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", switch(ne(meta_parent_policy_id,""), meta_parent_policy_id, policy_id) ])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+  end
+end
+
+
+datasource "ds_parent_policy_terminated" do
+  run_script $js_decide_if_self_terminate, $ds_get_policy, policy_id, meta_parent_policy_id
+end
+
+# If the policy was applied by a meta_parent_policy we confirm it exists if it doesn't we confirm we are deleting
+# This information is used in two places:
+# - determining whether or not we make a delete call
+# - determining if we should create an incident (we don't want to create an incident on the run where we terminate)
+script "js_decide_if_self_terminate", type: "javascript" do
+  parameters "found", "self_policy_id", "meta_parent_policy_id"
+  result "result"
+  code <<-EOS
+  var result
+  if (meta_parent_policy_id != "" && found.id == undefined) {
+    result = true
+  } else {
+    result = false
+  }
+  EOS
+end
+
+# Two potentials ways to set this up:
+# - this way and make a unneeded 'get' request when not deleting
+# - make the delete request an interate and have it iterate over an empty array when not deleting and an array with one item when deleting
+script "js_make_terminate_request", type: "javascript" do
+  parameters "should_delete", "policy_id", "rs_project_id", "rs_governance_host"
+  result "request"
+  code <<-EOS
+
+  var request = {
+    auth:  'auth_flexera',
+    host: rs_governance_host,
+    path: "/api/governance/projects/" + rs_project_id + "/applied_policies/" + policy_id,
+    headers: {
+      "API-Version": "1.0",
+      "Content-Type":"application/json"
+    },
+  }
+
+  if (should_delete) {
+    request.verb = 'DELETE'
+  }
+  EOS
+end
+
+datasource "ds_terminate_self" do
+  request do
+    run_script $js_make_terminate_request, $ds_parent_policy_terminated, policy_id, rs_project_id, rs_governance_host
+  end
+end
+
+datasource "ds_is_deleted" do
+  run_script $js_check_deleted, $ds_terminate_self
+end
+
+# This is just a way to have the check delete request connect to the farthest leaf from policy.
+# We want the delete check to the first thing the policy does to avoid the policy erroring before it can decide whether or not it needs to self terminate
+# Example a customer deletes a credential and then terminates the parent policy. We still want the children to self terminate
+# The only way I could see this not happening is if the user who applied the parent_meta_policy was offboarded or lost policy access, the policies who are impersonating the user
+# would not have access to self-terminate
+# It may be useful for the backend to enable a mass terminate at some point for all meta_child_policies associated with an id.
+script "js_check_deleted", type: "javascript" do
+  parameters "response"
+  result "result"
+  code <<-EOS
+  result = {"path":"/"}
+  EOS
 end

--- a/security/storage/aws/public_buckets/aws_public_buckets_meta_parent.pt
+++ b/security/storage/aws/public_buckets/aws_public_buckets_meta_parent.pt
@@ -775,12 +775,6 @@ policy "policy_scheduled_report" do
       field "owner" do
         label "Owner"
       end
-      field "grantee_id" do
-        label "Grantee ID"
-      end
-      field "grantee_name" do
-        label "Grantee Name"
-      end
       field "grantee_uri" do
         label "Grantee URI"
       end

--- a/security/storage/aws/public_buckets/aws_public_buckets_meta_parent.pt
+++ b/security/storage/aws/public_buckets/aws_public_buckets_meta_parent.pt
@@ -729,8 +729,8 @@ script "js_ds_aws_public_buckets_combined_incidents", type: "javascript" do
   result = []
   _.each(ds_child_incident_details, function(incident) {
     s = incident["summary"];
-    // If the incident summary contains "AWS Public Object Storage Buckets Found" then include it in the filter result
-    if (s.indexOf("AWS Public Object Storage Buckets Found") > -1) {
+    // If the incident summary contains "AWS S3 Buckets With Public Access Found" then include it in the filter result
+    if (s.indexOf("AWS S3 Buckets With Public Access Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
         violation["incident_id"] = incident["id"];
         result.push(violation);
@@ -749,9 +749,9 @@ end
 # Could also just have one incident and use meta_status to determine which escalation happens
 policy "policy_scheduled_report" do
   # Consolidated Incident Check(s)
-    # Consolidated incident for AWS Public Object Storage Buckets Found
+    # Consolidated incident for AWS S3 Buckets With Public Access Found
   validate $ds_aws_public_buckets_combined_incidents do
-    summary_template "Consolidated Incident: {{ len data }} AWS Public Object Storage Buckets Found"
+    summary_template "Consolidated Incident: {{ len data }} AWS S3 Buckets With Public Access Found"
     escalate $esc_email
     
     check eq(size(data), 0)

--- a/security/storage/aws/public_buckets/aws_public_buckets_meta_parent.pt
+++ b/security/storage/aws/public_buckets/aws_public_buckets_meta_parent.pt
@@ -1,0 +1,1147 @@
+name "AWS Open S3 Buckets Meta Parent"
+rs_pt_ver 20180301
+type "policy"
+short_description "Applies and manages \"child\" [AWS Open S3 Buckets](https://github.com/flexera-public/policy_templates/tree/master/security/storage/aws/public_buckets) Policies."
+severity "low"
+category "Cost"
+tenancy "single"
+default_frequency "15 minutes"
+info(
+  provider: "AWS",
+  version: "3.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  publish: "false"
+)
+
+##############################################################################
+# Parameters
+##############################################################################
+
+## Meta Parent Parameters
+## These are params specific to the meta parent policy.
+parameter "param_combined_incident_email" do
+  type "list"
+  label "Email addresses for combined incident"
+  description "A list of email addresses to notify with the consolidated child policy incident."
+  default []
+end
+
+parameter "param_dimension_filter_includes" do
+  type "list"
+  label "Dimension Include Filters"
+  description <<-EOS
+  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
+  If no include filters are provided, then all AWS Accounts are included by default.
+  Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
+  EOS
+  default []
+end
+
+parameter "param_dimension_filter_excludes" do
+  type "list"
+  label "Dimension Exclude Filters"
+  description <<-EOS
+  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
+  Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
+  Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
+  EOS
+  default []
+end
+
+parameter "param_policy_schedule" do
+  type "string"
+  label "Child Policy Schedule"
+  description "The interval at which the child policy checks for conditions and generates incidents."
+  default "daily"
+  allowed_values "daily", "weekly", "monthly"
+end
+
+parameter "param_template_source" do
+  type "string"
+  label "Child Policy Template Source"
+  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  default "Published Catalog Template"
+  allowed_values "Published Catalog Template", "Uploaded Template"
+end
+
+## Child Policy Parameters
+parameter "param_regions_allow_or_deny" do
+  type "string"
+  category "Filters"
+  label "Allow/Deny Regions"
+  description "Allow or Deny entered regions. See the README for more details"
+  allowed_values "Allow", "Deny"
+  default "Allow"
+end
+
+parameter "param_regions_list" do
+  type "list"
+  category "Filters"
+  label "Allow/Deny Regions List"
+  allowed_pattern /^([a-zA-Z-_]+-[a-zA-Z0-9-_]+-[0-9-_]+,*|)+$/
+  description "A list of allowed or denied regions. See the README for more details"
+  default []
+end
+
+###############################################################################
+# Authentication
+###############################################################################
+credentials "auth_aws" do
+  schemes "aws", "aws_sts"
+  label "AWS"
+  description "Select the AWS Credential from the list"
+  tags "provider=aws"
+  aws_account_number $param_aws_account_number
+end
+
+credentials "auth_flexera" do
+  schemes "oauth2"
+  label "Flexera"
+  description "Select Flexera One OAuth2 credentials"
+  tags "provider=flexera"
+end
+
+###############################################################################
+# Datasources
+###############################################################################
+
+# Get Applied Parent Policy Details
+datasource "ds_self_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    field "name", jmes_path(response, "name")
+    field "creator_id", jmes_path(response, "created_by.id")
+    field "credentials", jmes_path(response, "credentials")
+    field "options", jmes_path(response, "options")
+  end
+end
+
+datasource "ds_child_policy_options" do
+  run_script $js_child_policy_options, $ds_self_policy_information
+end
+
+script "js_child_policy_options", type: "javascript" do
+  parameters "ds_self_policy_information"
+  result "options"
+  code <<-EOS
+  // Filter Options that are not appropriate for Child Policy
+  var options = _.map(ds_self_policy_information.options, function(option){
+    // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes, param_policy_schedule are exclusion to Meta Parent Policy Parameters
+    if (!_.contains(["param_combined_incident_email", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+      return { "name": option.name, "value": option.value };
+    }
+  });
+  // Explicitly add param_email which is disabled/does not exist in meta parent policy
+  options.push({
+    "name": "param_email",
+    "value": []
+  });
+  EOS
+end
+
+datasource "ds_child_policy_options_map" do
+  run_script $js_child_policy_options_map, $ds_child_policy_options
+end
+
+script "js_child_policy_options_map", type: "javascript" do
+  parameters "ds_child_policy_options"
+  result "options"
+  code <<-EOS
+  function format_options_keyvalue(options) {
+    var options_keyvalue_map = {};
+    _.each(options, function(option) {
+      options_keyvalue_map[option.name] = option.value;
+    });
+    return options_keyvalue_map;
+  }
+  var options = format_options_keyvalue(ds_child_policy_options)
+  EOS
+end
+
+datasource "ds_format_self" do
+  run_script $js_format_self, $ds_self_policy_information, $ds_child_policy_options_map
+end
+
+script "js_format_self", type: "javascript" do
+  parameters "ds_self_policy_information", "ds_child_policy_options_map"
+  result "formatted"
+  code <<-EOS
+  var formatted = {
+    "name": ds_self_policy_information["name"],
+    "creator_id": ds_self_policy_information["creator_id"],
+    "credentials": ds_self_policy_information["credentials"],
+    "options": ds_child_policy_options_map
+  };
+  EOS
+end
+
+
+# Get Pulished Policy Details
+datasource "ds_published_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/orgs/", rs_org_id, "/published_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the published policy that is published by "support@flexera.com" and matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "AWS Open S3 Buckets" and .created_by.email == "support@flexera.com")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+# Get Uploaded Policy Details
+datasource "ds_project_child_policy_information" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    # Select the uploaded policy that matches the name of the child policy template
+    collect jq(response, '.items[] | select(.name == "AWS Open S3 Buckets")' ) do
+      field "name", jmes_path(col_item, "name")
+      field "href", jmes_path(col_item, "href")
+      field "short_description", jmes_path(col_item, "short_description")
+    end
+  end
+end
+
+datasource "ds_get_billing_centers" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/analytics/orgs/",rs_org_id,"/billing_centers"])
+    header "Api-Version", "1.0"
+    header "User-Agent", "RS Policies"
+    query "view", "allocation_table"
+    ignore_status [403]
+  end
+  result do
+    encoding "json"
+    # Select the Billing Centers that have "parent_id" undefined or "" (i.e. top-level Billing Centers)
+    collect jq(response, '.[] | select(.parent_id == null)' ) do
+      field "href", jq(col_item,".href")
+      field "id", jq(col_item,".id")
+      field "name", jq(col_item,".name")
+      field "parent_id", jq(col_item,".parent_id")
+    end
+  end
+end
+
+script "js_make_billing_center_request", type: "javascript" do
+  parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
+  result "request"
+  code <<-EOS
+
+  billing_centers_formatted = []
+
+  for (x=0; x< billing_centers_unformatted.length; x++) {
+    billing_centers_formatted.push(billing_centers_unformatted[x]["id"])
+  }
+
+  finish = new Date()
+  finishFormatted = finish.toJSON().split("T")[0]
+  start = new Date()
+  start.setDate(start.getDate() - 30)
+  startFormatted = start.toJSON().split("T")[0]
+
+  // Default dimensions and filter expressions required for meta parent policy
+  var dimensions = ["vendor_account", "vendor_account_name"];
+  var filter_expressions = [
+    { dimension: "vendor", type: "equal", value: "AWS" }
+  ]
+
+  // Append to default dimensions and filter expressions using parent policy params
+  _.each(param_dimension_filter_includes, function (v) {
+    // split key=value string
+    var split = v.split("=");
+    var k = split[0];
+    var v = split[1];
+    // append to lists
+    dimensions.push(k);
+    filter_expressions.push({ dimension: k, type: "equal", value: v });
+  });
+
+  // Append to filter expressions using exclude policy params
+  _.each(param_dimension_filter_excludes, function (v) {
+    // split key=value string
+    var split = v.split("=");
+    var k = split[0];
+    var v = split[1];
+    // append to lists
+    dimensions.push(k);
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+  });
+
+  // Produces a duplicate-free version of the array
+  dimensions = _.uniq(dimensions);
+
+  var body = {
+    "dimensions": dimensions,
+    "granularity":"day",
+    "start_at": startFormatted,
+    "end_at": finishFormatted,
+    "metrics":["cost_amortized_unblended_adj"],
+    "billing_center_ids": billing_centers_formatted,
+    "filter":
+    {
+      "type": "and",
+      "expressions": filter_expressions
+    },
+    "summarized": true
+  }
+  var request = {
+    auth:  'auth_flexera',
+    host:  rs_optima_host,
+    scheme: 'https',
+    verb: 'POST',
+    path:  "/bill-analysis/orgs/"+ rs_org_id + "/costs/aggregated",
+    headers: {
+      "API-Version": "1.0",
+      "Content-Type":"application/json"
+    },
+    body: JSON.stringify(body)
+  }
+  EOS
+end
+
+# Get the AWS acounts
+datasource "ds_get_aws_accounts" do
+  request do
+    run_script $js_make_billing_center_request, rs_org_id, rs_optima_host, $ds_get_billing_centers, $param_dimension_filter_includes, $param_dimension_filter_excludes
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response,"rows[*]") do
+      field "aws_account_id", jmes_path(col_item,"dimensions.vendor_account")
+      field "aws_account_name", jmes_path(col_item,"dimensions.vendor_account_name")
+    end
+  end
+end
+
+# Get Child policies
+datasource "ds_get_existing_policies" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies"])
+    header "Api-Version", "1.0"
+    query "meta_parent_policy_id", policy_id
+  end
+  result do
+    collect jq(response, '.items[]?') do
+      field "name", jq(col_item, ".name")
+      field "applied_policy_id", jq(col_item, ".id")
+      field "options", jq(col_item, ".options")
+      field "updated_at", jq(col_item, ".updated_at")
+      field "status", jq(col_item, ".status")
+    end
+  end
+end
+
+# Get Child policies incidents
+datasource "ds_get_existing_policies_incidents" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/incidents"])
+    header "Api-Version", "1.0"
+    query "meta_parent_policy_id", policy_id
+  end
+  result do
+    collect jq(response, '.items[]?') do
+      field "incident_id", jq(col_item, ".id")
+      field "applied_policy_id", jq(col_item, ".applied_policy.id")
+      field "state", jq(col_item, ".state")
+      field "violation_data_count", jq(col_item, ".violation_data_count")
+      field "updated_at", jq(col_item, ".updated_at")
+      field "meta_parent_policy_id", jq(col_item, ".meta_parent_policy_id")
+    end
+  end
+end
+
+datasource "ds_format_incidents" do
+  run_script $js_format_existing_policies_incidents, $ds_get_existing_policies_incidents
+end
+
+script "js_format_existing_policies_incidents", type: "javascript" do
+  parameters "unformatted"
+  result "formatted"
+  code <<-EOS
+  formatted={}
+  for (x=0;x<unformatted.length; x++) {
+    current = unformatted[x]
+    formatted[current.applied_policy_id] = {incident_id: current.incident_id, state: current.state, violation_data_count: current.violation_data_count, updated_at: current.updated_at}
+  }
+  EOS
+end
+
+datasource "ds_format_existing_policies" do
+  run_script $js_format_existing_policies, $ds_get_existing_policies, $ds_format_incidents
+end
+
+# format
+# duplicates logic should compare updated at
+# we can validate update here when destructring the existing policy options, don't need updated at
+# format options
+script "js_format_existing_policies", type: "javascript" do
+  parameters "ds_get_existing_policies", "ds_format_incidents"
+  result "result"
+  code <<-EOS
+  function format_options_keyvalue(options) {
+    var options_keyvalue_map = {};
+    _.each(options, function(option) {
+      options_keyvalue_map[option.name] = option.value;
+    });
+    return options_keyvalue_map;
+  }
+
+  result = {}
+  formatted = {}
+  duplicates = []
+  // tracking holds all existing policies and later can be used to determine if existing policies should be deleted [i.e. if cloud account was removed]
+  tracking = {}
+
+  for (x=0; x<ds_get_existing_policies.length; x++) {
+    options = format_options_keyvalue(ds_get_existing_policies[x].options);
+
+    aws_account_id=options["param_aws_account_number"]
+    if (formatted[aws_account_id] == undefined) {
+      formatted[aws_account_id] = {
+        "applied_policy_id":ds_get_existing_policies[x]["applied_policy_id"],
+        "applied_policy_name":ds_get_existing_policies[x]["name"],
+        "status":ds_get_existing_policies[x]["status"],
+        "updated_at":ds_get_existing_policies[x]["updated_at"],
+        "incident": ds_format_incidents[ds_get_existing_policies[x]["applied_policy_id"]],
+        "options": options
+      }
+      tracking[aws_account_id] = false
+    } else {
+      current = formatted[aws_account_id]
+
+      currDate = new Date(current.updated_at)
+      newDate = new Date(ds_get_existing_policies[x].updated_at)
+
+      if (currDate > newDate) {
+        duplicates.push({
+          "applied_policy_id":ds_get_existing_policies[x]["applied_policy_id"],
+          "applied_policy_name":ds_get_existing_policies[x]["name"],
+          "status":ds_get_existing_policies[x]["status"],
+          "updated_at":ds_get_existing_policies[x]["updated_at"],
+          "incident": ds_format_incidents[ds_get_existing_policies[x]["applied_policy_id"]]
+        })
+      } else {
+        duplicates.push({
+          "applied_policy_id":current["applied_policy_id"],
+          "applied_policy_name":current["applied_policy_name"],
+          "status":current["status"],
+          "updated_at":current["updated_at"],
+          "incident": current["incident"]
+        })
+        formatted[aws_account_id] = {
+          "applied_policy_id":ds_get_existing_policies[x]["applied_policy_id"],
+          "applied_policy_name":ds_get_existing_policies[x]["name"],
+          "status":ds_get_existing_policies[x]["status"],
+          "updated_at":ds_get_existing_policies[x]["updated_at"],
+          "incident": ds_format_incidents[ds_get_existing_policies[x]["applied_policy_id"]],
+          "options": options
+        }
+
+      }
+    }
+  }
+
+  result.formatted=formatted
+  result.duplicates=duplicates
+  result.tracking=tracking
+  EOS
+end
+
+datasource "ds_take_in_parameters" do
+  run_script $js_take_in_parameters, $ds_get_aws_accounts, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+end
+
+# hardcode template href with id from catalog
+# catalog policies show in customer's published templates with their org id
+# "template_href": "/api/governance/orgs/" + rs_org_id + "/published_templates/62618616e3dff80001572bf0"
+# update logic: the only reason we're going to update the child policies for is changes to options
+# and only some options, email is always blank and aws_account_id is tied to the idenity of each policy, so: new account creation, removal of account: termination
+# param_automatic_action is a list with only one action, unless the person is applying using an API and putting the same value multiple times this should either be a length of 0 or 1
+# param_log_to_cm_audit_entries is a String of Yes or No
+# param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
+# If we only want to do an update on the values changing we could sort before doing the equality check.
+script "js_take_in_parameters", type: "javascript" do
+  parameters "ds_get_aws_accounts", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  result "grid_and_cwf"
+  code <<-EOS
+
+  // Set Child Policy Information based on param_template_source value
+  if (param_template_source == "Published Catalog Template") {
+    child_policy_information = ds_published_child_policy_information
+  } else {
+    child_policy_information = ds_project_child_policy_information
+  }
+
+  max_actions = 50;
+
+  grid_and_cwf={grid:[], to_create:[], to_update:[], to_delete:[], parent_policy:ds_format_self};
+
+  should_keep = ds_format_existing_policies.tracking;
+
+  // Construct UI URL prefixes for policy template summary
+  ui_url_prefix = "https://" + f1_app_host + "/orgs/" + rs_org_id;
+  applied_policy_url_prefix = ui_url_prefix + "/automation/applied-policies/projects/" + rs_project_id + "?noIndex=1&policyId=";
+  incident_url_prefix       = ui_url_prefix + "/automation/incidents/projects/" + rs_project_id + "?noIndex=1&incidentId=";
+
+  function add_to_grid(ep, action) {
+    policy_status={
+      "policy_name": ep["applied_policy_name"],
+      "policy_link": applied_policy_url_prefix + ep["applied_policy_id"],
+      "meta_policy_status": action,
+      "policy_status": ep["status"],
+      "policy_last_update": ep["updated_at"],
+    };
+    if (ep.incident != null) {
+      policy_status["incident_link"] = incident_url_prefix + ep.incident.incident_id;
+      policy_status["incident_state"] = ep.incident.state;
+      policy_status["incident_violation_data_count"] = ep.incident.violation_data_count;
+      policy_status["incident_last_update"] = ep.incident.updated_at;
+    }
+    grid_and_cwf.grid.push(policy_status);
+  }
+
+  for (x=0; x<ds_format_existing_policies.duplicates.length; x++) {
+    if (grid_and_cwf.to_delete.length < max_actions) {
+      grid_and_cwf.to_delete.push({"id":ds_format_existing_policies.duplicates[x]["applied_policy_id"], "name": ds_format_existing_policies.duplicates[x]["applied_policy_name"]})
+      add_to_grid(ds_format_existing_policies.duplicates[x], "terminating")
+    } else {
+      add_to_grid(ds_format_existing_policies.duplicates[x], "to be terminated")
+    }
+  }
+
+  for (x=0; x<ds_get_aws_accounts.length; x++) {
+    cur = ds_get_aws_accounts[x];
+    cur_aws_account_id = cur.aws_account_id.replace(/['"]+/g, '');
+
+    // Name and description do not vary between create or updates so defining them here
+    name = child_policy_information.name + ": " + cur.aws_account_name + " (" + cur_aws_account_id + ") (child policy)";
+    description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to AWS Account **" + cur.aws_account_name +"** (`" + cur_aws_account_id + "`).  " + child_policy_information.short_description;
+
+    // Check if child policy exists for current account id
+    if ( ! _.contains(_.keys(ds_format_existing_policies.formatted), cur_aws_account_id) ) {
+      console.log("Child Policy for "+cur_aws_account_id+" does not exist and should be created");
+
+      // Child Policy does not exist for current account ID and should be created
+
+
+      // Use the options from the parent policy in "name value" list format
+      options = _.toArray(ds_child_policy_options);
+
+      // Set param_aws_account_id values for this child policy
+      options.push({
+        "name": "param_aws_account_number",
+        "value": cur_aws_account_id
+      });
+
+      if (grid_and_cwf.to_create.length < max_actions) {
+        grid_and_cwf.to_create.push({
+          "name" : name,
+          "description" : description,
+          "credentials" : ds_format_self.credentials,
+          "options" : options,
+          "frequency" : param_policy_schedule,
+          "meta_parent_policy_id": meta_parent_policy_id,
+          "template_href": child_policy_information.href
+        })
+        policy_status={
+          "policy_name": name,
+          "meta_policy_status": "creating policy",
+          "policy_status": "",
+          "policy_last_update": "",
+        }
+        grid_and_cwf.grid.push(policy_status)
+      } else {
+        policy_status={
+          "policy_name": name,
+          "meta_policy_status": "policy to be created",
+          "policy_status": "",
+          "policy_last_update": "",
+        }
+        grid_and_cwf.grid.push(policy_status)
+      }
+    } else {
+      console.log("Child Policy for "+cur_aws_account_id+" does exist for current account ID and may need to be updated or deleted");
+      // Child Policy does exist for current account ID and may need to be updated or deleted
+      // Assume by default we should keep it and not update it
+      should_keep[cur_aws_account_id] = true;
+      should_update = false;
+
+      // Use the options from the parent policy in "name value" list format
+      options = _.toArray(ds_child_policy_options);
+
+      // Set param_aws_account_id values for this child policy
+      options.push({
+        "name": "param_aws_account_number",
+        "value": cur_aws_account_id
+      });
+
+      // Check if child policy params match parent policy params
+      _.each(ds_format_self.options, function(value, key) {
+        // If any child and parent param values do not match, mark the child policy as should_update
+        if ( !_.isEqual(value, ds_format_existing_policies["formatted"][cur_aws_account_id]["options"][key]) ) {
+          console.log("Child Policy Param does not match Parent Policy and should be updated. "+key+" does not match "+value+"!="+ds_format_existing_policies["formatted"][cur_aws_account_id]["options"][key]);
+          should_update = true;
+        }
+      });
+
+
+      if (should_update) {
+        // Child policy needs to be updated
+        if (grid_and_cwf.to_update.length < max_actions) {
+          // Child policy needs to be updated and is within the max_actions limit
+          console.log("Child Policy needs to be updated. ds_format_existing_policies.formatted[cur_aws_account_id]="+JSON.stringify(ds_format_existing_policies.formatted[cur_aws_account_id]));
+          add_to_grid(ds_format_existing_policies.formatted[cur_aws_account_id], "updating")
+          name = ds_format_existing_policies.formatted[cur_aws_account_id].applied_policy_name
+          // Add to_update
+          grid_and_cwf.to_update.push({
+            "applied_policy_id": ds_format_existing_policies.formatted[cur_aws_account_id].applied_policy_id,
+            "name" : name,
+            "description" : description,
+            "credentials" : ds_format_self.credentials,
+            "options" : options,
+            "frequency" : param_policy_schedule,
+          })
+        } else {
+          // Child policy needs to be updated but is outside the max_actions limit
+          // Add to grid but do not add to to_update
+          console.log("Child Policy needs to be updated. ds_format_existing_policies.formatted[cur_aws_account_id]="+JSON.stringify(ds_format_existing_policies.formatted[cur_aws_account_id]));
+          add_to_grid(ds_format_existing_policies.formatted[cur_aws_account_id], "to be updated");
+        }
+      } else {
+        // Child policy does not need to be updated
+        add_to_grid(ds_format_existing_policies.formatted[cur_aws_account_id], "running");
+      }
+    }
+  }
+
+  console.log("Checking if policies should be deleted. "+JSON.stringify(should_keep));
+  _.each(should_keep, function(keep, account_id) {
+    console.log("Should keep "+account_id+"="+keep);
+    if (!keep) {
+      if (grid_and_cwf.to_delete.length < max_actions) {
+        grid_and_cwf.to_delete.push({"id":ds_format_existing_policies.formatted[account_id].applied_policy_id, "name": ds_format_existing_policies.formatted[account_id].applied_policy_name})
+        add_to_grid(ds_format_existing_policies.formatted[account_id], "terminating")
+      } else {
+        add_to_grid(ds_format_existing_policies.formatted[account_id], "to be terminated")
+      }
+    }
+  });
+
+  EOS
+end
+
+datasource "ds_only_grid" do
+  run_script $js_only_grid, $ds_take_in_parameters
+end
+
+script "js_only_grid", type: "javascript" do
+  parameters "results"
+  result "only_grid"
+  code <<-EOS
+    only_grid = results.grid
+  EOS
+end
+
+datasource "ds_to_create" do
+  run_script $js_only_create, $ds_take_in_parameters
+end
+
+script "js_only_create", type: "javascript" do
+  parameters "results"
+  result "only_create"
+  code <<-EOS
+    only_create = results.to_create
+  EOS
+end
+
+datasource "ds_to_update" do
+  run_script $js_only_update, $ds_take_in_parameters
+end
+
+script "js_only_update", type: "javascript" do
+  parameters "results"
+  result "only_update"
+  code <<-EOS
+    only_update = results.to_update
+  EOS
+end
+
+datasource "ds_to_delete" do
+  run_script $js_only_delete, $ds_take_in_parameters
+end
+
+script "js_only_delete", type: "javascript" do
+  parameters "results"
+  result "only_delete"
+  code <<-EOS
+    only_delete = results.to_delete
+  EOS
+end
+
+# The following datasources consolidate the child incident output into a single incident.
+# This is because it is more convenient for many users to have a single incident with all of the data.
+datasource "ds_child_incident_details" do
+  iterate $ds_get_existing_policies_incidents
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/incidents/", val(iter_item, 'incident_id')])
+    verb "GET"
+    header "User-Agent", "RS Policies"
+    header "Api-Version", "1.0"
+    query "view", "extended"
+  end
+end
+
+datasource "ds_aws_public_buckets_combined_incidents" do
+  run_script $js_ds_aws_public_buckets_combined_incidents, $ds_child_incident_details
+end
+
+script "js_ds_aws_public_buckets_combined_incidents", type: "javascript" do
+  parameters "ds_child_incident_details"
+  result "result"
+  code <<-EOS
+  result = []
+  _.each(ds_child_incident_details, function(incident) {
+    s = incident["summary"];
+    // If the incident summary contains "AWS Public Object Storage Buckets Found" then include it in the filter result
+    if (s.indexOf("AWS Public Object Storage Buckets Found") > -1) {
+      _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
+        result.push(violation);
+      });
+    }
+  });
+EOS
+end
+
+
+
+
+# Summary and a conditional incident which will show up if any policy is being applied, updated or deleted.
+# Minimum of 1 incident, max of four
+# Could swap the summary to only showing running
+# Could also just have one incident and use meta_status to determine which escalation happens
+policy "policy_scheduled_report" do
+  # Consolidated Incident Check(s)
+    # Consolidated incident for AWS Public Object Storage Buckets Found
+  validate $ds_aws_public_buckets_combined_incidents do
+    summary_template "Consolidated Incident: {{ len data }} AWS Public Object Storage Buckets Found"
+    escalate $esc_email
+    
+    check eq(size(data), 0)
+    export do
+      resource_level true
+      field "accountID" do
+        label "Account ID"
+      end
+      field "accountName" do
+        label "Account Name"
+      end
+      field "id" do
+        label "Bucket Name"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "creation_date" do
+        label "Creation Date"
+      end
+      field "owner" do
+        label "Owner"
+      end
+      field "grantee_id" do
+        label "Grantee ID"
+      end
+      field "grantee_name" do
+        label "Grantee Name"
+      end
+      field "grantee_uri" do
+        label "Grantee URI"
+      end
+      field "incident_id" do
+        label "Child Incident ID"
+      end
+    end
+  end
+
+  # Status Incident Check
+  validate $ds_take_in_parameters do
+    summary_template "{{ data.parent_policy.name }}: Status of Child Policies"
+    detail_template <<-EOS
+The current status of Child Policies for **{{ data.parent_policy.name }}**:
+
+Total Child Applied Policies: {{ len data.grid }}
+
+| Applied Policy | Meta Child Policy Status | Policy Status | Policy Last Update | Incident | Incident State | Violation Count | Incident Last Update |
+| -------------- | ------------------------ | ------------- | ------------------ | -------- | -------------- | --------------- | -------------------- |
+{{ range data.grid -}}
+| {{- if .policy_link }} [{{ .policy_name }}]({{ .policy_link }}) {{ else }} {{ .policy_name }} {{- end }} | {{- if .meta_policy_status }} {{ .meta_policy_status }} {{ else }} No value {{- end }} | {{- if .policy_status }} {{ .policy_status }} {{ else }} No value {{- end }} | {{- if .policy_last_update }} {{ .policy_last_update }} {{ else }} No value {{- end }} | {{- if .incident_link }} [Incident]({{ .incident_link }}) {{ else }} No Incident {{- end }} | {{- if .incident_state }} {{ .incident_state }} {{ else }} No Incident {{- end }} | {{- if .incident_last_update }} {{ .incident_violation_data_count }} {{ else }} No Incident {{- end }} | {{- if .incident_last_update }} {{ .incident_last_update }} {{ else }} No Incident {{- end }} |
+{{ end -}}
+
+EOS
+    check false # always trigger this status incident
+    # Export Table disabled for now until UI can support URL / linking
+    # Without linking the `policy_link`, `incident_link` values are not usable directly from UI
+    # export "grid" do
+    #   resource_level true
+    #   field "id" do
+    #     label "Applied Policy ID"
+    #   end
+    #   field "policy_name" do
+    #     label "Applied Policy Name"
+    #   end
+    #   field "policy_link" do
+    #     label "Applied Policy Link"
+    #   end
+    #   field "meta_policy_status" do
+    #     label "Meta Child Policy Status"
+    #   end
+    #   field "policy_status" do
+    #     label "Policy Status"
+    #   end
+    #   field "policy_last_update" do
+    #     label "Policy Last Update"
+    #   end
+    #   field "incident_link" do
+    #     label "Incident Link"
+    #   end
+    #   field "incident_state" do
+    #     label "Incident State"
+    #   end
+    #   field "incident_violation_data_count" do
+    #     label "Incident Violation Count"
+    #   end
+    #   field "incident_last_update" do
+    #     label "Incident Last Update"
+    #   end
+    # end
+  end
+
+  # Create Child Policies Incident Check
+  validate $ds_to_create do
+    summary_template "Policies being created"
+    detail_template <<-EOS
+    Policies Being Created:
+
+    | Applied Policy |
+    | --------------- |
+    {{ range data -}}
+    | {{ .name }} |
+    {{ end -}}
+    EOS
+    escalate $create_policies
+    check eq(size(data),0)
+  end
+
+  # Update Child Policies Incident Check
+  validate $ds_to_update do
+    summary_template "Policies being updated"
+    detail_template <<-EOS
+    Policies Being Updated:
+
+    | Applied Policy |
+    | --------------- |
+    {{ range data -}}
+    | {{ .name }} |
+    {{ end -}}
+    EOS
+    escalate $update_policies
+    check eq(size(data),0)
+  end
+
+  # Delete Child Policies Incident Check
+  validate $ds_to_delete do
+    summary_template "Policies being deleted"
+    detail_template <<-EOS
+    Policies being Deleted:
+
+    | Applied Policy |
+    | --------------- |
+    {{ range data -}}
+    | {{ .name }} |
+    {{ end -}}
+    EOS
+    escalate $delete_policies
+    check eq(size(data),0)
+  end
+end
+
+# Begin Shared Functions for Child Actions from Consolidated Incident
+define groupByIncidentID($data) return $incidents do
+  # Empty hash to store incidents is incident_id
+  $incidents = {}
+
+  task_label("Grouping items by Incident ID")
+  $index = 1
+  foreach $item in $data do
+    task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data)))
+    if !$incidents[$item["incident_id"]]
+      #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". New Incident: "+$item["incident_id"])
+      $incidents[$item["incident_id"]] = {"id": $item["incident_id"], "resource_ids": []}
+    end
+    #task_label("Grouping items by Incident ID. "+to_s($index)+"/"+to_s(size($data))". Appending Resource: "+$item["id"])
+    # Append resource id to the list for the incident
+    $incidents[$item["incident_id"]]["resource_ids"] = $incidents[$item["incident_id"]]["resource_ids"] + [$item["id"]]
+  end
+end
+
+define child_run_action($data, $governance_host, $rs_project_id, $action_label) do
+  # Empty global array for log strings, helpful for debugging
+  $$debug = []
+
+  # Group Resources by Incident ID
+  # This reduces the number of requests made to the Flexera API
+  call groupByIncidentID($data) retrieve $incidents
+  $$debug_incidents = to_json($incidents)
+
+  call runActions($incidents, $action_label, $governance_host, $rs_project_id)
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+
+  # If we made it here, all actions completed successfully
+  # Celebrate Success!
+  task_label("All \""+$action_label+"\" actions completed successfully!")
+end
+
+define runActions($incidents, $action_label, $governance_host, $rs_project_id) do
+  foreach $id in keys($incidents) do
+    sub on_error: handle_error() do
+      $incident = $incidents[$id]
+      task_label("Triggering action \""+$action_label+"\" on "+size($incident["resource_ids"])+" count resources via incident "+$incident["id"])
+      $request = {
+        auth: $$auth_flexera,
+        verb: "get",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"]]),
+        headers: { "Api-Version": "1.0" },
+        query_strings: { "view": "extended" }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      $action_id = ""
+      foreach $action in $response["body"]["available_actions"] do
+        # If we have not already found the action id, and the label matches, set the action id
+        # The first check is to prevent looking through the entire list if we already have the id
+        if $action["label"] == $action_label
+          $action_id = $action["id"]
+        end
+      end
+      if $action_id == ""
+        raise "Could not find action id for \""+$action_label+"\" response="+to_json($response)
+      end
+      # Now we are reach to trigger the action
+      $request = {
+        auth: $$auth_flexera,
+        verb: "post",
+        https: true,
+        host: $governance_host,
+        href: join(["/api/governance/projects/", $rs_project_id, "/incidents/", $incident["id"],"/actions/", $action_id,"/run_action"]),
+        headers: { "Api-Version": "1.0" },
+        body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
+      }
+      $response = http_request($request)
+      $$debug << to_json({
+        "request": $request,
+        "response": $response
+      })
+      # Get the action status from response header
+      $action_location = $response["headers"]["Location"]
+
+      # Setup some variables for the wait loop
+      $action_status = ""
+      $loop_count = 0
+      $loop_endtime = now() + (3600*2) # 2 hours from now
+      # [ queued, aborted, pending, running, completed, failed, denied ]
+      while ($action_status !~ /^(aborted|completed|failed|denied)/) && (now() <= $loop_endtime) do
+        # Using Loop Count to slowly increment the sleep time
+        # This is to prevent the loop from hammering our APIs
+        $loop_count = $loop_count + 1
+        task_label("action_status=\""+$action_status+"\" Sleeping for "+to_s($loop_count)+" seconds")
+        sleep($loop_count)
+        task_label("action_status=\""+$action_status+"\" Getting action status")
+        $request = {
+          auth: $$auth_flexera,
+          verb: "get",
+          https: true,
+          host: $governance_host,
+          href: $action_location,
+          headers: { "Api-Version": "1.0" },
+          query_strings: { "view": "extended" }
+        }
+        $response = http_request($request)
+        $$debug << to_json({
+          "request": $request,
+          "response": $response
+        })
+        $action_status = $response["body"]["status"]
+      end
+      if ($action_status != "completed")
+        # Check if we are out of time first
+        if (now() > $loop_endtime)
+          raise "action_status=\""+$action_status+"\" Action did not complete in time. Aborting to prevent endless loop. action_status_json="+to_json($response)
+        else
+          # If not, then it was aborted, failed or denied
+          raise "action_status=\""+$action_status+"\" Action did not complete as expected. action_status_json="+to_json($response)
+        end
+      end
+      # If we made it here, the action completed successfully
+      task_label("action_status=\""+$action_status+"\" Action completed successfully")
+    end
+  end
+end
+# End Shared Functions for Child Actions from Consolidated Incident
+
+# CWF function to handle errors
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
+end
+
+# Used only for emailing the combined child incident if so desired
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_combined_incident_email
+end
+
+escalation "create_policies" do
+  run "create_applied_policies", data, rs_governance_host, rs_project_id
+end
+
+# if name !=null
+define create_applied_policies($data, $governance_host, $rs_project_id) return $responses do
+  $responses = []
+  $$debug = []
+  $item_index = 0
+  $item_total = size($data)
+  foreach $item in $data do
+    $item_index = $item_index + 1
+    $status = to_s("("+$item_index+"/"+$item_total+")")
+    task_label($status+" Creating Applied Policy with Options: " + to_json($item["options"]))
+    $response = http_request(
+      auth: $$auth_flexera,
+      verb: "post",
+      https: true,
+      host: $governance_host,
+      href: join(["/api/governance/projects/", $rs_project_id, "/applied_policies"]),
+      headers: { "Api-Version": "1.0" },
+      body: {
+        "name": $item["name"],
+        "description": $item["description"],
+        "template_href": $item["template_href"],
+        "frequency": $item["frequency"],
+        "options": $item["options"],
+        "credentials": $item["credentials"],
+        "meta_parent_policy_id": $item["meta_parent_policy_id"]
+      }
+    )
+    $responses << $response
+    $$debug << to_json({
+      "response": $response,
+      "item": $item,
+      "governance_host": $governance_host
+    })
+  end
+end
+
+escalation "update_policies" do
+  run "update_applied_policies", data, rs_governance_host, rs_project_id
+end
+
+define update_applied_policies($data, $governance_host, $rs_project_id) return $responses do
+  $responses = []
+  $$debug = []
+  $item_index = 0
+  $item_total = size($data)
+  foreach $item in $data do
+    $item_index = $item_index + 1
+    $status = to_s("("+$item_index+"/"+$item_total+")")
+    task_label($status+" Updating Applied Policy with Options: " + to_json($item["options"]))
+    $response = http_request(
+      auth: $$auth_flexera,
+      verb: "patch",
+      https: true,
+      host: $governance_host,
+      href: join(["/api/governance/projects/", $rs_project_id, "/applied_policies/", $item["applied_policy_id"]]),
+      headers: { "Api-Version": "1.0" },
+      body: {
+        "options": $item["options"]
+      }
+    )
+    $responses << $response
+    $$debug << to_json({
+      "response": $response,
+      "item": $item,
+      "governance_host": $governance_host
+    })
+  end
+end
+
+escalation "delete_policies" do
+  run "delete_applied_policies", data, rs_governance_host, rs_project_id
+end
+
+define delete_applied_policies($data, $governance_host, $rs_project_id) return $responses do
+  $responses = []
+  $$debug = []
+  $item_index = 0
+  $item_total = size($data)
+  foreach $item in $data do
+    $item_index = $item_index + 1
+    $status = to_s("("+$item_index+"/"+$item_total+")")
+    task_label($status+" Deleting Applied Policy: " + $item["id"])
+    $response = http_request(
+      auth: $$auth_flexera,
+      verb: "delete",
+      https: true,
+      host: $governance_host,
+      href: join(["/api/governance/projects/", $rs_project_id, "/applied_policies/", $item["id"]]),
+      headers: { "Api-Version": "1.0" }
+    )
+    $responses << $response
+    $$debug << to_json({
+      "response": $response,
+      "item": $item,
+      "governance_host": $governance_host
+    })
+  end
+end

--- a/security/storage/aws/public_buckets/aws_public_buckets_meta_parent.pt
+++ b/security/storage/aws/public_buckets/aws_public_buckets_meta_parent.pt
@@ -775,6 +775,9 @@ policy "policy_scheduled_report" do
       field "owner" do
         label "Owner"
       end
+      field "recommendationDetails" do
+        label "Recommendation"
+      end
       field "grantee_uri" do
         label "Grantee URI"
       end

--- a/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
+++ b/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
@@ -28,6 +28,7 @@ default_child_policy_template_files = [
   "../../operational/aws/tag_cardinality/aws_tag_cardinality.pt",
   "../../security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes.pt",
   "../../security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances.pt",
+  "../../security/storage/aws/public_buckets/aws_public_buckets.pt",
   # Azure Policy Templates
   "../../compliance/azure/azure_disallowed_regions/azure_disallowed_regions.pt",
   "../../compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry.pt",


### PR DESCRIPTION
### Description

This is a revamp of the AWS Open Buckets policy to clean up the code/functionality and to enable meta policy support.

From the CHANGELOG:

- Several parameters altered to be more descriptive and human-readable
- Added ability to filter resources by region
- Added additional context to incident description
- Normalized incident export to be consistent with other policies
- Added human-readable recommendation to incident export
- Policy no longer raises new escalations if bucket owner has changed but nothing else has
- Streamlined code for better readability and faster execution
- Policy now requires a valid Flexera credential

### Link to Example Applied Policy

https://app.flexera.com/orgs/27018/automation/applied-policies/projects/116186?policyId=6568f20399745e0001588354

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
