### PR TITLE
POL-958 Add 'Minimum Age' to Azure Rightsize SQL

### DIFF
--- a/cost/azure/rightsize_sql_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_sql_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.3
+
+- Added optional `Minimum Age (Days)` parameter to filter results by age
+
 ## v4.2
 
 - Policy action error logging modernized and now works as expected in EU/APAC

--- a/cost/azure/rightsize_sql_instances/README.md
+++ b/cost/azure/rightsize_sql_instances/README.md
@@ -29,6 +29,7 @@ The policy includes the estimated monthly savings. The estimated monthly savings
 - *Email Addresses* - Email addresses of the recipients you wish to notify when new incidents are created.
 - *Azure Endpoint* - The endpoint to send Azure API requests to. Recommended to leave this at default unless using this policy with Azure China.
 - *Minimum Savings Threshold* - Minimum potential savings required to generate a recommendation.
+- *Minimum Age (Days)* - The minimum age, in days, since a SQL database was created to produce recommendations for it. Set to 0 to ignore age entirely.
 - *Allow/Deny Subscriptions* - Determines whether the Allow/Deny Subscriptions List parameter functions as an allow list (only providing results for the listed subscriptions) or a deny list (providing results for all subscriptions except for the listed subscriptions).
 - *Allow/Deny Subscriptions List* - A list of allowed or denied Subscription IDs/names. If empty, no filtering will occur and recommendations will be produced for all subscriptions.
 - *Allow/Deny Regions* - Whether to treat Allow/Deny Regions List parameter as allow or deny list. Has no effect if Allow/Deny Regions List is left empty.

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.2",
+  version: "4.3",
   provider: "Azure",
   service: "SQL",
   policy_set: "Rightsize Database Instances",
@@ -42,6 +42,15 @@ parameter "param_min_savings" do
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
   default 0
+end
+
+parameter "param_minimum_age" do
+  type "number"
+  category "Policy Settings"
+  label "Minimum Age (Days)"
+  description "The minimum age, in days, since a SQL database was created to produce recommendations for it. Set to 0 to ignore age entirely."
+  default 0
+  min_value 0
 end
 
 parameter "param_subscriptions_allow_or_deny" do
@@ -331,6 +340,7 @@ datasource "ds_azure_sql_databases" do
       field "kind", jmes_path(col_item, "kind")
       field "sku" , jmes_path(col_item, "sku")
       field "tags", jmes_path(col_item, "tags")
+      field "createdTime", jmes_path(col_item, "createdTime")
       field "resourceGroup", get(4, split(jmes_path(col_item,"id"), "/"))
       field "subscriptionId",val(iter_item, "id")
       field "subscriptionName",val(iter_item, "name")
@@ -338,15 +348,38 @@ datasource "ds_azure_sql_databases" do
   end
 end
 
+datasource "ds_azure_sql_databases_age_filtered" do
+  run_script $js_azure_sql_databases_age_filtered, $ds_azure_sql_databases, $param_minimum_age
+end
+
+script "js_azure_sql_databases_age_filtered", type: "javascript" do
+  parameters "ds_azure_sql_databases", "param_minimum_age"
+  result "result"
+  code <<-EOS
+  if (param_minimum_age > 0) {
+    today = new Date()
+
+    result = _.filter(ds_azure_sql_databases, function(db) {
+      created = new Date(db['createdTime'])
+      age = Math.round((today - created) / 1000 / 60 / 60 / 24)
+
+      return age >= param_minimum_age
+    })
+  } else {
+    result = ds_azure_sql_databases
+  }
+EOS
+end
+
 datasource "ds_azure_sql_databases_system_filtered" do
-  run_script $js_azure_sql_databases_system_filtered, $ds_azure_sql_databases
+  run_script $js_azure_sql_databases_system_filtered, $ds_azure_sql_databases_age_filtered
 end
 
 script "js_azure_sql_databases_system_filtered", type: "javascript" do
-  parameters "ds_azure_sql_databases"
+  parameters "ds_azure_sql_databases_age_filtered"
   result "result"
   code <<-EOS
