### PR TITLE
POL-977 AWS Rightsize RDS: Change Parameter Default Value

### DIFF
--- a/cost/aws/rightsize_rds_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_rds_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.1
+
+- Changed default value of `Underutilized Instance CPU Threshold (%)` parameter to 40%.
+
 ## v4.0
 
 - Added parameter to specify how far back to check instances for activity

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.0",
+  version: "4.1",
   provider: "AWS",
   service: "RDS",
   policy_set: "Rightsize Database Instances",
@@ -86,7 +86,7 @@ parameter "param_stats_underutil_threshold_cpu_value" do
   description "The CPU threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing."
   min_value 0
   max_value 100
-  default 60
+  default 40
 end
 
 parameter "param_stats_lookback" do

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 
@@ -118,7 +118,7 @@ parameter "param_stats_underutil_threshold_cpu_value" do
   description "The CPU threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing."
   min_value 0
   max_value 100
-  default 60
+  default 40
 end
 
 parameter "param_stats_lookback" do


### PR DESCRIPTION
### Description

This just changes the default value of the `Underutilized Instance CPU Threshold (%)` parameter to 40% to match other policies and ensure that our recommendations won't cause performance issues.
