### PR TITLE
POL-1051 Google Committed Use Discount Recommender - Update Permissions in README

### DIFF
--- a/cost/google/cud_recommendations/README.md
+++ b/cost/google/cud_recommendations/README.md
@@ -46,11 +46,9 @@ This Policy Template requires that several APIs be enabled in your Google Cloud 
 This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).
 
 - [**Google Cloud Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_4083446696_1121577) (*provider=gce*) which has the following:
-  - Roles
-    - `Project Usage Commitment Recommender Viewer`
-
   - Permissions
     - `resourcemanager.projects.get`
+    - `compute.regions.list`
     - `recommender.usageCommitmentRecommendations.list`
     - `billing.resourceCosts.get`*
     - `billing.accounts.getSpendingInformation`*


### PR DESCRIPTION
Added "compute.regions.list" permission; removed "Project Usage Commitment Recommender Viewer"

### Description

<!-- Describe what this change achieves below -->
This is a ticket to update the README to:

- Add the following permission - compute.regions.list
- Remove the following role - Project Usage Commitment Recommender Viewer (we want to move away from using roles)

### Issues Resolved

<!-- List any existing issues this PR resolves below -->
Removes the reliance on Roles for Policy Automation Credential permissions, and switches to using solely individual Permissions.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->https://app.flexera.com/orgs/30105/automation/applied-policies/projects/133807?policyId=65b9199793d20b0001790c17


### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