-  result = _.reject(ds_azure_sql_databases, function(db) {
+  result = _.reject(ds_azure_sql_databases_age_filtered, function(db) {
     sku_name = null
     if (typeof(db['sku']) == 'object') { sku_name = db['sku']['name'] }
 
@@ -512,6 +545,7 @@ script "js_merged_metrics", type: "javascript" do
       type: db['type'],
       sku: db['sku'],
       tags: db_tags.join(', '),
+      createdTime: db['createdTime'],
       resourceGroup: db['resourceGroup'],
       subscriptionId: db['subscriptionId'],
       subscriptionName: db['subscriptionName'],
@@ -767,6 +801,7 @@ script "js_downsize_sql_incident", type: "javascript" do
         resourceType: db['type'],
         sku: db['sku'],
         tags: db['tags'],
+        createdTime: db['createdTime'],
         resourceGroup: db['resourceGroup'],
         accountID: db['subscriptionId'],
         accountName: db['subscriptionName'],
@@ -836,7 +871,7 @@ script "js_downsize_sql_incident", type: "javascript" do
     newResourceType: "",    cpuAverage: "",            lookbackPeriod: "",
     threshold: "",          policy_name: "",           savings: "",
     savingsCurrency: "",    service: "",               platform: "",
-    total_savings: "",      message: ""
+    createdTime: "",        total_savings: "",         message: ""
   })
 
   result[0]['total_savings'] = savings_message
@@ -898,6 +933,7 @@ script "js_unused_sql_incident", type: "javascript" do
         resourceType: db['type'],
         sku: db['sku'],
         tags: db['tags'],
+        createdTime: db['createdTime'],
         resourceGroup: db['resourceGroup'],
         accountID: db['subscriptionId'],
         accountName: db['subscriptionName'],
@@ -955,7 +991,8 @@ script "js_unused_sql_incident", type: "javascript" do
     accountName: "",       recommendationType: "",    recommendationDetails: "",
     lookbackPeriod: "",    threshold: "",             policy_name: "",
     savings: "",           savingsCurrency: "",       service: "",
-    platform: "",          total_savings: "",         message: ""
+    platform: "",          createdTime: "",           total_savings: "",
+    message: ""
   })
 
   result[0]['total_savings'] = savings_message
@@ -996,6 +1033,9 @@ policy "pol_azure_sql_utilization" do
       end
       field "tags" do
         label "Resource Tags"
+      end
+      field "createdTime" do
+        label "Created At"
       end
       field "recommendationDetails" do
         label "Recommendation"
@@ -1078,6 +1118,9 @@ policy "pol_azure_sql_utilization" do
       end
       field "tags" do
         label "Resource Tags"
+      end
+      field "createdTime" do
+        label "Created At"
       end
       field "recommendationDetails" do
         label "Recommendation"

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
@@ -326,6 +326,7 @@ datasource "ds_azure_sql_databases" do
     path join(["/subscriptions/", val(iter_item, "id"), "/resources"])
     query "api-version", "2019-08-01"
     query "$filter", "resourceType eq 'Microsoft.Sql/servers/databases'"
+    query "$expand", "createdTime"
     header "User-Agent", "RS Policies"
     # Ignore status 400, 403, and 404 which can be returned in certain (legacy) types of Azure Subscriptions
     ignore_status [400,403,404]
@@ -747,11 +748,11 @@ EOS
 end
 
 datasource "ds_downsize_sql_incident" do
-  run_script $js_downsize_sql_incident, $ds_merged_metrics, $ds_azure_sql_databases_region_filtered, $ds_sql_costs_grouped, $ds_currency, $param_min_savings, $param_stats_lookback, $param_stats_underutil_threshold_cpu_value, $param_unused_or_underutilized
+  run_script $js_downsize_sql_incident, $ds_merged_metrics, $ds_azure_sql_databases_region_filtered, $ds_sql_costs_grouped, $ds_currency, $param_min_savings, $param_stats_lookback, $param_stats_underutil_threshold_cpu_value, $param_unused_or_underutilized, $param_minimum_age
 end
 
 script "js_downsize_sql_incident", type: "javascript" do
-  parameters "ds_merged_metrics", "ds_azure_sql_databases_region_filtered", "ds_sql_costs_grouped", "ds_currency", "param_min_savings", "param_stats_lookback", "param_stats_underutil_threshold_cpu_value", "param_unused_or_underutilized"
+  parameters "ds_merged_metrics", "ds_azure_sql_databases_region_filtered", "ds_sql_costs_grouped", "ds_currency", "param_min_savings", "param_stats_lookback", "param_stats_underutil_threshold_cpu_value", "param_unused_or_underutilized", "param_minimum_age"
   result "result"
   code <<-'EOS'
   // Function for formatting currency numbers later
@@ -848,14 +849,24 @@ script "js_downsize_sql_incident", type: "javascript" do
     context_message = [
       "An Azure SQL Database is considered underutilized if it has an average CPU usage below ",
       param_stats_underutil_threshold_cpu_value, "% for the last ", param_stats_lookback, " ", day_message,
-      ", regardless of whether it has had any connections to it in that same time period.\n\n"
+      ", regardless of whether it has had any connections to it in that same time period. "
     ].join('')
   } else {
     context_message = [
       "An Azure SQL Database is considered underutilized if it has had at least one connection to it ",
       "in the last ", param_stats_lookback, " ", day_message, " but has an average CPU usage below ",
-      param_stats_underutil_threshold_cpu_value, "% for that same time period.\n\n"
+      param_stats_underutil_threshold_cpu_value, "% for that same time period. "
     ].join('')
+  }
+
+  min_age_message = "Results were not filtered by age.\n\n"
+
+  if (param_minimum_age == 1) {
+    min_age_message = "Only Azure SQL Databases created more than 1 day ago were included in the results.\n\n"
+  }
+
+  if (param_minimum_age > 1) {
+    min_age_message = "Only Azure SQL Databases created more than " + param_minimum_age + " days ago were included in the results.\n\n"
   }
 
   disclaimer = "The above settings can be modified by editing the applied policy and changing the appropriate parameters.\n\n"
