### PR TITLE
FOPTS-2702 Enabling hyperlinks in Turb policies for incidents.

### DIFF
--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3
+
+- Added Hyperlinks for `System Details URL` incident field.
+
 ## v0.2
 
 - Added `RI Utilization` incident field.

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.2",
+  version: "0.3",
   provider: "AWS",
   source: "Turbonomic",
   service: "Usage Discount",
@@ -240,7 +240,7 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
                         ri.riUtilization = Number(ri.coupons.value * 100 / ri.coupons.capacity.avg).toFixed(2)
                       }
                     }
-                    ri.url = "https://" + param_turbonomic_host + "/app/index.html#/view/main/action/" + ri.uuid
+                    ri.url = "Buy AWS RI: " + ri.resourceType  + " || https://" + param_turbonomic_host + "/app/index.html#/view/main/action/" + ri.uuid
                     instances.push(ri)
                 }
             }
@@ -358,6 +358,7 @@ EOS
       end
       field "url" do
         label "System Details URL"
+        format "link-external"
       end
     end
     escalate $esc_email

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/CHANGELOG.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3
+
+- Added Hyperlinks for `System Details URL` incident field.
+
 ## v0.2
 
 - Added `System Details Url` incident field.

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.2",
+  version: "0.3",
   provider: "Azure",
   source: "Turbonomic",
   service: "Usage Discount",
@@ -259,7 +259,7 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
                     ri.savings = Math.round(ri.savings * 730*100)/100
                     ri.effectiveCost = Number(ri.effectiveCost * 730 * ri.termValue * 12 * ri.numberOfInstances).toFixed(2)
                     ri.recurringCost = Number(ri.recurringCost * 730 * ri.numberOfInstances).toFixed(2)
-                    ri.url = "https://"+ turbonomic_endpoint + "/app/index.html#/view/main/action/" + ri.actionID
+                    ri.url = "Buy Azure RI: " + ri.resourceType  + " || https://" + turbonomic_endpoint + "/app/index.html#/view/main/action/" + ri.actionID
                     monthlySavings = monthlySavings + ri.savings
                     instances.push(ri)
                 }
@@ -337,6 +337,7 @@ EOS
       end
       field "url" do
         label "System Details URL"
+        format "link-external"
       end
       field "riCoverage" do
         label "RI Coverage"

--- a/cost/turbonomics/delete_unattached_volumes/aws/CHANGELOG.md
+++ b/cost/turbonomics/delete_unattached_volumes/aws/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6
+
+- Added Hyperlinks for `System Details URL` incident field.
+
 ## v0.5
 
 - Renamed `Storage Access` incident field to `Provisioned IOPs`.

--- a/cost/turbonomics/delete_unattached_volumes/aws/turbonomics_delete_virtual_volumes.pt
+++ b/cost/turbonomics/delete_unattached_volumes/aws/turbonomics_delete_virtual_volumes.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.5",
+  version: "0.6",
   provider: "AWS",
   source: "Turbonomic",
   service: "Storage",
@@ -258,7 +258,7 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
         }
         volume.savings = (Math.round(volume.savings * 730 * 1000) / 1000)
         monthlySavings = monthlySavings + volume.savings
-        volume.url = param_turbonomic_host + "/app/index.html#/view/main/action/" + volume.uuid
+        volume.url = "System name: " + volume.resourceName  + " || https://" + param_turbonomic_host + "/app/index.html#/view/main/action/" + volume.uuid
         instances.push(volume)
       }
     })
@@ -361,6 +361,7 @@ EOS
       end
       field "url" do
         label "System Details URL"
+        format "link-external"
       end
     end
     escalate $esc_email

--- a/cost/turbonomics/delete_unattached_volumes/azure/CHANGELOG.md
+++ b/cost/turbonomics/delete_unattached_volumes/azure/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5
+
+- Added Hyperlinks for `System Details URL` incident field.
+
 ## v0.4
 
 - Added `Provisioned IOPs` incident field.

