### PR TITLE
POL-1068 Cloud Cost Anomaly Alerts Link Fix

### DIFF
--- a/cost/cloud_cost_anomaly_alerts/CHANGELOG.md
+++ b/cost/cloud_cost_anomaly_alerts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1
+
+- Fixed bug where incident link would render incorrectly if spaces were present in filter value
+
 ## v3.0
 
 - Link to Flexera One Cloud Cost Anomalies page now includes filters

--- a/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
+++ b/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.0",
+  version: "3.1",
   provider: "Flexera",
   service: "Optima",
   policy_set: ""
@@ -394,11 +394,15 @@ script "js_filter_anomalies", type: "javascript" do
   filters = ds_filter_dimensions['filters'].concat(ds_filter_dimensions['bc_filters'])
 
   dimensions_groupby_string = _.map(dimensions, function(id) {
-    return "&groupBy=" + id
+    value = "&groupBy=" + id
+    while (value.split(' ')[1] != undefined) { value = value.replace(' ', '%20') }
+    return value
   }).join('')
 
   dimensions_filterby_string = _.map(filters, function(filter) {
-    return "&filterBy=anomaly." + filter['id'] + "." + filter['value']
+    value = "&filterBy=anomaly." + filter['id'] + "." + filter['value']
+    while (value.split(' ')[1] != undefined) { value = value.replace(' ', '%20') }
+    return value.replace(' ', '%20').replace(' ', '%20').replace(' ', '%20').replace(' ', '%20')
   }).join('')
 
   link = [

--- a/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
+++ b/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
@@ -402,7 +402,7 @@ script "js_filter_anomalies", type: "javascript" do
   dimensions_filterby_string = _.map(filters, function(filter) {
     value = "&filterBy=anomaly." + filter['id'] + "." + filter['value']
     while (value.split(' ')[1] != undefined) { value = value.replace(' ', '%20') }
-    return value.replace(' ', '%20').replace(' ', '%20').replace(' ', '%20').replace(' ', '%20')
+    return value
   }).join('')
 
   link = [


### PR DESCRIPTION
### Description

This fixes a bug where the link would render incorrectly if spaces were present. Spaces are now appropriately replaced with %20 in the link.

### Link to Example Applied Policy

The change was tested in a customized version of this same policy. It also works in node:

❯ node
> filter = {'id': 'some stuff with spaces', 'value': 'even more spaces omg'}
{ id: 'some stuff with spaces', value: 'even more spaces omg' }
> value = "&filterBy=anomaly." + filter['id'] + "." + filter['value']
'&filterBy=anomaly.some stuff with spaces.even more spaces omg'
> while (value.split(' ')[1] != undefined) { value = value.replace(' ', '%20') }
'&filterBy=anomaly.some%20stuff%20with%20spaces.even%20more%20spaces%20omg'
>

### Contribution Check List

- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
