### PR TITLE
FOPTS-3031 Update parameters of Azure Rightsize Managed Disk policy

### DIFF
--- a/cost/azure/rightsize_managed_disks/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_disks/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.2
+
+- Updated the descriptions and labels of the IOPS and throughput parameters in the README and policy template files.
+- Updated the short description of the policy.
+- Changed the functionality of `param_min_savings`: Before this version, the `param_min_savings` parameter was used to consider the total savings (the sum of all the savings per resource) and not the savings per resource to decide whether to recommend or not. In this new version, this parameter is used to recommend or not based on the savings of each resource, just as other policies do.
+
 ## v1.1
 
 - Fixed error where policy would fail completely when trying to access resources credential does not have access to. Policy will now simply skip these resources.

--- a/cost/azure/rightsize_managed_disks/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_disks/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Updated the descriptions and labels of the IOPS and throughput parameters in the README and policy template files.
 - Updated the short description of the policy.
-- Changed the functionality of `param_min_savings`: Before this version, the `param_min_savings` parameter was used to consider the total savings (the sum of all the savings per resource) and not the savings per resource to decide whether to recommend or not. In this new version, this parameter is used to recommend or not based on the savings of each resource, just as other policies do.
+- Fixed the functionality of *Minimum Savings Threshold* parameter. This parameter is used to suppress recommendations with potential savings below the specified threshold.
 
 ## v1.1
 

--- a/cost/azure/rightsize_managed_disks/README.md
+++ b/cost/azure/rightsize_managed_disks/README.md
@@ -2,10 +2,9 @@
 
 ## What it does
 
-This Policy Template scans all volumes in the given account and identifies any volume that meets the user-specified criteria for being oversized. The user can filter volumes based on usage percentage of IOPS, usage percentage of throughput, or any combination of these. Any volumes that meet the user-specified criteria are considered oversized. If any oversized volumes are found, an incident report will show the volumes and related information. An email will be sent to the user-specified email addresses.
+This policy checks managed disks in Azure subscriptions and identifies underutilized disks based on disk performance metrics over a lookback period and a threshold specified by the user; if underutilized disks are found, then disk type downgrade is recommended. An email will be sent to the user-specified email addresses.
 
-- It is important that you keep constant LUN numbers for your data disks because when policy retrieves metrics for them. It will only look for the latest LUN number assigned to the data disk; if changed multiple times before running the policy, only the data points using the current LUN the disk has will be retrieved for analysis.
-- Currently the policy only works for righsizing using the disk used IOPS and throughput since disk capacity (GiB) is not retrievable from Azure.
+Note: It is preferred to keep the disk LUN number constant when detaching and re-attaching a data disk to a virtual machine. LUN number is used to retrieve disk performance metrics (IOPs and throughput).
 
 ### Policy Saving Details
 
@@ -24,10 +23,10 @@ The policy includes the estimated monthly savings. The estimated monthly savings
 - *Allow/Deny Subscriptions List* - A list of allowed or denied Subscription IDs/names. If empty, no filtering will occur and recommendations will be produced for all subscriptions.
 - *Allow/Deny Regions* - Whether to treat Allow/Deny Regions List parameter as allow or deny list. Has no effect if Allow/Deny Regions List is left empty.
 - *Allow/Deny Regions List* - Filter results by region, either only allowing this list or denying it depending on how the above parameter is set. Leave blank to consider all the regions.
-- *Minimum Used Disk IOPS %* - The minimum used disk IOPS percentage threshold at which to consider a disk to be 'oversized' and therefore be flagged for downsizing.
-- *Aggregation Type For Disk IOPS* - Statistic to use when determining if the disk IOPS is more than the disk actually uses.
-- *Minimum Used Disk Throughput %* - The minimum used disk throughput percentage threshold at which to consider a disk to be 'oversized' and therefore be flagged for downsizing.
-- *Aggregation Type For Disk Throughput* - Statistic to use when determining if the disk throughput is more than the disk actually uses.
+- *IOPS Threshold* - The IOPS threshold at which to consider a managed disk to be underutilized.
+- *IOPS Threshold Statistic* - Statistic to use for IOPS when determining if a managed disk is underutilized.
+- *Throughput Threshold* - The throughput threshold at which to consider a managed disk to be underutilized.
+- *Throughput Threshold Statistic* - Statistic to use for throughput when determining if a managed disk is underutilized.
 - *Lookback Period* - How many days back to look at disk IOPS and throughput data. This value cannot be set higher than 90 because Azure does not retain metrics for longer than 90 days.
 
 ## Policy Actions