--- a/cost/turbonomics/delete_unattached_volumes/azure/turbonomics_delete_virtual_volumes.pt
+++ b/cost/turbonomics/delete_unattached_volumes/azure/turbonomics_delete_virtual_volumes.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.4",
+  version: "0.5",
   provider: "Azure",
   source: "Turbonomic",
   service: "Storage",
@@ -258,7 +258,7 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
         }
         volume.savings = (Math.round(volume.savings * 730 * 1000) / 1000)
         monthlySavings = monthlySavings + volume.savings
-        volume.url = param_turbonomic_host + "/app/index.html#/view/main/action/" + volume.uuid
+        volume.url = "System name: " + volume.resourceName  + " || https://" + param_turbonomic_host + "/app/index.html#/view/main/action/" + volume.uuid
         instances.push(volume)
       }
     })
@@ -361,6 +361,7 @@ EOS
       end
       field "url" do
         label "System Details URL"
+        format "link-external"
       end
     end
 

--- a/cost/turbonomics/delete_unattached_volumes/gcp/CHANGELOG.md
+++ b/cost/turbonomics/delete_unattached_volumes/gcp/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6
+
+- Added Hyperlinks for `System Details URL` incident field.
+
 ## v0.5
 
 - Added `Provisioned IOPs` incident field.

--- a/cost/turbonomics/delete_unattached_volumes/gcp/turbonomics_delete_virtual_volumes.pt
+++ b/cost/turbonomics/delete_unattached_volumes/gcp/turbonomics_delete_virtual_volumes.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.5",
+  version: "0.6",
   provider: "Google",
   source: "Turbonomic",
   service: "Storage",
@@ -259,7 +259,7 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
         }
         volume.savings = (Math.round(volume.savings * 730 * 1000) / 1000)
         monthlySavings = monthlySavings + volume.savings
-        volume.url = param_turbonomic_host + "/app/index.html#/view/main/action/" + volume.uuid
+        volume.url = "System name: " + volume.resourceName  + " || https://" + param_turbonomic_host + "/app/index.html#/view/main/action/" + volume.uuid
         instances.push(volume)
       }
     })
@@ -362,6 +362,7 @@ EOS
       end
       field "url" do
         label "System Details URL"
+        format "link-external"
       end
     end
     escalate $esc_email

--- a/cost/turbonomics/rightsize_databases_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_databases_recommendations/aws/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4
+
+- Added Hyperlinks for `System Details URL` incident field.
+
 ## v0.3
 
 - Added `Recommendation Created Time` incident field.

--- a/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
+++ b/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.3",
+  version: "0.4",
   source: "Turbonomic",
   service: "Usage Discount",
   provider: "AWS",
@@ -240,7 +240,7 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
 
             db.savings = (Math.round(db.savings * 730 * 1000) / 1000)
             monthlySavings = monthlySavings + db.savings
-            db.url = "https://"+ turbonomic_endpoint + "/app/index.html#/view/main/action/" + db.actionID
+            db.url = "System name: " + db.resourceName  + " || https://" + turbonomic_endpoint + "/app/index.html#/view/main/action/" + db.actionID
             instances.push(db)
         }
     })
@@ -471,6 +471,7 @@ policy "pol_turbonomic_rightsize_databases" do
       end
       field "url" do
         label "System Details URL"
+        format "link-external"
       end
       field "size" do
         label "Storage (GB)"

--- a/cost/turbonomics/rightsize_databases_recommendations/azure/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_databases_recommendations/azure/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5
+
+- Added Hyperlinks for `System Details URL` incident field.
+
 ## v0.4
 
 - Added request for Turbonomic search API to know what Pricing Model are related to the Database and return Aspects for their stats request.

--- a/cost/turbonomics/rightsize_databases_recommendations/azure/turbonomics_rightsize_databases_recommendations.pt
+++ b/cost/turbonomics/rightsize_databases_recommendations/azure/turbonomics_rightsize_databases_recommendations.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.4",
+  version: "0.5",
   source: "Turbonomic",
   service: "Usage Discount",
   provider: "Azure",
@@ -238,7 +238,7 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
 
             db.savings = (Math.round(db.savings * 730 * 1000) / 1000)
             monthlySavings = monthlySavings + db.savings
