### PR TITLE
POL-1071 Merge 'AWS RDS Instances' policy into 'AWS Rightsize RDS Instances'

### DIFF
--- a/cost/aws/rds_instance_license_info/CHANGELOG.md
+++ b/cost/aws/rds_instance_license_info/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.2
+
+- Deprecated: This policy is no longer being updated. Please see policy README for more information.
+
 ## v4.1
 
 - Updated description of `Account Number` parameter

--- a/cost/aws/rds_instance_license_info/README.md
+++ b/cost/aws/rds_instance_license_info/README.md
@@ -2,7 +2,7 @@
 
 ## Deprecated
 
-This policy is no longer being updated. The [AWS Rightsize RDS Instances](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/rightsize_rds_instances/) policy can be used with the `Underutilized Instance CPU Threshold (%)` parameter set to `100` to retrieve the same information.
+This policy is no longer being updated. The [AWS Rightsize RDS Instances](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/rightsize_rds_instances/) policy can be used with the `Underutilized Instance CPU Threshold (%)` parameter set to `100` and the `Report Unused or Underutilized` parameter set to `Underutilized` to retrieve the same information.
 
 ## What it does
 

--- a/cost/aws/rds_instance_license_info/README.md
+++ b/cost/aws/rds_instance_license_info/README.md
@@ -1,5 +1,9 @@
 # AWS RDS Instance License Information
 
+## Deprecated
+
+This policy is no longer being updated. The [AWS Rightsize RDS Instances](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/rightsize_rds_instances/) policy can be used with the `Underutilized Instance CPU Threshold (%)` parameter set to `100` to retrieve the same information.
+
 ## What it does
 
 This Policy Template gathers AWS RDS Instance data related to licensing.

--- a/cost/aws/rds_instance_license_info/rds_instance_license_info.pt
+++ b/cost/aws/rds_instance_license_info/rds_instance_license_info.pt
@@ -1,13 +1,13 @@
 name "AWS RDS Instances"
 rs_pt_ver 20180301
 type "policy"
-short_description "Collects all RDS instances in an account. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/rds_instance_license_info/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "**Deprecated: This policy is no longer being updated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/rds_instance_license_info/) for more details.**  Collects all RDS instances in an account. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/rds_instance_license_info/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "4.1",
+  version: "4.2",
   provider: "AWS",
   service: "RDS",
   policy_set: ""

--- a/cost/aws/rds_instance_license_info/rds_instance_license_info_meta_parent.pt
+++ b/cost/aws/rds_instance_license_info/rds_instance_license_info_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "4.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 

--- a/cost/aws/rightsize_rds_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_rds_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.1
+
+- Added Availability Zone, License Model, and vCPUs to incident output
+
 ## v5.0
 
 - Added support for regex when filtering resources by tag

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "5.0",
+  version: "5.1",
   provider: "AWS",
   service: "RDS",
   policy_set: "Rightsize Database Instances",
@@ -515,6 +515,14 @@ datasource "ds_rds_instances_set" do
       field "privateDnsName", xpath(col_item, "Endpoint/Address")
       field "databaseEngine", xpath(col_item, "Engine")
       field "engineVersion", xpath(col_item, "EngineVersion")
+      field "availabilityZone", xpath(col_item, "AvailabilityZone")
+      field "licenseModel", xpath(col_item, "LicenseModel")
+      field "processorFeatures" do
+        collect xpath(col_item, "ProcessorFeatures/ProcessorFeature") do
+          field "name", xpath(col_item, "Name")
+          field "value", xpath(col_item, "Value")
+        end
+      end
       field "region", val(iter_item, "region")
     end
   end
@@ -593,11 +601,11 @@ EOS
 end
 
 datasource "ds_rds_instances" do
-  run_script $js_rds_instances, $ds_rds_instances_set, $ds_resource_tags, $param_exclusion_tags, $param_exclusion_tags_boolean
+  run_script $js_rds_instances, $ds_rds_instances_set, $ds_resource_tags, $ds_aws_instance_size_map, $param_exclusion_tags, $param_exclusion_tags_boolean
 end
 
 script "js_rds_instances", type: "javascript" do
