### PR TITLE
POL-969 - Update Azure instance_type.json file for Eas series

### DIFF
--- a/data/azure/instance_types.json
+++ b/data/azure/instance_types.json
@@ -3436,7 +3436,7 @@
     "up": "Standard_E4as_v4",
     "down": null,
     "superseded": {
-      "regular": "Standard_E2as_v5"
+      "regular": "Standard_E2ads_v5"
     },
     "vcpu": 2,
     "nfu": "1"
@@ -3445,7 +3445,7 @@
     "up": "Standard_E8as_v4",
     "down": "Standard_E2as_v4",
     "superseded": {
-      "regular": "Standard_E4as_v5"
+      "regular": "Standard_E4ads_v5"
     },
     "vcpu": 4,
     "nfu": "2"
@@ -3454,7 +3454,7 @@
     "up": "Standard_E16as_v4",
     "down": "Standard_E4as_v4",
     "superseded": {
-      "regular": "Standard_E8as_v5"
+      "regular": "Standard_E8ads_v5"
     },
     "vcpu": 8,
     "nfu": "4"
@@ -3463,7 +3463,7 @@
     "up": "Standard_E20as_v4",
     "down": "Standard_E8as_v4",
     "superseded": {
-      "regular": "Standard_E16as_v5"
+      "regular": "Standard_E16ads_v5"
     },
     "vcpu": 16,
     "nfu": "8"
@@ -3472,7 +3472,7 @@
     "up": "Standard_E32as_v4",
     "down": "Standard_E16as_v4",
     "superseded": {
-      "regular": "Standard_E20as_v5"
+      "regular": "Standard_E20ads_v5"
     },
     "vcpu": 20,
     "nfu": "10"
@@ -3481,7 +3481,7 @@
     "up": "Standard_E48as_v4",
     "down": "Standard_E20as_v4",
     "superseded": {
-      "regular": "Standard_E32as_v5"
+      "regular": "Standard_E32ads_v5"
     },
     "vcpu": 32,
     "nfu": "16"
@@ -3490,7 +3490,7 @@
     "up": "Standard_E64as_v4",
     "down": "Standard_E32as_v4",
     "superseded": {
-      "regular": "Standard_E48as_v5"
+      "regular": "Standard_E48ads_v5"
     },
     "vcpu": 48,
     "nfu": "24"
@@ -3499,7 +3499,7 @@
     "up": "Standard_E96as_v4",
     "down": "Standard_E48as_v4",
     "superseded": {
-      "regular": "Standard_E64as_v5"
+      "regular": "Standard_E64ads_v5"
     },
     "vcpu": 64,
     "nfu": "32"
@@ -3509,7 +3509,7 @@
     "down": "Standard_E64as_v4",
     "superseded": {
       "superseded": {
-        "regular": "Standard_E96as_v5"
+        "regular": "Standard_E96ads_v5"
       }
     },
     "vcpu": 96,


### PR DESCRIPTION
### Description

Vestas Wind Systems noticed that Azure Superseded Compute Instances policy recommends to upgrade **Standard_E16as_v4** machine to **Standard_E16as_v5**. Customer disputes this recommendation as incorrect due to current SKU provides temporary storage whilst the recommended SKU doesn’t. 

The correct recommendation would be to upgrade to SKU **Standard_E16ads_v5** with temporary storage:
**Standard_E16as_v4** = 16 vCPUs, 128 GB RAM, **256 GB** Temporary storage
**Standard_E16as_v5** = 16 vCPUs, 128 GB RAM, **0 GB** Temporary storage
**Standard_E16ads_v5** = 16 vCPUs, 128 GB RAM, **600 GB** Temporary storage

Azure instance_type.json needs to be corrected as Eas v4 instances are marked as superseded  by Eas v5 instead of Eads v5

### Issues Resolved

https://flexera.atlassian.net/browse/POL-969

### Link to Example Applied Policy

NA

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