-            db.url = "https://"+ turbonomic_endpoint + "/app/index.html#/view/main/action/" + db.actionID
+            db.url = "System name: " + db.resourceName  + " || https://" + turbonomic_endpoint + "/app/index.html#/view/main/action/" + db.actionID
             instances.push(db)
         }
     })
@@ -533,6 +533,7 @@ policy "pol_turbonomic_rightsize_databases" do
       end
       field "url" do
         label "System Details URL"
+        format "link-external"
       end
       field "size" do
         label "Storage (GB)"

--- a/cost/turbonomics/rightsize_databases_recommendations/gcp/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_databases_recommendations/gcp/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5
+
+- Added Hyperlinks for `System Details URL` incident field.
+
 ## v0.4
 
 - Renamed `Created Time` incident field to `Recommendation Created Time`.

--- a/cost/turbonomics/rightsize_databases_recommendations/gcp/turbonomics_rightsize_databases_recommendations.pt
+++ b/cost/turbonomics/rightsize_databases_recommendations/gcp/turbonomics_rightsize_databases_recommendations.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.4",
+  version: "0.5",
   source: "Turbonomic",
   service: "Usage Discount",
   provider: "Google",
@@ -239,7 +239,7 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
 
             db.savings = (Math.round(db.savings * 730 * 1000) / 1000)
             monthlySavings = monthlySavings + db.savings
-            db.url = "https://"+ turbonomic_endpoint + "/app/index.html#/view/main/action/" + db.actionID
+            db.url = "System name: " + db.resourceName  + " || https://" + turbonomic_endpoint + "/app/index.html#/view/main/action/" + db.actionID
             instances.push(db)
         }
     })
@@ -466,6 +466,7 @@ policy "pol_turbonomic_rightsize_databases" do
       end
       field "url" do
         label "System Details URL"
+        format "link-external"
       end
       field "size" do
         label "Storage (GB)"

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/aws/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4
+
+- Added Hyperlinks for `System Details URL` incident field.
+
 ## v0.3
 
 - Added `Attached VM` incident field.

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/aws/turbonomics_rightsize_virtual_volumes_recommendations.pt
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/aws/turbonomics_rightsize_virtual_volumes_recommendations.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.3",
+  version: "0.4",
   source: "Turbonomic",
   service: "Usage Discount",
   provider: "AWS",
@@ -240,7 +240,7 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
         }
         volume.savings = (Math.round(volume.savings * 730 * 1000) / 1000)
         monthlySavings = monthlySavings + volume.savings
-        volume.url = param_turbonomic_host + "/app/index.html#/view/main/action/" + volume.urlUUID
+        volume.url = "System name: " + volume.resourceName  + " || https://" + param_turbonomic_host + "/app/index.html#/view/main/action/" + volume.urlUUID
         instances.push(volume)
       }
     })
@@ -274,7 +274,7 @@ script "js_get_stats", type: "javascript" do
           }
         ],
         "startDate": startDate.getTime(),
-        "endDate": endDate.getTime()     
+        "endDate": endDate.getTime()
       },
       headers: {
         "Content-Type": "application/json"
@@ -322,7 +322,7 @@ script "js_filtered_stats", type: "javascript" do
                     }
                   })
                 }
-              })         
+              })
             }
             if (statistic.name == "StorageAmount"){
               _.each(statistic.filters, function(filter){
@@ -334,7 +334,7 @@ script "js_filtered_stats", type: "javascript" do
                     }
                   })
                 }
-              })         
+              })
             }
             if (statistic.name == "IOThroughput"){
               _.each(statistic.filters, function(filter){
@@ -346,7 +346,7 @@ script "js_filtered_stats", type: "javascript" do
                     }
                   })
                 }
-              })         
+              })
             }
           })
         }
@@ -362,7 +362,7 @@ script "js_filtered_stats", type: "javascript" do
                     }
                   })
                 }
