### PR TITLE
POL-1070 Deprecate AWS Inefficient Instance Utilization using CloudWatch

### DIFF
--- a/cost/aws/instance_cloudwatch_utilization/CHANGELOG.md
+++ b/cost/aws/instance_cloudwatch_utilization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.3
+
+- Deprecated: This policy is no longer being updated. Please see policy README for more information.
+
 ## v3.2
 
 - Updated description of `Account Number` parameter

--- a/cost/aws/instance_cloudwatch_utilization/README.md
+++ b/cost/aws/instance_cloudwatch_utilization/README.md
@@ -1,5 +1,9 @@
 # AWS Inefficient Instance Utilization using CloudWatch
 
+## Deprecated
+
+This policy is no longer being updated. The [AWS Rightsize EC2 Instances](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/rightsize_ec2_instances/) policy now includes this functionality and is the recommended policy for obtaining these recommendations.
+
 ## What it does
 
 This Policy Template gathers AWS instances with inefficient utilization using CloudWatch CPU and Memory Metrics over a 30 day average and downsized after approval.

--- a/cost/aws/instance_cloudwatch_utilization/aws_instance_cloudwatch_utilization.pt
+++ b/cost/aws/instance_cloudwatch_utilization/aws_instance_cloudwatch_utilization.pt
@@ -1,13 +1,13 @@
 name "AWS Inefficient Instance Utilization using CloudWatch"
 rs_pt_ver 20180301
 type "policy"
-short_description "Checks inefficient instance utilization using provided CPU and Memory thresholds. Instances matching the criteria can be resized after user approval. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/instance_cloudwatch_utilization/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "**Deprecated: This policy is no longer being updated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/instance_cloudwatch_utilization/) for more details.** Checks inefficient instance utilization using provided CPU and Memory thresholds. Instances matching the criteria can be resized after user approval. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/instance_cloudwatch_utilization/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "3.2",
+  version: "3.3",
   provider: "AWS",
   service: "Compute",
   policy_set: "Inefficient Instance Usage"


### PR DESCRIPTION
### Description

The AWS Inefficient Instance Utilization using CloudWatch policy does basically the same thing as the existing Rightsize EC2 policy, so it is being deprecated.