@@ -875,16 +886,16 @@ script "js_downsize_sql_incident", type: "javascript" do
   })
 
   result[0]['total_savings'] = savings_message
-  result[0]['message'] = findings + context_message + disclaimer
+  result[0]['message'] = findings + context_message + min_age_message + disclaimer
 EOS
 end
 
 datasource "ds_unused_sql_incident" do
-  run_script $js_unused_sql_incident, $ds_merged_metrics, $ds_azure_sql_databases_region_filtered, $ds_sql_costs_grouped, $ds_currency, $param_min_savings, $param_stats_lookback
+  run_script $js_unused_sql_incident, $ds_merged_metrics, $ds_azure_sql_databases_region_filtered, $ds_sql_costs_grouped, $ds_currency, $param_min_savings, $param_stats_lookback, $param_minimum_age
 end
 
 script "js_unused_sql_incident", type: "javascript" do
-  parameters "ds_merged_metrics", "ds_azure_sql_databases_region_filtered", "ds_sql_costs_grouped", "ds_currency", "param_min_savings", "param_stats_lookback"
+  parameters "ds_merged_metrics", "ds_azure_sql_databases_region_filtered", "ds_sql_costs_grouped", "ds_currency", "param_min_savings", "param_stats_lookback", "param_minimum_age"
   result "result"
   code <<-'EOS'
   // Function for formatting currency numbers later
@@ -976,8 +987,18 @@ script "js_unused_sql_incident", type: "javascript" do
 
   context_message = [
     "An Azure SQL Database is considered unused if it has not had any connections ",
-    "for at least ", param_stats_lookback, " ", day_message, ".\n\n"
+    "for at least ", param_stats_lookback, " ", day_message, ". "
   ].join('')
+
+  min_age_message = "Results were not filtered by age.\n\n"
+
+  if (param_minimum_age == 1) {
+    min_age_message = "Only Azure SQL Databases created more than 1 day ago were included in the results.\n\n"
+  }
+
+  if (param_minimum_age > 1) {
+    min_age_message = "Only Azure SQL Databases created more than " + param_minimum_age + " days ago were included in the results.\n\n"
+  }
 
   disclaimer = "The above settings can be modified by editing the applied policy and changing the appropriate parameters.\n\n"
 
@@ -996,7 +1017,7 @@ script "js_unused_sql_incident", type: "javascript" do
   })
 
   result[0]['total_savings'] = savings_message
-  result[0]['message'] = findings + context_message + disclaimer
+  result[0]['message'] = findings + context_message + min_age_message + disclaimer
 EOS
 end
 

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 
@@ -82,6 +82,15 @@ parameter "param_min_savings" do
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
   default 0
+end
+
+parameter "param_minimum_age" do
+  type "number"
+  category "Policy Settings"
+  label "Minimum Age (Days)"
+  description "The minimum age, in days, since a SQL database was created to produce recommendations for it. Set to 0 to ignore age entirely."
+  default 0
+  min_value 0
 end
 
 parameter "param_regions_allow_or_deny" do
@@ -888,6 +897,9 @@ policy "policy_scheduled_report" do
       field "tags" do
         label "Resource Tags"
       end
+      field "createdTime" do
+        label "Created At"
+      end
       field "recommendationDetails" do
         label "Recommendation"
       end
@@ -964,6 +976,9 @@ policy "policy_scheduled_report" do
       end
       field "tags" do
         label "Resource Tags"
+      end
+      field "createdTime" do
+        label "Created At"
       end
       field "recommendationDetails" do
         label "Recommendation"


### PR DESCRIPTION
### Description

Added optional `Minimum Age (Days)` parameter to filter results by age. This is for users that want to avoid reporting on freshly created databases that, as a result of their newness, have not had any connections and would therefore be seen as "unused" by the policy.

This is not a breaking change since the default value of this parameter is 0 and this functions just like the policy did without the parameter.

From the README:

- *Minimum Age (Days)* - The minimum age, in days, since a SQL database was created to produce recommendations for it. Set to 0 to ignore age entirely.

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=659c1da07cc18300018b73f7

(Note: The above does not produce an incident because we don't have any old SQL servers in our test account. If you review the log, you'll see that `ds_azure_sql_databases` returns two system databases, and the filter correctly filters out one of them based on age for `ds_azure_sql_databases_age_filtered`)

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