-              })         
+              })
             }
             if (statistic.name == "StorageAmount"){
               _.each(statistic.filters, function(filter){
@@ -374,7 +374,7 @@ script "js_filtered_stats", type: "javascript" do
                     }
                   })
                 }
-              })         
+              })
             }
             if (statistic.name == "IOThroughput"){
               _.each(statistic.filters, function(filter){
@@ -386,7 +386,7 @@ script "js_filtered_stats", type: "javascript" do
                     }
                   })
                 }
-              })         
+              })
             }
           })
         }
@@ -524,6 +524,7 @@ policy "pol_turbonomic_rightsize_volumes" do
       end
       field "url" do
         label "System Details URL"
+        format "link-external"
       end
     end
     escalate $esc_email

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/azure/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/azure/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4
+
+- Added Hyperlinks for `System Details URL` incident field.
+
 ## v0.3
 
 - Added `Attached VM` incident field.

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/azure/turbonomics_rightsize_virtual_volumes_recommendations.pt
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/azure/turbonomics_rightsize_virtual_volumes_recommendations.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.3",
+  version: "0.4",
   source: "Turbonomic",
   service: "Usage Discount",
   provider: "Azure",
@@ -240,7 +240,7 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
         }
         volume.savings = (Math.round(volume.savings * 730 * 1000) / 1000)
         monthlySavings = monthlySavings + volume.savings
-        volume.url = param_turbonomic_host + "/app/index.html#/view/main/action/" + volume.urlUUID
+        volume.url = "System name: " + volume.resourceName  + " || https://" + param_turbonomic_host + "/app/index.html#/view/main/action/" + volume.urlUUID
         instances.push(volume)
       }
     })
@@ -274,7 +274,7 @@ script "js_get_stats", type: "javascript" do
           }
         ],
         "startDate": startDate.getTime(),
-        "endDate": endDate.getTime()     
+        "endDate": endDate.getTime()
       },
       headers: {
         "Content-Type": "application/json"
@@ -322,7 +322,7 @@ script "js_filtered_stats", type: "javascript" do
                     }
                   })
                 }
-              })         
+              })
             }
             if (statistic.name == "StorageAmount"){
               _.each(statistic.filters, function(filter){
@@ -334,7 +334,7 @@ script "js_filtered_stats", type: "javascript" do
                     }
                   })
                 }
-              })         
+              })
             }
             if (statistic.name == "IOThroughput"){
               _.each(statistic.filters, function(filter){
@@ -346,7 +346,7 @@ script "js_filtered_stats", type: "javascript" do
                     }
                   })
                 }
-              })         
+              })
             }
           })
         }
@@ -362,7 +362,7 @@ script "js_filtered_stats", type: "javascript" do
                     }
                   })
                 }
-              })         
+              })
             }
             if (statistic.name == "StorageAmount"){
               _.each(statistic.filters, function(filter){
@@ -374,7 +374,7 @@ script "js_filtered_stats", type: "javascript" do
                     }
                   })
                 }
-              })         
+              })
             }
             if (statistic.name == "IOThroughput"){
               _.each(statistic.filters, function(filter){
@@ -386,7 +386,7 @@ script "js_filtered_stats", type: "javascript" do
                     }
                   })
                 }
-              })         
+              })
             }
           })
         }
@@ -524,6 +524,7 @@ policy "pol_turbonomic_rightsize_volumes" do
       end
       field "url" do
         label "System Details URL"
+        format "link-external"
       end
     end
     escalate $esc_email

--- a/cost/turbonomics/scale_virtual_machines_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/aws/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6
+
+- Added Hyperlinks for `System Details URL` incident field.
+
 ## v0.5
 
 - Added `Resource Type` incident field.

--- a/cost/turbonomics/scale_virtual_machines_recommendations/aws/turbonomics_scale_virtual_machines.pt
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/aws/turbonomics_scale_virtual_machines.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.5",
+  version: "0.6",
   provider: "AWS",
   source: "Turbonomic",
   service: "Compute",
@@ -318,7 +318,7 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
         }
         vm.savings = (Math.round(vm.savings * 730 * 1000 * (vm.uptime/100)) / 1000)
         monthlySavings = monthlySavings + vm.savings
