### PR TITLE
POL-991 AWS Disallowed Regions Revamp

### DIFF
--- a/compliance/aws/disallowed_regions/CHANGELOG.md
+++ b/compliance/aws/disallowed_regions/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v5.0
+
+- Several parameters altered to be more descriptive and human-readable
+- Added ability to filter resources by multiple tag key:value pairs
+- Added additional context to incident description
+- Normalized incident export to be consistent with other policies
+- Added human-readable recommendation to incident export
+- Policy no longer raises new escalations if tag data has changed for an instance
+- Policy action error logging modernized and now works as expected in EU/APAC
+- Streamlined code for better readability and faster execution
+
 ## v4.1
 
 - Updated description of `Account Number` parameter

--- a/compliance/aws/disallowed_regions/README.md
+++ b/compliance/aws/disallowed_regions/README.md
@@ -10,7 +10,7 @@ This policy finds all AWS EC2 instances within a user-specified list of disallow
 - *Account Number* - The Account number for use with the AWS STS Cross Account Role. Leave blank when using AWS IAM Access key and secret. It only needs to be passed when the desired AWS account is different than the one associated with the Flexera One credential. [more](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1123608)
 - *Exclusion Tags (Key:Value)* - Cloud native tags to ignore resources that you don't want to produce recommendations for. Use Key:Value format for specific tag key/value pairs, and Key:\* format to match any resource with a particular key, regardless of value. Examples: env:production, DO_NOT_DELETE:\*
 - *Disallow/Allow Regions* - Whether to allow or disallow the regions specified in the `Disallow/Allow Regions List` parameter. If set to "Allow", all EC2 instances outside of the listed regions will be considered out of compliance. If set to "Disallow", all EC2 instances within the listed regions will be considered out of compliance.
-- *Disallow/Allow Regions List* - A list of regions to disallow or allow.
+- *Disallow/Allow Regions List* - A list of regions to disallow or allow. Example: us-east-1
 - *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).
 
 Please note that the "Automatic Actions" parameter contains a list of action(s) that can be performed on the resources. When it is selected, the policy will automatically execute the corresponding action on the data that failed the checks, post incident generation. Please leave it blank for *manual* action.

--- a/compliance/aws/disallowed_regions/aws_disallowed_regions.pt
+++ b/compliance/aws/disallowed_regions/aws_disallowed_regions.pt
@@ -56,7 +56,7 @@ parameter "param_regions_list" do
   category "Filters"
   label "Disallow/Allow Regions List"
   description "A list of disallowed or allowed regions. See the README for more details"
-  allowed_values [ "us-east-2", "us-east-1", "us-west-1", "us-west-2", "af-south-1", "ap-east-1", "ap-south-2", "ap-southeast-3", "ap-southeast-4", "ap-south-1", "ap-northeast-3", "ap-northeast-2", "ap-southeast-1", "ap-southeast-2", "ap-northeast-1", "ca-central-1", "ca-west-1", "eu-central-1", "eu-west-1", "eu-west-2", "eu-south-1", "eu-west-3", "eu-south-2", "eu-north-1", "eu-central-2", "il-central-1", "me-south-1", "me-central-1", "sa-east-1", "us-gov-east-1", "us-gov-west-1" ]
+  allowed_pattern /^[a-z]{2}(-gov)?-[a-z]+-[0-9]+$/
   default []
 end
 

--- a/compliance/aws/disallowed_regions/aws_disallowed_regions.pt
+++ b/compliance/aws/disallowed_regions/aws_disallowed_regions.pt
@@ -1,13 +1,13 @@
 name "AWS Disallowed Regions"
 rs_pt_ver 20180301
 type "policy"
