### PR TITLE
POL-945 Currency Conversion Backfill Support

### DIFF
--- a/cost/currency_conversion/CHANGELOG.md
+++ b/cost/currency_conversion/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1
+
+- Added parameters to allow the user to configure currency conversion for previous months
+
 ## v2.0
 
 - Removed requirement for dedicated xe.com credential

--- a/cost/currency_conversion/README.md
+++ b/cost/currency_conversion/README.md
@@ -2,7 +2,7 @@
 
 ## What It Does
 
-This Policy creates adjustment rules that convert the currency of the cost associated with the Cloud Vendor of choice. It utilizes xe.com to retrieve the latest exchange rates.
+This policy creates adjustment rules that convert the currency of the cost associated with the Cloud Vendor of choice. It utilizes xe.com to retrieve the latest exchange rates.
 
 ## Functional Details
 

--- a/cost/currency_conversion/README.md
+++ b/cost/currency_conversion/README.md
@@ -1,8 +1,29 @@
 # Currency Conversion
 
-## What it does
+## What It Does
 
-This Policy creates an adjustment rule that converts the currency of the cost associated with the Cloud Vendor of choice. It utilizes xe.com to retrieve the latest exchange rates.
+This Policy creates adjustment rules that convert the currency of the cost associated with the Cloud Vendor of choice. It utilizes xe.com to retrieve the latest exchange rates.
+
+## Functional Details
+
+- This policy supports currency codes as per [ISO 4217](https://www.xe.com/iso4217.php), and uses the xe.com API to retrieve monthly average exchange rate.
+- This policy supports four cloud providers natively: AWS, Azure, Google Cloud, and Oracle Cloud.
+- This policy also supports custom cloud provider names to handle specialized use cases.
+- This policy creates an adjustment rule for currency conversion using the exchange rate from xe.com.
+- This policy can create such adjustment rules for the current month or backfill previous months.
+
+### Input Parameters
+
+This policy has the following input parameters required when launching the policy.
+
+- *Email Addresses* - Email addresses of the recipients you wish to notify when currency conversion adjustment rules are updated.
+- *Backfill Adjustments* - Whether to add/modify currency conversion to just the current month or to backfill previous months.
+- *Backfill Start Date* - The month and year in YYYY-MM format to backfill adjustments to. Only applicable if `Backfill Previous Months` is selected for the `Backfill Adjustments` parameter.
+- *Backfill Exchange Rates* - Whether or not to use the current exchange rate, or the exchange rate at the time, when applying currency conversion to previous months. Only applicable if `Backfill Previous Months` is selected for the `Backfill Adjustments` parameter.
+- *Cloud Provider* - Cloud provider costs that you want to apply currency conversion to. Select 'Other' to specify the name of a cloud provider manually.
+- *Cloud Provider Name* - Name of the cloud provider to apply currency conversion to. Only applicable if 'Other' is selected for Cloud Provider. This should correspond to the Cloud Vendor field in the Flexera One UI or the 'vendor' field in Optima.
+- *Currency From* - Currency you want to convert from (based on ISO 4217 codes - e.g., 'USD' for US Dollar)
+- *Currency To* - Currency you want to convert to (based on ISO 4217 codes - e.g., 'EUR' for Euro)
 
 ## Prerequisites
 
@@ -12,23 +33,6 @@ This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Auto
   - `enterprise_manager`
 
 The [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) page in the docs has detailed instructions for setting up Credentials for the most common providers.
-
-## Functional Details
-
-- This policy supports currency codes as per [ISO 4217](https://www.xe.com/iso4217.php), and uses the xe.com API to retrieve monthly average exchange rate.
-- This policy supports four cloud providers natively: AWS, Azure, Google Cloud, and Oracle Cloud.
-- This policy also supports custom cloud provider names to handle specialized use cases.
-- This policy creates an adjustment rule for currency conversion using the exchange rate from xe.com.
-
-### Input Parameters
-
-This policy has the following input parameters required when launching the policy.
-
-- *Email Addresses* - Email addresses of the recipients you wish to notify when currency conversion adjustment rules are updated.
-- *Cloud Provider* - Cloud provider costs that you want to apply currency conversion to. Select 'Other' to specify the name of a cloud provider manually.
-- *Cloud Provider Name* - Name of the cloud provider to apply currency conversion to. Only applicable if 'Other' is selected for Cloud Provider. This should correspond to the Cloud Vendor field in the Flexera One UI or the 'vendor' field in Optima.
-- *Currency From* - Currency you want to convert from (based on ISO 4217 codes - e.g., 'USD' for US Dollar)
-- *Currency To* - Currency you want to convert to (based on ISO 4217 codes - e.g., 'EUR' for Euro)
 
 ## Supported Clouds
 

--- a/cost/currency_conversion/currency_conversion.pt
+++ b/cost/currency_conversion/currency_conversion.pt
@@ -165,33 +165,30 @@ script "js_month_list", type: "javascript" do
 EOS
 end
 
-datasource "ds_month_list_for_xe" do
-  run_script $js_month_list_for_xe, $ds_month_list
+datasource "ds_year_list_for_xe" do
+  run_script $js_year_list_for_xe, $ds_month_list
 end
 
-script "js_month_list_for_xe", type: "javascript" do
+script "js_year_list_for_xe", type: "javascript" do
   parameters "ds_month_list"
   result "result"
   code <<-'EOS'
   dates = _.uniq(_.pluck(ds_month_list, 'previous').concat(_.pluck(ds_month_list, 'current')))
-
-  result = _.map(dates, function(date) {
-    return { year: date.split('-')[0], month: date.split('-')[1] }
-  })
+  years = _.map(dates, function(date) { return date.split('-')[0] })
+  result = _.uniq(years).sort()
 EOS
 end
 
 # Gather exchange rates for each year
 datasource "ds_xe_exchange_rates" do
-  iterate $ds_month_list_for_xe
+  iterate $ds_year_list_for_xe
   request do
     host "api.xe-auth.flexeraeng.com"
     path "/prod/{proxy+}"
     query "from", $param_currency_from
     query "to", $param_currency_to
     query "amount", "1"
-    query "year", val(iter_item, "year")
-    query "month", val(iter_item, "month")
+    query "year", iter_item
   end
   result do
     encoding "json"

--- a/cost/currency_conversion/currency_conversion.pt
+++ b/cost/currency_conversion/currency_conversion.pt
@@ -42,6 +42,32 @@ parameter "param_cloud_provider_name" do
   default ""
 end
 
+parameter "param_backfill" do
+  type "string"
+  category "Policy Settings"
+  label "Backfill Adjustments"
+  description "Whether to add/modify currency conversion to just the current month or to backfill previous months."
+  allowed_values "Current Month", "Backfill Previous Months"
+  default "Current Month"
+end
+
+parameter "param_backfill_start_date" do
+  type "string"
+  category "Policy Settings"
+  label "Backfill Start Date"
+  description "The month and year in YYYY-MM format to backfill adjustments to. Only applicable if \"Backfill Previous Months\" is selected."
+  default ""
+end
+
+parameter "param_backfill_exchange_rate" do
+  type "string"
+  category "Policy Settings"
+  label "Backfill Exchange Rates"
+  description "Whether or not to use the current exchange rate, or the exchange rate at the time, when applying currency conversion to previous months. Only applicable if \"Backfill Previous Months\" is selected."
+  allowed_values "Current Exchange Rate", "Backdated Exchange Rate"
+  default "Backdated Exchange Rate"
+end
+
 parameter "param_currency_from" do
   type "string"
   category "Currency"
@@ -73,38 +99,115 @@ end
 # Datasources & Scripts
 ###############################################################################
 
-datasource "ds_date" do
-  run_script $js_date
+datasource "ds_rate_years" do
+  run_script $js_rate_years, $param_backfill, $param_backfill_start_date, $param_backfill_exchange_rate
 end
 
-script "js_date", type: "javascript" do
+script "js_rate_years", type: "javascript" do
+  parameters "param_backfill", "param_backfill_start_date", "param_backfill_exchange_rate"
   result "result"
   code <<-EOS
-  date = new Date()
-  current_date = date.toISOString().split("T")
-  current_month = current_date[0].split("-")[0] + "-" + current_date[0].split("-")[1]
+  result = []
 
-  date.setMonth(date.getMonth() - 1)
-  previous_date = date.toISOString().split("T")
-  previous_month = previous_date[0].split("-")[0] + "-" + previous_date[0].split("-")[1]
+  if (param_backfill == "Current Month" || param_backfill_exchange_rate == "Current Exchange Rate") {
+    result.push(new Date().toISOString().split('-')[0])
+  } else {
+    back_year = Number(new Date(param_backfill_start_date).toISOString().split('-')[0])
+    current_year = Number(new Date().toISOString().split('-')[0])
 
-  result = {
-    previousMonth: previous_month,
-    currentMonth: current_month
+    do {
+      result.push(back_year.toString())
+      back_year += 1
+    } while (back_year != current_year)
   }
 EOS
 end
 
 datasource "ds_xe_monthly_average" do
+  iterate $ds_rate_years
   request do
     host "api.xe-auth.flexeraeng.com"
     path "/prod/{proxy+}"
     query "from", $param_currency_from
     query "to", $param_currency_to
     query "amount", "1"
-    query "year", first(split(val($ds_date, "previousMonth"), "-"))
-    query "month", last(split(val($ds_date, "previousMonth"), "-"))
+    query "year", iter_item
+    query "month", "01"
   end
+  result do
+    encoding "json"
+    field "from", jmes_path(response, "from")
+    field "to", jmes_path(response, "to")
+    field "year", jmes_path(response, "year")
+  end
+end
+
+datasource "ds_exchange_rates" do
+  run_script $js_exchange_rates, $ds_xe_monthly_average, $param_currency_to
+end
+
+script "js_exchange_rates", type: "javascript" do
+  parameters "ds_xe_monthly_average", "param_currency_to"
+  result "result"
+  code <<-EOS
+  result = {}
+  currency_code = param_currency_to.toUpperCase().trim()
+
+  _.each(ds_xe_monthly_average, function(item) {
+    year = item['year'].toString()
+
+    _.each(item['to'][currency_code], function(month) {
+      month_num = month['month'].toString()
+      if (month['month'] < 10) { month_num = '0' + month_num }
+
+      if (result[year] == undefined) { result[year] = {} }
+      result[year][month_num] = month['monthlyAverage']
+    }
+  })
+EOS
+end
+
+datasource "ds_date_list" do
+  run_script $js_date_list, $param_backfill, $param_backfill_start_date
+end
+
+script "js_date_list", type: "javascript" do
+  parameters "param_backfill", "param_backfill_start_date"
+  result "result"
+  code <<-EOS
+  result = []
+
+  now_date = new Date()
+  now_date = new Date(now_date.toISOString().split("T")[0])
+  now_month = now_date.toISOString().split('-')[1]
+  now_year = now_date.toISOString().split('-')[0]
+
+  start_date = now_date
+
+  if (param_backfill == "Backfill Previous Months") {
+    start_date = new Date(param_backfill_start_date)
+  }
+
+  start_month = start_date.toISOString().split('-')[1]
+  start_year = start_date.toISOString().split('-')[0]
+
+  do {
+    result.push(start_year + '-' + start_month)
+
+    if (start_month == '12') {
+      start_year = (Number(start_year) + 1).toString()
+      start_month = '01'
+    } else {
+      start_month = Number(start_month) + 1
+
+      if (start_month < 10) {
+        start_month = '0' + start_month.toString()
+      } else {
+        start_month = start_month.toString()
+      }
+    }
+  } while (now_month != start_month && now_year != start_year)
+EOS
 end
 
 datasource "ds_current_adjustments" do
@@ -117,77 +220,85 @@ datasource "ds_current_adjustments" do
 end
 
 datasource "ds_updated_adjustments" do
-  run_script $js_update_adjustments, $ds_xe_monthly_average, $ds_current_adjustments, $ds_date, $param_cloud_provider, $param_cloud_provider_name, $param_currency_from, $param_currency_to
+  run_script $js_update_adjustments, $ds_exchange_rates, $ds_current_adjustments, $ds_date_list, $param_cloud_provider, $param_cloud_provider_name, $param_currency_from, $param_currency_to, $param_backfill_exchange_rate
 end
 
 script "js_update_adjustments", type: "javascript" do
-  parameters "ds_xe_monthly_average", "ds_adjustments", "ds_date", "param_cloud_provider", "param_cloud_provider_name", "param_currency_from", "param_currency_to"
+  parameters "ds_exchange_rates", "ds_current_adjustments", "ds_date_list", "param_cloud_provider", "param_cloud_provider_name", "param_currency_from", "param_currency_to", "param_backfill_exchange_rate"
   result "result"
   code <<-EOS
-  // Get conversion rate (monthly average)
-  conversion_rate = ds_xe_monthly_average.to[param_currency_to][0].monthlyAverage
+  now_date = new Date()
+  now_date = new Date(now_date.toISOString().split("T")[0])
+  now_month = now_date.toISOString().split('-')[1]
+  now_year = now_date.toISOString().split('-')[0]
+
+  existing_adjustment_lists = {}
+
+  _.each(ds_current_adjustments['dated_adjustment_lists'], function(list) {
+    existing_adjustment_lists[list['effective_at']] = list['adjustment_list']
+  })
+
+  // Include any existing rules for months we don't intend to modify
+  new_adjustments = _.reject(ds_current_adjustments['dated_adjustment_lists'], function(list) {
+    return _.contains(ds_date_list, list['effective_at'])
+  })
 
   // Cloud provider
   cloud_provider = param_cloud_provider
   if (param_cloud_provider == "Google Cloud") { cloud_provider = "GCP" }
   if (param_cloud_provider == "Other") { cloud_provider = param_cloud_provider_name }
-
-  // Create currency coversion adjustment rule
   new_adj_name = "Currency Conversion - " + cloud_provider
 
-  currency_conversion_rule = {
-    name: new_adj_name,
-    rules: [
-      {
-        condition: {
-          type: "dimension_equals",
-          dimension: "vendor",
-          value: cloud_provider
-        },
-        cost_multiplier: conversion_rate - 1,
-        label: param_currency_from + " to " + param_currency_to
-      }
-    ]
-  }
+  _.each(ds_date_list, function(date) {
+    year = date.split('-')[0]
+    month = date.split('-')[1]
+    existing_list = existing_adjustment_lists[date]
 
-  // Get adjustment list for current month (as this is the one that needs to be modified) if it exists
-  current_effective_at_month = ds_date['currentMonth']
-  dated_adjustment_lists = ds_adjustments['dated_adjustment_lists']
+    if (param_backfill_exchange_rate == "Backdated Exchange Rate") {
+      conversion_rate = ds_exchange_rates[year][month]
+    } else {
+      conversion_rate = ds_exchange_rates[now_year][now_month]
+    }
 
-  current_adjustment_list = _.find(dated_adjustment_lists, function(adj_list) {
-    return adj_list['effective_at'] == current_effective_at_month
+    currency_conversion_rule = {
+      name: new_adj_name,
+      rules: [
+        {
+          condition: {
+            type: "dimension_equals",
+            dimension: "vendor",
+            value: cloud_provider
+          },
+          cost_multiplier: conversion_rate - 1,
+          label: param_currency_from + " to " + param_currency_to
+        }
+      ]
+    }
+
+    adjustment_list = [ currency_conversion_rule ]
+
+    if (existing_list != undefined) {
+      // Check if a Currency Conversion adjustment rule already exists for current month
+      adj_name = _.find(existing_list, function(list) {
+        return list['name'] == new_adj_name
+      })
+
+      // Add CC rule to existing rules while filtering for existing CC rules
+      adjustment_list = _.filter(existing_list, function(list) {
+        // Return 'true' for all items if we did not find an existing CC rule
+        return list['name'] != new_adj_name || adj_name == undefined
+      })
+
+      adjustment_list.push(currency_conversion_rule)
+    }
+
+    new_adjustment_list = {
+      adjustment_list: adjustment_list,
+      effective_at: date
+    }
+
+    new_adjustments.push(new_adjustment_list)
   })
-
-  // Set new adjustment list to our currency conversion rule generated above
-  adjustment_list = [ currency_conversion_rule ]
-
-  // If adjustments exist for current month, add our rule to them
-  if (current_adjustment_list != undefined) {
-    // Check if a Currency Conversion adjustment rule already exists for current month
-    adj_name = _.find(current_adjustment_list['adjustment_list'], function(list) {
-      return list['name'] == new_adj_name
-    })
-
-    // Add CC rule to existing rules while filtering for existing CC rules
-    adjustment_list = _.filter(current_adjustment_list['adjustment_list'], function(list) {
-      // Return 'true' for all items if we did not find an existing CC rule
-      return list['name'] != new_adj_name || adj_name == undefined
-    })
-
-    adjustment_list.push(currency_conversion_rule)
-  }
-
-  new_adjustment_list = {
-    adjustment_list: adjustment_list,
-    effective_at: current_effective_at_month
-  }
-
-  // Reject adjustments for current month (if exists) from existing adjustment lists object
-  new_adjustments = _.reject(ds_adjustments['dated_adjustment_lists'], function(list) {
-    return list['effective_at'] == current_effective_at_month
-  })
-
-  new_adjustments.push(new_adjustment_list)
 
   result = { new_adjustment_list: JSON.stringify({ dated_adjustment_lists: new_adjustments }) }
 EOS

--- a/cost/currency_conversion/currency_conversion.pt
+++ b/cost/currency_conversion/currency_conversion.pt
@@ -265,6 +265,9 @@ script "js_update_adjustments", type: "javascript" do
   if (param_cloud_provider == "Other") { cloud_provider = param_cloud_provider_name }
   new_adj_name = "Currency Conversion - " + cloud_provider
 
+  // Rule information stored for incident
+  message_rules = []
+
   // Create a new adjustment list for each month
   _.each(ds_month_list, function(date) {
     // Set the currency conversion rate based on user parameter
@@ -285,6 +288,9 @@ script "js_update_adjustments", type: "javascript" do
         }
       ]
     }
+
+    // Store rule information for incident
+    message_rules.push(date + ": " + conversion_rate.toString())
 
     // Incorporate the new rule into the existing rule set if necessary
     adjustment_list = [ currency_conversion_rule ]
@@ -317,21 +323,21 @@ script "js_update_adjustments", type: "javascript" do
 
   this_month = new Date().toISOString().split('-')[0] + '-' + new Date().toISOString().split('-')[1]
 
-  message = "Adjustments applied for cloud provider " + cloud_provider + " for month of " + this_month + "."
+  message = "Adjustments applied for cloud provider " + cloud_provider + " for month of " + this_month + ".\n\n"
 
   if (param_backfill != 'Current Month' && param_backfill_start_date != '') {
-    message = "Adjustments applied for cloud provider " + cloud_provider + " from month of " + param_backfill_start_date + " to month of " + this_month + ".\n\n"
+    message = "Adjustments applied for cloud provider " + cloud_provider + " from month of " + param_backfill_start_date + " to month of " + this_month + ". "
 
     if (param_backfill_exchange_rate == 'Backdated Exchange Rate') {
-      message += "Backdated exchange rates were used for previous months."
+      message += "Backdated exchange rates were used for previous months.\n\n"
     } else {
-      message += "Current exchange rate was used for previous months."
+      message += "Current exchange rate was used for previous months.\n\n"
     }
   }
 
   result = [{
     list: JSON.stringify({ dated_adjustment_lists: new_adjustments }),
-    message: message
+    message: message + message_rules.join("\n")
   }]
 EOS
 end

--- a/cost/currency_conversion/currency_conversion.pt
+++ b/cost/currency_conversion/currency_conversion.pt
@@ -142,22 +142,20 @@ script "js_month_list", type: "javascript" do
 
   result = []
 
-  current_date = new Date().toISOString().split('-')
-  current_date = [current_date[0], current_date[1]].join('-')
-
-  start_date = current_date
+  current_date_parts = new Date().toISOString().split('-')
+  current_date = [current_date_parts[0], current_date_parts[1]].join('-')
 
   if (param_backfill == "Backfill Previous Months" && param_backfill_start_date != '') {
-    start_date = param_backfill_start_date
-  }
+    iterating_date = param_backfill_start_date
 
-  while (start_date != current_date) {
-    result.push({
-      previous: move_month(start_date, -1),
-      current: start_date
-    })
+    while (iterating_date != current_date) {
+      result.push({
+        previous: move_month(iterating_date, -1),
+        current: iterating_date
+      })
 
-    start_date = move_month(start_date, 1)
+      iterating_date = move_month(iterating_date, 1)
+    }
   }
 
   result.push({

--- a/cost/currency_conversion/currency_conversion.pt
+++ b/cost/currency_conversion/currency_conversion.pt
@@ -99,6 +99,7 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+# Get a list of years that we need monthly exchange rates for based on parameters
 datasource "ds_rate_years" do
   run_script $js_rate_years, $param_backfill, $param_backfill_start_date, $param_backfill_exchange_rate
 end
@@ -109,10 +110,18 @@ script "js_rate_years", type: "javascript" do
   code <<-EOS
   result = []
 
-  if (param_backfill == "Current Month" || param_backfill_exchange_rate == "Current Exchange Rate") {
-    result.push(new Date().toISOString().split('-')[0])
+  // We need to get exchange rates for previous year in case current month is January and
+  // we need exchange rate info from December of the previous year
+  if (param_backfill == "Current Month" || param_backfill_exchange_rate == "Current Exchange Rate" || param_backfill_start_date == '') {
+    current_year = Number(new Date().toISOString().split('-')[0])
+    previous_year = current_year - 1
+
+    result.push(previous_year.toString())
+    result.push(current_year.toString())
   } else {
     back_year = Number(new Date(param_backfill_start_date).toISOString().split('-')[0])
+    back_year -= 1
+
     current_year = Number(new Date().toISOString().split('-')[0])
 
     do {
@@ -123,7 +132,8 @@ script "js_rate_years", type: "javascript" do
 EOS
 end
 
-datasource "ds_xe_monthly_average" do
+# Gather exchange rates for each year
+datasource "ds_xe_exchange_rates" do
   iterate $ds_rate_years
   request do
     host "api.xe-auth.flexeraeng.com"
@@ -142,57 +152,76 @@ datasource "ds_xe_monthly_average" do
   end
 end
 
+# Assemble exchange rates into a simple object that can be used later
 datasource "ds_exchange_rates" do
-  run_script $js_exchange_rates, $ds_xe_monthly_average, $param_currency_to
+  run_script $js_exchange_rates, $ds_xe_exchange_rates, $param_currency_to
 end
 
 script "js_exchange_rates", type: "javascript" do
-  parameters "ds_xe_monthly_average", "param_currency_to"
+  parameters "ds_xe_exchange_rates", "param_currency_to"
   result "result"
   code <<-EOS
   result = {}
   currency_code = param_currency_to.toUpperCase().trim()
 
-  _.each(ds_xe_monthly_average, function(item) {
-    year = item['year'].toString()
+  _.each(ds_xe_exchange_rates, function(item) {
+    year_num = item['year'].toString()
 
     _.each(item['to'][currency_code], function(month) {
       month_num = month['month'].toString()
       if (month['month'] < 10) { month_num = '0' + month_num }
+      date = [year_num, month_num].join('-')
 
-      if (result[year] == undefined) { result[year] = {} }
-      result[year][month_num] = month['monthlyAverage']
-    }
+      result[date] = month['monthlyAverage']
+    })
   })
 EOS
 end
 
-datasource "ds_date_list" do
-  run_script $js_date_list, $param_backfill, $param_backfill_start_date
+# Create a list of months in YYYY-MM format that we need to apply adjustments for
+datasource "ds_month_list" do
+  run_script $js_month_list, $param_backfill, $param_backfill_start_date
 end
 
-script "js_date_list", type: "javascript" do
+script "js_month_list", type: "javascript" do
   parameters "param_backfill", "param_backfill_start_date"
   result "result"
   code <<-EOS
   result = []
 
-  now_date = new Date()
-  now_date = new Date(now_date.toISOString().split("T")[0])
-  now_month = now_date.toISOString().split('-')[1]
-  now_year = now_date.toISOString().split('-')[0]
+  now_month = new Date().toISOString().split('-')[1]
+  now_year = new Date().toISOString().split('-')[0]
 
-  start_date = now_date
+  // Start at current month unless user has specified to backfill
+  start_date = new Date()
 
-  if (param_backfill == "Backfill Previous Months") {
+  if (param_backfill == "Backfill Previous Months" && param_backfill_start_date != '') {
     start_date = new Date(param_backfill_start_date)
   }
 
   start_month = start_date.toISOString().split('-')[1]
   start_year = start_date.toISOString().split('-')[0]
 
-  do {
-    result.push(start_year + '-' + start_month)
+  // Move back one month so that we have the previousDate value
+  // Note: Due to how JS handles date objects, we have no simple way to move forward or backwards
+  // one month that doesn't have edge cases where this fails.
+  // This is why we track the month and year as integers.
+  if (start_month == '01') {
+    start_year = (Number(start_year) - 1).toString()
+    start_month = '12'
+  } else {
+    start_month = Number(start_month) - 1
+
+    if (start_month < 10) {
+      start_month = '0' + start_month.toString()
+    } else {
+      start_month = start_month.toString()
+    }
+  }
+
+  // Iterate until we have a list with every month until current month
+  while (now_month != start_month && now_year != start_year) {
+    previousDate = start_year + '-' + start_month
 
     if (start_month == '12') {
       start_year = (Number(start_year) + 1).toString()
@@ -206,7 +235,14 @@ script "js_date_list", type: "javascript" do
         start_month = start_month.toString()
       }
     }
-  } while (now_month != start_month && now_year != start_year)
+
+    currentDate = start_year + '-' + start_month
+
+    result.push({
+      previousDate: previousDate,
+      currentDate: currentDate
+    })
+  }
 EOS
 end
 
@@ -220,17 +256,35 @@ datasource "ds_current_adjustments" do
 end
 
 datasource "ds_updated_adjustments" do
-  run_script $js_update_adjustments, $ds_exchange_rates, $ds_current_adjustments, $ds_date_list, $param_cloud_provider, $param_cloud_provider_name, $param_currency_from, $param_currency_to, $param_backfill_exchange_rate
+  run_script $js_update_adjustments, $ds_exchange_rates, $ds_current_adjustments, $ds_month_list, $param_cloud_provider, $param_cloud_provider_name, $param_currency_from, $param_currency_to, $param_backfill_exchange_rate
 end
 
 script "js_update_adjustments", type: "javascript" do
-  parameters "ds_exchange_rates", "ds_current_adjustments", "ds_date_list", "param_cloud_provider", "param_cloud_provider_name", "param_currency_from", "param_currency_to", "param_backfill_exchange_rate"
+  parameters "ds_exchange_rates", "ds_current_adjustments", "ds_month_list", "param_cloud_provider", "param_cloud_provider_name", "param_currency_from", "param_currency_to", "param_backfill_exchange_rate"
   result "result"
   code <<-EOS
   now_date = new Date()
   now_date = new Date(now_date.toISOString().split("T")[0])
   now_month = now_date.toISOString().split('-')[1]
   now_year = now_date.toISOString().split('-')[0]
+
+  previous_month = now_month
+  previous_year = now_year
+
+  if (previous_month == '01') {
+    previous_year = (Number(previous_year) - 1).toString()
+    previous_month = '12'
+  } else {
+    previous_month = Number(previous_month) - 1
+
+    if (previous_month < 10) {
+      previous_month = '0' + previous_month.toString()
+    } else {
+      previous_month = previous_month.toString()
+    }
+  }
+
+  previous_date = previous_year + '-' + previous_month
 
   existing_adjustment_lists = {}
 
@@ -240,7 +294,7 @@ script "js_update_adjustments", type: "javascript" do
 
   // Include any existing rules for months we don't intend to modify
   new_adjustments = _.reject(ds_current_adjustments['dated_adjustment_lists'], function(list) {
-    return _.contains(ds_date_list, list['effective_at'])
+    return _.contains(_.pluck(ds_month_list, 'currentDate'), list['effective_at'])
   })
 
   // Cloud provider
@@ -249,15 +303,13 @@ script "js_update_adjustments", type: "javascript" do
   if (param_cloud_provider == "Other") { cloud_provider = param_cloud_provider_name }
   new_adj_name = "Currency Conversion - " + cloud_provider
 
-  _.each(ds_date_list, function(date) {
-    year = date.split('-')[0]
-    month = date.split('-')[1]
-    existing_list = existing_adjustment_lists[date]
+  _.each(ds_month_list, function(date) {
+    existing_list = existing_adjustment_lists[date['currentDate']]
+
+    conversion_rate = ds_exchange_rates[previous_date]
 
     if (param_backfill_exchange_rate == "Backdated Exchange Rate") {
-      conversion_rate = ds_exchange_rates[year][month]
-    } else {
-      conversion_rate = ds_exchange_rates[now_year][now_month]
+      conversion_rate = ds_exchange_rates[date['previousDate']]
     }
 
     currency_conversion_rule = {
@@ -321,7 +373,7 @@ end
 # Policy
 ###############################################################################
 
-policy "pol_currency_conversion_daily_rates" do
+policy "pol_currency_conversion" do
   validate $ds_new_adjustments do
     summary_template "Currency Conversion - {{ parameters.param_cloud_provider }} - {{ parameters.param_currency_from }} to {{ parameters.param_currency_to }}"
     detail_template "Adjustments Uploaded"

--- a/cost/currency_conversion/currency_conversion.pt
+++ b/cost/currency_conversion/currency_conversion.pt
@@ -107,7 +107,7 @@ end
 script "js_month_list", type: "javascript" do
   parameters "param_backfill", "param_backfill_start_date"
   result "result"
-  code <<-EOS
+  code <<-'EOS'
   // Function to take YYYY-MM formatted date and move it backwards or forwards by month
   function move_month(date_string, amount) {
     year = Number(date_string.split('-')[0])
@@ -172,7 +172,7 @@ end
 script "js_month_list_for_xe", type: "javascript" do
   parameters "ds_month_list"
   result "result"
-  code <<-EOS
+  code <<-'EOS'
   dates = _.uniq(_.pluck(ds_month_list, 'previous').concat(_.pluck(ds_month_list, 'current')))
 
   result = _.map(dates, function(date) {
@@ -209,7 +209,7 @@ end
 script "js_exchange_rates", type: "javascript" do
   parameters "ds_xe_exchange_rates", "param_currency_to"
   result "result"
-  code <<-EOS
+  code <<-'EOS'
   result = {}
   currency_code = param_currency_to.toUpperCase().trim()
 
@@ -237,13 +237,13 @@ datasource "ds_current_adjustments" do
 end
 
 datasource "ds_updated_adjustments" do
-  run_script $js_update_adjustments, $ds_exchange_rates, $ds_current_adjustments, $ds_month_list, $param_cloud_provider, $param_cloud_provider_name, $param_currency_from, $param_currency_to, $param_backfill_exchange_rate
+  run_script $js_update_adjustments, $ds_exchange_rates, $ds_current_adjustments, $ds_month_list, $param_cloud_provider, $param_cloud_provider_name, $param_currency_from, $param_currency_to, $param_backfill_exchange_rate, $param_backfill, $param_backfill_start_date
 end
 
 script "js_update_adjustments", type: "javascript" do
-  parameters "ds_exchange_rates", "ds_current_adjustments", "ds_month_list", "param_cloud_provider", "param_cloud_provider_name", "param_currency_from", "param_currency_to", "param_backfill_exchange_rate"
+  parameters "ds_exchange_rates", "ds_current_adjustments", "ds_month_list", "param_cloud_provider", "param_cloud_provider_name", "param_currency_from", "param_currency_to", "param_backfill_exchange_rate", "param_backfill", "param_backfill_start_date"
   result "result"
-  code <<-EOS
+  code <<-'EOS'
   // Get most recent exchange rate
   current_conversion_rate = ds_exchange_rates[ds_month_list[ds_month_list.length - 1]['previous']]
 
@@ -315,12 +315,30 @@ script "js_update_adjustments", type: "javascript" do
     new_adjustments.push(new_adjustment_list)
   })
 
-  result = { new_adjustment_list: JSON.stringify({ dated_adjustment_lists: new_adjustments }) }
+  this_month = new Date().toISOString().split('-')[0] + '-' + new Date().toISOString().split('-')[1]
+
+  message = "Adjustments applied for cloud provider " + cloud_provider + " for month of " + this_month + "."
+
+  if (param_backfill != 'Current Month' && param_backfill_start_date != '') {
+    message = "Adjustments applied for cloud provider " + cloud_provider + " from month of " + param_backfill_start_date + " to month of " + this_month + ".\n\n"
+
+    if (param_backfill_exchange_rate == 'Backdated Exchange Rate') {
+      message += "Backdated exchange rates were used for previous months."
+    } else {
+      message += "Current exchange rate was used for previous months."
+    }
+  }
+
+  result = [{
+    list: JSON.stringify({ dated_adjustment_lists: new_adjustments }),
+    message: message
+  }]
 EOS
 end
 
 # Update adjustment table to include new currency conversion adjustments
 datasource "ds_new_adjustments" do
+  iterate $ds_updated_adjustments
   request do
     auth $auth_flexera
     host rs_optima_host
@@ -328,7 +346,11 @@ datasource "ds_new_adjustments" do
     path join(["/bill-analysis/orgs/", rs_org_id, "/adjustments/"])
     header "content-type", "application/json"
     header "User-Agent", "RS Policies"
-    body val($ds_updated_adjustments, "new_adjustment_list")
+    body val(iter_item, "list")
+  end
+  result do
+    encoding "json"
+    field "message", val(iter_item, "message")
   end
 end
 
@@ -337,9 +359,9 @@ end
 ###############################################################################
 
 policy "pol_currency_conversion" do
-  validate $ds_new_adjustments do
+  validate_each $ds_new_adjustments do
     summary_template "Currency Conversion - {{ parameters.param_cloud_provider }} - {{ parameters.param_currency_from }} to {{ parameters.param_currency_to }}"
-    detail_template "Adjustments Uploaded"
+    detail_template "{{ with index data 0 }}{{ .message }}{{ end }}"
     check eq(0, 1)
   end
 end

--- a/cost/currency_conversion/currency_conversion.pt
+++ b/cost/currency_conversion/currency_conversion.pt
@@ -99,50 +99,96 @@ end
 # Datasources & Scripts
 ###############################################################################
 
-# Get a list of years that we need monthly exchange rates for based on parameters
-datasource "ds_rate_years" do
-  run_script $js_rate_years, $param_backfill, $param_backfill_start_date, $param_backfill_exchange_rate
+# Create a list of months in YYYY-MM format that we need to apply adjustments for
+datasource "ds_month_list" do
+  run_script $js_month_list, $param_backfill, $param_backfill_start_date
 end
 
-script "js_rate_years", type: "javascript" do
-  parameters "param_backfill", "param_backfill_start_date", "param_backfill_exchange_rate"
+script "js_month_list", type: "javascript" do
+  parameters "param_backfill", "param_backfill_start_date"
   result "result"
   code <<-EOS
+  // Function to take YYYY-MM formatted date and move it backwards or forwards by month
+  function move_month(date_string, amount) {
+    year = Number(date_string.split('-')[0])
+    month = Number(date_string.split('-')[1])
+
+    if (amount > 0) {
+      for (var i = 1; i <= amount; i++) {
+        if (month == 12) {
+          year += 1
+          month = 1
+        } else {
+          month += 1
+        }
+      }
+    }
+
+    if (amount < 0) {
+      for (var i = -1; i >= amount; i--) {
+        if (month == 1) {
+          year -= 1
+          month = 12
+        } else {
+          month -= 1
+        }
+      }
+    }
+
+    if (month < 10) { month = '0' + month }
+
+    return [year, month].join('-')
+  }
+
   result = []
 
-  // We need to get exchange rates for previous year in case current month is January and
-  // we need exchange rate info from December of the previous year
-  if (param_backfill == "Current Month" || param_backfill_exchange_rate == "Current Exchange Rate" || param_backfill_start_date == '') {
-    current_year = Number(new Date().toISOString().split('-')[0])
-    previous_year = current_year - 1
+  current_date = new Date().toISOString().split('-')
+  current_date = [current_date[0], current_date[1]].join('-')
 
-    result.push(previous_year.toString())
-    result.push(current_year.toString())
-  } else {
-    back_year = Number(new Date(param_backfill_start_date).toISOString().split('-')[0])
-    back_year -= 1
+  start_date = current_date
 
-    current_year = Number(new Date().toISOString().split('-')[0])
-
-    do {
-      result.push(back_year.toString())
-      back_year += 1
-    } while (back_year != current_year)
+  if (param_backfill == "Backfill Previous Months" && param_backfill_start_date != '') {
+    start_date = param_backfill_start_date
   }
+
+  do {
+    result.push({
+      previous: move_month(start_date, -1),
+      current: start_date
+    })
+
+    start_date = move_month(start_date, 1)
+  } while (start_date != current_date)
+EOS
+end
+
+datasource "ds_month_list_for_xe" do
+  run_script $js_month_list_for_xe, $ds_month_list
+end
+
+script "js_month_list_for_xe", type: "javascript" do
+  parameters "ds_month_list"
+  result "result"
+  code <<-EOS
+  dates = _.uniq(_.pluck(ds_month_list, 'previous').concat(_.pluck(ds_month_list, 'current')))
+
+  result = _.map(dates, function(date) {
+    return { year: date.split('-')[0], month: date.split('-')[1] }
+  })
 EOS
 end
 
 # Gather exchange rates for each year
 datasource "ds_xe_exchange_rates" do
-  iterate $ds_rate_years
+  iterate $ds_month_list_for_xe
   request do
     host "api.xe-auth.flexeraeng.com"
     path "/prod/{proxy+}"
     query "from", $param_currency_from
     query "to", $param_currency_to
     query "amount", "1"
-    query "year", iter_item
-    query "month", "01"
+    query "year", val(iter_item, "year")
+    query "month", val(iter_item, "month")
   end
   result do
     encoding "json"
@@ -178,74 +224,6 @@ script "js_exchange_rates", type: "javascript" do
 EOS
 end
 
-# Create a list of months in YYYY-MM format that we need to apply adjustments for
-datasource "ds_month_list" do
-  run_script $js_month_list, $param_backfill, $param_backfill_start_date
-end
-
-script "js_month_list", type: "javascript" do
-  parameters "param_backfill", "param_backfill_start_date"
-  result "result"
-  code <<-EOS
-  result = []
-
-  now_month = new Date().toISOString().split('-')[1]
-  now_year = new Date().toISOString().split('-')[0]
-
-  // Start at current month unless user has specified to backfill
-  start_date = new Date()
-
-  if (param_backfill == "Backfill Previous Months" && param_backfill_start_date != '') {
-    start_date = new Date(param_backfill_start_date)
-  }
-
-  start_month = start_date.toISOString().split('-')[1]
-  start_year = start_date.toISOString().split('-')[0]
-
-  // Move back one month so that we have the previousDate value
-  // Note: Due to how JS handles date objects, we have no simple way to move forward or backwards
-  // one month that doesn't have edge cases where this fails.
-  // This is why we track the month and year as integers.
-  if (start_month == '01') {
-    start_year = (Number(start_year) - 1).toString()
-    start_month = '12'
-  } else {
-    start_month = Number(start_month) - 1
-
-    if (start_month < 10) {
-      start_month = '0' + start_month.toString()
-    } else {
-      start_month = start_month.toString()
-    }
-  }
-
-  // Iterate until we have a list with every month until current month
-  while (now_month != start_month && now_year != start_year) {
-    previousDate = start_year + '-' + start_month
-
-    if (start_month == '12') {
-      start_year = (Number(start_year) + 1).toString()
-      start_month = '01'
-    } else {
-      start_month = Number(start_month) + 1
-
-      if (start_month < 10) {
-        start_month = '0' + start_month.toString()
-      } else {
-        start_month = start_month.toString()
-      }
-    }
-
-    currentDate = start_year + '-' + start_month
-
-    result.push({
-      previousDate: previousDate,
-      currentDate: currentDate
-    })
-  }
-EOS
-end
-
 datasource "ds_current_adjustments" do
   request do
     auth $auth_flexera
@@ -263,29 +241,10 @@ script "js_update_adjustments", type: "javascript" do
   parameters "ds_exchange_rates", "ds_current_adjustments", "ds_month_list", "param_cloud_provider", "param_cloud_provider_name", "param_currency_from", "param_currency_to", "param_backfill_exchange_rate"
   result "result"
   code <<-EOS
-  now_date = new Date()
-  now_date = new Date(now_date.toISOString().split("T")[0])
-  now_month = now_date.toISOString().split('-')[1]
-  now_year = now_date.toISOString().split('-')[0]
+  // Get most recent exchange rate
+  current_conversion_rate = ds_exchange_rates[ds_month_list[ds_month_list.length - 1]['previous']]
 
-  previous_month = now_month
-  previous_year = now_year
-
-  if (previous_month == '01') {
-    previous_year = (Number(previous_year) - 1).toString()
-    previous_month = '12'
-  } else {
-    previous_month = Number(previous_month) - 1
-
-    if (previous_month < 10) {
-      previous_month = '0' + previous_month.toString()
-    } else {
-      previous_month = previous_month.toString()
-    }
-  }
-
-  previous_date = previous_year + '-' + previous_month
-
+  // Create an object containing all of the existing adjustment rule lists by date
   existing_adjustment_lists = {}
 
   _.each(ds_current_adjustments['dated_adjustment_lists'], function(list) {
@@ -294,40 +253,40 @@ script "js_update_adjustments", type: "javascript" do
 
   // Include any existing rules for months we don't intend to modify
   new_adjustments = _.reject(ds_current_adjustments['dated_adjustment_lists'], function(list) {
-    return _.contains(_.pluck(ds_month_list, 'currentDate'), list['effective_at'])
+    return _.contains(_.pluck(ds_month_list, 'current'), list['effective_at'])
   })
 
-  // Cloud provider
+  // Cloud provider details
   cloud_provider = param_cloud_provider
   if (param_cloud_provider == "Google Cloud") { cloud_provider = "GCP" }
   if (param_cloud_provider == "Other") { cloud_provider = param_cloud_provider_name }
   new_adj_name = "Currency Conversion - " + cloud_provider
 
+  // Create a new adjustment list for each month
   _.each(ds_month_list, function(date) {
-    existing_list = existing_adjustment_lists[date['currentDate']]
-
-    conversion_rate = ds_exchange_rates[previous_date]
+    // Set the currency conversion rate based on user parameter
+    conversion_rate = current_conversion_rate
 
     if (param_backfill_exchange_rate == "Backdated Exchange Rate") {
-      conversion_rate = ds_exchange_rates[date['previousDate']]
+      conversion_rate = ds_exchange_rates[date['previous']]
     }
 
+    // Create the currency conversion rule
     currency_conversion_rule = {
       name: new_adj_name,
       rules: [
         {
-          condition: {
-            type: "dimension_equals",
-            dimension: "vendor",
-            value: cloud_provider
-          },
+          condition: { type: "dimension_equals", dimension: "vendor", value: cloud_provider },
           cost_multiplier: conversion_rate - 1,
           label: param_currency_from + " to " + param_currency_to
         }
       ]
     }
 
+    // Incorporate the new rule into the existing rule set if necessary
     adjustment_list = [ currency_conversion_rule ]
+
+    existing_list = existing_adjustment_lists[date['current']]
 
     if (existing_list != undefined) {
       // Check if a Currency Conversion adjustment rule already exists for current month
@@ -344,9 +303,10 @@ script "js_update_adjustments", type: "javascript" do
       adjustment_list.push(currency_conversion_rule)
     }
 
+    // Create the new adjustment list for this month
     new_adjustment_list = {
       adjustment_list: adjustment_list,
-      effective_at: date
+      effective_at: date['current']
     }
 
     new_adjustments.push(new_adjustment_list)
@@ -356,7 +316,7 @@ script "js_update_adjustments", type: "javascript" do
 EOS
 end
 
-#UPDATE CURRENT ADJUSTMENT RULES WITH NEW ADJUSTMENT RULES
+# Update adjustment table to include new currency conversion adjustments
 datasource "ds_new_adjustments" do
   request do
     auth $auth_flexera

--- a/cost/currency_conversion/currency_conversion.pt
+++ b/cost/currency_conversion/currency_conversion.pt
@@ -151,14 +151,19 @@ script "js_month_list", type: "javascript" do
     start_date = param_backfill_start_date
   }
 
-  do {
+  while (start_date != current_date) {
     result.push({
       previous: move_month(start_date, -1),
       current: start_date
     })
 
     start_date = move_month(start_date, 1)
-  } while (start_date != current_date)
+  }
+
+  result.push({
+    previous: move_month(current_date, -1),
+    current: current_date
+  })
 EOS
 end
 

--- a/cost/currency_conversion/currency_conversion.pt
+++ b/cost/currency_conversion/currency_conversion.pt
@@ -7,7 +7,7 @@ severity "low"
 default_frequency "monthly"
 category "Cost"
 info(
-  version: "2.0",
+  version: "2.1",
   provider: "",
   service: "",
   policy_set: ""


### PR DESCRIPTION
### Description

This update adds the ability to backfill previous months when applying the policy. From the README:

- *Backfill Adjustments* - Whether to add/modify currency conversion to just the current month or to backfill previous months.

- *Backfill Start Date* - The month and year in YYYY-MM format to backfill adjustments to. Only applicable if `Backfill Previous Months` is selected for the `Backfill Adjustments` parameter.
 
- *Backfill Exchange Rates* - Whether or not to use the current exchange rate, or the exchange rate at the time, when applying currency conversion to previous months. Only applicable if `Backfill Previous Months` is selected for the `Backfill Adjustments` parameter.

### Link to Example Applied Policy

https://app.flexera.com/orgs/27018/automation/applied-policies/projects/116186?policyId=6570d8ff99745e00015883c7

(Results can be assessed by viewing the adjustments on this account.)

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
