### PR TITLE
POL-1043 Meta Policy Substring Support

### DIFF
--- a/compliance/aws/disallowed_regions/CHANGELOG.md
+++ b/compliance/aws/disallowed_regions/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v5.0
+
+- Several parameters altered to be more descriptive and human-readable
+- Added ability to filter resources by multiple tag key:value pairs
+- Added additional context to incident description
+- Normalized incident export to be consistent with other policies
+- Added human-readable recommendation to incident export
+- Policy no longer raises new escalations if tag data has changed for an instance
+- Policy action error logging modernized and now works as expected in EU/APAC
+- Streamlined code for better readability and faster execution
+
 ## v4.1
 
 - Updated description of `Account Number` parameter

--- a/compliance/aws/disallowed_regions/README.md
+++ b/compliance/aws/disallowed_regions/README.md
@@ -1,31 +1,25 @@
 # AWS Disallowed Regions
 
-## What it does
+## What It Does
 
-This policy checks all instances outside of a set of allowed regions. The user is given the option to Terminate the instance after approval.
-
-## Functional Details
-
-- The policy leverages the AWS API to check all instances that exist outside of an allowed region.
-- When an EC2 instance in disallowed region is detected, an email action is triggered automatically to notify the specified users of the incident. Users then have the option to terminate instances after manual approval if needed.
+This policy finds all AWS EC2 instances within a user-specified list of disallowed regions or outside of a user-specified list of allowed regions. An incident is raised and a report emailed containing all of the non-compliant instances, with the option to stop or terminate offending instances.
 
 ## Input Parameters
 
-- *Email addresses to notify* - Email addresses of the recipients you wish to notify when new incidents are created.
+- *Email Addresses* - Email addresses of the recipients you wish to notify when new incidents are created.
 - *Account Number* - The Account number for use with the AWS STS Cross Account Role. Leave blank when using AWS IAM Access key and secret. It only needs to be passed when the desired AWS account is different than the one associated with the Flexera One credential. [more](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1123608)
-- *Exclusion Tag* - List of tags that will exclude EC2 instances from being evaluated by this policy. Multiple tags are evaluated as an 'OR' condition. Tag keys or key/value pairs can be listed. Example: 'test,env=dev'.
-- *Allowed/Denied Regions* - Whether to treat regions parameter as allow or deny list.
-- *Regions* - A list of regions to allow or deny for an AWS account. Please enter the regions code if SCP is enabled, see [Available Regions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) in AWS; otherwise, the policy may fail on regions that are disabled via SCP. Leave blank to consider all the regions.
+- *Exclusion Tags (Key:Value)* - Cloud native tags to ignore resources that you don't want to produce recommendations for. Use Key:Value format for specific tag key/value pairs, and Key:\* format to match any resource with a particular key, regardless of value. Examples: env:production, DO_NOT_DELETE:\*
+- *Disallow/Allow Regions* - Whether to allow or disallow the regions specified in the `Disallow/Allow Regions List` parameter. If set to "Allow", all EC2 instances outside of the listed regions will be considered out of compliance. If set to "Disallow", all EC2 instances within the listed regions will be considered out of compliance.
+- *Disallow/Allow Regions List* - A list of regions to disallow or allow. Example: us-east-1
 - *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).
 
-Note:Refer Region column under Amazon Elastic Compute Cloud (Amazon EC2) in below link for AWS supported regions \n See the [README](https://docs.aws.amazon.com/general/latest/gr/rande.html).
-
-Also please note that the "*Automatic Actions*" parameter contains a list of action(s) that can be performed on the resources. When it is selected, the policy will automatically execute the corresponding action on the data that failed the checks, post incident generation. Please leave it blank for *manual* action.
-For example if a user selects the "Terminate Instances" action while applying the policy, all the identified instances that didn't satisfy the policy condition will be terminated.
+Please note that the "Automatic Actions" parameter contains a list of action(s) that can be performed on the resources. When it is selected, the policy will automatically execute the corresponding action on the data that failed the checks, post incident generation. Please leave it blank for *manual* action.
+For example, if a user selects the "Terminate Instances" action while applying the policy, all the EC2 instances that didn't satisfy the policy condition will be deleted.
 
 ## Policy Actions
 
 - Sends an email notification.
+- Stop reported instances after approval.
 - Terminate reported instances after approval.
 
 ## Prerequisites
@@ -33,11 +27,13 @@ For example if a user selects the "Terminate Instances" action while applying th
 This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).
 
 - [**AWS Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1121575) (*provider=aws*) which has the following permissions:
+  - `sts:GetCallerIdentity`
   - `ec2:DescribeRegions`
   - `ec2:DescribeInstances`
+  - `ec2:StopInstances`*
   - `ec2:TerminateInstances`*
 
-  \* Only required for taking action (deletion); the policy will still function in a read-only capacity without these permissions.
+  \* Only required for taking action; the policy will still function in a read-only capacity without these permissions.
 
   Example IAM Permission Policy:
 
