### PR TITLE
POL-466 Remove ce:* Permissions from AWS READMEs

### DIFF
--- a/cost/aws/reserved_instances/compute_purchase_recommendation/README.md
+++ b/cost/aws/reserved_instances/compute_purchase_recommendation/README.md
@@ -10,12 +10,6 @@ This Policy Template will send an email notifications when AWS RI Recommendation
 
 It will email the user specified in `Email addresses of the recipients you wish to notify`
 
-## Prerequisites
-
-- The following RightScale Credentials
-  - `AWS_ACCESS_KEY_ID` - The Access Key of an IAM User in the Master Payer account, which has access to Cost Explorer.
-  - `AWS_SECRET_ACCESS_KEY` - The Secret Access Key of the IAM User.
-
 ## Input Parameters
 
 This policy has the following input parameters required when launching the policy.

--- a/cost/aws/reserved_instances/compute_purchase_recommendation/README.md
+++ b/cost/aws/reserved_instances/compute_purchase_recommendation/README.md
@@ -41,27 +41,33 @@ The following policy actions are taken on any resources found to be out of compl
 - Cloud Management - Observer
 - Cloud Management - credential_viewer
 
-## AWS Required Permissions
+## Prerequisites
 
-This policy requires permissions to describe AWS Cost Explorer.
-The Cloud Management Platform automatically creates two Credentials when connecting AWS to Cloud Management; AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. The IAM user credentials contained in those credentials will require the following permissions:
+This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).
 
-```javascript
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ce:*"
-      ],
-      "Resource": [
-        "*"
+- [**AWS Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1121575) (*provider=aws*) which has the following permissions:
+  - `ce:GetReservationPurchaseRecommendation`
+  - `ec2:DescribeReservedInstancesOfferings`
+  - `ec2:PurchaseReservedInstancesOffering`
+
+  Example IAM Permission Policy:
+
+  ```json
+  {
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "ce:GetReservationPurchaseRecommendation",
+                  "ec2:DescribeReservedInstancesOfferings",
+                  "ec2:PurchaseReservedInstancesOffering"
+              ],
+              "Resource": "*"
+          }
       ]
-    }
-  ]
-}
-```
+  }
+  ```
 
 ## Supported Clouds
 

--- a/cost/aws/reserved_instances/coverage/README.md
+++ b/cost/aws/reserved_instances/coverage/README.md
@@ -21,32 +21,27 @@ The following policy actions are taken on any resources found to be out of compl
 
 ## Prerequisites
 
-This policy uses [credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for connecting to the cloud -- in order to apply this policy you must have a credential registered in the system that is compatible with this policy. If there are no credentials listed when you apply the policy, please contact your cloud admin and ask them to register a credential that is compatible with this policy. The information below should be consulted when creating the credential.
+This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).
 
-### Credential configuration
+- [**AWS Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1121575) (*provider=aws*) which has the following permissions:
+  - `ce:GetReservationCoverage`
 
-For administrators [creating and managing credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) to use with this policy, the following information is needed:
+  Example IAM Permission Policy:
 
-Provider tag value to match this policy: `aws`
-
-Required permissions in the provider:
-
-```javascript
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ce:*"
-      ],
-      "Resource": [
-        "*"
+  ```json
+  {
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "ce:GetReservationCoverage"
+              ],
+              "Resource": "*"
+          }
       ]
-    }
-  ]
-}
-```
+  }
+  ```
 
 ## Supported Clouds
 

--- a/cost/aws/savings_plan/utilization/README.md
+++ b/cost/aws/savings_plan/utilization/README.md
@@ -11,24 +11,24 @@ This Policy Template leverages the [AWS Savings Plans Utilization API](https://d
 This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).
 
 - [**AWS Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1121575) (*provider=aws*) which has the following permissions:
-  - `ce:*`
+  - `ce:GetSavingsPlansUtilization`
+  - `savingsplans:DescribeSavingsPlans`
 
   Example IAM Permission Policy:
 
   ```json
   {
-    "Version": "2012-10-17",
-    "Statement": [
-      {
-        "Effect": "Allow",
-        "Action": [
-          "ce:*"
-        ],
-        "Resource": [
-          "*"
-        ]
-      }
-    ]
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "ce:GetSavingsPlansUtilization",
+                  "savingsplans:DescribeSavingsPlans"
+              ],
+              "Resource": "*"
+          }
+      ]
   }
   ```
 


### PR DESCRIPTION
### Description

Several READMEs listed ce:* permissions instead of more granular permissions. This aims to correct that.

### Contribution Check List

- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