-short_description "Check for instances that are outside of an allowed region with the option to terminate them. \n See the [README](https://github.com/flexera-public/policy_templates/tree/master/compliance/aws/disallowed_regions) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "Check for instances that are outside of an allowed region with the option to stop or terminate them. See the [README](https://github.com/flexera-public/policy_templates/tree/master/compliance/aws/disallowed_regions) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.1",
+  version: "5.0",
   provider: "AWS",
   service: "Compute",
   policy_set: "Disallowed Regions"
@@ -19,8 +19,10 @@ info(
 
 parameter "param_email" do
   type "list"
-  label "Email addresses to notify"
-  description "Email addresses of the recipients you wish to notify when new incidents are created."
+  category "Policy Settings"
+  label "Email Addresses"
+  description "Email addresses of the recipients you wish to notify when new incidents are created"
+  default []
 end
 
 parameter "param_aws_account_number" do
@@ -31,34 +33,39 @@ parameter "param_aws_account_number" do
   default ""
 end
 
-parameter "param_exclude_tags" do
+parameter "param_exclusion_tags" do
   type "list"
-  category "User Inputs"
-  label "Exclusion Tag"
-  description "List of tags that will exclude EC2 instances from being evaluated by this policy. Multiple tags are evaluated as an 'OR' condition. Tag keys or key/value pairs can be listed. Example: 'test,env=dev'."
+  category "Filters"
+  label "Exclusion Tags (Key:Value)"
+  description "Cloud native tags to ignore resources that you don't want to produce recommendations for. Use Key:Value format for specific tag key/value pairs, and Key:* format to match any resource with a particular key, regardless of value. Examples: env:production, DO_NOT_DELETE:*"
+  allowed_pattern /(^$)|[\w]*\:.*/
   default []
 end
 
-parameter "param_allowed_regions_allow_or_deny" do
+parameter "param_regions_disallow_or_allow" do
   type "string"
-  label "Allow/Deny Regions"
-  description "Allow or Deny entered regions. See the README for more details"
-  allowed_values "Allow", "Deny"
-  default "Allow"
+  category "Filters"
+  label "Disallow/Allow Regions"
+  description "Disallow or Allow entered regions. See the README for more details"
+  allowed_values "Disallow", "Allow"
+  default "Disallow"
 end
 
-parameter "param_allowed_regions" do
+parameter "param_regions_list" do
   type "list"
-  label "Regions"
-  allowed_pattern /^([a-zA-Z-_]+-[a-zA-Z0-9-_]+-[0-9-_]+,*|)+$/
-  description "A list of allowed or denied regions. See the README for more details"
+  category "Filters"
+  label "Disallow/Allow Regions List"
+  description "A list of disallowed or allowed regions. See the README for more details"
+  allowed_values [ "us-east-2", "us-east-1", "us-west-1", "us-west-2", "af-south-1", "ap-east-1", "ap-south-2", "ap-southeast-3", "ap-southeast-4", "ap-south-1", "ap-northeast-3", "ap-northeast-2", "ap-southeast-1", "ap-southeast-2", "ap-northeast-1", "ca-central-1", "ca-west-1", "eu-central-1", "eu-west-1", "eu-west-2", "eu-south-1", "eu-west-3", "eu-south-2", "eu-north-1", "eu-central-2", "il-central-1", "me-south-1", "me-central-1", "sa-east-1", "us-gov-east-1", "us-gov-west-1" ]
+  default []
 end
 
 parameter "param_automatic_action" do
   type "list"
+  category "Actions"
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
-  allowed_values ["Terminate Instances"]
+  allowed_values ["Stop Instances", "Terminate Instances"]
   default []
 end
 
@@ -66,9 +73,8 @@ end
 # Authentication
 ###############################################################################
 
-#authenticate with AWS
 credentials "auth_aws" do
-  schemes "aws","aws_sts"
+  schemes "aws", "aws_sts"
   label "AWS"
   description "Select the AWS Credential from the list"
   tags "provider=aws"
@@ -86,22 +92,117 @@ end
 # Pagination
 ###############################################################################
 
-pagination "aws_pagination_xml" do
+pagination "pagination_aws" do
   get_page_marker do
-    body_path "//DescribeInstancesResponse/nextToken"
+    body_path jmes_path(response, "NextToken")
   end
   set_page_marker do
-    query "NextToken"
+    body_field "NextToken"
   end
 end
 
 ###############################################################################
-# Datasources
+# Datasources & Scripts
 ###############################################################################
 
-# ds_region_list is a list of regions that are opted-in or opt-in-not-required
-datasource "ds_regions_list" do
-  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+# Get applied policy metadata for use later
+datasource "ds_applied_policy" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    header "Api-Version", "1.0"
+  end
+end
+
+# Get region-specific Flexera API endpoints
+datasource "ds_flexera_api_hosts" do
+  run_script $js_flexera_api_hosts, rs_optima_host
+end
+
+script "js_flexera_api_hosts", type: "javascript" do
+  parameters "rs_optima_host"
+  result "result"
+  code <<-'EOS'
+  host_table = {
+    "api.optima.flexeraeng.com": {
+      flexera: "api.flexera.com",
+      fsm: "api.fsm.flexeraeng.com"
+    },
+    "api.optima-eu.flexeraeng.com": {
+      flexera: "api.flexera.eu",
+      fsm: "api.fsm-eu.flexeraeng.com"
+    },
+    "api.optima-apac.flexeraeng.com": {
+      flexera: "api.flexera.au",
+      fsm: "api.fsm-apac.flexeraeng.com"
+    }
+  }
+
+  result = host_table[rs_optima_host]
+EOS
+end
+
+# Get AWS account info
+datasource "ds_cloud_vendor_accounts" do
+  request do
+    auth $auth_flexera
+    host val($ds_flexera_api_hosts, 'flexera')
+    path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "values[*]") do
+      field "id", jmes_path(col_item, "aws.accountId")
+      field "name", jmes_path(col_item, "name")
+      field "tags", jmes_path(col_item, "tags")
+    end
+  end
+end
+
+datasource "ds_get_caller_identity" do
+  request do
+    auth $auth_aws
+    verb "GET"
+    host "sts.amazonaws.com"
+    path "/"
+    header "User-Agent", "RS Policies"
+    query "Action", "GetCallerIdentity"
+    query "Version", "2011-06-15"
+  end
+  result do
+    encoding "xml"
+    collect xpath(response, "//GetCallerIdentityResponse/GetCallerIdentityResult") do
+      field "account", xpath(col_item, "Account")
+    end
+  end
+end
+
+datasource "ds_aws_account" do
+  run_script $js_aws_account, $ds_cloud_vendor_accounts, $ds_get_caller_identity
+end
+
+script "js_aws_account", type:"javascript" do
+  parameters "ds_cloud_vendor_accounts", "ds_get_caller_identity"
+  result "result"
+  code <<-'EOS'
+  result = _.find(ds_cloud_vendor_accounts, function(account) {
+    return account['id'] == ds_get_caller_identity[0]['account']
+  })
+
+  // This is in case the API does not return the relevant account info
+  if (result == undefined) {
+    result = {
+      id: ds_get_caller_identity[0]['account'],
+      name: "",
+      tags: {}
+    }
+  }
+EOS
+end
+
+datasource "ds_describe_regions" do
   request do
     auth $auth_aws
     verb "GET"
@@ -124,125 +225,232 @@ datasource "ds_regions_list" do
   end
 end
 
-# Get only SCP enabled regions
 datasource "ds_regions" do
-  run_script $js_regions, $param_allowed_regions, $ds_regions_list, $param_allowed_regions_allow_or_deny
+  run_script $js_regions, $ds_describe_regions, $param_regions_list, $param_regions_disallow_or_allow
 end
-# Get the list of all EC2 Instances across all regions.
-# https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html
-datasource "ds_disallowed_instances_list" do
+
+script "js_regions", type:"javascript" do
+  parameters "ds_describe_regions", "param_regions_list", "param_regions_disallow_or_allow"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  // Inverted from other policies since we're looking for instances outside of these regions
+  allow_deny_test = { "Allow": false, "Disallow": true }
+
+  if (param_regions_list.length > 0) {
+    result = _.filter(ds_describe_regions, function(item) {
+      return _.contains(param_regions_list, item['region']) == allow_deny_test[param_regions_disallow_or_allow]
+    })
+  }
+EOS
+end
+
+datasource "ds_instance_sets" do
   iterate $ds_regions
   request do
     auth $auth_aws
-    pagination $aws_pagination_xml
-    verb "GET"
-    host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
-    path "/"
-    query "Action", "DescribeInstances"
-    query "Version", "2016-11-15"
+    host join(['ec2.', val(iter_item, 'region'), '.amazonaws.com'])
+    path '/'
+    header 'User-Agent', 'RS Policies'
+    header 'Content-Type', 'text/xml'
+    query 'Action', 'DescribeInstances'
+    query 'Version', '2016-11-15'
+    query 'Filter.1.Name', 'instance-state-name'
+    query 'Filter.1.Value.1', 'running'
   end
   result do
     encoding "xml"
-    collect xpath(response, "//DescribeInstancesResponse/reservationSet/item/instancesSet/item", "array") do
-      field "instance_id", xpath(col_item, "instanceId")
-      field "region", val(iter_item, "regionName")
-      field "instance_state", xpath(col_item, "instanceState/name")
-      field "instance_type", xpath(col_item, "instanceType")
-      field "tags" do
-        collect xpath(col_item, "tagSet/item") do
-          field "tagKey", xpath(col_item, "key")
-          field "tagValue", xpath(col_item, "value")
+    collect xpath(response, "//DescribeInstancesResponse/reservationSet/item", "array") do
+      field "instances_set" do
+        collect xpath(col_item,"instancesSet/item","array") do
+          field "region",val(iter_item, "region")
+          field "instanceId", xpath(col_item, "instanceId")
+          field "imageId", xpath(col_item, "imageId")
+          field "resourceType", xpath(col_item, "instanceType")
+          field "platform", xpath(col_item, "platformDetails")
+          field "privateDnsName", xpath(col_item, "privateDnsName")
+          field "launchTime", xpath(col_item, "launchTime")
+          field "tags" do
+            collect xpath(col_item,"tagSet/item", "array") do
+              field "key", xpath(col_item, "key")
+              field "value", xpath(col_item, "value")
+            end
+          end
         end
       end
     end
   end
 end
 
-datasource "ds_list_aws_instances" do
-  run_script $js_filter_aws_instances, $ds_disallowed_instances_list, $param_exclude_tags
+datasource "ds_instances" do
+  run_script $js_instances, $ds_instance_sets, $param_exclusion_tags
 end
 
-###############################################################################
-# Scripts
-###############################################################################
+script "js_instances", type: "javascript" do
+  parameters "ds_instance_sets", "param_exclusion_tags"
+  result "result"
+  code <<-'EOS'
+  result = []
 
-script "js_regions", type:"javascript" do
-  parameters "user_entered_regions", "all_regions", "regions_allow_or_deny"
-  result "regions"
-  code <<-EOS
-    if(_.isEmpty(user_entered_regions)){
-      regions = all_regions;
-    }else{
-      //Filter unique regions
-      var uniqueRegions = _.uniq(user_entered_regions);
-      var all_regions_list = [];
-      //Filter and remove denied regions from all_regions
-      if (regions_allow_or_deny == "Deny"){
-        var all_regions = all_regions.filter(function(obj){
-          return user_entered_regions.indexOf(obj.region) === -1;
-        });
-      }
-      all_regions.forEach(function(all_region){
-        all_regions_list.push(all_region.region)
-      })
-      //Filter valid regions
-      var valid_regions = [];
-      _.map(uniqueRegions, function(uniqueRegion){
-        if(all_regions_list.indexOf(uniqueRegion) > -1){
-          valid_regions.push({"region": uniqueRegion})
+  _.each(ds_instance_sets, function(item) {
+    if (param_exclusion_tags.length > 0) {
+      filtered_instances = _.reject(item['instances_set'], function(instance) {
+        instance_tags = []
+
+        if (instance['tags'] != null && instance['tags'] != undefined) {
+          _.each(instance['tags'], function(tag) {
+            instance_tags.push([tag['key'], tag['value']].join(':'))
+            instance_tags.push([tag['key'], '*'].join(':'))
+          })
         }
-      })
 
-      //Throw an error if no valid regions found
-      if (_.isEmpty(valid_regions)) {
-        regions = all_regions;
-      }else{
-        regions = valid_regions
-      }
-    }
-  EOS
-end
+        exclude_instance = false
 
-script "js_filter_aws_instances", type: "javascript" do
-  parameters "ds_disallowed_instances_list","param_exclude_tags"
-  result "res"
-  code <<-EOS
-    res = []
-    var param_exclude_tags_lower=[];
-    for(var i=0; i < param_exclude_tags.length; i++){
-      param_exclude_tags_lower[i]=param_exclude_tags[i].toString().toLowerCase();
-    }
-    for (var j = 0; j < ds_disallowed_instances_list.length; j++) {
-      var instance = ds_disallowed_instances_list[j];
-      var tags=instance['tags'];
-      var is_tag_matched=false
-      var tag_key_value=""
-      if(typeof(tags) != "undefined"){
-        for(var k=0;k<tags.length;k++){
-          var tag=tags[k];
-          if((param_exclude_tags_lower.indexOf((tag['tagKey']).toLowerCase()) !== -1) || (param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1)){
-            is_tag_matched = true;
+        _.each(param_exclusion_tags, function(exclusion_tag) {
+          if (_.contains(instance_tags, exclusion_tag)) {
+            exclude_instance = true
           }
-          // Constructing tags with comma separated to display in detail_template
-          if((tag['tagValue']).length > 0){
-            tag_key_value = tag_key_value + ', '+ tag['tagKey']+'='+tag['tagValue']
-          }else{
-            tag_key_value = tag_key_value + ', '+ tag['tagKey']
-          }
-        }
-      }
-      if(!is_tag_matched && instance['instance_state']!="terminated"){
-        res.push({
-          id: instance['instance_id'],
-          region: instance['region'],
-          instance_state: instance['instance_state'],
-          tagKeyValue: (tag_key_value.slice(1)),
-          instance_type: instance['instance_type']
         })
-      }
+
+        return exclude_instance
+      })
+
+      result = result.concat(filtered_instances)
+    } else {
+      result = result.concat(item['instances_set'])
     }
-    res = _.sortBy(res, 'region');
-  EOS
+  })
+EOS
+end
+
+datasource "ds_instances_in_bad_regions" do
+  run_script $js_instances_in_bad_regions, $ds_instances, $ds_aws_account, $ds_applied_policy, $param_regions_disallow_or_allow, $param_regions_list
+end
+
+script "js_instances_in_bad_regions", type: "javascript" do
+  parameters "ds_instances", "ds_aws_account", "ds_applied_policy", "param_regions_disallow_or_allow", "param_regions_list"
+  result "result"
+  code <<-'EOS'
+  result = _.map(ds_instances, function(instance) {
+    tags = []
+    resourceName = ""
+
+    if (instance['tags'] != undefined && instance['tags'] != null) {
+      _.each(instance['tags'], function(tag) {
+        tags.push([tag['key'], tag['value']].join('='))
+
+        if (tag['key'].toLowerCase() == 'name') { resourceName = tag['value'] }
+      })
+    }
+
+    recommendationDetails = [
+      "Terminate EC2 instance ", instance["resourceID"], " ",
+      "in AWS Account ", ds_aws_account['name'], " ",
+      "(", ds_aws_account['id'], ")"
+    ].join('')
+
+    return {
+      accountID: ds_aws_account['id'],
+      accountName: ds_aws_account['name'],
+      resourceID: instance['instanceId'],
+      resourceName: resourceName,
+      tags: tags.join(', '),
+      recommendationDetails: recommendationDetails,
+      resourceType: instance['resourceType'],
+      region: instance['region'],
+      platform: instance['platform'],
+      hostname: instance['privateDnsName'].split('.')[0],
+      launchTime: instance['launchTime'],
+      service: "EC2",
+      policy_name: ds_applied_policy['name'],
+      message: ""
+    }
+  })
+
+  total_instances = result.length
+
+  instance_phrase = "instances were"
+  if (total_instances == 1) { instance_phrase = "instance was" }
+
+  region_phrase = "in"
+  if (param_regions_disallow_or_allow == 'Allow') { region_phrase = "outside of" }
+
+  region_adj = "disallowed"
+  if (param_regions_disallow_or_allow == 'Allow') { region_adj = "allowed" }
+
+  findings = [
+    total_instances, " AWS EC2 ", instance_phrase,
+    " found ", region_phrase, " the following ", region_adj,
+    " regions: ", param_regions_list.join(', '), ".\n\n"
+  ].join('')
+
+  disclaimer = "The above settings can be modified by editing the applied policy and changing the appropriate parameters."
+
+  // Dummy entry to ensure validation occurs at least once
+  result.push({ resourceID: "", tags: "", policy_name: "", message: "" })
+
+  result[0]['message'] = findings + disclaimer
+EOS
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "pol_disallowed_regions" do
+  validate_each $ds_instances_in_bad_regions do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} AWS EC2 Instances In Disallowed Regions Found"
+    detail_template "{{ with index data 0 }}{{ .message }}{{ end }}"
+    check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
+    escalate $esc_email
+    escalate $esc_stop_instances
+    escalate $esc_terminate_instances
+    hash_exclude "message", "tags"
+    export do
+      resource_level true
+      field "accountID" do
+        label "Account ID"
+      end
+      field "accountName" do
+        label "Account Name"
+      end
+      field "resourceID" do
+        label "Resource ID"
+      end
+      field "resourceName" do
+        label "Resource Name"
+      end
+      field "tags" do
+        label "Resource Tags"
+      end
+      field "recommendationDetails" do
+        label "Recommendation"
+      end
+      field "resourceType" do
+        label "Instance Size"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "platform" do
+        label "Platform"
+      end
+      field "hostname" do
+        label "Hostname"
+      end
+      field "launchTime" do
+        label "Launch Time"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "id" do
+        label "ID"
+        path "resourceID"
+      end
+    end
+  end
 end
 
 ###############################################################################
@@ -251,108 +459,168 @@ end
 
 escalation "esc_email" do
   automatic true
-  label "Send Mail"
-  description "Sends incident email"
+  label "Send Email"
+  description "Send incident email"
   email $param_email
 end
 
-escalation "esc_terminate_instances_disallowed_region" do
-  automatic contains($param_automatic_action, "Terminate Instances")
-  label "Delete Instances"
-  description "Delete instances found in disallowd regions."
-  run "terminate_instances", data, rs_optima_host
+escalation "esc_stop_instances" do
+  automatic contains($param_automatic_action, "Stop Instances")
+  label "Stop Instances"
+  description "Approval to stop all selected instances"
+  run "stop_instances", data
 end
 
-###############################################################################
-# Policy
-###############################################################################
-
-policy "pol_list_aws_instances" do
-  validate $ds_list_aws_instances do
-    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} AWS Instance(s) in Disallowed regions"
-    export do
-      resource_level true
-      field "id" do
-        label "Instance ID"
-      end
-      field "instance_state" do
-        label "Instance State"
-      end
-      field "region" do
-        label "Region"
-      end
-      field "instance_type" do
-        label "Instance Type"
-      end
-      field "tagKeyValue" do
-        label "Tags"
-      end
-    end
-    # Policy check fails and incident is created only if data is not empty and the Parent Policy has not been terminated
-    check logic_or($ds_parent_policy_terminated, eq(size(data),0))
-    escalate $esc_email
-    escalate $esc_terminate_instances_disallowed_region
-  end
+escalation "esc_terminate_instances" do
+  automatic contains($param_automatic_action, "Terminate Instances")
+  label "Terminate Instances"
+  description "Approval to terminate all selected instances"
+  run "terminate_instances", data
 end
 
 ###############################################################################
 # Cloud Workflow
 ###############################################################################
 
-# https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TerminateInstances.html
-define terminate_instances($data, $$rs_optima_host) return $all_responses do
-  $$debug=true
-  $all_responses = []
-  foreach $item in $data do
-  sub on_error: skip do
-  $response = http_request(
-      verb: "get",
-      host: join(["ec2.",$item["region"],".amazonaws.com"]),
-      auth: $$auth_aws,
-      href: join(["/", "?Action=TerminateInstances", "&InstanceId.1=", $item["id"], "&Version=2016-11-15"]),
-      https: true,
-      headers:{
-        "cache-control": "no-cache",
-        "content-type": "application/json"
-      }
-    )
-    $all_responses << $response
-    call sys_log('terminate instances in disallowed region response',to_s($response))
+# Core CWF function to stop instances
+define stop_instances($data) do
+  foreach $instance in $data do
+    sub on_error: handle_error() do
+      call get_instance_state($instance) retrieve $initial_state
+
+      if $initial_state != "terminated" && $initial_state != "pending"
+        if $initial_state != "stopped"
+          call stop_instance($instance)
+        end
+      end
     end
+  end
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
   end
 end
 
-define sys_log($subject, $detail) do
-  # Create empty errors array if doesn't already exist
+# Core CWF function to terminate instances
+define terminate_instances($data) do
+  foreach $instance in $data do
+    sub on_error: handle_error() do
+      call get_instance_state($instance) retrieve $initial_state
+
+      if $initial_state != "terminated" && $initial_state != "pending"
+        call terminate_instance($instance)
+      end
+    end
+  end
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+end
+
+# CWF function to get the current state of an instance
+define get_instance_state($instance) return $instance_state do
+  task_label("Getting Instance State: " + $instance["id"])
+  $response = http_request(
+    auth: $$auth_aws,
+    https: true,
+    verb: "post",
+    href: "/",
+    host: "ec2." + $instance["region"] + ".amazonaws.com",
+    query_strings: {
+      "Action": "DescribeInstanceStatus",
+      "Version": "2016-11-15",
+      "IncludeAllInstances": "true",
+      "InstanceId.1": $instance["id"]
+    }
+  )
+  call handle_response($response)
+  $instance_state = $response["body"]["DescribeInstanceStatusResponse"]["instanceStatusSet"]["item"]["instanceState"]["name"]
+end
+
+# CWF function to stop an instance
+define stop_instance($instance) return $response do
+  task_label("Stopping Instance: " + $instance["id"])
+  $response = http_request(
+    auth: $$auth_aws,
+    https: true,
+    verb: "post",
+    href: "/",
+    host: "ec2." + $instance['region'] + ".amazonaws.com",
+    query_strings: {
+      "Action": "StopInstances",
+      "Version": "2016-11-15",
+      "InstanceId.1": $instance["id"]
+    }
+  )
+  call handle_response($response)
+
+  task_label("Checking for expected response code for Stop Instance: " + $instance["id"])
+  if $response["code"] != 202 && $response["code"] != 200
+    raise 'Unexpected response Stop Instance: '+to_json($response)
+  else
+    task_label("Successful Stop Instance: " + $instance["id"])
+    call get_instance_state($instance) retrieve $instance_state
+    while $instance_state != "stopped" do
+      call get_instance_state($instance) retrieve $instance_state
+      task_label("Waiting for Stop.. Instance State: " + $instance["id"] +" "+ $instance_state)
+      sleep(10)
+    end
+    task_label("Completed Stop Instance: " + $instance["id"])
+  end
+end
+
+# CWF function to terminate an instance
+define terminate_instance($instance) return $response do
+  task_label("Terminating Instance: " + $instance["id"])
+  $response = http_request(
+    auth: $$auth_aws,
+    https: true,
+    verb: "post",
+    href: "/",
+    host: "ec2." + $instance["region"] + ".amazonaws.com",
+    query_strings: {
+      "Action": "TerminateInstances",
+      "Version": "2016-11-15",
+      "InstanceId.1": $instance["id"]
+    }
+  )
+  call handle_response($response)
+
+  task_label("Checking for expected response code for Terminate Instance: " + $instance["id"])
+  if $response["code"] != 202 && $response["code"] != 200
+    raise 'Unexpected response Terminate Instance: '+to_json($response)
+  else
+    task_label("Successful Terminate Instance: " + $instance["id"])
+    call get_instance_state($instance) retrieve $instance_state
+    while $instance_state != "terminated" do
+      call get_instance_state($instance) retrieve $instance_state
+      task_label("Waiting for Terminate Instance: " + $instance["id"] +" "+ $instance_state)
+      sleep(10)
+    end
+    task_label("Completed Modify Instance: " + $instance["id"])
+  end
+end
+
+# CWF function to handle responses
+define handle_response($response) do
+  if !$$all_responses
+    $$all_responses = []
+  end
+  # Convert response object to JSON string.  Easier to interpret
+  $$all_responses << to_json($response)
+end
+
+# CWF function to handle errors
+define handle_error() do
   if !$$errors
     $$errors = []
   end
-  # Check if debug is enabled
-  if $$debug
-    # Append to global $$errors
-    # This is the suggested way to capture errors
-    $$errors << "Unexpected error for " + $subject + "\n  " + to_s($detail)
-    # If Flexera NAM Zone, create audit_entries [to be deprecated]
-    # This is the legacy method for capturing errors and only supported on Flexera NAM
-    if $$rs_optima_host == "api.optima.flexeraeng.com"
-      # skip_error_and_append is used to catch error if rs_cm.audit_entries.create fails unexpectedly
-      $task_label = "Creating audit entry for " + $subject
-      sub task_label: $task, on_error: skip_error_and_append($task) do
-        rs_cm.audit_entries.create(
-          notify: "None",
-          audit_entry: {
-            auditee_href: @@account,
-            summary: $subject,
-            detail: $detail
-          }
-        )
-      end # End sub on_error
-    end # End if rs_optima_host
-  end # End if debug is enabled
-end
-
-define skip_error_and_append($subject) do
-  $$errors << "Unexpected error for " + $subject + "\n  " + to_s($_error)
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
   $_error_behavior = "skip"
 end
 
@@ -376,7 +644,6 @@ datasource "ds_get_policy" do
     field "id", jmes_path(response, "id")
   end
 end
-
 
 datasource "ds_parent_policy_terminated" do
   run_script $js_decide_if_self_terminate, $ds_get_policy, policy_id, meta_parent_policy_id

--- a/compliance/aws/disallowed_regions/aws_disallowed_regions_meta_parent.pt
+++ b/compliance/aws/disallowed_regions/aws_disallowed_regions_meta_parent.pt
@@ -89,7 +89,7 @@ parameter "param_regions_list" do
   category "Filters"
   label "Disallow/Allow Regions List"
   description "A list of disallowed or allowed regions. See the README for more details"
-  allowed_values [ "us-east-2", "us-east-1", "us-west-1", "us-west-2", "af-south-1", "ap-east-1", "ap-south-2", "ap-southeast-3", "ap-southeast-4", "ap-south-1", "ap-northeast-3", "ap-northeast-2", "ap-southeast-1", "ap-southeast-2", "ap-northeast-1", "ca-central-1", "ca-west-1", "eu-central-1", "eu-west-1", "eu-west-2", "eu-south-1", "eu-west-3", "eu-south-2", "eu-north-1", "eu-central-2", "il-central-1", "me-south-1", "me-central-1", "sa-east-1", "us-gov-east-1", "us-gov-west-1" ]
+  allowed_pattern /^[a-z]{2}(-gov)?-[a-z]+-[0-9]+$/
   default []
 end
 

--- a/compliance/aws/disallowed_regions/aws_disallowed_regions_meta_parent.pt
+++ b/compliance/aws/disallowed_regions/aws_disallowed_regions_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "4.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 
@@ -66,34 +66,39 @@ parameter "param_template_source" do
 end
 
 ## Child Policy Parameters
-parameter "param_exclude_tags" do
+parameter "param_exclusion_tags" do
   type "list"
-  category "User Inputs"
-  label "Exclusion Tag"
-  description "List of tags that will exclude EC2 instances from being evaluated by this policy. Multiple tags are evaluated as an 'OR' condition. Tag keys or key/value pairs can be listed. Example: 'test,env=dev'."
+  category "Filters"
+  label "Exclusion Tags (Key:Value)"
+  description "Cloud native tags to ignore resources that you don't want to produce recommendations for. Use Key:Value format for specific tag key/value pairs, and Key:* format to match any resource with a particular key, regardless of value. Examples: env:production, DO_NOT_DELETE:*"
+  allowed_pattern /(^$)|[\w]*\:.*/
   default []
 end
 
-parameter "param_allowed_regions_allow_or_deny" do
+parameter "param_regions_disallow_or_allow" do
   type "string"
-  label "Allow/Deny Regions"
-  description "Allow or Deny entered regions. See the README for more details"
-  allowed_values "Allow", "Deny"
-  default "Allow"
+  category "Filters"
+  label "Disallow/Allow Regions"
+  description "Disallow or Allow entered regions. See the README for more details"
+  allowed_values "Disallow", "Allow"
+  default "Disallow"
 end
 
-parameter "param_allowed_regions" do
+parameter "param_regions_list" do
   type "list"
-  label "Regions"
-  allowed_pattern /^([a-zA-Z-_]+-[a-zA-Z0-9-_]+-[0-9-_]+,*|)+$/
-  description "A list of allowed or denied regions. See the README for more details"
+  category "Filters"
+  label "Disallow/Allow Regions List"
+  description "A list of disallowed or allowed regions. See the README for more details"
+  allowed_values [ "us-east-2", "us-east-1", "us-west-1", "us-west-2", "af-south-1", "ap-east-1", "ap-south-2", "ap-southeast-3", "ap-southeast-4", "ap-south-1", "ap-northeast-3", "ap-northeast-2", "ap-southeast-1", "ap-southeast-2", "ap-northeast-1", "ca-central-1", "ca-west-1", "eu-central-1", "eu-west-1", "eu-west-2", "eu-south-1", "eu-west-3", "eu-south-2", "eu-north-1", "eu-central-2", "il-central-1", "me-south-1", "me-central-1", "sa-east-1", "us-gov-east-1", "us-gov-west-1" ]
+  default []
 end
 
 parameter "param_automatic_action" do
   type "list"
+  category "Actions"
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
-  allowed_values ["Terminate Instances"]
+  allowed_values ["Stop Instances", "Terminate Instances"]
   default []
 end
 
@@ -101,7 +106,7 @@ end
 # Authentication
 ###############################################################################
 credentials "auth_aws" do
-  schemes "aws","aws_sts"
+  schemes "aws", "aws_sts"
   label "AWS"
   description "Select the AWS Credential from the list"
   tags "provider=aws"
@@ -731,19 +736,19 @@ datasource "ds_child_incident_details" do
   end
 end
 
-datasource "ds_list_aws_instances_combined_incidents" do
-  run_script $js_ds_list_aws_instances_combined_incidents, $ds_child_incident_details
+datasource "ds_instances_in_bad_regions_combined_incidents" do
+  run_script $js_ds_instances_in_bad_regions_combined_incidents, $ds_child_incident_details
 end
 
-script "js_ds_list_aws_instances_combined_incidents", type: "javascript" do
+script "js_ds_instances_in_bad_regions_combined_incidents", type: "javascript" do
   parameters "ds_child_incident_details"
   result "result"
   code <<-EOS
   result = []
   _.each(ds_child_incident_details, function(incident) {
     s = incident["summary"];
-    // If the incident summary contains "in Disallowed regions" then include it in the filter result
-    if (s.indexOf("in Disallowed regions") > -1) {
+    // If the incident summary contains "AWS EC2 Instances In Disallowed Regions Found" then include it in the filter result
+    if (s.indexOf("AWS EC2 Instances In Disallowed Regions Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
         violation["incident_id"] = incident["id"];
         result.push(violation);
@@ -754,15 +759,26 @@ EOS
 end
 
 
-# Escalation for Delete Instances
-escalation "esc_terminate_instances_disallowed_region" do
+# Escalation for Stop Instances
+escalation "esc_stop_instances" do
   automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Delete Instances"
-  description "Delete instances found in disallowd regions."
-  run "esc_terminate_instances_disallowed_region", data, rs_governance_host, rs_project_id
+  label "Stop Instances"
+  description "Approval to stop all selected instances"
+  run "esc_stop_instances", data, rs_governance_host, rs_project_id
 end
-define esc_terminate_instances_disallowed_region($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Delete Instances")
+define esc_stop_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Stop Instances")
+end
+
+# Escalation for Terminate Instances
+escalation "esc_terminate_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Terminate Instances"
+  description "Approval to terminate all selected instances"
+  run "esc_terminate_instances", data, rs_governance_host, rs_project_id
+end
+define esc_terminate_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instances")
 end
 
 
@@ -772,28 +788,53 @@ end
 # Could also just have one incident and use meta_status to determine which escalation happens
 policy "policy_scheduled_report" do
   # Consolidated Incident Check(s)
-    # Consolidated incident for in Disallowed regions
-  validate $ds_list_aws_instances_combined_incidents do
-    summary_template "Consolidated Incident: {{ len data }} in Disallowed regions"
+    # Consolidated incident for AWS EC2 Instances In Disallowed Regions Found
+  validate $ds_instances_in_bad_regions_combined_incidents do
+    summary_template "Consolidated Incident: {{ len data }} AWS EC2 Instances In Disallowed Regions Found"
     escalate $esc_email
-    escalate $esc_terminate_instances_disallowed_region
+    escalate $esc_stop_instances
+    escalate $esc_terminate_instances
     check eq(size(data), 0)
     export do
       resource_level true
-      field "id" do
-        label "Instance ID"
+      field "accountID" do
+        label "Account ID"
       end
-      field "instance_state" do
-        label "Instance State"
+      field "accountName" do
+        label "Account Name"
+      end
+      field "resourceID" do
+        label "Resource ID"
+      end
+      field "resourceName" do
+        label "Resource Name"
+      end
+      field "tags" do
+        label "Resource Tags"
+      end
+      field "recommendationDetails" do
+        label "Recommendation"
+      end
+      field "resourceType" do
+        label "Instance Size"
       end
       field "region" do
         label "Region"
       end
-      field "instance_type" do
-        label "Instance Type"
+      field "platform" do
+        label "Platform"
       end
-      field "tagKeyValue" do
-        label "Tags"
+      field "hostname" do
+        label "Hostname"
+      end
+      field "launchTime" do
+        label "Launch Time"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "id" do
+        label "ID"
       end
       field "incident_id" do
         label "Child Incident ID"


### PR DESCRIPTION
### Description

This is a revamp of the AWS Disallowed Regions policy. Both the policy itself and CWF code for actions have been updated. Most of the code was adapted from similar policies that have received similar improvements. From the CHANGELOG:

- Several parameters altered to be more descriptive and human-readable
- Added ability to filter resources by multiple tag key:value pairs
- Added additional context to incident description
- Normalized incident export to be consistent with other policies
- Added human-readable recommendation to incident export
- Policy no longer raises new escalations if tag data has changed for an instance
- Policy action error logging modernized and now works as expected in EU/APAC
- Streamlined code for better readability and faster execution

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=659c42e39f8a200001eceef0

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
