### PR TITLE
POL-978 Update Default Frequency of Children to "Weekly"

### DIFF
--- a/compliance/aws/disallowed_regions/aws_disallowed_regions_meta_parent.pt
+++ b/compliance/aws/disallowed_regions/aws_disallowed_regions_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/compliance/aws/disallowed_regions/aws_disallowed_regions_meta_parent.pt
+++ b/compliance/aws/disallowed_regions/aws_disallowed_regions_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"AWS Disallowed Regions\" Policy Template from Catalog.  Optionally, you can use the \"AWS Disallowed Regions\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent_meta_parent.pt
+++ b/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent_meta_parent.pt
+++ b/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"AWS EC2 Instances not running FlexNet Inventory Agent\" Policy Template from Catalog.  Optionally, you can use the \"AWS EC2 Instances not running FlexNet Inventory Agent\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/compliance/aws/long_stopped_instances/aws_long_stopped_instances_meta_parent.pt
+++ b/compliance/aws/long_stopped_instances/aws_long_stopped_instances_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"AWS Long-stopped Instances\" Policy Template from Catalog.  Optionally, you can use the \"AWS Long-stopped Instances\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/compliance/aws/long_stopped_instances/aws_long_stopped_instances_meta_parent.pt
+++ b/compliance/aws/long_stopped_instances/aws_long_stopped_instances_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry_meta_parent.pt
+++ b/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the Azure AHUB Utilization with Manual Entry Policy Template from Catalog.  Optionally, you can use the Azure AHUB Utilization with Manual Entry Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry_meta_parent.pt
+++ b/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the Azure AHUB Utilization with Manual Entry Policy Template from Catalog.  Optionally, you can use the Azure AHUB Utilization with Manual Entry Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Azure AHUB Utilization with Manual Entry\" Policy Template from Catalog.  Optionally, you can use the \"Azure AHUB Utilization with Manual Entry\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry_meta_parent.pt
+++ b/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent.pt
+++ b/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the Azure Disallowed Regions Policy Template from Catalog.  Optionally, you can use the Azure Disallowed Regions Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Azure Disallowed Regions\" Policy Template from Catalog.  Optionally, you can use the \"Azure Disallowed Regions\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent.pt
+++ b/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the Azure Disallowed Regions Policy Template from Catalog.  Optionally, you can use the Azure Disallowed Regions Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent.pt
+++ b/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/compliance/azure/azure_long_stopped_instances/long_stopped_instances_azure_meta_parent.pt
+++ b/compliance/azure/azure_long_stopped_instances/long_stopped_instances_azure_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the Azure Long Stopped Instances Policy Template from Catalog.  Optionally, you can use the Azure Long Stopped Instances Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/compliance/azure/azure_long_stopped_instances/long_stopped_instances_azure_meta_parent.pt
+++ b/compliance/azure/azure_long_stopped_instances/long_stopped_instances_azure_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/compliance/azure/azure_long_stopped_instances/long_stopped_instances_azure_meta_parent.pt
+++ b/compliance/azure/azure_long_stopped_instances/long_stopped_instances_azure_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the Azure Long Stopped Instances Policy Template from Catalog.  Optionally, you can use the Azure Long Stopped Instances Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Azure Long Stopped Instances\" Policy Template from Catalog.  Optionally, you can use the \"Azure Long Stopped Instances\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
+++ b/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the Azure Instances not running FlexNet Inventory Agent Policy Template from Catalog.  Optionally, you can use the Azure Instances not running FlexNet Inventory Agent Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Azure Instances not running FlexNet Inventory Agent\" Policy Template from Catalog.  Optionally, you can use the \"Azure Instances not running FlexNet Inventory Agent\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
+++ b/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the Azure Instances not running FlexNet Inventory Agent Policy Template from Catalog.  Optionally, you can use the Azure Instances not running FlexNet Inventory Agent Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
+++ b/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume_meta_parent.pt
+++ b/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"AWS GP3 Upgradeable Volumes\" Policy Template from Catalog.  Optionally, you can use the \"AWS GP3 Upgradeable Volumes\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume_meta_parent.pt
+++ b/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
+++ b/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
+++ b/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"AWS Idle Compute Instances\" Policy Template from Catalog.  Optionally, you can use the \"AWS Idle Compute Instances\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"AWS Object Storage Optimization\" Policy Template from Catalog.  Optionally, you can use the \"AWS Object Storage Optimization\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"AWS Old Snapshots\" Policy Template from Catalog.  Optionally, you can use the \"AWS Old Snapshots\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/aws/rds_instance_license_info/rds_instance_license_info_meta_parent.pt
+++ b/cost/aws/rds_instance_license_info/rds_instance_license_info_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/aws/rds_instance_license_info/rds_instance_license_info_meta_parent.pt
+++ b/cost/aws/rds_instance_license_info/rds_instance_license_info_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"AWS RDS Instances\" Policy Template from Catalog.  Optionally, you can use the \"AWS RDS Instances\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"AWS Rightsize EBS Volumes\" Policy Template from Catalog.  Optionally, you can use the \"AWS Rightsize EBS Volumes\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"AWS Rightsize EC2 Instances\" Policy Template from Catalog.  Optionally, you can use the \"AWS Rightsize EC2 Instances\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"AWS Rightsize RDS Instances\" Policy Template from Catalog.  Optionally, you can use the \"AWS Rightsize RDS Instances\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check_meta_parent.pt
+++ b/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"AWS S3 Bucket Intelligent Tiering Check\" Policy Template from Catalog.  Optionally, you can use the \"AWS S3 Bucket Intelligent Tiering Check\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check_meta_parent.pt
+++ b/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/aws/schedule_instance/aws_schedule_instance_meta_parent.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"AWS Schedule Instance\" Policy Template from Catalog.  Optionally, you can use the \"AWS Schedule Instance\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/aws/schedule_instance/aws_schedule_instance_meta_parent.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"AWS Superseded EC2 Instances\" Policy Template from Catalog.  Optionally, you can use the \"AWS Superseded EC2 Instances\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"AWS Unused IP Addresses\" Policy Template from Catalog.  Optionally, you can use the \"AWS Unused IP Addresses\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/aws/unused_rds/unused_rds_meta_parent.pt
+++ b/cost/aws/unused_rds/unused_rds_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"AWS Unused RDS Instances\" Policy Template from Catalog.  Optionally, you can use the \"AWS Unused RDS Instances\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/aws/unused_rds/unused_rds_meta_parent.pt
+++ b/cost/aws/unused_rds/unused_rds_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"AWS Unused Volumes\" Policy Template from Catalog.  Optionally, you can use the \"AWS Unused Volumes\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the Azure Hybrid Use Benefit for Windows Server Policy Template from Catalog.  Optionally, you can use the Azure Hybrid Use Benefit for Windows Server Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Azure Hybrid Use Benefit for Windows Server\" Policy Template from Catalog.  Optionally, you can use the \"Azure Hybrid Use Benefit for Windows Server\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the Azure Hybrid Use Benefit for Windows Server Policy Template from Catalog.  Optionally, you can use the Azure Hybrid Use Benefit for Windows Server Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the Azure Hybrid Use Benefit for Linux Server Policy Template from Catalog.  Optionally, you can use the Azure Hybrid Use Benefit for Linux Server Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the Azure Hybrid Use Benefit for Linux Server Policy Template from Catalog.  Optionally, you can use the Azure Hybrid Use Benefit for Linux Server Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Azure Hybrid Use Benefit for Linux Server\" Policy Template from Catalog.  Optionally, you can use the \"Azure Hybrid Use Benefit for Linux Server\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the Azure Hybrid Use Benefit for SQL Policy Template from Catalog.  Optionally, you can use the Azure Hybrid Use Benefit for SQL Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Azure Hybrid Use Benefit for SQL\" Policy Template from Catalog.  Optionally, you can use the \"Azure Hybrid Use Benefit for SQL\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the Azure Hybrid Use Benefit for SQL Policy Template from Catalog.  Optionally, you can use the Azure Hybrid Use Benefit for SQL Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the Azure Idle Compute Instances Policy Template from Catalog.  Optionally, you can use the Azure Idle Compute Instances Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the Azure Idle Compute Instances Policy Template from Catalog.  Optionally, you can use the Azure Idle Compute Instances Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Azure Idle Compute Instances\" Policy Template from Catalog.  Optionally, you can use the \"Azure Idle Compute Instances\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the Azure Old Snapshots Policy Template from Catalog.  Optionally, you can use the Azure Old Snapshots Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Azure Old Snapshots\" Policy Template from Catalog.  Optionally, you can use the \"Azure Old Snapshots\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the Azure Old Snapshots Policy Template from Catalog.  Optionally, you can use the Azure Old Snapshots Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the Azure Rightsize Compute Instances Policy Template from Catalog.  Optionally, you can use the Azure Rightsize Compute Instances Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the Azure Rightsize Compute Instances Policy Template from Catalog.  Optionally, you can use the Azure Rightsize Compute Instances Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Azure Rightsize Compute Instances\" Policy Template from Catalog.  Optionally, you can use the \"Azure Rightsize Compute Instances\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the Azure Rightsize SQL Databases Policy Template from Catalog.  Optionally, you can use the Azure Rightsize SQL Databases Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Azure Rightsize SQL Databases\" Policy Template from Catalog.  Optionally, you can use the \"Azure Rightsize SQL Databases\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the Azure Rightsize SQL Databases Policy Template from Catalog.  Optionally, you can use the Azure Rightsize SQL Databases Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the Azure Schedule Instance Policy Template from Catalog.  Optionally, you can use the Azure Schedule Instance Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Azure Schedule Instance\" Policy Template from Catalog.  Optionally, you can use the \"Azure Schedule Instance\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the Azure Schedule Instance Policy Template from Catalog.  Optionally, you can use the Azure Schedule Instance Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent.pt
+++ b/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the Azure Storage Accounts without Lifecycle Management Policies Policy Template from Catalog.  Optionally, you can use the Azure Storage Accounts without Lifecycle Management Policies Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Azure Storage Accounts without Lifecycle Management Policies\" Policy Template from Catalog.  Optionally, you can use the \"Azure Storage Accounts without Lifecycle Management Policies\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent.pt
+++ b/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent.pt
+++ b/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the Azure Storage Accounts without Lifecycle Management Policies Policy Template from Catalog.  Optionally, you can use the Azure Storage Accounts without Lifecycle Management Policies Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the Azure Superseded Compute Instances Policy Template from Catalog.  Optionally, you can use the Azure Superseded Compute Instances Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Azure Superseded Compute Instances\" Policy Template from Catalog.  Optionally, you can use the \"Azure Superseded Compute Instances\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the Azure Superseded Compute Instances Policy Template from Catalog.  Optionally, you can use the Azure Superseded Compute Instances Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the Azure Unused IP Addresses Policy Template from Catalog.  Optionally, you can use the Azure Unused IP Addresses Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the Azure Unused IP Addresses Policy Template from Catalog.  Optionally, you can use the Azure Unused IP Addresses Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Azure Unused IP Addresses\" Policy Template from Catalog.  Optionally, you can use the \"Azure Unused IP Addresses\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
+++ b/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the Azure Unused SQL Databases Policy Template from Catalog.  Optionally, you can use the Azure Unused SQL Databases Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Azure Unused SQL Databases\" Policy Template from Catalog.  Optionally, you can use the \"Azure Unused SQL Databases\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
+++ b/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
+++ b/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the Azure Unused SQL Databases Policy Template from Catalog.  Optionally, you can use the Azure Unused SQL Databases Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the Azure Unused Volumes Policy Template from Catalog.  Optionally, you can use the Azure Unused Volumes Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the Azure Unused Volumes Policy Template from Catalog.  Optionally, you can use the Azure Unused Volumes Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Azure Unused Volumes\" Policy Template from Catalog.  Optionally, you can use the \"Azure Unused Volumes\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations_meta_parent.pt
+++ b/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Google Idle Cloud SQL Instance Recommender\" Policy Template from Catalog.  Optionally, you can use the \"Google Idle Cloud SQL Instance Recommender\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations_meta_parent.pt
+++ b/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/google/cud_recommendations/google_committed_use_discount_recommendations_meta_parent.pt
+++ b/cost/google/cud_recommendations/google_committed_use_discount_recommendations_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Google Committed Use Discount Recommender\" Policy Template from Catalog.  Optionally, you can use the \"Google Committed Use Discount Recommender\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/google/cud_recommendations/google_committed_use_discount_recommendations_meta_parent.pt
+++ b/cost/google/cud_recommendations/google_committed_use_discount_recommendations_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Google Idle IP Address Recommender\" Policy Template from Catalog.  Optionally, you can use the \"Google Idle IP Address Recommender\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Google Idle Persistent Disk Recommender\" Policy Template from Catalog.  Optionally, you can use the \"Google Idle Persistent Disk Recommender\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Google Old Snapshots\" Policy Template from Catalog.  Optionally, you can use the \"Google Old Snapshots\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
+++ b/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
+++ b/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Google Rightsize VM Recommender\" Policy Template from Catalog.  Optionally, you can use the \"Google Rightsize VM Recommender\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate_meta_parent.pt
+++ b/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"AWS Lambda Functions with high error rate\" Policy Template from Catalog.  Optionally, you can use the \"AWS Lambda Functions with high error rate\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate_meta_parent.pt
+++ b/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
+++ b/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
+++ b/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"AWS Long Running Instances\" Policy Template from Catalog.  Optionally, you can use the \"AWS Long Running Instances\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/operational/aws/tag_cardinality/aws_tag_cardinality_meta_parent.pt
+++ b/operational/aws/tag_cardinality/aws_tag_cardinality_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/operational/aws/tag_cardinality/aws_tag_cardinality_meta_parent.pt
+++ b/operational/aws/tag_cardinality/aws_tag_cardinality_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"AWS Tag Cardinality Report\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality Report\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
+++ b/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
+++ b/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the Expiring Azure Certificates Policy Template from Catalog.  Optionally, you can use the Expiring Azure Certificates Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Expiring Azure Certificates\" Policy Template from Catalog.  Optionally, you can use the \"Expiring Azure Certificates\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
+++ b/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the Expiring Azure Certificates Policy Template from Catalog.  Optionally, you can use the Expiring Azure Certificates Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the Azure Long Running Instances Policy Template from Catalog.  Optionally, you can use the Azure Long Running Instances Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the Azure Long Running Instances Policy Template from Catalog.  Optionally, you can use the Azure Long Running Instances Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Azure Long Running Instances\" Policy Template from Catalog.  Optionally, you can use the \"Azure Long Running Instances\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
+++ b/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the Azure Tag Cardinality Report Policy Template from Catalog.  Optionally, you can use the Azure Tag Cardinality Report Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Azure Tag Cardinality Report\" Policy Template from Catalog.  Optionally, you can use the \"Azure Tag Cardinality Report\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
+++ b/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the Azure Tag Cardinality Report Policy Template from Catalog.  Optionally, you can use the Azure Tag Cardinality Report Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
+++ b/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent.pt
+++ b/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the Azure VMs Not Using Managed Disks Policy Template from Catalog.  Optionally, you can use the Azure VMs Not Using Managed Disks Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent.pt
+++ b/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the Azure VMs Not Using Managed Disks Policy Template from Catalog.  Optionally, you can use the Azure VMs Not Using Managed Disks Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"Azure VMs Not Using Managed Disks\" Policy Template from Catalog.  Optionally, you can use the \"Azure VMs Not Using Managed Disks\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent.pt
+++ b/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes_meta_parent.pt
+++ b/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"AWS Unencrypted Volumes\" Policy Template from Catalog.  Optionally, you can use the \"AWS Unencrypted Volumes\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes_meta_parent.pt
+++ b/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances_meta_parent.pt
+++ b/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances_meta_parent.pt
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances_meta_parent.pt
+++ b/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances_meta_parent.pt
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"AWS Publicly Accessible RDS Instances\" Policy Template from Catalog.  Optionally, you can use the \"AWS Publicly Accessible RDS Instances\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"__PLACEHOLDER_FOR_CHILD_POLICY_NAME__\" Policy Template from Catalog.  Optionally, you can use the \"__PLACEHOLDER_FOR_CHILD_POLICY_NAME__\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the __PLACEHOLDER_FOR_CHILD_POLICY_NAME__ Policy Template from Catalog.  Optionally, you can use the __PLACEHOLDER_FOR_CHILD_POLICY_NAME__ Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 