-  parameters "ds_rds_instances_set", "ds_resource_tags", "param_exclusion_tags", "param_exclusion_tags_boolean"
+  parameters "ds_rds_instances_set", "ds_resource_tags", "ds_aws_instance_size_map", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-EOS
   comparators = _.map(param_exclusion_tags, function(item) {
@@ -687,6 +695,18 @@ script "js_rds_instances", type: "javascript" do
 
       tag_string = tag_string.join(', ')
 
+      vcpus = null
+
+      if (typeof(instance["processorFeatures"]) == 'object') {
+        cores = _.findWhere(instance["processorFeatures"], { "name": "coreCount" })["value"]
+        threads = _.findWhere(instance["processorFeatures"], { "name": "threadsPerCore" })["value"]
+        vcpus = cores * threads
+      }
+
+      if (vcpus == null && ds_aws_instance_size_map[instance["resourceType"]] != undefined) {
+        vcpus = ds_aws_instance_size_map[instance["resourceType"]]["vcpu"]
+      }
+
       result.push({
         instanceId: instance['instanceId'],
         instanceArn: instance['instanceArn'],
@@ -697,6 +717,10 @@ script "js_rds_instances", type: "javascript" do
         engineVersion: instance['engineVersion'],
         privateDnsName: instance['privateDnsName'],
         region: instance['region'],
+        availabilityZone: instance['availabilityZone'],
+        licenseModel: instance['licenseModel'],
+        processorFeatures: instance['processorFeatures'],
+        vcpus: vcpus,
         tags: tag_string
       })
     }
@@ -882,6 +906,10 @@ script "js_rds_idle_instances", type: "javascript" do
         privateDnsName: instance['privateDnsName'],
         region: instance['region'],
         tags: instance['tags'],
+        availabilityZone: instance['availabilityZone'],
+        licenseModel: instance['licenseModel'],
+        processorFeatures: instance['processorFeatures'],
+        vcpus: instance['vcpus'],
         savings: savings,
         instance_activity: instance_activity
       })
@@ -1120,6 +1148,10 @@ script "js_rds_nonidle_instances_with_metrics", type: "javascript" do
           privateDnsName: instance['privateDnsName'],
           region: instance['region'],
           tags: instance['tags'],
+          availabilityZone: instance['availabilityZone'],
+          licenseModel: instance['licenseModel'],
+          processorFeatures: instance['processorFeatures'],
+          vcpus: instance['vcpus'],
           savings: savings,
           newResourceType: newResourceType
         }
@@ -1329,6 +1361,10 @@ script "js_rds_idle_incident", type: "javascript" do
         databaseEngine: instance['databaseEngine'],
         platform: instance['databaseEngine'],
         engineVersion: instance['engineVersion'],
+        availabilityZone: instance['availabilityZone'],
+        licenseModel: instance['licenseModel'],
+        processorFeatures: instance['processorFeatures'],
+        vcpus: instance['vcpus'],
         savings: parseFloat(savings.toFixed(3)),
         savingsCurrency: ds_currency['symbol'],
         lookbackPeriod: param_stats_lookback,
@@ -1456,6 +1492,10 @@ script "js_rds_underutil_incident", type: "javascript" do
         cpuP99: instance['cpu_p99'],
         cpuP95: instance['cpu_p95'],
         cpuP90: instance['cpu_p90'],
+        availabilityZone: instance['availabilityZone'],
+        licenseModel: instance['licenseModel'],
+        processorFeatures: instance['processorFeatures'],
+        vcpus: instance['vcpus'],
         savings: parseFloat(savings.toFixed(3)),
         savingsCurrency: ds_currency['symbol'],
         lookbackPeriod: param_stats_lookback,
@@ -1563,6 +1603,9 @@ policy "pol_rightsize_rds" do
       field "region" do
         label "Region"
       end
