### PR TITLE
FOPTS-3238 Update `short_description` of the policy Azure Rightsize NetApp Files

### DIFF
--- a/cost/azure/rightsize_netapp_files/CHANGELOG.md
+++ b/cost/azure/rightsize_netapp_files/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.1
+
+- Updated the `short_description` of the policy to match with the Flexera documentation.
+
 ## v1.0
 
 - Initial release.

--- a/cost/azure/rightsize_netapp_files/azure_rightsize_netapp_files.pt
+++ b/cost/azure/rightsize_netapp_files/azure_rightsize_netapp_files.pt
@@ -1,13 +1,13 @@
 name "Azure Rightsize NetApp Files"
 rs_pt_ver 20180301
 type "policy"
-short_description "Checks for oversized NetApp Capacity Pools and suggest recommendations to save money. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/rightsize_netapp_files/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "Checks for oversized NetApp capacity pools and suggests recommendations for rightsizing the capacity pools and volumes to optimize efficiency and reduce costs. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/rightsize_netapp_files/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "1.0",
+  version: "1.1",
   provider: "Azure",
   service: "NetApp Files",
   policy_set: "Rightsize Storage",


### PR DESCRIPTION
### Description

The short description of the policy Azure Rightsize NetApp Files was in sync with the Flexera documentation, this change updated the `short_description` of the policy so both descriptions match.

### Issues Resolved

- https://flexera.atlassian.net/browse/FOPTS-3238

### Link to Example Applied Policy

This did not updated any part of the code, only the short description, despite this I still applied the policy just in case:
https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/60073?policyId=65ddfce1f73314000135e2c4

It uploaded correctly, that means the code is fine. I attach this GIF if you are not able to log in Flexera test:
![azure-rightsize-netapp-files-v1 1](https://github.com/flexera-public/policy_templates/assets/54189123/729082fd-4ca2-4741-b026-c3b89754d3e8)

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
