### PR TITLE
FOPTS-2229 Added a way to url decode the skiptoken

### DIFF
--- a/operational/itam/schedule_itam_report/CHANGELOG.md
+++ b/operational/itam/schedule_itam_report/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.1.2
 
-- Added a filter to convert `%3D` to his corresponding `=` symbol to prevent bad api token request.
+- Before this change the policy wont be able to retrieve all the corresponding data because the request has an extra symbol, now a filter was applied that convert to the correct value to prevent a bad request
 
 ## v0.1.1
 

--- a/operational/itam/schedule_itam_report/CHANGELOG.md
+++ b/operational/itam/schedule_itam_report/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.1.2
 
-- Before this change the policy wont be able to retrieve all the corresponding data because the request has an extra symbol, now a filter was applied that convert to the correct value to prevent a bad request
+- Fixed pagination bug that caused the `skipToken` query parameter to be sent with extra equal sign characters in the URL, thus making an HTTP request fail.
 
 ## v0.1.1
 

--- a/operational/itam/schedule_itam_report/CHANGELOG.md
+++ b/operational/itam/schedule_itam_report/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.1.2
 
-- Added a way to decode the pagination token
+- Added a filter to convert `%3D` to his corresponding `=` symbol to prevent bad api token request.
 
 ## v0.1.1
 

--- a/operational/itam/schedule_itam_report/CHANGELOG.md
+++ b/operational/itam/schedule_itam_report/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.1.1
+## v0.1.2
 
 - Added a way to decode the pagination token
 

--- a/operational/itam/schedule_itam_report/CHANGELOG.md
+++ b/operational/itam/schedule_itam_report/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.1.2
 
-- Fixed pagination bug that caused the `skipToken` query parameter to be sent with extra equal sign characters in the URL, thus making an HTTP request fail.
+- Fixed a pagination bug that caused an error when the policy template requested information from the IT Asset Management (ITAM) server, thus failing the execution.
 
 ## v0.1.1
 

--- a/operational/itam/schedule_itam_report/CHANGELOG.md
+++ b/operational/itam/schedule_itam_report/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.1.1
 
+- Added a way to decode the pagination token
+
+## v0.1.1
+
 - Fixed the broken link for the README at the policy template file
 
 ## v0.1.0

--- a/operational/itam/schedule_itam_report/schedule-itam-report.pt
+++ b/operational/itam/schedule_itam_report/schedule-itam-report.pt
@@ -7,7 +7,7 @@ severity "medium"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "0.1.1",
+  version: "0.1.2",
   provider: "Flexera ITAM",
   service: "",
   policy_set: "Schedule Flexera ITAM Report"
@@ -54,7 +54,7 @@ end
 
 pagination "itam_pagination" do
   get_page_marker do
-    body_path jq(response, 'try(.nextPage | split("skipToken=") | .[1] | rtrimstr("%3D") | .+"=") catch null') # The skipToken is url encoded, so we need to decode the %3D to = .  This is not ideal implementation this seems to be enough without a true urldecode function
+    body_path jq(response, 'try(.nextPage | split("skipToken=") | .[1] | sub("%3D";"=") | .+"=") catch null') # The skipToken is url encoded, so we need to decode the %3D to = .  This is not ideal implementation this seems to be enough without a true urldecode function
   end
   set_page_marker do
     query "skipToken"

--- a/operational/itam/schedule_itam_report/schedule-itam-report.pt
+++ b/operational/itam/schedule_itam_report/schedule-itam-report.pt
@@ -54,7 +54,7 @@ end
 
 pagination "itam_pagination" do
   get_page_marker do
-    body_path jq(response, 'try(.nextPage | split("skipToken=") | .[1] | sub("%3D";"=")) catch null') # The skipToken is url encoded, so we need to decode the %3D to = .  This is not ideal implementation this seems to be enough without a true urldecode function
+    body_path jq(response, 'try(.nextPage | split("skipToken=") | .[1] | sub("%3D";"=";"g") | sub("%253D";"=";"g")) catch null') # The skipToken is url encoded, so we need to decode the %3D and %253D to = .  This is not ideal implementation this seems to be enough without a true urldecode function
   end
   set_page_marker do
     query "skipToken"

--- a/operational/itam/schedule_itam_report/schedule-itam-report.pt
+++ b/operational/itam/schedule_itam_report/schedule-itam-report.pt
@@ -54,7 +54,7 @@ end
 
 pagination "itam_pagination" do
   get_page_marker do
-    body_path jq(response, 'try(.nextPage | split("skipToken=") | .[1] | sub("%3D";"=") | .+"=") catch null') # The skipToken is url encoded, so we need to decode the %3D to = .  This is not ideal implementation this seems to be enough without a true urldecode function
+    body_path jq(response, 'try(.nextPage | split("skipToken=") | .[1] | sub("%3D";"=")) catch null') # The skipToken is url encoded, so we need to decode the %3D to = .  This is not ideal implementation this seems to be enough without a true urldecode function
   end
   set_page_marker do
     query "skipToken"


### PR DESCRIPTION
### Description

Replaced the jq function used from rt

### Issues Resolved

[FOPTS-2229](https://flexera.atlassian.net/browse/FOPTS-2229)

### Link to Example Applied Policy

https://app.flexera.com/orgs/28576/automation/applied-policies/projects/126887?policyId=659c762c9f8a200001ecef8a

If you don't have access to testing org 28576, you can watch the following GIF that shows the fixed error related to pagination:

![itam_report_fixed_demo](https://github.com/flexera-public/policy_templates/assets/54189123/3381ea20-a6e2-484a-b326-3b68a4a3c2ee)


### Contribution Check List

- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