--- a/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the __PLACEHOLDER_FOR_CHILD_POLICY_NAME__ Policy Template from Catalog.  Optionally, you can use the __PLACEHOLDER_FOR_CHILD_POLICY_NAME__ Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"__PLACEHOLDER_FOR_CHILD_POLICY_NAME__\" Policy Template from Catalog.  Optionally, you can use the \"__PLACEHOLDER_FOR_CHILD_POLICY_NAME__\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
@@ -60,7 +60,7 @@ end
 parameter "param_template_source" do
   type "string"
   label "Child Policy Template Source"
-  description "By default, will use the \"AWS Tag Cardinality\" Policy Template from Catalog.  Optionally, you can use the \"AWS Tag Cardinality\" Policy Template uploaded in the current Flexera Project."
+  description "By default, will use the \"__PLACEHOLDER_FOR_CHILD_POLICY_NAME__\" Policy Template from Catalog.  Optionally, you can use the \"__PLACEHOLDER_FOR_CHILD_POLICY_NAME__\" Policy Template uploaded in the current Flexera Project."
   default "Published Catalog Template"
   allowed_values "Published Catalog Template", "Uploaded Template"
 end

--- a/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
@@ -53,7 +53,7 @@ parameter "param_policy_schedule" do
   type "string"
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
-  default "daily"
+  default "weekly"
   allowed_values "daily", "weekly", "monthly"
 end
 


### PR DESCRIPTION
### Description

The default frequency for child policies is currently "daily", which is excessive in most cases and does not align with most child policies. This PR is to change it to "weekly"

This also fixes an issue where one of the meta policy parameters would refer to the Tag Cardinality policy instead of the name of the actual policy the meta policy is for.