--- a/cost/azure/rightsize_managed_disks/README.md
+++ b/cost/azure/rightsize_managed_disks/README.md
@@ -23,9 +23,9 @@ The policy includes the estimated monthly savings. The estimated monthly savings
 - *Allow/Deny Subscriptions List* - A list of allowed or denied Subscription IDs/names. If empty, no filtering will occur and recommendations will be produced for all subscriptions.
 - *Allow/Deny Regions* - Whether to treat Allow/Deny Regions List parameter as allow or deny list. Has no effect if Allow/Deny Regions List is left empty.
 - *Allow/Deny Regions List* - Filter results by region, either only allowing this list or denying it depending on how the above parameter is set. Leave blank to consider all the regions.
-- *IOPS Threshold* - The IOPS threshold at which to consider a managed disk to be underutilized.
+- *IOPS Threshold (%)* - The IOPS threshold percentage at which to consider a managed disk to be underutilized.
 - *IOPS Threshold Statistic* - Statistic to use for IOPS when determining if a managed disk is underutilized.
-- *Throughput Threshold* - The throughput threshold at which to consider a managed disk to be underutilized.
+- *Throughput Threshold (%)* - The throughput threshold at which to consider a managed disk to be underutilized.
 - *Throughput Threshold Statistic* - Statistic to use for throughput when determining if a managed disk is underutilized.
 - *Lookback Period* - How many days back to look at disk IOPS and throughput data. This value cannot be set higher than 90 because Azure does not retain metrics for longer than 90 days.
 

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
@@ -1,4 +1,4 @@
-name "Azure Rightsize Managed Disks v1.2"
+name "Azure Rightsize Managed Disks"
 rs_pt_ver 20180301
 type "policy"
 short_description "This policy finds underutilized managed disks and recommends downgrading the managed disk tier if this results in savings and satisfies required usage levels. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/rightsize_managed_disks/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
@@ -1,4 +1,4 @@
-name "Azure Rightsize Managed Disks v1.2"
+name "Azure Rightsize Managed Disks"
 rs_pt_ver 20180301
 type "policy"
 short_description "This policy finds underutilized managed disks and recommends downgrading the managed disk tier if this results in savings and satisfies required usage levels.. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/rightsize_managed_disks/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
@@ -90,7 +90,7 @@ end
 parameter "param_min_used_disk_iops_pct" do
   type "number"
   category "Filters"
-  label "IOPS Threshold"
+  label "IOPS Threshold (%)"
   description "The IOPs threshold at which to consider a managed disk to be underutilized. Set to -1 to turn off this filter."
   min_value -1
   max_value 100
@@ -109,7 +109,7 @@ end
 parameter "param_min_used_disk_throughput_pct" do
   type "number"
   category "Filters"
-  label "Throughput Threshold"
+  label "Throughput Threshold (%)"
   description "The throughput threshold at which to consider a managed disk to be underutilized. Set to -1 to turn off this filter."
   min_value -1
   max_value 100

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
@@ -1,13 +1,13 @@
-name "Azure Rightsize Managed Disks"
+name "Azure Rightsize Managed Disks v1.2"
 rs_pt_ver 20180301
 type "policy"
