### PR TITLE
POL-1012 AWS Rightsize RDS Dash Fix

### DIFF
--- a/cost/aws/rightsize_rds_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_rds_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.2
+
+- Fixed issue with incorrectly reporting on instances with hyphens or underscores in their name.
+
 ## v4.1
 
 - Changed default value of `Underutilized Instance CPU Threshold (%)` parameter to 40%.

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
@@ -995,15 +995,8 @@ script "js_cloudwatch_underutil_sorted", type: "javascript" do
   _.each(ds_cloudwatch_underutil_data, function(item) {
     region = item['region']
 
-    // id contains both the instance name and metric, so we split it up by underscore
-    // example id: sandbox_mysqlv2_one_CPUUtilization_Average
-    id_parts = item['id'].split('_')
-
-    // Metric name is always the last item in the list
-    metric = id_parts.pop()
-
-    // Remove the metric name and "CPUUtilization" from the list
-    id_parts.pop()
+    // Metric name is always the last item in the id
+    metric = item['id'].split('_').pop()
 
     // Obtain the instance name from the label
     instance_name = item['label'].split(' ')[0].toLowerCase()

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.1",
+  version: "4.2",
   provider: "AWS",
   service: "RDS",
   policy_set: "Rightsize Database Instances",

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
@@ -685,7 +685,7 @@ script "js_cloudwatch_idle_queries", type: "javascript" do
   _.each(ds_rds_instances_to_check, function(resource) {
     query = {
       // Replace `-` with `_` in the Id to avoid CloudWatch API error
-      "Id": resource['name'].replace(/\-/g, '_') + "_" + metric + "_" + statistic,
+      "Id": resource['name'].split('-').join('_') + "_" + metric + "_" + statistic,
       "Label": resource['name'] + " " + metric + " " + statistic,
       "MetricStat": {
         "Metric": {
@@ -798,21 +798,22 @@ script "js_rds_idle_instances", type: "javascript" do
   cloudwatch_activity = {}
 
   _.each(ds_cloudwatch_idle_data, function(item) {
-    instanceId = item['label'].split(' ')[0].toLowerCase()
+    instance_name = item['label'].split(' ')[0].toLowerCase()
 
-    if (cloudwatch_activity[instanceId] == undefined) {
-      cloudwatch_activity[instanceId] = 0
+    if (cloudwatch_activity[instance_name] == undefined) {
+      cloudwatch_activity[instance_name] = 0
     }
 
     if (typeof(item['values']) == 'object') {
       _.each(item['values'], function(value) {
-        cloudwatch_activity[instanceId] += value
+        cloudwatch_activity[instance_name] += value
       })
     }
   })
 
   _.each(ds_rds_instances_to_check, function(instance) {
-    instanceId = instance['instanceId'].toLowerCase()
+    cloudwatch_name = instance['name'].split('-').join('_').toLowerCase()
+    instance_activity = cloudwatch_activity[cloudwatch_name]
     savings_name = "db:" + instance['name'].toLowerCase()
     savings = 0.0
 
@@ -820,7 +821,7 @@ script "js_rds_idle_instances", type: "javascript" do
       savings = ds_instance_costs_grouped[savings_name]
     }
 
-    if (cloudwatch_activity[instanceId] == undefined || cloudwatch_activity[instanceId] == 0) {
+    if (instance_activity == undefined || instance_activity == 0) {
       result.push({
         instanceId: instance['instanceId'],
         instanceArn: instance['instanceArn'],
@@ -877,7 +878,7 @@ script "js_cloudwatch_underutil_queries", type: "javascript" do
     _.each(statistics, function(statistic) {
       query = {
         // Replace `-` with `_` in the Id to avoid CloudWatch API error
-        "Id": resource['name'].replace(/\-/g, '_') + "_" + metric + "_" + statistic,
+        "Id": resource['name'].split('-').join('_') + "_" + metric + "_" + statistic,
         "Label": resource['name'] + " " + metric + " " + statistic,
         "MetricStat": {
           "Metric": {
@@ -1006,7 +1007,7 @@ script "js_cloudwatch_underutil_sorted", type: "javascript" do
 
     // Recreate instance name now that we've removed the above.
     // We can't simply grab the first item because the instance name may have underscores in it
-    instance_name = id_parts.join('_')
+    instance_name = id_parts.join('_').toLowerCase()
 
     // Grabbing index 0 SHOULD be safe because we should only get one result.
     // Just in case AWS slices the data weirdly and returns 2 results, we make
@@ -1035,7 +1036,7 @@ script "js_rds_nonidle_instances_with_metrics", type: "javascript" do
   _.each(ds_rds_nonidle_instances, function(instance) {
     region = instance['region']
     id = instance['instanceId']
-    cloudwatch_name = instance['name'].split('-').join('_')
+    cloudwatch_name = instance['name'].split('-').join('_').toLowerCase()
     resourceType = instance['resourceType']
     newResourceType = null
 

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
@@ -812,7 +812,7 @@ script "js_rds_idle_instances", type: "javascript" do
   })
 
   _.each(ds_rds_instances_to_check, function(instance) {
-    cloudwatch_name = instance['name'].split('-').join('_').toLowerCase()
+    cloudwatch_name = instance['name'].toLowerCase()
     instance_activity = cloudwatch_activity[cloudwatch_name]
     savings_name = "db:" + instance['name'].toLowerCase()
     savings = 0.0
@@ -1005,9 +1005,8 @@ script "js_cloudwatch_underutil_sorted", type: "javascript" do
     // Remove the metric name and "CPUUtilization" from the list
     id_parts.pop()
 
-    // Recreate instance name now that we've removed the above.
-    // We can't simply grab the first item because the instance name may have underscores in it
-    instance_name = id_parts.join('_').toLowerCase()
+    // Obtain the instance name from the label
+    instance_name = item['label'].split(' ')[0].toLowerCase()
 
     // Grabbing index 0 SHOULD be safe because we should only get one result.
     // Just in case AWS slices the data weirdly and returns 2 results, we make
@@ -1036,7 +1035,7 @@ script "js_rds_nonidle_instances_with_metrics", type: "javascript" do
   _.each(ds_rds_nonidle_instances, function(instance) {
     region = instance['region']
     id = instance['instanceId']
-    cloudwatch_name = instance['name'].split('-').join('_').toLowerCase()
+    cloudwatch_name = instance['name'].toLowerCase()
     resourceType = instance['resourceType']
     newResourceType = null
 

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
@@ -833,7 +833,8 @@ script "js_rds_idle_instances", type: "javascript" do
         privateDnsName: instance['privateDnsName'],
         region: instance['region'],
         tags: instance['tags'],
-        savings: savings
+        savings: savings,
+        instance_activity: instance_activity
       })
     }
   })

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "4.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 


### PR DESCRIPTION
### Description

This fixes an issue where the policy was not correctly identifying unused instances if they had dashes in the name. The policy was incorrectly using the instance id, rather than the instance name, to find the instance in the Cloudwatch data.

### Link to Example Applied Policy

https://app.flexera.com/orgs/27018/automation/applied-policies/projects/116186?policyId=6581a75fd1dc74000182cdbb

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in CHANGELOG.MD
