### PR TITLE
POL-757 Azure Rightsize Compute Fixes/Improvements

### DIFF
--- a/cost/azure/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v4.0
 
 - Fixed issue with resource count in incident subject being off by 1
+- Fixed minor grammar issue if results only include 1 item
 - Added ability to filter resources by tag key
 - Added option to power off idle instances
 - Added ability to indicate whether to do a graceful or forced shutdown when powering off instances

--- a/cost/azure/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Fixed issue with resource count in incident subject being off by 1
 - Fixed minor grammar issue if results only include 1 item
 - Renamed policy actions to make it clear whether they are for underutilized or idle instances
-- Added ability to filter resources by tag key
+- Added ability to filter resources by tag key via wildcard
 - Added option to power off idle instances
 - Added ability to indicate whether to do a graceful or forced shutdown when powering off instances
 - Improved code related to incident export

--- a/cost/azure/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed issue with resource count in incident subject being off by 1
 - Fixed minor grammar issue if results only include 1 item
+- Renamed policy actions to make it clear whether they are for underutilized or idle instances
 - Added ability to filter resources by tag key
 - Added option to power off idle instances
 - Added ability to indicate whether to do a graceful or forced shutdown when powering off instances

--- a/cost/azure/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v3.4
+
+- Fixed issue with resource count in incident subject being off by 1
+- Added ability to filter resources by tag key
+- Improved code related to incident export
+- Updated and improved code for policy actions
+
 ## v3.3
 
 - Added ability to filter resources by region

--- a/cost/azure/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-## v3.4
+## v4.0
 
 - Fixed issue with resource count in incident subject being off by 1
 - Added ability to filter resources by tag key
+- Added option to power off idle instances
+- Added ability to indicate whether to do a graceful or forced shutdown when powering off instances
 - Improved code related to incident export
 - Updated and improved code for policy actions
 

--- a/cost/azure/rightsize_compute_instances/README.md
+++ b/cost/azure/rightsize_compute_instances/README.md
@@ -8,7 +8,7 @@ This policy checks all the instances in Azure Subscriptions for the average or m
 
 - The policy leverages the Azure API to check all instances and then checks the instance average or maximum CPU and memory utilization over a user-specified number of days.
 - The policy identifies all instances that have CPU and/or memory utilization below the user-specified idle thresholds and provides the relevant recommendation.
-- The recommendation provided for Idle Instances is a deletion action. These instances can be deleted in an automated manner or after approval.
+- The recommendation provided for Idle Instances is a deletion action. These instances can be deleted or powered off in an automated manner or after approval.
 - The policy identifies all instances that have CPU and/or memory utilization below the user-specified underutilized thresholds and provides the relevant recommendation.
 - The recommendation provided for Underutilized Instances is a downsize action. These instances can be downsized in an automated manner or after approval.
 
@@ -39,8 +39,9 @@ The policy includes the estimated monthly savings. The estimated monthly savings
 - *Idle/Utilized for both CPU/Memory or either* - Set whether an instance should be considered idle and/or underutilized only if both CPU and memory are under the thresholds or if either CPU or memory are under. Has no effect if other parameters are configured such that only CPU or memory is being considered.
 - *Threshold Statistic* - Statistic to use when determining if an instance is idle/underutilized.
 - *Statistic Lookback Period* - How many days back to look at CPU and/or memory data for instances. This value cannot be set higher than 90 because Azure does not retain metrics for longer than 90 days.
-- *Exclusion Tags (Key:Value)* - Cloud native tags to ignore instances that you don't want to consider for downsizing or deletion. Format: Key:Value
+- *Exclusion Tags (Key:Value)* - Cloud native tags to ignore resources that you don't want to produce recommendations for. Use Key:Value format for specific tag key/value pairs, and Key:\* format to match any resource with a particular key, regardless of value. Examples: env:production, DO_NOT_DELETE:\*
 - *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).