@@ -48,8 +44,10 @@ This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Auto
           {
               "Effect": "Allow",
               "Action": [
+                  "sts:GetCallerIdentity",
                   "ec2:DescribeRegions",
                   "ec2:DescribeInstances",
+                  "ec2:StopInstances",
                   "ec2:TerminateInstances"
               ],
               "Resource": "*"

--- a/compliance/aws/disallowed_regions/aws_disallowed_regions.pt
+++ b/compliance/aws/disallowed_regions/aws_disallowed_regions.pt
@@ -1,13 +1,13 @@
 name "AWS Disallowed Regions"
 rs_pt_ver 20180301
 type "policy"
-short_description "Check for instances that are outside of an allowed region with the option to terminate them. \n See the [README](https://github.com/flexera-public/policy_templates/tree/master/compliance/aws/disallowed_regions) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "Check for instances that are outside of an allowed region with the option to stop or terminate them. See the [README](https://github.com/flexera-public/policy_templates/tree/master/compliance/aws/disallowed_regions) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.1",
+  version: "5.0",
   provider: "AWS",
   service: "Compute",
   policy_set: "Disallowed Regions"
@@ -19,8 +19,10 @@ info(
 
 parameter "param_email" do
   type "list"
-  label "Email addresses to notify"
-  description "Email addresses of the recipients you wish to notify when new incidents are created."
+  category "Policy Settings"
+  label "Email Addresses"
+  description "Email addresses of the recipients you wish to notify when new incidents are created"
+  default []
 end
 
 parameter "param_aws_account_number" do
@@ -31,34 +33,39 @@ parameter "param_aws_account_number" do
   default ""
 end
 
-parameter "param_exclude_tags" do
+parameter "param_exclusion_tags" do
   type "list"
-  category "User Inputs"
-  label "Exclusion Tag"
-  description "List of tags that will exclude EC2 instances from being evaluated by this policy. Multiple tags are evaluated as an 'OR' condition. Tag keys or key/value pairs can be listed. Example: 'test,env=dev'."
+  category "Filters"
+  label "Exclusion Tags (Key:Value)"
+  description "Cloud native tags to ignore resources that you don't want to produce recommendations for. Use Key:Value format for specific tag key/value pairs, and Key:* format to match any resource with a particular key, regardless of value. Examples: env:production, DO_NOT_DELETE:*"
+  allowed_pattern /(^$)|[\w]*\:.*/
   default []
 end
 
-parameter "param_allowed_regions_allow_or_deny" do
+parameter "param_regions_disallow_or_allow" do
   type "string"
-  label "Allow/Deny Regions"
-  description "Allow or Deny entered regions. See the README for more details"
-  allowed_values "Allow", "Deny"
-  default "Allow"
+  category "Filters"
+  label "Disallow/Allow Regions"
+  description "Disallow or Allow entered regions. See the README for more details"
+  allowed_values "Disallow", "Allow"
+  default "Disallow"
 end
 
-parameter "param_allowed_regions" do
+parameter "param_regions_list" do
   type "list"
-  label "Regions"
-  allowed_pattern /^([a-zA-Z-_]+-[a-zA-Z0-9-_]+-[0-9-_]+,*|)+$/
-  description "A list of allowed or denied regions. See the README for more details"
+  category "Filters"
+  label "Disallow/Allow Regions List"
+  description "A list of disallowed or allowed regions. See the README for more details"
+  allowed_pattern /^[a-z]{2}(-gov)?-[a-z]+-[0-9]+$/
+  default []
 end
 
 parameter "param_automatic_action" do
   type "list"
+  category "Actions"
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
-  allowed_values ["Terminate Instances"]
+  allowed_values ["Stop Instances", "Terminate Instances"]
   default []
 end
 
@@ -66,9 +73,8 @@ end
 # Authentication
 ###############################################################################
 
-#authenticate with AWS
 credentials "auth_aws" do
-  schemes "aws","aws_sts"
+  schemes "aws", "aws_sts"
   label "AWS"
   description "Select the AWS Credential from the list"
   tags "provider=aws"
@@ -86,22 +92,117 @@ end
 # Pagination
 ###############################################################################
 
-pagination "aws_pagination_xml" do
+pagination "pagination_aws" do
   get_page_marker do
-    body_path "//DescribeInstancesResponse/nextToken"
+    body_path jmes_path(response, "NextToken")
   end
   set_page_marker do
-    query "NextToken"
+    body_field "NextToken"
   end
 end
 
 ###############################################################################
-# Datasources
+# Datasources & Scripts
 ###############################################################################
 
-# ds_region_list is a list of regions that are opted-in or opt-in-not-required
-datasource "ds_regions_list" do
-  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+# Get applied policy metadata for use later
+datasource "ds_applied_policy" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    header "Api-Version", "1.0"
+  end
+end
+
+# Get region-specific Flexera API endpoints
+datasource "ds_flexera_api_hosts" do
+  run_script $js_flexera_api_hosts, rs_optima_host
+end
+
+script "js_flexera_api_hosts", type: "javascript" do
+  parameters "rs_optima_host"
+  result "result"
+  code <<-'EOS'
+  host_table = {
+    "api.optima.flexeraeng.com": {
+      flexera: "api.flexera.com",
+      fsm: "api.fsm.flexeraeng.com"
+    },
+    "api.optima-eu.flexeraeng.com": {
+      flexera: "api.flexera.eu",
+      fsm: "api.fsm-eu.flexeraeng.com"
+    },
+    "api.optima-apac.flexeraeng.com": {
+      flexera: "api.flexera.au",
+      fsm: "api.fsm-apac.flexeraeng.com"
+    }
+  }
+
+  result = host_table[rs_optima_host]
+EOS
+end
+
+# Get AWS account info
+datasource "ds_cloud_vendor_accounts" do
+  request do
+    auth $auth_flexera
+    host val($ds_flexera_api_hosts, 'flexera')
+    path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "values[*]") do
+      field "id", jmes_path(col_item, "aws.accountId")
+      field "name", jmes_path(col_item, "name")
+      field "tags", jmes_path(col_item, "tags")
+    end
+  end
+end
+
+datasource "ds_get_caller_identity" do
+  request do
+    auth $auth_aws
+    verb "GET"
+    host "sts.amazonaws.com"
+    path "/"
+    header "User-Agent", "RS Policies"
+    query "Action", "GetCallerIdentity"
+    query "Version", "2011-06-15"
+  end
+  result do
+    encoding "xml"
+    collect xpath(response, "//GetCallerIdentityResponse/GetCallerIdentityResult") do
+      field "account", xpath(col_item, "Account")
+    end
+  end
+end
+
+datasource "ds_aws_account" do
+  run_script $js_aws_account, $ds_cloud_vendor_accounts, $ds_get_caller_identity
+end
+
+script "js_aws_account", type:"javascript" do
+  parameters "ds_cloud_vendor_accounts", "ds_get_caller_identity"
+  result "result"
+  code <<-'EOS'
+  result = _.find(ds_cloud_vendor_accounts, function(account) {
+    return account['id'] == ds_get_caller_identity[0]['account']
+  })
+
+  // This is in case the API does not return the relevant account info
+  if (result == undefined) {
+    result = {
+      id: ds_get_caller_identity[0]['account'],
+      name: "",
+      tags: {}
+    }
+  }
+EOS
+end
+
+datasource "ds_describe_regions" do
   request do
     auth $auth_aws
     verb "GET"
@@ -124,125 +225,232 @@ datasource "ds_regions_list" do
   end
 end
 
-# Get only SCP enabled regions
 datasource "ds_regions" do
-  run_script $js_regions, $param_allowed_regions, $ds_regions_list, $param_allowed_regions_allow_or_deny
+  run_script $js_regions, $ds_describe_regions, $param_regions_list, $param_regions_disallow_or_allow
 end
-# Get the list of all EC2 Instances across all regions.
-# https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html
-datasource "ds_disallowed_instances_list" do
+
+script "js_regions", type:"javascript" do
+  parameters "ds_describe_regions", "param_regions_list", "param_regions_disallow_or_allow"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  // Inverted from other policies since we're looking for instances outside of these regions
+  allow_deny_test = { "Allow": false, "Disallow": true }
+
+  if (param_regions_list.length > 0) {
+    result = _.filter(ds_describe_regions, function(item) {
+      return _.contains(param_regions_list, item['region']) == allow_deny_test[param_regions_disallow_or_allow]
+    })
+  }
+EOS
+end
+
+datasource "ds_instance_sets" do
   iterate $ds_regions
   request do
     auth $auth_aws
-    pagination $aws_pagination_xml
-    verb "GET"
-    host join(["ec2.",val(iter_item,"region"),".amazonaws.com"])
-    path "/"
-    query "Action", "DescribeInstances"
-    query "Version", "2016-11-15"
+    host join(['ec2.', val(iter_item, 'region'), '.amazonaws.com'])
+    path '/'
+    header 'User-Agent', 'RS Policies'
+    header 'Content-Type', 'text/xml'
+    query 'Action', 'DescribeInstances'
+    query 'Version', '2016-11-15'
+    query 'Filter.1.Name', 'instance-state-name'
+    query 'Filter.1.Value.1', 'running'
   end
   result do
     encoding "xml"
-    collect xpath(response, "//DescribeInstancesResponse/reservationSet/item/instancesSet/item", "array") do
-      field "instance_id", xpath(col_item, "instanceId")
-      field "region", val(iter_item, "regionName")
-      field "instance_state", xpath(col_item, "instanceState/name")
-      field "instance_type", xpath(col_item, "instanceType")
-      field "tags" do
-        collect xpath(col_item, "tagSet/item") do
-          field "tagKey", xpath(col_item, "key")
-          field "tagValue", xpath(col_item, "value")
+    collect xpath(response, "//DescribeInstancesResponse/reservationSet/item", "array") do
+      field "instances_set" do
+        collect xpath(col_item,"instancesSet/item","array") do
+          field "region",val(iter_item, "region")
+          field "instanceId", xpath(col_item, "instanceId")
+          field "imageId", xpath(col_item, "imageId")
+          field "resourceType", xpath(col_item, "instanceType")
+          field "platform", xpath(col_item, "platformDetails")
+          field "privateDnsName", xpath(col_item, "privateDnsName")
+          field "launchTime", xpath(col_item, "launchTime")
+          field "tags" do
+            collect xpath(col_item,"tagSet/item", "array") do
+              field "key", xpath(col_item, "key")
+              field "value", xpath(col_item, "value")
+            end
+          end
         end
       end
     end
   end
 end
 
-datasource "ds_list_aws_instances" do
-  run_script $js_filter_aws_instances, $ds_disallowed_instances_list, $param_exclude_tags
+datasource "ds_instances" do
+  run_script $js_instances, $ds_instance_sets, $param_exclusion_tags
 end
 
-###############################################################################
-# Scripts
-###############################################################################
+script "js_instances", type: "javascript" do
+  parameters "ds_instance_sets", "param_exclusion_tags"
+  result "result"
+  code <<-'EOS'
+  result = []
 
-script "js_regions", type:"javascript" do
-  parameters "user_entered_regions", "all_regions", "regions_allow_or_deny"
-  result "regions"
-  code <<-EOS
-    if(_.isEmpty(user_entered_regions)){
-      regions = all_regions;
-    }else{
-      //Filter unique regions
-      var uniqueRegions = _.uniq(user_entered_regions);
-      var all_regions_list = [];
-      //Filter and remove denied regions from all_regions
-      if (regions_allow_or_deny == "Deny"){
-        var all_regions = all_regions.filter(function(obj){
-          return user_entered_regions.indexOf(obj.region) === -1;
-        });
-      }
-      all_regions.forEach(function(all_region){
-        all_regions_list.push(all_region.region)
-      })
-      //Filter valid regions
-      var valid_regions = [];
-      _.map(uniqueRegions, function(uniqueRegion){
-        if(all_regions_list.indexOf(uniqueRegion) > -1){
-          valid_regions.push({"region": uniqueRegion})
+  _.each(ds_instance_sets, function(item) {
+    if (param_exclusion_tags.length > 0) {
+      filtered_instances = _.reject(item['instances_set'], function(instance) {
+        instance_tags = []
+
+        if (instance['tags'] != null && instance['tags'] != undefined) {
+          _.each(instance['tags'], function(tag) {
+            instance_tags.push([tag['key'], tag['value']].join(':'))
+            instance_tags.push([tag['key'], '*'].join(':'))
+          })
         }
-      })
 
-      //Throw an error if no valid regions found
-      if (_.isEmpty(valid_regions)) {
-        regions = all_regions;
-      }else{
-        regions = valid_regions
-      }
-    }
-  EOS
-end
+        exclude_instance = false
 
-script "js_filter_aws_instances", type: "javascript" do
-  parameters "ds_disallowed_instances_list","param_exclude_tags"
-  result "res"
-  code <<-EOS
-    res = []
-    var param_exclude_tags_lower=[];
-    for(var i=0; i < param_exclude_tags.length; i++){
-      param_exclude_tags_lower[i]=param_exclude_tags[i].toString().toLowerCase();
-    }
-    for (var j = 0; j < ds_disallowed_instances_list.length; j++) {
-      var instance = ds_disallowed_instances_list[j];
-      var tags=instance['tags'];
-      var is_tag_matched=false
-      var tag_key_value=""
-      if(typeof(tags) != "undefined"){
-        for(var k=0;k<tags.length;k++){
-          var tag=tags[k];
-          if((param_exclude_tags_lower.indexOf((tag['tagKey']).toLowerCase()) !== -1) || (param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1)){
-            is_tag_matched = true;
+        _.each(param_exclusion_tags, function(exclusion_tag) {
+          if (_.contains(instance_tags, exclusion_tag)) {
+            exclude_instance = true
           }
-          // Constructing tags with comma separated to display in detail_template
-          if((tag['tagValue']).length > 0){
-            tag_key_value = tag_key_value + ', '+ tag['tagKey']+'='+tag['tagValue']
-          }else{
-            tag_key_value = tag_key_value + ', '+ tag['tagKey']
-          }
-        }
-      }
-      if(!is_tag_matched && instance['instance_state']!="terminated"){
-        res.push({
-          id: instance['instance_id'],
-          region: instance['region'],
-          instance_state: instance['instance_state'],
-          tagKeyValue: (tag_key_value.slice(1)),
-          instance_type: instance['instance_type']
         })
-      }
+
+        return exclude_instance
+      })
+
+      result = result.concat(filtered_instances)
+    } else {
+      result = result.concat(item['instances_set'])
     }
-    res = _.sortBy(res, 'region');
-  EOS
+  })
+EOS
+end
+
+datasource "ds_instances_in_bad_regions" do
+  run_script $js_instances_in_bad_regions, $ds_instances, $ds_aws_account, $ds_applied_policy, $param_regions_disallow_or_allow, $param_regions_list
+end
+
+script "js_instances_in_bad_regions", type: "javascript" do
+  parameters "ds_instances", "ds_aws_account", "ds_applied_policy", "param_regions_disallow_or_allow", "param_regions_list"
+  result "result"
+  code <<-'EOS'
+  result = _.map(ds_instances, function(instance) {
+    tags = []
+    resourceName = ""
+
+    if (instance['tags'] != undefined && instance['tags'] != null) {
+      _.each(instance['tags'], function(tag) {
+        tags.push([tag['key'], tag['value']].join('='))
+
+        if (tag['key'].toLowerCase() == 'name') { resourceName = tag['value'] }
+      })
+    }
+
+    recommendationDetails = [
+      "Terminate EC2 instance ", instance["resourceID"], " ",
+      "in AWS Account ", ds_aws_account['name'], " ",
+      "(", ds_aws_account['id'], ")"
+    ].join('')
+
+    return {
+      accountID: ds_aws_account['id'],
+      accountName: ds_aws_account['name'],
+      resourceID: instance['instanceId'],
+      resourceName: resourceName,
+      tags: tags.join(', '),
+      recommendationDetails: recommendationDetails,
+      resourceType: instance['resourceType'],
+      region: instance['region'],
+      platform: instance['platform'],
+      hostname: instance['privateDnsName'].split('.')[0],
+      launchTime: instance['launchTime'],
+      service: "EC2",
+      policy_name: ds_applied_policy['name'],
+      message: ""
+    }
+  })
+
+  total_instances = result.length
+
+  instance_phrase = "instances were"
+  if (total_instances == 1) { instance_phrase = "instance was" }
+
+  region_phrase = "in"
+  if (param_regions_disallow_or_allow == 'Allow') { region_phrase = "outside of" }
+
+  region_adj = "disallowed"
+  if (param_regions_disallow_or_allow == 'Allow') { region_adj = "allowed" }
+
+  findings = [
+    total_instances, " AWS EC2 ", instance_phrase,
+    " found ", region_phrase, " the following ", region_adj,
+    " regions: ", param_regions_list.join(', '), ".\n\n"
+  ].join('')
+
+  disclaimer = "The above settings can be modified by editing the applied policy and changing the appropriate parameters."
+
+  // Dummy entry to ensure validation occurs at least once
+  result.push({ resourceID: "", tags: "", policy_name: "", message: "" })
+
+  result[0]['message'] = findings + disclaimer
+EOS
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "pol_disallowed_regions" do
+  validate_each $ds_instances_in_bad_regions do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} AWS EC2 Instances In Disallowed Regions Found"
+    detail_template "{{ with index data 0 }}{{ .message }}{{ end }}"
+    check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
+    escalate $esc_email
+    escalate $esc_stop_instances
+    escalate $esc_terminate_instances
+    hash_exclude "message", "tags"
+    export do
+      resource_level true
+      field "accountID" do
+        label "Account ID"
+      end
+      field "accountName" do
+        label "Account Name"
+      end
+      field "resourceID" do
+        label "Resource ID"
+      end
+      field "resourceName" do
+        label "Resource Name"
+      end
+      field "tags" do
+        label "Resource Tags"
+      end
+      field "recommendationDetails" do
+        label "Recommendation"
+      end
+      field "resourceType" do
+        label "Instance Size"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "platform" do
+        label "Platform"
+      end
+      field "hostname" do
+        label "Hostname"
+      end
+      field "launchTime" do
+        label "Launch Time"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "id" do
+        label "ID"
+        path "resourceID"
+      end
+    end
+  end
 end
 
 ###############################################################################
@@ -251,108 +459,168 @@ end
 
 escalation "esc_email" do
   automatic true
-  label "Send Mail"
-  description "Sends incident email"
+  label "Send Email"
+  description "Send incident email"
   email $param_email
 end
 
-escalation "esc_terminate_instances_disallowed_region" do
-  automatic contains($param_automatic_action, "Terminate Instances")
-  label "Delete Instances"
-  description "Delete instances found in disallowd regions."
-  run "terminate_instances", data, rs_optima_host
+escalation "esc_stop_instances" do
+  automatic contains($param_automatic_action, "Stop Instances")
+  label "Stop Instances"
+  description "Approval to stop all selected instances"
+  run "stop_instances", data
 end
 
-###############################################################################
-# Policy
-###############################################################################
-
-policy "pol_list_aws_instances" do
-  validate $ds_list_aws_instances do
-    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} AWS Instance(s) in Disallowed regions"
-    export do
-      resource_level true
-      field "id" do
-        label "Instance ID"
-      end
-      field "instance_state" do
-        label "Instance State"
-      end
-      field "region" do
-        label "Region"
-      end
-      field "instance_type" do
-        label "Instance Type"
-      end
-      field "tagKeyValue" do
-        label "Tags"
-      end
-    end
-    # Policy check fails and incident is created only if data is not empty and the Parent Policy has not been terminated
-    check logic_or($ds_parent_policy_terminated, eq(size(data),0))
-    escalate $esc_email
-    escalate $esc_terminate_instances_disallowed_region
-  end
+escalation "esc_terminate_instances" do
+  automatic contains($param_automatic_action, "Terminate Instances")
+  label "Terminate Instances"
+  description "Approval to terminate all selected instances"
+  run "terminate_instances", data
 end
 
 ###############################################################################
 # Cloud Workflow
 ###############################################################################
 
-# https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TerminateInstances.html
-define terminate_instances($data, $$rs_optima_host) return $all_responses do
-  $$debug=true
-  $all_responses = []
-  foreach $item in $data do
-  sub on_error: skip do
-  $response = http_request(
-      verb: "get",
-      host: join(["ec2.",$item["region"],".amazonaws.com"]),
-      auth: $$auth_aws,
-      href: join(["/", "?Action=TerminateInstances", "&InstanceId.1=", $item["id"], "&Version=2016-11-15"]),
-      https: true,
-      headers:{
-        "cache-control": "no-cache",
-        "content-type": "application/json"
-      }
-    )
-    $all_responses << $response
-    call sys_log('terminate instances in disallowed region response',to_s($response))
+# Core CWF function to stop instances
+define stop_instances($data) do
+  foreach $instance in $data do
+    sub on_error: handle_error() do
+      call get_instance_state($instance) retrieve $initial_state
+
+      if $initial_state != "terminated" && $initial_state != "pending"
+        if $initial_state != "stopped"
+          call stop_instance($instance)
+        end
+      end
     end
+  end
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
   end
 end
 
-define sys_log($subject, $detail) do
-  # Create empty errors array if doesn't already exist
+# Core CWF function to terminate instances
+define terminate_instances($data) do
+  foreach $instance in $data do
+    sub on_error: handle_error() do
+      call get_instance_state($instance) retrieve $initial_state
+
+      if $initial_state != "terminated" && $initial_state != "pending"
+        call terminate_instance($instance)
+      end
+    end
+  end
+
+  # If we encountered any errors, use `raise` to mark the CWF process as errored
+  if inspect($$errors) != "null"
+    raise join($$errors,"\n")
+  end
+end
+
+# CWF function to get the current state of an instance
+define get_instance_state($instance) return $instance_state do
+  task_label("Getting Instance State: " + $instance["id"])
+  $response = http_request(
+    auth: $$auth_aws,
+    https: true,
+    verb: "post",
+    href: "/",
+    host: "ec2." + $instance["region"] + ".amazonaws.com",
+    query_strings: {
+      "Action": "DescribeInstanceStatus",
+      "Version": "2016-11-15",
+      "IncludeAllInstances": "true",
+      "InstanceId.1": $instance["id"]
+    }
+  )
+  call handle_response($response)
+  $instance_state = $response["body"]["DescribeInstanceStatusResponse"]["instanceStatusSet"]["item"]["instanceState"]["name"]
+end
+
+# CWF function to stop an instance
+define stop_instance($instance) return $response do
+  task_label("Stopping Instance: " + $instance["id"])
+  $response = http_request(
+    auth: $$auth_aws,
+    https: true,
+    verb: "post",
+    href: "/",
+    host: "ec2." + $instance['region'] + ".amazonaws.com",
+    query_strings: {
+      "Action": "StopInstances",
+      "Version": "2016-11-15",
+      "InstanceId.1": $instance["id"]
+    }
+  )
+  call handle_response($response)
+
+  task_label("Checking for expected response code for Stop Instance: " + $instance["id"])
+  if $response["code"] != 202 && $response["code"] != 200
+    raise 'Unexpected response Stop Instance: '+to_json($response)
+  else
+    task_label("Successful Stop Instance: " + $instance["id"])
+    call get_instance_state($instance) retrieve $instance_state
+    while $instance_state != "stopped" do
+      call get_instance_state($instance) retrieve $instance_state
+      task_label("Waiting for Stop.. Instance State: " + $instance["id"] +" "+ $instance_state)
+      sleep(10)
+    end
+    task_label("Completed Stop Instance: " + $instance["id"])
+  end
+end
+
+# CWF function to terminate an instance
+define terminate_instance($instance) return $response do
+  task_label("Terminating Instance: " + $instance["id"])
+  $response = http_request(
+    auth: $$auth_aws,
+    https: true,
+    verb: "post",
+    href: "/",
+    host: "ec2." + $instance["region"] + ".amazonaws.com",
+    query_strings: {
+      "Action": "TerminateInstances",
+      "Version": "2016-11-15",
+      "InstanceId.1": $instance["id"]
+    }
+  )
+  call handle_response($response)
+
+  task_label("Checking for expected response code for Terminate Instance: " + $instance["id"])
+  if $response["code"] != 202 && $response["code"] != 200
+    raise 'Unexpected response Terminate Instance: '+to_json($response)
+  else
+    task_label("Successful Terminate Instance: " + $instance["id"])
+    call get_instance_state($instance) retrieve $instance_state
+    while $instance_state != "terminated" do
+      call get_instance_state($instance) retrieve $instance_state
+      task_label("Waiting for Terminate Instance: " + $instance["id"] +" "+ $instance_state)
+      sleep(10)
+    end
+    task_label("Completed Modify Instance: " + $instance["id"])
+  end
+end
+
+# CWF function to handle responses
+define handle_response($response) do
+  if !$$all_responses
+    $$all_responses = []
+  end
+  # Convert response object to JSON string.  Easier to interpret
+  $$all_responses << to_json($response)
+end
+
+# CWF function to handle errors
+define handle_error() do
   if !$$errors
     $$errors = []
   end
-  # Check if debug is enabled
-  if $$debug
-    # Append to global $$errors
-    # This is the suggested way to capture errors
-    $$errors << "Unexpected error for " + $subject + "\n  " + to_s($detail)
-    # If Flexera NAM Zone, create audit_entries [to be deprecated]
-    # This is the legacy method for capturing errors and only supported on Flexera NAM
-    if $$rs_optima_host == "api.optima.flexeraeng.com"
-      # skip_error_and_append is used to catch error if rs_cm.audit_entries.create fails unexpectedly
-      $task_label = "Creating audit entry for " + $subject
-      sub task_label: $task, on_error: skip_error_and_append($task) do
-        rs_cm.audit_entries.create(
-          notify: "None",
-          audit_entry: {
-            auditee_href: @@account,
-            summary: $subject,
-            detail: $detail
-          }
-        )
-      end # End sub on_error
-    end # End if rs_optima_host
-  end # End if debug is enabled
-end
-
-define skip_error_and_append($subject) do
-  $$errors << "Unexpected error for " + $subject + "\n  " + to_s($_error)
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
   $_error_behavior = "skip"
 end
 
@@ -376,7 +644,6 @@ datasource "ds_get_policy" do
     field "id", jmes_path(response, "id")
   end
 end
-
 
 datasource "ds_parent_policy_terminated" do
   run_script $js_decide_if_self_terminate, $ds_get_policy, policy_id, meta_parent_policy_id

--- a/compliance/aws/disallowed_regions/aws_disallowed_regions_meta_parent.pt
+++ b/compliance/aws/disallowed_regions/aws_disallowed_regions_meta_parent.pt
@@ -302,7 +302,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -321,7 +326,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/compliance/aws/disallowed_regions/aws_disallowed_regions_meta_parent.pt
+++ b/compliance/aws/disallowed_regions/aws_disallowed_regions_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -287,23 +289,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/compliance/aws/disallowed_regions/aws_disallowed_regions_meta_parent.pt
+++ b/compliance/aws/disallowed_regions/aws_disallowed_regions_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "4.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 
@@ -66,34 +66,39 @@ parameter "param_template_source" do
 end
 
 ## Child Policy Parameters
-parameter "param_exclude_tags" do
+parameter "param_exclusion_tags" do
   type "list"
-  category "User Inputs"
-  label "Exclusion Tag"
-  description "List of tags that will exclude EC2 instances from being evaluated by this policy. Multiple tags are evaluated as an 'OR' condition. Tag keys or key/value pairs can be listed. Example: 'test,env=dev'."
+  category "Filters"
+  label "Exclusion Tags (Key:Value)"
+  description "Cloud native tags to ignore resources that you don't want to produce recommendations for. Use Key:Value format for specific tag key/value pairs, and Key:* format to match any resource with a particular key, regardless of value. Examples: env:production, DO_NOT_DELETE:*"
+  allowed_pattern /(^$)|[\w]*\:.*/
   default []
 end
 
-parameter "param_allowed_regions_allow_or_deny" do
+parameter "param_regions_disallow_or_allow" do
   type "string"
-  label "Allow/Deny Regions"
-  description "Allow or Deny entered regions. See the README for more details"
-  allowed_values "Allow", "Deny"
-  default "Allow"
+  category "Filters"
+  label "Disallow/Allow Regions"
+  description "Disallow or Allow entered regions. See the README for more details"
+  allowed_values "Disallow", "Allow"
+  default "Disallow"
 end
 
-parameter "param_allowed_regions" do
+parameter "param_regions_list" do
   type "list"
-  label "Regions"
-  allowed_pattern /^([a-zA-Z-_]+-[a-zA-Z0-9-_]+-[0-9-_]+,*|)+$/
-  description "A list of allowed or denied regions. See the README for more details"
+  category "Filters"
+  label "Disallow/Allow Regions List"
+  description "A list of disallowed or allowed regions. See the README for more details"
+  allowed_pattern /^[a-z]{2}(-gov)?-[a-z]+-[0-9]+$/
+  default []
 end
 
 parameter "param_automatic_action" do
   type "list"
+  category "Actions"
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
-  allowed_values ["Terminate Instances"]
+  allowed_values ["Stop Instances", "Terminate Instances"]
   default []
 end
 
@@ -101,7 +106,7 @@ end
 # Authentication
 ###############################################################################
 credentials "auth_aws" do
-  schemes "aws","aws_sts"
+  schemes "aws", "aws_sts"
   label "AWS"
   description "Select the AWS Credential from the list"
   tags "provider=aws"
@@ -731,19 +736,19 @@ datasource "ds_child_incident_details" do
   end
 end
 
-datasource "ds_list_aws_instances_combined_incidents" do
-  run_script $js_ds_list_aws_instances_combined_incidents, $ds_child_incident_details
+datasource "ds_instances_in_bad_regions_combined_incidents" do
+  run_script $js_ds_instances_in_bad_regions_combined_incidents, $ds_child_incident_details
 end
 
-script "js_ds_list_aws_instances_combined_incidents", type: "javascript" do
+script "js_ds_instances_in_bad_regions_combined_incidents", type: "javascript" do
   parameters "ds_child_incident_details"
   result "result"
   code <<-EOS
   result = []
   _.each(ds_child_incident_details, function(incident) {
     s = incident["summary"];
-    // If the incident summary contains "in Disallowed regions" then include it in the filter result
-    if (s.indexOf("in Disallowed regions") > -1) {
+    // If the incident summary contains "AWS EC2 Instances In Disallowed Regions Found" then include it in the filter result
+    if (s.indexOf("AWS EC2 Instances In Disallowed Regions Found") > -1) {
       _.each(incident["violation_data"], function(violation) {
         violation["incident_id"] = incident["id"];
         result.push(violation);
@@ -754,15 +759,26 @@ EOS
 end
 
 
-# Escalation for Delete Instances
-escalation "esc_terminate_instances_disallowed_region" do
+# Escalation for Stop Instances
+escalation "esc_stop_instances" do
   automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
-  label "Delete Instances"
-  description "Delete instances found in disallowd regions."
-  run "esc_terminate_instances_disallowed_region", data, rs_governance_host, rs_project_id
+  label "Stop Instances"
+  description "Approval to stop all selected instances"
+  run "esc_stop_instances", data, rs_governance_host, rs_project_id
 end
-define esc_terminate_instances_disallowed_region($data, $governance_host, $rs_project_id) do
-  call child_run_action($data, $governance_host, $rs_project_id, "Delete Instances")
+define esc_stop_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Stop Instances")
+end
+
+# Escalation for Terminate Instances
+escalation "esc_terminate_instances" do
+  automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
+  label "Terminate Instances"
+  description "Approval to terminate all selected instances"
+  run "esc_terminate_instances", data, rs_governance_host, rs_project_id
+end
+define esc_terminate_instances($data, $governance_host, $rs_project_id) do
+  call child_run_action($data, $governance_host, $rs_project_id, "Terminate Instances")
 end
 
 
@@ -772,28 +788,53 @@ end
 # Could also just have one incident and use meta_status to determine which escalation happens
 policy "policy_scheduled_report" do
   # Consolidated Incident Check(s)
-    # Consolidated incident for in Disallowed regions
-  validate $ds_list_aws_instances_combined_incidents do
-    summary_template "Consolidated Incident: {{ len data }} in Disallowed regions"
+    # Consolidated incident for AWS EC2 Instances In Disallowed Regions Found
+  validate $ds_instances_in_bad_regions_combined_incidents do
+    summary_template "Consolidated Incident: {{ len data }} AWS EC2 Instances In Disallowed Regions Found"
     escalate $esc_email
-    escalate $esc_terminate_instances_disallowed_region
+    escalate $esc_stop_instances
+    escalate $esc_terminate_instances
     check eq(size(data), 0)
     export do
       resource_level true
-      field "id" do
-        label "Instance ID"
+      field "accountID" do
+        label "Account ID"
       end
-      field "instance_state" do
-        label "Instance State"
+      field "accountName" do
+        label "Account Name"
+      end
+      field "resourceID" do
+        label "Resource ID"
+      end
+      field "resourceName" do
+        label "Resource Name"
+      end
+      field "tags" do
+        label "Resource Tags"
+      end
+      field "recommendationDetails" do
+        label "Recommendation"
+      end
+      field "resourceType" do
+        label "Instance Size"
       end
       field "region" do
         label "Region"
       end
-      field "instance_type" do
-        label "Instance Type"
+      field "platform" do
+        label "Platform"
       end
-      field "tagKeyValue" do
-        label "Tags"
+      field "hostname" do
+        label "Hostname"
+      end
+      field "launchTime" do
+        label "Launch Time"
+      end
+      field "service" do
+        label "Service"
+      end
+      field "id" do
+        label "ID"
       end
       field "incident_id" do
         label "Child Incident ID"

--- a/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent_meta_parent.pt
+++ b/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent_meta_parent.pt
@@ -302,7 +302,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -321,7 +326,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent_meta_parent.pt
+++ b/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -287,23 +289,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/compliance/aws/long_stopped_instances/aws_long_stopped_instances_meta_parent.pt
+++ b/compliance/aws/long_stopped_instances/aws_long_stopped_instances_meta_parent.pt
@@ -302,7 +302,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -321,7 +326,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/compliance/aws/long_stopped_instances/aws_long_stopped_instances_meta_parent.pt
+++ b/compliance/aws/long_stopped_instances/aws_long_stopped_instances_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -287,23 +289,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry_meta_parent.pt
+++ b/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry_meta_parent.pt
@@ -335,7 +335,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -354,7 +359,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry_meta_parent.pt
+++ b/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -320,23 +322,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent.pt
+++ b/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent.pt
@@ -312,7 +312,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -331,7 +336,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent.pt
+++ b/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -297,23 +299,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/compliance/azure/azure_long_stopped_instances/long_stopped_instances_azure.pt
+++ b/compliance/azure/azure_long_stopped_instances/long_stopped_instances_azure.pt
@@ -1,13 +1,13 @@
-name "Azure Long Stopped Instances"
+name "Azure Long Stopped Compute Instances"
 rs_pt_ver 20180301
 type "policy"
-short_description "Check for instances that have been stopped for a long time with the option to terminates them after approval. \n See the [README](https://github.com/flexera-public/policy_templates/tree/master/compliance/azure/azure_long_stopped_instances) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "Check for Azure virtual machines that have been stopped for a long time with the option to delete them after approval. See the [README](https://github.com/flexera-public/policy_templates/tree/master/compliance/azure/azure_long_stopped_instances) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 category "Compliance"
 severity "low"
-default_frequency "daily"
+default_frequency "weekly"
 info(
-  version: "3.0",
+  version: "4.0",
   provider: "Azure",
   service: "Compute",
   policy_set: "Long Stopped Instances"
@@ -19,34 +19,54 @@ info(
 
 parameter "param_email" do
   type "list"
-  label "Email List"
-  description "Email addresses of the recipients you wish to notify"
+  category "Policy Settings"
+  label "Email addresses"
+  description "A list of email addresses to notify."
+  default []
 end
 
 parameter "param_azure_endpoint" do
   type "string"
+  category "Policy Settings"
   label "Azure Endpoint"
+  description "Select the API endpoint to use for Azure. Use default value of management.azure.com unless using Azure China."
   allowed_values "management.azure.com", "management.chinacloudapi.cn"
   default "management.azure.com"
 end
 
-parameter "param_subscription_allowed_list" do
-  label "Subscription Allowed List"
-  type "list"
-  description "Allowed Subscriptions, if empty, all subscriptions will be checked"
+parameter "param_subscriptions_allow_or_deny" do
+  type "string"
+  category "Filters"
+  label "Allow/Deny Subscriptions"
+  description "Allow or Deny entered Subscriptions. See the README for more details."
+  allowed_values "Allow", "Deny"
+  default "Allow"
 end
 
-parameter "param_numberofdays" do
-  type "string"
-  label "Days"
-  description "Threshold of days to consider an instance long running."
+parameter "param_subscriptions_list" do
+  type "list"
+  category "Filters"
+  label "Allow/Deny Subscriptions List"
+  description "A list of allowed or denied Subscription IDs/names. See the README for more details."
+  default []
+end
+
+parameter "param_stopped_days" do
+  type "number"
+  category "Policy Settings"
+  label "Stopped Days"
+  description "The number of days a virtual machine needs to be stopped to include it in the incident report."
+  default 7
+  min_value 1
+  max_value 90
 end
 
 parameter "param_automatic_action" do
   type "list"
+  category "Actions"
   label "Automatic Actions"
-  description "When this value is set, this policy will automatically take the selected action(s)"
-  allowed_values ["Terminate Instances"]
+  description "When this value is set, this policy will automatically take the selected action."
+  allowed_values ["Delete Instances"]
   default []
 end
 
@@ -72,7 +92,7 @@ end
 # Pagination
 ###############################################################################
 
-pagination "azure_pagination" do
+pagination "pagination_azure" do
   get_page_marker do
     body_path "nextLink"
   end
@@ -89,7 +109,7 @@ end
 datasource "ds_subscriptions" do
   request do
     auth $auth_azure
-    pagination $azure_pagination
+    pagination $pagination_azure
     host $param_azure_endpoint
     path "/subscriptions/"
     query "api-version","2019-06-01"
@@ -117,7 +137,7 @@ datasource "ds_azure_virtualmachines" do
   iterate $ds_filtered_subscriptions
   request do
     auth $auth_azure
-    pagination $azure_pagination
+    pagination $pagination_azure
     host $param_azure_endpoint
     path join(["/subscriptions/", val(iter_item,"subscriptionId"), "/providers/Microsoft.Compute/virtualMachines"])
     query "api-version","2018-06-01"
@@ -142,7 +162,7 @@ datasource "ds_azure_instances" do
   iterate $ds_azure_virtualmachines
   request do
     auth $auth_azure
-    pagination $azure_pagination
+    pagination $pagination_azure
     host $param_azure_endpoint
     path join(["/subscriptions/", val(iter_item,"subscriptionId"), "/resourceGroups/", val(iter_item,"rg"), "/providers/Microsoft.Compute/virtualMachines/",val(iter_item,"name"),"/instanceView"])
     ignore_status [404]
@@ -163,7 +183,7 @@ end
 
 #filter list down to only machines that are long running
 datasource "ds_filtered_resources" do
-  run_script $js_filter_resources, $ds_azure_instances, $param_numberofdays
+  run_script $js_filter_resources, $ds_azure_instances, $param_stopped_days
 end
 
 ###############################################################################
@@ -190,7 +210,7 @@ EOS
 end
 
 script "js_filter_resources", type: "javascript" do
-  parameters "ds_azure_instances", "param_numberofdays"
+  parameters "ds_azure_instances", "param_stopped_days"
   result "result"
   code <<-EOS
   var result=[];
@@ -206,7 +226,7 @@ script "js_filter_resources", type: "javascript" do
       var nowtime = Date.now();
       var res = Math.abs(timeofevent.valueOf() - nowtime.valueOf());
       var daysElapsed = Math.ceil(res / (1000 * 3600 * 24));
-      if (daysElapsed > param_numberofdays) {
+      if (daysElapsed > param_stopped_days) {
         result.push({
           "name": instance["name"],
           "status": displayStatus,
@@ -228,7 +248,7 @@ end
 
 policy "azure_resource_policy" do
   validate $ds_filtered_resources do
-    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} Azure VMs in Stopped State for Over {{parameters.param_numberofdays}} Day(s)"
+    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} Azure VMs in Stopped State for Over {{parameters.param_stopped_days}} Day(s)"
     escalate $email
     escalate $delete_resources
     check logic_or($ds_parent_policy_terminated, eq(size(data), 0))

--- a/compliance/azure/azure_long_stopped_instances/long_stopped_instances_azure.pt
+++ b/compliance/azure/azure_long_stopped_instances/long_stopped_instances_azure.pt
@@ -1,13 +1,13 @@
-name "Azure Long Stopped Compute Instances"
+name "Azure Long Stopped Instances"
 rs_pt_ver 20180301
 type "policy"
-short_description "Check for Azure virtual machines that have been stopped for a long time with the option to delete them after approval. See the [README](https://github.com/flexera-public/policy_templates/tree/master/compliance/azure/azure_long_stopped_instances) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "Check for instances that have been stopped for a long time with the option to terminates them after approval. \n See the [README](https://github.com/flexera-public/policy_templates/tree/master/compliance/azure/azure_long_stopped_instances) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 category "Compliance"
 severity "low"
-default_frequency "weekly"
+default_frequency "daily"
 info(
-  version: "4.0",
+  version: "3.0",
   provider: "Azure",
   service: "Compute",
   policy_set: "Long Stopped Instances"
@@ -19,54 +19,34 @@ info(
 
 parameter "param_email" do
   type "list"
-  category "Policy Settings"
-  label "Email addresses"
-  description "A list of email addresses to notify."
-  default []
+  label "Email List"
+  description "Email addresses of the recipients you wish to notify"
 end
 
 parameter "param_azure_endpoint" do
   type "string"
-  category "Policy Settings"
   label "Azure Endpoint"
-  description "Select the API endpoint to use for Azure. Use default value of management.azure.com unless using Azure China."
   allowed_values "management.azure.com", "management.chinacloudapi.cn"
   default "management.azure.com"
 end
 
-parameter "param_subscriptions_allow_or_deny" do
-  type "string"
-  category "Filters"
-  label "Allow/Deny Subscriptions"
-  description "Allow or Deny entered Subscriptions. See the README for more details."
-  allowed_values "Allow", "Deny"
-  default "Allow"
-end
-
-parameter "param_subscriptions_list" do
+parameter "param_subscription_allowed_list" do
+  label "Subscription Allowed List"
   type "list"
-  category "Filters"
-  label "Allow/Deny Subscriptions List"
-  description "A list of allowed or denied Subscription IDs/names. See the README for more details."
-  default []
+  description "Allowed Subscriptions, if empty, all subscriptions will be checked"
 end
 
-parameter "param_stopped_days" do
-  type "number"
-  category "Policy Settings"
-  label "Stopped Days"
-  description "The number of days a virtual machine needs to be stopped to include it in the incident report."
-  default 7
-  min_value 1
-  max_value 90
+parameter "param_numberofdays" do
+  type "string"
+  label "Days"
+  description "Threshold of days to consider an instance long running."
 end
 
 parameter "param_automatic_action" do
   type "list"
-  category "Actions"
   label "Automatic Actions"
-  description "When this value is set, this policy will automatically take the selected action."
-  allowed_values ["Delete Instances"]
+  description "When this value is set, this policy will automatically take the selected action(s)"
+  allowed_values ["Terminate Instances"]
   default []
 end
 
@@ -92,7 +72,7 @@ end
 # Pagination
 ###############################################################################
 
-pagination "pagination_azure" do
+pagination "azure_pagination" do
   get_page_marker do
     body_path "nextLink"
   end
@@ -109,7 +89,7 @@ end
 datasource "ds_subscriptions" do
   request do
     auth $auth_azure
-    pagination $pagination_azure
+    pagination $azure_pagination
     host $param_azure_endpoint
     path "/subscriptions/"
     query "api-version","2019-06-01"
@@ -137,7 +117,7 @@ datasource "ds_azure_virtualmachines" do
   iterate $ds_filtered_subscriptions
   request do
     auth $auth_azure
-    pagination $pagination_azure
+    pagination $azure_pagination
     host $param_azure_endpoint
     path join(["/subscriptions/", val(iter_item,"subscriptionId"), "/providers/Microsoft.Compute/virtualMachines"])
     query "api-version","2018-06-01"
@@ -162,7 +142,7 @@ datasource "ds_azure_instances" do
   iterate $ds_azure_virtualmachines
   request do
     auth $auth_azure
-    pagination $pagination_azure
+    pagination $azure_pagination
     host $param_azure_endpoint
     path join(["/subscriptions/", val(iter_item,"subscriptionId"), "/resourceGroups/", val(iter_item,"rg"), "/providers/Microsoft.Compute/virtualMachines/",val(iter_item,"name"),"/instanceView"])
     ignore_status [404]
@@ -183,7 +163,7 @@ end
 
 #filter list down to only machines that are long running
 datasource "ds_filtered_resources" do
-  run_script $js_filter_resources, $ds_azure_instances, $param_stopped_days
+  run_script $js_filter_resources, $ds_azure_instances, $param_numberofdays
 end
 
 ###############################################################################
@@ -210,7 +190,7 @@ EOS
 end
 
 script "js_filter_resources", type: "javascript" do
-  parameters "ds_azure_instances", "param_stopped_days"
+  parameters "ds_azure_instances", "param_numberofdays"
   result "result"
   code <<-EOS
   var result=[];
@@ -226,7 +206,7 @@ script "js_filter_resources", type: "javascript" do
       var nowtime = Date.now();
       var res = Math.abs(timeofevent.valueOf() - nowtime.valueOf());
       var daysElapsed = Math.ceil(res / (1000 * 3600 * 24));
-      if (daysElapsed > param_stopped_days) {
+      if (daysElapsed > param_numberofdays) {
         result.push({
           "name": instance["name"],
           "status": displayStatus,
@@ -248,7 +228,7 @@ end
 
 policy "azure_resource_policy" do
   validate $ds_filtered_resources do
-    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} Azure VMs in Stopped State for Over {{parameters.param_stopped_days}} Day(s)"
+    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} Azure VMs in Stopped State for Over {{parameters.param_numberofdays}} Day(s)"
     escalate $email
     escalate $delete_resources
     check logic_or($ds_parent_policy_terminated, eq(size(data), 0))

--- a/compliance/azure/azure_long_stopped_instances/long_stopped_instances_azure_meta_parent.pt
+++ b/compliance/azure/azure_long_stopped_instances/long_stopped_instances_azure_meta_parent.pt
@@ -312,7 +312,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -331,7 +336,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/compliance/azure/azure_long_stopped_instances/long_stopped_instances_azure_meta_parent.pt
+++ b/compliance/azure/azure_long_stopped_instances/long_stopped_instances_azure_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -297,23 +299,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent.pt
+++ b/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent.pt
@@ -351,7 +351,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -370,7 +375,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent.pt
+++ b/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -336,23 +338,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/compliance/azure/azure_untagged_vms/untagged_vms_meta_parent.pt
+++ b/compliance/azure/azure_untagged_vms/untagged_vms_meta_parent.pt
@@ -352,7 +352,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -371,7 +376,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/compliance/azure/azure_untagged_vms/untagged_vms_meta_parent.pt
+++ b/compliance/azure/azure_untagged_vms/untagged_vms_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -337,23 +339,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
+++ b/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -305,23 +307,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
+++ b/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 
@@ -801,7 +801,7 @@ policy "policy_scheduled_report" do
   validate $ds_formatted_instances_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} is missing in FlexNet Manager"
     escalate $esc_email
-    escalate $report_instances
+    
     check eq(size(data), 0)
     export do
       resource_level true

--- a/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
+++ b/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
@@ -320,7 +320,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -339,7 +344,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume_meta_parent.pt
+++ b/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "4.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 
@@ -810,7 +810,7 @@ policy "policy_scheduled_report" do
   validate $ds_volume_cost_mapping_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Upgradeable Volumes Found"
     escalate $esc_email
-    escalate $report_volumes
+    
     check eq(size(data), 0)
     export do
       resource_level true

--- a/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume_meta_parent.pt
+++ b/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume_meta_parent.pt
@@ -313,7 +313,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -332,7 +337,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume_meta_parent.pt
+++ b/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -298,23 +300,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
+++ b/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
@@ -349,7 +349,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -368,7 +373,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
+++ b/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -334,23 +336,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -285,23 +287,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "3.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 
@@ -786,24 +786,24 @@ end
 
 
 # Escalation for Approve S3 Object Storage Class Change
-escalation "esc_modify_s3_object_storage_class_approval" do
+escalation "esc_modify" do
   automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
   label "Approve S3 Object Storage Class Change"
   description "Approve selected S3 object storage class change"
-  run "esc_modify_s3_object_storage_class_approval", data, rs_governance_host, rs_project_id
+  run "esc_modify", data, rs_governance_host, rs_project_id
 end
-define esc_modify_s3_object_storage_class_approval($data, $governance_host, $rs_project_id) do
+define esc_modify($data, $governance_host, $rs_project_id) do
   call child_run_action($data, $governance_host, $rs_project_id, "Approve S3 Object Storage Class Change")
 end
 
 # Escalation for Delete S3 Objects
-escalation "esc_delete_s3_objects_approval" do
+escalation "esc_delete" do
   automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
   label "Delete S3 Objects"
   description "Delete selected S3 objects"
-  run "esc_delete_s3_objects_approval", data, rs_governance_host, rs_project_id
+  run "esc_delete", data, rs_governance_host, rs_project_id
 end
-define esc_delete_s3_objects_approval($data, $governance_host, $rs_project_id) do
+define esc_delete($data, $governance_host, $rs_project_id) do
   call child_run_action($data, $governance_host, $rs_project_id, "Delete S3 Objects")
 end
 
@@ -818,9 +818,8 @@ policy "policy_scheduled_report" do
   validate $ds_aws_filtered_s3_objects_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Opportunities for AWS Object Storage Optimization"
     escalate $esc_email
-    escalate $esc_report_s3_Objects_list
-    escalate $esc_modify_s3_object_storage_class_approval
-    escalate $esc_delete_s3_objects_approval
+    escalate $esc_modify
+    escalate $esc_delete
     check eq(size(data), 0)
     export do
       resource_level true

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
@@ -300,7 +300,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -319,7 +324,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -340,23 +342,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
@@ -355,7 +355,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -374,7 +379,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/rds_instance_license_info/rds_instance_license_info_meta_parent.pt
+++ b/cost/aws/rds_instance_license_info/rds_instance_license_info_meta_parent.pt
@@ -281,7 +281,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -300,7 +305,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/rds_instance_license_info/rds_instance_license_info_meta_parent.pt
+++ b/cost/aws/rds_instance_license_info/rds_instance_license_info_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -266,23 +268,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -305,23 +307,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
@@ -320,7 +320,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -339,7 +344,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -364,23 +366,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
@@ -379,7 +379,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -398,7 +403,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
@@ -358,7 +358,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -377,7 +382,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -343,23 +345,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check_meta_parent.pt
+++ b/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check_meta_parent.pt
@@ -273,7 +273,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -292,7 +297,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check_meta_parent.pt
+++ b/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -258,23 +260,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/schedule_instance/aws_schedule_instance_meta_parent.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance_meta_parent.pt
@@ -295,7 +295,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -314,7 +319,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/schedule_instance/aws_schedule_instance_meta_parent.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -280,23 +282,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -305,23 +307,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
@@ -320,7 +320,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -339,7 +344,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/unused_clbs/aws_unused_clbs_meta_parent.pt
+++ b/cost/aws/unused_clbs/aws_unused_clbs_meta_parent.pt
@@ -319,7 +319,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -338,7 +343,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/unused_clbs/aws_unused_clbs_meta_parent.pt
+++ b/cost/aws/unused_clbs/aws_unused_clbs_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -304,23 +306,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -306,23 +308,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
@@ -321,7 +321,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -340,7 +345,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/unused_rds/unused_rds_meta_parent.pt
+++ b/cost/aws/unused_rds/unused_rds_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -305,23 +307,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/unused_rds/unused_rds_meta_parent.pt
+++ b/cost/aws/unused_rds/unused_rds_meta_parent.pt
@@ -320,7 +320,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -339,7 +344,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -323,23 +325,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
@@ -338,7 +338,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -357,7 +362,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/databricks/rightsize_compute/azure_databricks_rightsize_compute_meta_parent.pt
+++ b/cost/azure/databricks/rightsize_compute/azure_databricks_rightsize_compute_meta_parent.pt
@@ -413,7 +413,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -432,7 +437,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/databricks/rightsize_compute/azure_databricks_rightsize_compute_meta_parent.pt
+++ b/cost/azure/databricks/rightsize_compute/azure_databricks_rightsize_compute_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -398,23 +400,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -329,23 +331,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
@@ -344,7 +344,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -363,7 +368,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
@@ -335,7 +335,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -354,7 +359,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -320,23 +322,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -299,23 +301,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
@@ -314,7 +314,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -333,7 +338,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
@@ -331,7 +331,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -350,7 +355,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -316,23 +318,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -338,23 +340,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
@@ -353,7 +353,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -372,7 +377,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -406,23 +408,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
@@ -421,7 +421,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -440,7 +445,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
@@ -382,7 +382,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -401,7 +406,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -367,23 +369,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
@@ -313,7 +313,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -332,7 +337,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -298,23 +300,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent.pt
+++ b/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent.pt
@@ -315,7 +315,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -334,7 +339,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent.pt
+++ b/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -300,23 +302,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -329,23 +331,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
@@ -344,7 +344,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -363,7 +368,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -330,23 +332,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
@@ -345,7 +345,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -364,7 +369,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
+++ b/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
@@ -322,7 +322,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -341,7 +346,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
+++ b/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -307,23 +309,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
@@ -381,7 +381,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -400,7 +405,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -366,23 +368,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations_meta_parent.pt
+++ b/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Google Projects returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Google Projects returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Google Projects who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Google Projects are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Google Projects returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Google Projects returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Google Projects who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Google Projects [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -320,23 +322,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations_meta_parent.pt
+++ b/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations_meta_parent.pt
@@ -335,7 +335,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -354,7 +359,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/google/cud_recommendations/google_committed_use_discount_recommendations_meta_parent.pt
+++ b/cost/google/cud_recommendations/google_committed_use_discount_recommendations_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Google Projects returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Google Projects returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Google Projects who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Google Projects are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Google Projects returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Google Projects returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Google Projects who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Google Projects [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -320,23 +322,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/google/cud_recommendations/google_committed_use_discount_recommendations_meta_parent.pt
+++ b/cost/google/cud_recommendations/google_committed_use_discount_recommendations_meta_parent.pt
@@ -335,7 +335,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -354,7 +359,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Google Projects returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Google Projects returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Google Projects who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Google Projects are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Google Projects returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Google Projects returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Google Projects who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Google Projects [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -320,23 +322,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
@@ -335,7 +335,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -354,7 +359,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Google Projects returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Google Projects returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Google Projects who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Google Projects are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Google Projects returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Google Projects returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Google Projects who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Google Projects [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -338,23 +340,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
@@ -353,7 +353,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -372,7 +377,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Google Projects returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Google Projects returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Google Projects who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Google Projects are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Google Projects returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Google Projects returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Google Projects who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Google Projects [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -303,23 +305,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
@@ -318,7 +318,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -337,7 +342,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
+++ b/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
@@ -344,7 +344,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -363,7 +368,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
+++ b/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Google Projects returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Google Projects returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Google Projects who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Google Projects are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Google Projects returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Google Projects returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Google Projects who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Google Projects [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -329,23 +331,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate_meta_parent.pt
+++ b/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -278,23 +280,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate_meta_parent.pt
+++ b/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate_meta_parent.pt
@@ -293,7 +293,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -312,7 +317,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate_meta_parent.pt
+++ b/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "4.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 
@@ -790,7 +790,7 @@ policy "policy_scheduled_report" do
   validate $ds_merged_results_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} AWS Functions over error percentage"
     escalate $esc_email
-    escalate $esc_functions_in_error
+    
     check eq(size(data), 0)
     export do
       resource_level true

--- a/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
+++ b/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
@@ -311,7 +311,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -330,7 +335,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
+++ b/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -296,23 +298,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/operational/aws/tag_cardinality/aws_tag_cardinality_meta_parent.pt
+++ b/operational/aws/tag_cardinality/aws_tag_cardinality_meta_parent.pt
@@ -268,7 +268,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -287,7 +292,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/operational/aws/tag_cardinality/aws_tag_cardinality_meta_parent.pt
+++ b/operational/aws/tag_cardinality/aws_tag_cardinality_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -253,23 +255,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
+++ b/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "3.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 
@@ -792,7 +792,7 @@ policy "policy_scheduled_report" do
   validate $ds_filtered_certificates_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Expired Certificates Found"
     escalate $esc_email
-    escalate $esc_report_bad_certs
+    
     check eq(size(data), 0)
     export do
       resource_level true

--- a/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
+++ b/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
@@ -311,7 +311,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -330,7 +335,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
+++ b/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -296,23 +298,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -329,23 +331,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
@@ -344,7 +344,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -363,7 +368,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
+++ b/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -283,23 +285,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
+++ b/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
@@ -298,7 +298,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -317,7 +322,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent.pt
+++ b/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -290,23 +292,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent.pt
+++ b/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent.pt
@@ -305,7 +305,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -324,7 +329,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes_meta_parent.pt
+++ b/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes_meta_parent.pt
@@ -287,7 +287,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -306,7 +311,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes_meta_parent.pt
+++ b/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "4.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 
@@ -784,7 +784,7 @@ policy "policy_scheduled_report" do
   validate $ds_unencrypted_volumes_map_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Unencrypted Volumes Found in AWS"
     escalate $esc_email
-    escalate $report_unencrypted_volumes
+    
     check eq(size(data), 0)
     export do
       resource_level true

--- a/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes_meta_parent.pt
+++ b/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -272,23 +274,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances_meta_parent.pt
+++ b/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "4.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 
@@ -781,24 +781,24 @@ end
 
 
 # Escalation for Update Instance
-escalation "modify_publicly_accessible_RDS_instance_approval" do
+escalation "esc_modify" do
   automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
   label "Update Instance"
   description "Approve selected RDS public access rule configuration change"
-  run "modify_publicly_accessible_RDS_instance_approval", data, rs_governance_host, rs_project_id
+  run "esc_modify", data, rs_governance_host, rs_project_id
 end
-define modify_publicly_accessible_RDS_instance_approval($data, $governance_host, $rs_project_id) do
+define esc_modify($data, $governance_host, $rs_project_id) do
   call child_run_action($data, $governance_host, $rs_project_id, "Update Instance")
 end
 
 # Escalation for Delete Instance
-escalation "delete_publicly_accessible_RDS_instances_approval" do
+escalation "esc_delete" do
   automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
   label "Delete Instance"
   description "Delete selected publicly accessible RDS-instances"
-  run "delete_publicly_accessible_RDS_instances_approval", data, rs_governance_host, rs_project_id
+  run "esc_delete", data, rs_governance_host, rs_project_id
 end
-define delete_publicly_accessible_RDS_instances_approval($data, $governance_host, $rs_project_id) do
+define esc_delete($data, $governance_host, $rs_project_id) do
   call child_run_action($data, $governance_host, $rs_project_id, "Delete Instance")
 end
 
@@ -813,9 +813,8 @@ policy "policy_scheduled_report" do
   validate $ds_rds_publicly_accessible_instance_map_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Publicly Accessible RDS Instances Found in AWS"
     escalate $esc_email
-    escalate $report_publicly_accessible_RDS_instances
-    escalate $modify_publicly_accessible_RDS_instance_approval
-    escalate $delete_publicly_accessible_RDS_instances_approval
+    escalate $esc_modify
+    escalate $esc_delete
     check eq(size(data), 0)
     export do
       resource_level true

--- a/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances_meta_parent.pt
+++ b/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances_meta_parent.pt
@@ -295,7 +295,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -314,7 +319,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances_meta_parent.pt
+++ b/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -280,23 +282,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/security/storage/aws/public_buckets/aws_public_buckets_meta_parent.pt
+++ b/security/storage/aws/public_buckets/aws_public_buckets_meta_parent.pt
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -269,23 +271,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/security/storage/aws/public_buckets/aws_public_buckets_meta_parent.pt
+++ b/security/storage/aws/public_buckets/aws_public_buckets_meta_parent.pt
@@ -284,7 +284,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -303,7 +308,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all AWS Accounts are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which AWS Accounts returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select AWS Accounts who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific AWS Accounts [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -240,23 +242,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
@@ -255,7 +255,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -274,7 +279,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
@@ -281,7 +281,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -300,7 +305,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Azure Subscriptions are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Azure Subscriptions returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Azure Subscriptions who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Azure Subscriptions [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -266,23 +268,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array

--- a/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
@@ -281,7 +281,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: type, value: v });
+
+    if (type == "equal") {
+      filter_expressions.push({ dimension: k, type: "equal", value: v });
+    } else {
+      filter_expressions.push({ dimension: k, type: "substring", substring: v });
+    }
   });
 
   // Append to filter expressions using exclude policy params
@@ -300,7 +305,12 @@ script "js_make_billing_center_request", type: "javascript" do
 
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
+
+    if (type == "equal") {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    } else {
+      filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "substring", "substring": v } });
+    }
   });
 
   // Produces a duplicate-free version of the array

--- a/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
@@ -29,7 +29,8 @@ parameter "param_dimension_filter_includes" do
   type "list"
   label "Dimension Include Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Google Projects returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Google Projects returned by the Flexera Bill Analysis API to **INCLUDE** and be applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Google Projects who match **all** the filters defined and apply a child policy for each.
   If no include filters are provided, then all Google Projects are included by default.
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -41,7 +42,8 @@ parameter "param_dimension_filter_excludes" do
   type "list"
   label "Dimension Exclude Filters"
   description <<-EOS
-  Filters [`dimension_name=dimension_value` pairs] to determine which Google Projects returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Filters [`dimension_name=dimension_value` and `dimension_name=~dimension_value` pairs] to determine which Google Projects returned by  the Flexera Bill Analysis API to **EXCLUDE** and *not* have policy applied to.
+  Use = to match the entire value and =~ to match a substring contained in the value.
   During each run this policy will select Google Projects who match **all** the filters defined here and excludes them from results.
   Can be used to exclude specific Google Projects [`vendor_account=123456789012`]
   Most of the dimensions in Flexera can be used [default dimensions, custom tag dimensions, rule-based dimensions].  Full list of available dimensions documented in the [Bill Analysis API Docs](https://reference.rightscale.com/bill_analysis/).
@@ -266,23 +268,39 @@ script "js_make_billing_center_request", type: "javascript" do
   // Append to default dimensions and filter expressions using parent policy params
   _.each(param_dimension_filter_includes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ dimension: k, type: "equal", value: v });
+    filter_expressions.push({ dimension: k, type: type, value: v });
   });
 
   // Append to filter expressions using exclude policy params
   _.each(param_dimension_filter_excludes, function (v) {
     // split key=value string
-    var split = v.split("=");
+    if (v.indexOf('=~') == -1) {
+      var split = v.split("=");
+      var type = "equal"
+    } else {
+      var split = v.split("=~");
+      var type = "substring"
+    }
+
     var k = split[0];
     var v = split[1];
+
     // append to lists
     dimensions.push(k);
-    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": "equal", "value": v } });
+    filter_expressions.push({ "type": "not", "expression": { "dimension": k, "type": type, "value": v } });
   });
 
   // Produces a duplicate-free version of the array


### PR DESCRIPTION
### Description

This adds support for substrings when filtering dimensions in the parent policies. 

### Link to Example Applied Policy

https://app.flexera.com/orgs/27018/automation/applied-policies/projects/116186?policyId=65a001ca0620ac00011a9415

(dimension filter is vendor_account_name=~Datalake and if you look at the policies created incident, the only child is for an account whose name contains Datalake)

### Contribution Check List

- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
