### PR TITLE
POL-817 AWS instance_types.json Casing Fix

### DIFF
--- a/data/aws/instance_types.json
+++ b/data/aws/instance_types.json
@@ -1964,8 +1964,8 @@
     "enhanced_networking": true,
     "vcpu": "96"
   },
-  "Im4gn.large": {
-    "up": "Im4gn.xlarge",
+  "im4gn.large": {
+    "up": "im4gn.xlarge",
     "down": null,
     "superseded": null,
     "ec2_classic": false,
@@ -1973,53 +1973,53 @@
     "vcpu": "2",
     "nfu": "8"
   },
-  "Im4gn.xlarge": {
-    "up": "Im4gn.2xlarge",
-    "down": "Im4gn.large",
+  "im4gn.xlarge": {
+    "up": "im4gn.2xlarge",
+    "down": "im4gn.large",
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
     "nfu": "16"
   },
-  "Im4gn.2xlarge": {
-    "up": "Im4gn.4xlarge",
-    "down": "Im4gn.xlarge",
+  "im4gn.2xlarge": {
+    "up": "im4gn.4xlarge",
+    "down": "im4gn.xlarge",
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
     "nfu": "32"
   },
-  "Im4gn.4xlarge": {
-    "up": "Im4gn.8xlarge",
-    "down": "Im4gn.2xlarge",
+  "im4gn.4xlarge": {
+    "up": "im4gn.8xlarge",
+    "down": "im4gn.2xlarge",
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
     "nfu": "64"
   },
-  "Im4gn.8xlarge": {
-    "up": "Im4gn.16xlarge",
-    "down": "Im4gn.4xlarge",
+  "im4gn.8xlarge": {
+    "up": "im4gn.16xlarge",
+    "down": "im4gn.4xlarge",
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
     "nfu": "128"
   },
-  "Im4gn.16xlarge": {
+  "im4gn.16xlarge": {
     "up": null,
-    "down": "Im4gn.8xlarge",
+    "down": "im4gn.8xlarge",
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
     "nfu": "256"
   },
-  "Is4gen.medium": {
-    "up": "Is4gen.large",
+  "is4gen.medium": {
+    "up": "is4gen.large",
     "down": null,
     "superseded": null,
     "ec2_classic": false,
@@ -2027,45 +2027,45 @@
     "vcpu": "1",
     "nfu": "6"
   },
-  "Is4gen.large": {
-    "up": "Is4gen.xlarge",
-    "down": "Is4gen.medium",
+  "is4gen.large": {
+    "up": "is4gen.xlarge",
+    "down": "is4gen.medium",
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
     "nfu": "12"
   },
-  "Is4gen.xlarge": {
-    "up": "Is4gen.2xlarge",
-    "down": "Is4gen.large",
+  "is4gen.xlarge": {
+    "up": "is4gen.2xlarge",
+    "down": "is4gen.large",
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
     "nfu": "24"
   },
-  "Is4gen.2xlarge": {
-    "up": "Is4gen.4xlarge",
-    "down": "Is4gen.xlarge",
+  "is4gen.2xlarge": {
+    "up": "is4gen.4xlarge",
+    "down": "is4gen.xlarge",
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
     "nfu": "48"
   },
-  "Is4gen.4xlarge": {
-    "up": "Is4gen.8xlarge",
-    "down": "Is4gen.2xlarge",
+  "is4gen.4xlarge": {
+    "up": "is4gen.8xlarge",
+    "down": "is4gen.2xlarge",
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
     "nfu": "96"
   },
-  "Is4gen.8xlarge": {
+  "is4gen.8xlarge": {
     "up": null,
-    "down": "Is4gen.4xlarge",
+    "down": "is4gen.4xlarge",
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,


### PR DESCRIPTION
### Description

The Im4gn and Is4gen instance types, unlike all other types, were added to this file with the letter I capitalized. This caused issues for policies that expect consistent lowercase for this.

This is a simple fix to replace the above with their lowercase equivalents. I've searched the file for all capital letters in the alphabet and found no other instance types with this issue in this file.

### Link to Example Applied Policy

N/A.

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