+- *Power Off Type* - Whether to perform a graceful shutdown or a forced shutdown when powering off idle instances. Only applicable when taking action against instances.
 
 Please note that the "Automatic Actions" parameter contains a list of action(s) that can be performed on the resources. When it is selected, the policy will automatically execute the corresponding action on the data that failed the checks, post incident generation. Please leave it blank for *manual* action.
 For example if a user selects the "Delete Instances" action while applying the policy, all the resources that didn't satisfy the policy condition will be deleted.
@@ -48,6 +49,7 @@ For example if a user selects the "Delete Instances" action while applying the p
 ## Policy Actions
 
 - Sends an email notification
+- Power off virtual machines (if idle) after approval
 - Delete virtual machines (if idle) after approval
 - Downsize virtual machines (if underutilized) after approval
 
@@ -65,7 +67,7 @@ For administrators [creating and managing credentials](https://docs.flexera.com/
   - `Microsoft.Compute/skus/read`
   - `Microsoft.Insights/metrics/read`
 
-\* Only required for taking action (deleting or downsizing); the policy will still function in a read-only capacity without these permissions.
+\* Only required for taking action (deleting, powering off or downsizing); the policy will still function in a read-only capacity without these permissions.
 
 - [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
   - `billing_center_viewer`

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "3.4",
+  version: "4.0",
   provider: "Azure",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -160,8 +160,17 @@ parameter "param_automatic_action" do
   category "Actions"
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action."
-  allowed_values ["Downsize Instances", "Delete Instances"]
+  allowed_values ["Downsize Underutilized Instances", "Power Off Idle Instances", "Delete Idle Instances"]
   default []
+end
+
+parameter "param_skipshutdown" do
+  type "string"
+  category "Actions"
+  label "Power Off Type"
+  description "Whether to perform a graceful shutdown or a forced shutdown when powering off idle instances. Only applicable when taking action against instances."
+  allowed_values "Graceful", "Forced"
+  default "Graceful"
 end
 
 ###############################################################################
@@ -1218,6 +1227,7 @@ policy "pol_utilization" do
     # Policy check fails and incident is created only if data is not empty and the Parent Policy has not been terminated
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
+    escalate $esc_poweroff_instances
     escalate $esc_delete_instances
     hash_exclude "underutil_message", "idle_message", "underutil_total_savings", "idle_total_savings", "tags", "savings", "savingsCurrency", "cpu_maximum", "cpu_minimum", "cpu_average", "mem_maximum", "mem_minimum", "mem_average"
     export do
@@ -1320,15 +1330,22 @@ escalation "esc_email" do
 end
 
 escalation "esc_downsize_instances" do
-  automatic contains($param_automatic_action, "Downsize Instances")
-  label "Downsize Instances"
+  automatic contains($param_automatic_action, "Downsize Underutilized Instances")
+  label "Downsize Underutilized Instances"
   description "Approval to downsize all selected instances"
   run "downsize_instances", data, $param_azure_endpoint
 end
 
+escalation "esc_poweroff_instances" do
+  automatic contains($param_automatic_action, "Power Off Idle Instances")
+  label "Power Off Idle Instances"
+  description "Approval to power off all selected instances"
+  run "poweroff_instances", data, $param_azure_endpoint, $param_skipshutdown
+end
+
 escalation "esc_delete_instances" do
-  automatic contains($param_automatic_action, "Delete Instances")
-  label "Delete Instances"
+  automatic contains($param_automatic_action, "Delete Idle Instances")
+  label "Delete Idle Instances"
   description "Approval to delete all selected instances"
   run "delete_instances", data, $param_azure_endpoint
 end
@@ -1336,6 +1353,53 @@ end
 ###############################################################################
 # Cloud Workflow
 ###############################################################################
+
+define downsize_instances($data, $param_azure_endpoint) return $all_responses do
+  $$all_responses = []
+
+  foreach $instance in $data do
+    sub on_error: handle_error() do
+      call downsize_instance($instance, $param_azure_endpoint) retrieve $downsize_response
+    end
+  end
+
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+end
+
+define downsize_instance($instance, $param_azure_endpoint) return $response do
+  $host = $param_azure_endpoint
+  $href = $instance["id"]
+  $params = "?api-version=2023-07-01"
+  $url = $host + $href + $params
+  task_label("PATCH " + $url)
+
+  $response = http_request(
+    auth: $$auth_azure,
+    https: true,
+    verb: "patch",
+    host: $host,
+    href: $href,
+    query_strings: { "api-version": "2023-07-01" },
+    body: {
+      "properties":{
+        "hardwareProfile": {
+          "vmSize": $instance["recommendedVmSize"]
+        }
+      }
+    }
+  )
+
+  task_label("Patch Azure VM instance response: " + $instance["id"] + " " + to_json($response))
+  $$all_responses << to_json({"req": "DELETE " + $url, "resp": $response})
+
+  if $response["code"] != 204 && $response["code"] != 202 && $response["code"] != 200
+    raise "Unexpected response patching Azure VM instance: "+ $instance["id"] + " " + to_json($response)
+  else
+    task_label("Patch Azure VM instance successful: " + $instance["id"])
+  end
+end
 
 define poweroff_instances($data, $param_azure_endpoint, $param_skipshutdown) return $all_responses do
   $$all_responses = []

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -1337,91 +1337,101 @@ end
 # Cloud Workflow
 ###############################################################################
 
-#DOWNSIZE AZURE VM INSTANCE DEFINITION
-define downsize_instances($data, $param_azure_endpoint) return $all_responses do
-  # Change "No" to "Yes" to enable CWF debug logging
-  $log_to_cm_audit_entries = "No"
+define poweroff_instances($data, $param_azure_endpoint, $param_skipshutdown) return $all_responses do
+  $$all_responses = []
 
-  $$debug = $log_to_cm_audit_entries == "Yes"
-
-  $response={}
-
-  $syslog_subject = "Azure Instance Utilization with Log Analytics Policy: "
-  foreach $item in $data do
-    if $item["recommendedVmSize"] != "N/A"
-      sub on_error: skip do
-        $response = http_request(
-          auth: $$auth_azure,
-          verb: "patch",
-          host: $param_azure_endpoint,
-          https: true,
-          href: $item["id"],
-          query_strings: {
-            "api-version": "2019-03-01"
-          },
-          headers:{
-            "content-type": "application/json"
-          },
-          body: {
-            "properties":{
-              "hardwareProfile": {
-                "vmSize": $item["recommendedVmSize"]
-              }
-            }
-          }
-        )
-      call sys_log(join([$syslog_subject, "Response"]), to_s($response))
-      end
-  end
-  end
-end
-
-#TERMINATE AZURE VM INSTANCE DEFINITION
-define delete_instances($data, $param_azure_endpoint) return $all_responses do
-  # Change "No" to "Yes" to enable CWF debug logging
-  $log_to_cm_audit_entries = "No"
-
-  $$debug = $log_to_cm_audit_entries == "Yes"
-
-  $$log = []
-  $all_responses = []
-  $syslog_subject = "Azure Delete Instance: "
-  call sys_log(join([$syslog_subject, "Identified Instances"]),to_s($data))
-  $all_responses = []
-  foreach $item in $data do
-    sub on_error: skip do
-      $response = http_request(
-        verb: "delete",
-        host: $param_azure_endpoint,
-        auth: $$auth_azure,
-        href: $item["id"],
-        https: true,
-        query_strings: {
-          "api-version": "2018-06-01"
-        },
-        headers: {
-          "cache-control": "no-cache",
-          "content-type": "application/json"
-        }
-      )
-      $all_responses << $response
+  foreach $instance in $data do
+    sub on_error: handle_error() do
+      call poweroff_instance($instance, $param_azure_endpoint, $param_skipshutdown) retrieve $poweroff_response
     end
   end
-  call sys_log(join([$syslog_subject, "Responses"]), to_s($all_responses))
+
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
 end
 
-#function to log
-define sys_log($subject, $detail) do
-  if $$debug
-    rs_cm.audit_entries.create(
-      notify: "None",
-      audit_entry: {
-        auditee_href: @@account,
-        summary: $subject,
-        detail: $detail
-      }
-    )
+define poweroff_instance($instance, $param_azure_endpoint, $param_skipshutdown) return $response do
+  $host = $param_azure_endpoint
+  $href = $instance["id"] + "/powerOff"
+  $params = "?api-version=2023-07-01"
+  $url = $host + $href + $params
+  task_label("POST " + $url)
+
+  $query_strings = { "api-version": "2023-07-01" }
+
+  if $param_skipshutdown == "Forced"
+    $query_strings["skipShutdown"] = "true"
+    $params = $params + "&skipShutdown=true"
   end
+
+  $response = http_request(
+    auth: $$auth_azure,
+    https: true,
+    verb: "post",
+    host: $host,
+    href: $href,
+    query_strings: $query_strings
+  )
+
+  task_label("Power off Azure VM instance response: " + $instance["id"] + " " + to_json($response))
+  $$all_responses << to_json({"req": "POST " + $url, "resp": $response})
+
+  if $response["code"] != 204 && $response["code"] != 202 && $response["code"] != 200
+    raise "Unexpected response powering off Azure VM instance: "+ $instance["id"] + " " + to_json($response)
+  else
+    task_label("Power off Azure VM instance successful: " + $instance["id"])
+  end
+end
+
+define delete_instances($data, $param_azure_endpoint) return $all_responses do
+  $$all_responses = []
+
+  foreach $instance in $data do
+    sub on_error: handle_error() do
+      call delete_instance($instance, $param_azure_endpoint) retrieve $delete_response
+    end
+  end
+
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+end
+
+define delete_instance($instance, $param_azure_endpoint) return $response do
+  $host = $param_azure_endpoint
+  $href = $instance["id"]
+  $params = "?api-version=2023-07-01"
+  $url = $host + $href + $params
+  task_label("DELETE " + $url)
+
+  $response = http_request(
+    auth: $$auth_azure,
+    https: true,
+    verb: "delete",
+    host: $host,
+    href: $href,
+    query_strings: { "api-version": "2023-07-01" }
+  )
+
+  task_label("Delete Azure VM instance response: " + $instance["id"] + " " + to_json($response))
+  $$all_responses << to_json({"req": "DELETE " + $url, "resp": $response})
+
+  if $response["code"] != 204 && $response["code"] != 202 && $response["code"] != 200
+    raise "Unexpected response deleting Azure VM instance: "+ $instance["id"] + " " + to_json($response)
+  else
+    task_label("Delete Azure VM instance successful: " + $instance["id"])
+  end
+end
+
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
 end
 
 ###############################################################################

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -949,16 +949,22 @@ script "js_idle_and_underutil_instances", type:"javascript" do
     underutil_total_savings = ds_currency['symbol'] + ' ' + formatNumber(parseFloat(underutil_total_savings).toFixed(2), ds_currency['separator'])
     idle_total_savings = ds_currency['symbol'] + ' ' + formatNumber(parseFloat(idle_total_savings).toFixed(2), ds_currency['separator'])
 
+    underutil_verb = "are"
+    if (underutil_instances_total == 1) { underutil_verb = "is" }
+
+    idle_verb = "are"
+    if (idle_instances_total == 1) { idle_verb = "is" }
+
     underutil_findings = [
       "Out of ", instances_total, " Azure virtual machines analyzed, ",
       underutil_instances_total, " (", underutil_instances_percentage,
-      ") are underutilized and recommended for downsizing. "
+      ") ", underutil_verb, " underutilized and recommended for downsizing. "
     ].join('')
 
     idle_findings = [
       "Out of ", instances_total, " Azure virtual machines analyzed, ",
       idle_instances_total, " (", idle_instances_percentage,
-      ") are idle and recommended for termination. "
+      ") ", idle_verb, " idle and recommended for termination. "
     ].join('')
 
     if (checking_cpu && checking_mem) {

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "3.3",
+  version: "3.4",
   provider: "Azure",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -48,8 +48,8 @@ parameter "param_exclusion_tags" do
   type "list"
   category "Filters"
   label "Exclusion Tags (Key:Value)"
-  description "Cloud native tags to ignore instances that you don't want to consider for downsizing or deletion. Format: Key:Value"
-  allowed_pattern /(^$)|([\w]?)+\:([\w]?)+/
+  description "Cloud native tags to ignore resources that you don't want to produce recommendations for. Use Key:Value format for specific tag key/value pairs, and Key:* format to match any resource with a particular key, regardless of value. Examples: env:production, DO_NOT_DELETE:*"
+  allowed_pattern /(^$)|[\w]*\:.*/
   default []
 end
 
@@ -362,7 +362,7 @@ datasource "ds_azure_instances" do
   result do
     encoding "json"
     collect jmes_path(response, "value[*]") do
-      field "resourceId", jmes_path(col_item, "id")
+      field "resourceID", jmes_path(col_item, "id")
       field "resourceGroup", get(4, split(jmes_path(col_item, "id"), '/'))
       field "resourceKind", jmes_path(col_item, "type")
       field "name", jmes_path(col_item, "name")
@@ -391,6 +391,7 @@ script "js_azure_instances_tag_filtered", type: "javascript" do
       if (typeof(vm['tags']) == 'object') {
         _.each(Object.keys(vm['tags']), function(key) {
           vm_tags.push([key, ":", vm['tags'][key]].join(''))
+          vm_tags.push([key, ":*"].join(''))
         })
       }
 
@@ -485,14 +486,14 @@ end
 datasource "ds_azure_instances_metrics" do
   iterate $ds_azure_instances_region_filtered
   request do
-    run_script $js_azure_instances_metrics, val(iter_item, "resourceId"), $param_azure_endpoint, $param_stats_lookback
+    run_script $js_azure_instances_metrics, val(iter_item, "resourceID"), $param_azure_endpoint, $param_stats_lookback
   end
   result do
     encoding "json"
     field "value", val(response, "value")
     field "resourceName", val(iter_item, "name")
     field "resourceGroup", val(iter_item, "resourceGroup")
-    field "resourceId", val(iter_item, "resourceId")
+    field "resourceID", val(iter_item, "resourceID")
     field "resourceKind", val(iter_item, "resourceKind")
     field "region", val(iter_item, "region")
     field "tags", val(iter_item, "tags")
@@ -504,7 +505,7 @@ datasource "ds_azure_instances_metrics" do
 end
 
 script "js_azure_instances_metrics", type: "javascript" do
-  parameters "resourceId", "param_azure_endpoint", "param_stats_lookback"
+  parameters "resourceID", "param_azure_endpoint", "param_stats_lookback"
   result "request"
   code <<-EOS
   end_date = new Date()
@@ -526,7 +527,7 @@ script "js_azure_instances_metrics", type: "javascript" do
     pagination: "pagination_azure",
     host: param_azure_endpoint,
     verb: "GET",
-    path: resourceId + "/providers/microsoft.insights/metrics",
+    path: resourceID + "/providers/microsoft.insights/metrics",
     query_params: {
       "api-version": "2018-01-01",
       "timespan": timespan,
@@ -648,13 +649,13 @@ script "js_azure_instances_metrics_organized", type: "javascript" do
     result.push({
       resourceName: vm['resourceName'],
       resourceGroup: vm['resourceGroup'],
-      resourceId: vm['resourceId'],
+      resourceID: vm['resourceID'],
       resourceKind: vm['resourceKind'],
       region: vm['region'],
       osType: vm['osType'],
       resourceType: vm['resourceType'],
-      subscriptionId: vm['subscriptionId'],
-      subscriptionName: vm['subscriptionName'],
+      accountID: vm['subscriptionId'],
+      accountName: vm['subscriptionName'],
       tags: vm_tags.join(', '),
       cpu_minimum: parseFloat(cpu_min.toFixed(2)),
       cpu_maximum: parseFloat(cpu_max.toFixed(2)),
@@ -680,7 +681,7 @@ datasource "ds_instance_costs" do
   result do
     encoding "json"
     collect jmes_path(response, "rows[*]") do
-      field "resourceId", jmes_path(col_item, "dimensions.resource_id")
+      field "resourceID", jmes_path(col_item, "dimensions.resource_id")
       field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
     end
   end
@@ -770,7 +771,7 @@ script "js_instance_costs_grouped", type: "javascript" do
   result = {}
 
   _.each(ds_instance_costs, function(item) {
-    id = item['resourceId'].toLowerCase()
+    id = item['resourceID'].toLowerCase()
 
     if (result[id] == undefined) { result[id] = 0.0 }
     result[id] += item['cost'] * cost_multiplier
@@ -830,7 +831,7 @@ script "js_idle_and_underutil_instances", type:"javascript" do
   if (checking_cpu || checking_mem) {
     // Loop through metrics data, appending cost data
     _.each(ds_azure_instances_metrics_organized, function(instance) {
-      id = instance['resourceId'].toLowerCase()
+      id = instance['resourceID'].toLowerCase()
 
       // Assume cost is 0 unless we have cost data for the instance
       total_cost = 0.0
@@ -888,8 +889,8 @@ script "js_idle_and_underutil_instances", type:"javascript" do
 
         recommendationDetails = [
           "Delete Azure virtual machine ", instance["resourceName"], " ",
-          "in Azure Subscription ", instance["subscriptionName"], " ",
-          "(", instance["subscriptionId"], ")"
+          "in Azure Subscription ", instance["accountName"], " ",
+          "(", instance["accountID"], ")"
         ]
 
         instance["recommendationDetails"] = recommendationDetails.join('')
@@ -910,8 +911,8 @@ script "js_idle_and_underutil_instances", type:"javascript" do
 
         recommendationDetails = [
           "Resize Azure virtual machine ", instance["resourceName"], " ",
-          "in Azure Subscription ", instance["subscriptionName"], " ",
-          "(", instance["subscriptionId"], ") ",
+          "in Azure Subscription ", instance["accountName"], " ",
+          "(", instance["accountID"], ") ",
           "from ", instance["resourceType"], " ",
           "to ", instance["newResourceType"]
         ]
@@ -1069,20 +1070,11 @@ script "js_underutilized_instances", type: "javascript" do
   result "result"
   code <<-EOS
   result = [{
-    "recommendationType": "",
-    "underutil_message": "",
-    "idle_message": "",
-    "underutil_total_savings": "",
-    "idle_total_savings": "",
-    "tags": "",
-    "savings": "",
-    "savingsCurrency": "",
-    "cpu_maximum": "",
-    "cpu_minimum": "",
-    "cpu_average": "",
-    "mem_maximum": "",
-    "mem_minimum": "",
-    "mem_average": ""
+    "resourceID": "",    "recommendationType": "",       "underutil_message": "",
+    "idle_message": "",  "underutil_total_savings": "",  "idle_total_savings": "",
+    "tags": "",          "savings": "",                  "savingsCurrency": "",
+    "cpu_maximum": "",   "cpu_minimum": "",              "cpu_average": "",
+    "mem_maximum": "",   "mem_minimum": "",              "mem_average": ""
   }]
 
   result = ds_idle_and_underutil_instances["underutil_list"].concat(result)
@@ -1098,20 +1090,11 @@ script "js_idle_instances", type: "javascript" do
   result "result"
   code <<-EOS
   result = [{
-    "recommendationType": "",
-    "underutil_message": "",
-    "idle_message": "",
-    "underutil_total_savings": "",
-    "idle_total_savings": "",
-    "tags": "",
-    "savings": "",
-    "savingsCurrency": "",
-    "cpu_maximum": "",
-    "cpu_minimum": "",
-    "cpu_average": "",
-    "mem_maximum": "",
-    "mem_minimum": "",
-    "mem_average": ""
+    "resourceID": "",    "recommendationType": "",       "underutil_message": "",
+    "idle_message": "",  "underutil_total_savings": "",  "idle_total_savings": "",
+    "tags": "",          "savings": "",                  "savingsCurrency": "",
+    "cpu_maximum": "",   "cpu_minimum": "",              "cpu_average": "",
+    "mem_maximum": "",   "mem_minimum": "",              "mem_average": ""
   }]
 
   result = ds_idle_and_underutil_instances["idle_list"].concat(result)
@@ -1132,7 +1115,7 @@ policy "pol_utilization" do
     {{ with index data 0 }}{{ .underutil_message }}{{ end }}
     EOS
     # Policy check fails and incident is created only if data is not empty and the Parent Policy has not been terminated
-    check logic_or($ds_parent_policy_terminated, ne(val(item, "recommendationType"), "Downsize"))
+    check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_downsize_instances
     hash_exclude "underutil_message", "idle_message", "underutil_total_savings", "idle_total_savings", "tags", "savings", "savingsCurrency", "cpu_maximum", "cpu_minimum", "cpu_average", "mem_maximum", "mem_minimum", "mem_average"
@@ -1140,11 +1123,9 @@ policy "pol_utilization" do
       resource_level true
       field "accountID" do
         label "Subscription ID"
-        path "subscriptionId"
       end
       field "accountName" do
         label "Subscription Name"
-        path "subscriptionName"
       end
       field "resourceGroup" do
         label "Resource Group"
@@ -1154,7 +1135,6 @@ policy "pol_utilization" do
       end
       field "resourceID" do
         label "Resource ID"
-        path "resourceId"
       end
       field "tags" do
         label "Resource Tags"
@@ -1224,7 +1204,7 @@ policy "pol_utilization" do
       end
       field "id" do
         label "ID"
-        path "resourceId"
+        path "resourceID"
       end
     end
   end
@@ -1236,7 +1216,7 @@ policy "pol_utilization" do
     {{ with index data 0 }}{{ .idle_message }}{{ end }}
     EOS
     # Policy check fails and incident is created only if data is not empty and the Parent Policy has not been terminated
-    check logic_or($ds_parent_policy_terminated, ne(val(item, "recommendationType"), "Delete"))
+    check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_instances
     hash_exclude "underutil_message", "idle_message", "underutil_total_savings", "idle_total_savings", "tags", "savings", "savingsCurrency", "cpu_maximum", "cpu_minimum", "cpu_average", "mem_maximum", "mem_minimum", "mem_average"
@@ -1244,11 +1224,9 @@ policy "pol_utilization" do
       resource_level true
       field "accountID" do
         label "Subscription ID"
-        path "subscriptionId"
       end
       field "accountName" do
         label "Subscription Name"
-        path "subscriptionName"
       end
       field "resourceGroup" do
         label "Resource Group"
@@ -1258,7 +1236,6 @@ policy "pol_utilization" do
       end
       field "resourceID" do
         label "Resource ID"
-        path "resourceId"
       end
       field "tags" do
         label "Resource Tags"
@@ -1325,7 +1302,7 @@ policy "pol_utilization" do
       end
       field "id" do
         label "ID"
-        path "resourceId"
+        path "resourceID"
       end
     end
   end

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "3.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 
@@ -88,8 +88,8 @@ parameter "param_exclusion_tags" do
   type "list"
   category "Filters"
   label "Exclusion Tags (Key:Value)"
-  description "Cloud native tags to ignore instances that you don't want to consider for downsizing or deletion. Format: Key:Value"
-  allowed_pattern /(^$)|([\w]?)+\:([\w]?)+/
+  description "Cloud native tags to ignore resources that you don't want to produce recommendations for. Use Key:Value format for specific tag key/value pairs, and Key:* format to match any resource with a particular key, regardless of value. Examples: env:production, DO_NOT_DELETE:*"
+  allowed_pattern /(^$)|[\w]*\:.*/
   default []
 end
 
@@ -183,8 +183,17 @@ parameter "param_automatic_action" do
   category "Actions"
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action."
-  allowed_values ["Downsize Instances", "Delete Instances"]
+  allowed_values ["Downsize Underutilized Instances", "Power Off Idle Instances", "Delete Idle Instances"]
   default []
+end
+
+parameter "param_skipshutdown" do
+  type "string"
+  category "Actions"
+  label "Power Off Type"
+  description "Whether to perform a graceful shutdown or a forced shutdown when powering off idle instances. Only applicable when taking action against instances."
+  allowed_values "Graceful", "Forced"
+  default "Graceful"
 end
 
 ###############################################################################
@@ -875,26 +884,37 @@ EOS
 end
 
 
-# Escalation for Downsize Instances
+# Escalation for Downsize Underutilized Instances
 escalation "esc_downsize_instances" do
   automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Downsize Instances"
+  label "Downsize Underutilized Instances"
   description "Approval to downsize all selected instances"
   run "esc_downsize_instances", data, rs_governance_host, rs_project_id
 end
 define esc_downsize_instances($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Downsize Instances")
+  call child_run_action($data, $governance_host, $rs_project_id, "Downsize Underutilized Instances")
 end
 
-# Escalation for Delete Instances
+# Escalation for Power Off Idle Instances
+escalation "esc_poweroff_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Power Off Idle Instances"
+  description "Approval to power off all selected instances"
+  run "esc_poweroff_instances", data, rs_governance_host, rs_project_id
+end
+define esc_poweroff_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Power Off Idle Instances")
+end
+
+# Escalation for Delete Idle Instances
 escalation "esc_delete_instances" do
   automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Delete Instances"
+  label "Delete Idle Instances"
   description "Approval to delete all selected instances"
   run "esc_delete_instances", data, rs_governance_host, rs_project_id
 end
 define esc_delete_instances($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Delete Instances")
+  call child_run_action($data, $governance_host, $rs_project_id, "Delete Idle Instances")
 end
 
 
@@ -1000,6 +1020,7 @@ policy "policy_scheduled_report" do
   validate $ds_idle_instances_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Azure Idle Virtual Machines Found"
     escalate $esc_email
+    escalate $esc_poweroff_instances
     escalate $esc_delete_instances
     check eq(size(data), 0)
     export do


### PR DESCRIPTION
### Description

This is intended to fix a couple of issues with this policy, as well as implement some improvements made to other revamped policies to ensure this one is fully up to date. While this policy should continue to function without issue for most customers, a change to the `Automatic Actions` parameter does technically constitute a breaking change, hence the major version number change.

From the CHANGELOG:

- Fixed issue with resource count in incident subject being off by 1
- Fixed minor grammar issue if results only include 1 item
- Renamed policy actions to make it clear whether they are for underutilized or idle instances
- Added ability to filter resources by tag key via wildcard
- Added option to power off idle instances
- Added ability to indicate whether to do a graceful or forced shutdown when powering off instances
- Improved code related to incident export
- Updated and improved code for policy actions

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=65771cbf666365000101a729

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