-        vm.url = "https://" + param_turbonomic_endpoint + "/app/index.html#/view/main/action/" + vm.urlUUID
+        vm.url = "System name: " + vm.resourceName  + " || https://" + param_turbonomic_endpoint + "/app/index.html#/view/main/action/" + vm.urlUUID
         vm.resourceType = vm.currentResourceType
         instances.push(vm)
       }
@@ -548,6 +548,7 @@ EOS
       end
       field "url" do
         label "System Details URL"
+        format "link-external"
       end
     end
     escalate $esc_email

--- a/cost/turbonomics/scale_virtual_machines_recommendations/azure/CHANGELOG.md
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/azure/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6
+
+- Added Hyperlinks for `System Details URL` incident field.
+
 ## v0.5
 
 - Added `Resource Type` incident field.

--- a/cost/turbonomics/scale_virtual_machines_recommendations/azure/turbonomics_scale_virtual_machines.pt
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/azure/turbonomics_scale_virtual_machines.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.5",
+  version: "0.6",
   provider: "Azure",
   source: "Turbonomic",
   service: "Compute",
@@ -318,7 +318,7 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
         }
         vm.savings = (Math.round(vm.savings * 730 * 1000 * (vm.uptime/100)) / 1000)
         monthlySavings = monthlySavings + vm.savings
-        vm.url = "https://"+ turbonomic_endpoint + "/app/index.html#/view/main/action/" + vm.uuid
+        vm.url = "System name: " + vm.resourceName  + " || https://" + turbonomic_endpoint + "/app/index.html#/view/main/action/" + vm.uuid
         vm.resourceType = vm.currentResourceType
         instances.push(vm)
       }
@@ -517,6 +517,7 @@ policy "pol_turbonomics_scale_vms" do
       end
       field "url" do
         label "System Details URL"
+        format "link-external"
       end
       field "iops" do
         label "IOPs Capacity"

--- a/cost/turbonomics/scale_virtual_machines_recommendations/gcp/CHANGELOG.md
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/gcp/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.7
+
+- Added Hyperlinks for `System Details URL` incident field.
+
 ## v0.6
 
 - Added `Resource Type` incident field.

--- a/cost/turbonomics/scale_virtual_machines_recommendations/gcp/turbonomics_scale_virtual_machines.pt
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/gcp/turbonomics_scale_virtual_machines.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.6",
+  version: "0.7",
   provider: "Google",
   source: "Turbonomic",
   service: "Compute",
@@ -318,7 +318,7 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
         }
         vm.savings = (Math.round(vm.savings * 730 * 1000 * (vm.uptime/100)) / 1000)
         monthlySavings = monthlySavings + vm.savings
-        vm.url = "https://" + param_turbonomic_endpoint + "/app/index.html#/view/main/action/" + vm.urlUUID
+        vm.url = "System name: " + vm.resourceName  + " || https://" + param_turbonomic_endpoint + "/app/index.html#/view/main/action/" + vm.urlUUID
         vm.resourceType = vm.currentResourceType
         instances.push(vm)
       }
@@ -550,6 +550,7 @@ EOS
       end
       field "url" do
         label "System Details URL"
+        format "link-external"
       end
     end
     escalate $esc_email


### PR DESCRIPTION
### Description

Enabling hyperlinks in Turbonomics policies for incidents.

### Issues Resolved

[FOPTS-2702](https://flexera.atlassian.net/browse/FOPTS-2702)
### Link to Example Applied Policy

[E.g. Applied Policy](https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/60073?policyId=65806cba5f57b900018a9282)

- Rightsize Databases
      - aws
      - azure
      - gcp

- Allocate Virtual Machines
      - NA

- Buy RI
       - aws
       - azure

- Delete Virtual Volumes
        - aws
        - azure
        - gcp

- Rightsize Virtual Volumes
         - aws
         - azure
         - gcp NA

- Scale Virtual Machines
          - aws
          - azure
          - gcp

Changelog and version updated on each policy.
 

### Contribution Check List

- [x New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