-short_description "Looks for oversized managed disks and suggest recommendations to save money. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/rightsize_managed_disks/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "This policy finds underutilized managed disks and recommends downgrading the managed disk tier if this results in savings and satisfies required usage levels.. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/rightsize_managed_disks/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 category "Cost"
 severity "low"
 default_frequency "monthly"
 info(
-  version: "1.1",
+  version: "1.2",
   provider: "Azure",
   service: "Managed Disks",
   policy_set: "Rightsize Storage",
@@ -90,8 +90,8 @@ end
 parameter "param_min_used_disk_iops_pct" do
   type "number"
   category "Filters"
-  label "Used disk IOPS percentage threshold"
-  description "The minimum used disk IOPS percentage threshold at which to consider a disk to be 'oversized' and therefore be flagged for downsizing. Set to -1 to disable this filter."
+  label "IOPS Threshold"
+  description "The IOPs threshold at which to consider a managed disk to be underutilized. Set to -1 to turn off this filter."
   min_value -1
   max_value 100
   default -1
@@ -100,8 +100,8 @@ end
 parameter "param_stats_aggregation_for_disk_iops" do
   type "string"
   category "Statistics"
-  label "Aggregation type for determining oversized disk IOPS"
-  description "Statistic to use when determining if the disk IOPS is more than the disk actually uses."
+  label "IOPS Threshold Statistic"
+  description "Statistic to use for IOPS when determining if a managed disk is underutilized."
   allowed_values "Average", "Maximum"
   default "Maximum"
 end
@@ -109,8 +109,8 @@ end
 parameter "param_min_used_disk_throughput_pct" do
   type "number"
   category "Filters"
-  label "Used disk throughput percentage threshold"
-  description "The minimum used disk throughput percentage threshold at which to consider a disk to be 'oversized' and therefore be flagged for downsizing. Set to -1 to disable this filter."
+  label "Throughput Threshold"
+  description "The throughput threshold at which to consider a managed disk to be underutilized. Set to -1 to turn off this filter."
   min_value -1
   max_value 100
   default -1
@@ -119,8 +119,8 @@ end
 parameter "param_stats_aggregation_for_disk_throughput" do
   type "string"
   category "Statistics"
-  label "Aggregation type for determining oversized disk throughput"
-  description "Statistic to use when determining if the disk throughput is more than the disk actually uses."
+  label "Throughput Threshold Statistic"
+  description "Statistic to use for throughput when determining if a managed disk is underutilized."
   allowed_values "Average", "Maximum"
   default "Maximum"
 end
@@ -842,6 +842,10 @@ script "js_disk_rightsizing_recommendations", type: "javascript" do
       newResourceTypePriceCurrency = fittingDiskPrice.currencyCode
     } else continue;
 
+    if (monthlySavings < param_min_savings) {
+      continue;
+    }
+
     tags = []
     if (typeof(disk.tags) == 'object') {
       _.each(Object.keys(disk.tags), function(key) {
@@ -890,7 +894,7 @@ script "js_disk_rightsizing_recommendations", type: "javascript" do
     totalMonthlySavings += monthlySavings
   }
 
-  if (recommendations.length > 0 && totalMonthlySavings >= param_min_savings) {
+  if (recommendations.length > 0) {
     monthlySavings = monthlySavings.toFixed(2)
 
     recommendations[0].message = "Oversized disks are those that meet the following conditions within the last " + param_stats_lookback + " day(s):\n\n"

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
@@ -1,7 +1,7 @@
-name "Azure Rightsize Managed Disks"
+name "Azure Rightsize Managed Disks v1.2"
 rs_pt_ver 20180301
 type "policy"
-short_description "This policy finds underutilized managed disks and recommends downgrading the managed disk tier if this results in savings and satisfies required usage levels.. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/rightsize_managed_disks/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "This policy finds underutilized managed disks and recommends downgrading the managed disk tier if this results in savings and satisfies required usage levels. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/rightsize_managed_disks/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 category "Cost"
 severity "low"


### PR DESCRIPTION
### Description

- Updated the descriptions and labels of the IOPS and throughput parameters in the README and policy template files.
- Updated the short description of the policy.
- Changed the functionality of `param_min_savings`: Before this version, the `param_min_savings` parameter was used to consider the total savings (the sum of all the savings per resource) and not the savings per resource to decide whether to recommend or not. In this new version, this parameter is used to recommend or not based on the savings of each resource, just as other policies do.

### Issues Resolved

- https://flexera.atlassian.net/browse/FOPTS-3170

### Link to Example Applied Policy

You can find the link to the applied policy in the following comment at Jira:
https://flexera.atlassian.net/browse/FOPTS-3170?focusedCommentId=2248041

### Contribution Check List

- [x] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