+      field "availabilityZone" do
+        label "Availability Zone"
+      end
       field "state" do
         label "State"
       end
@@ -1604,6 +1647,12 @@ policy "pol_rightsize_rds" do
       end
       field "engineVersion" do
         label "Engine Version"
+      end
+      field "vcpus" do
+        label "vCPUs"
+      end
+      field "licenseModel" do
+        label "License Model"
       end
       field "arn" do
         label "ARN"
@@ -1658,6 +1707,9 @@ policy "pol_rightsize_rds" do
       field "region" do
         label "Region"
       end
+      field "availabilityZone" do
+        label "Availability Zone"
+      end
       field "state" do
         label "State"
       end
@@ -1678,6 +1730,12 @@ policy "pol_rightsize_rds" do
       end
       field "engineVersion" do
         label "Engine Version"
+      end
+      field "vcpus" do
+        label "vCPUs"
+      end
+      field "licenseModel" do
+        label "License Model"
       end
       field "arn" do
         label "ARN"

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
@@ -697,7 +697,7 @@ script "js_rds_instances", type: "javascript" do
 
       vcpus = null
 
-      if (typeof(instance["processorFeatures"]) == 'object') {
+      if (instance["processorFeatures"] != null) {
         cores = _.findWhere(instance["processorFeatures"], { "name": "coreCount" })["value"]
         threads = _.findWhere(instance["processorFeatures"], { "name": "threadsPerCore" })["value"]
         vcpus = cores * threads

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
@@ -697,10 +697,13 @@ script "js_rds_instances", type: "javascript" do
 
       vcpus = null
 
-      if (instance["processorFeatures"] != null) {
-        cores = _.findWhere(instance["processorFeatures"], { "name": "coreCount" })["value"]
-        threads = _.findWhere(instance["processorFeatures"], { "name": "threadsPerCore" })["value"]
-        vcpus = cores * threads
+      if (instance["processorFeatures"] != null && instance["processorFeatures"] != undefined) {
+        cores = _.findWhere(instance["processorFeatures"], { "name": "coreCount" })
+        threads = _.findWhere(instance["processorFeatures"], { "name": "threadsPerCore" })
+
+        if (cores != undefined && threads != undefined) {
+          vcpus = cores["value"] * threads["value"]
+        }
       }
 
       if (vcpus == null && ds_aws_instance_size_map[instance["resourceType"]] != undefined) {

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 
@@ -931,6 +931,9 @@ policy "policy_scheduled_report" do
       field "region" do
         label "Region"
       end
+      field "availabilityZone" do
+        label "Availability Zone"
+      end
       field "state" do
         label "State"
       end
@@ -972,6 +975,12 @@ policy "policy_scheduled_report" do
       end
       field "engineVersion" do
         label "Engine Version"
+      end
+      field "vcpus" do
+        label "vCPUs"
+      end
+      field "licenseModel" do
+        label "License Model"
       end
       field "arn" do
         label "ARN"
@@ -1023,6 +1032,9 @@ policy "policy_scheduled_report" do
       field "region" do
         label "Region"
       end
+      field "availabilityZone" do
+        label "Availability Zone"
+      end
       field "state" do
         label "State"
       end
@@ -1043,6 +1055,12 @@ policy "policy_scheduled_report" do
       end
       field "engineVersion" do
         label "Engine Version"
+      end
+      field "vcpus" do
+        label "vCPUs"
+      end
+      field "licenseModel" do
+        label "License Model"
       end
       field "arn" do
         label "ARN"


### PR DESCRIPTION
### Description

This modifies the AWS Rightsize RDS Instances policy to include Availability Zone, License Model, and vCPUs in the incident output, rendering the AWS RDS Instances policy obsolete.

Additionally, the AWS RDS Instances policy is flagged as deprecated, and users are directed to the AWS Rightsize RDS Instances policy in the README.

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=65de53f71b78750001a4d0b1

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
