### PR TITLE
POL-982 Hybrid Use Benefit Policy - currency separator symbol shown as undefined

### DIFF
--- a/cost/azure/hybrid_use_benefit/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.1
+
+- Added the currency separator for savings message
+
 ## v4.0
 
 - Several parameters altered to be more descriptive and human-readable

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit.pt
@@ -476,7 +476,7 @@ script "js_ahub_recommendations", type: "javascript" do
     while (values[0].length > 3) {
       var chunk = values[0].substr(-3)
       values[0] = values[0].substr(0, values[0].length - 3)
-      formatted_number = ds_currency['t_separator'] + chunk + formatted_number
+      formatted_number = separator + chunk + formatted_number
     }
 
     if (values[0].length > 0) { formatted_number = values[0] + formatted_number }
@@ -584,7 +584,7 @@ script "js_ahub_recommendations", type: "javascript" do
 
   savings_message = [
     ds_currency['symbol'], ' ',
-    formatNumber(parseFloat(total_savings).toFixed(2), ds_currency['separator'])
+    formatNumber(parseFloat(total_savings).toFixed(2), ds_currency['t_separator'])
   ].join('')
 
   result = _.sortBy(result, function(item) { return item['savings'] * -1 })

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "4.0",
+  version: "4.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Hybrid Use Benefit",
@@ -476,7 +476,7 @@ script "js_ahub_recommendations", type: "javascript" do
     while (values[0].length > 3) {
       var chunk = values[0].substr(-3)
       values[0] = values[0].substr(0, values[0].length - 3)
-      formatted_number = separator + chunk + formatted_number
+      formatted_number = ds_currency['t_separator'] + chunk + formatted_number
     }
 
     if (values[0].length > 0) { formatted_number = values[0] + formatted_number }


### PR DESCRIPTION
### Description

n the incident of Hybrid Use Benefit Policy, currency separator is shown as undefined:

### Issues Resolved

[POL-982](https://flexera.atlassian.net/browse/POL-982)

### Link to Example Applied Policy

[Applied policy](https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/60073?policyId=658230b65ec8620001b97922)

### Contribution Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
