### PR TITLE
POL-1006 Google Idle Persistent Disk Recommender Permissions Update

### DIFF
--- a/cost/google/idle_persistent_disk_recommendations/README.md
+++ b/cost/google/idle_persistent_disk_recommendations/README.md
@@ -43,9 +43,11 @@ This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Auto
     - `recommender.computeDiskIdleResourceRecommendations.list`
     - `resourcemanager.projects.get`
     - `compute.disks.list`
+    - `compute.snapshots.create`*
     - `compute.disks.createSnapshot`*
     - `compute.disks.delete`*
     - `compute.globalOperations.get`*
+    - `compute.zoneOperations.get`*
 
 \* Only required for taking action; the policy will still function in a read-only capacity without these permissions.
 


### PR DESCRIPTION
### Description

Two permissions are required for taking actions against disks raised in this policy that are not listed in the README. This adds them to the README.