### PR TITLE
POL-1118 Flexera CCO Delete All Billing Centers Policy

### DIFF
--- a/automation/flexera/delete_all_billing_centers/CHANGELOG.md
+++ b/automation/flexera/delete_all_billing_centers/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v1.0
+
+- initial release

--- a/automation/flexera/delete_all_billing_centers/README.md
+++ b/automation/flexera/delete_all_billing_centers/README.md
@@ -7,10 +7,11 @@ This policy deletes all Billing Centers in the Flexera organization it is execut
 ## How It Works
 
 - During execution, the policy determines if this is the second time it has run since it was applied by comparing the applied policy's `created_at` date/time with the current date/time. If the difference between the two is greater than 1 minute, it is assumed the policy is running a second time.
+- If this is the policy's second time running, the policy self-terminates before completing execution as a failsafe in case the user has forgotten to terminate the policy after usage.
 - An incident is always raised, with the `Self Terminate` field in the incident table being true if this is the policy's second time executing since it was applied.
 - Cloud Workflow is automatically kicked off.
-  - If this is the policy's second time executing, the policy takes no action against Billing Centers and instead terminates itself as a failsafe in case it was applied and forgotten about by the user.
-  - If this is the policy's first time executing, deletes all of the Billing Centers in the Flexera organization.
+  - If this is the policy's second time executing, but for some reason the policy has failed to self-terminate, no action will be taken.
+  - If this is the policy's first time executing, all of the Billing Centers in the Flexera organization are deleted.
 
 ## Prerequisites
 
@@ -26,7 +27,7 @@ The [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automati
 
 ## Supported Clouds
 
-- Google
+- Flexera
 
 ## Cost
 

--- a/automation/flexera/delete_all_billing_centers/README.md
+++ b/automation/flexera/delete_all_billing_centers/README.md
@@ -2,7 +2,7 @@
 
 ## What It Does
 
-This policy deletes all Billing Centers in the Flexera organization it is executed within.
+This policy deletes all Billing Centers in the Flexera organization it is executed within. The policy will automatically self-terminate the second time it runs to avoid accidental future deletion of Billing Centers.
 
 ## How It Works
 

--- a/automation/flexera/delete_all_billing_centers/README.md
+++ b/automation/flexera/delete_all_billing_centers/README.md
@@ -6,7 +6,7 @@ This policy deletes all Billing Centers in the Flexera organization it is execut
 
 ## How It Works
 
-- During execution, the policy determines if this is the second time it has run since it was applied by comparing the applied policy's `created_at` date/time with the current date/time. If the difference between the two is greater than 5 minutes, it is assumed the policy is running a second time.
+- During execution, the policy determines if this is the second time it has run since it was applied by comparing the applied policy's `created_at` date/time with the current date/time. If the difference between the two is greater than 1 minute, it is assumed the policy is running a second time.
 - An incident is always raised, with the `Self Terminate` field in the incident table being true if this is the policy's second time executing since it was applied.
 - Cloud Workflow is automatically kicked off.
   - If this is the policy's second time executing, the policy takes no action against Billing Centers and instead terminates itself as a failsafe in case it was applied and forgotten about by the user.

--- a/automation/flexera/delete_all_billing_centers/README.md
+++ b/automation/flexera/delete_all_billing_centers/README.md
@@ -1,0 +1,33 @@
+# Flexera CCO Delete All Billing Centers
+
+## What It Does
+
+This policy deletes all Billing Centers in the Flexera organization it is executed within.
+
+## How It Works
+
+- During execution, the policy determines if this is the second time it has run since it was applied by comparing the applied policy's `created_at` date/time with the current date/time. If the difference between the two is greater than 5 minutes, it is assumed the policy is running a second time.
+- An incident is always raised, with the `Self Terminate` field in the incident table being true if this is the policy's second time executing since it was applied.
+- Cloud Workflow is automatically kicked off.
+  - If this is the policy's second time executing, the policy takes no action against Billing Centers and instead terminates itself as a failsafe in case it is applied and forgotten about by the user.
+  - If this is the policy's first time executing, deletes all of the Billing Centers in the Flexera organization.
+
+## Prerequisites
+
+This policy uses [credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for connecting to the cloud -- in order to apply this policy you must have a credential registered in the system that is compatible with this policy. If there are no credentials listed when you apply the policy, please contact your cloud admin and ask them to register a credential that is compatible with this policy. The information below should be consulted when creating the credential.
+
+### Credential configuration
+
+- [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
+  - `common:org:own`
+  - `optima:rule_based_dimension`
+
+The [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) page in the docs has detailed instructions for setting up Credentials for the most common providers.
+
+## Supported Clouds
+
+- Google
+
+## Cost
+
+This Policy Template does not launch any instances, and so does not incur any cloud costs.

--- a/automation/flexera/delete_all_billing_centers/README.md
+++ b/automation/flexera/delete_all_billing_centers/README.md
@@ -9,7 +9,7 @@ This policy deletes all Billing Centers in the Flexera organization it is execut
 - During execution, the policy determines if this is the second time it has run since it was applied by comparing the applied policy's `created_at` date/time with the current date/time. If the difference between the two is greater than 5 minutes, it is assumed the policy is running a second time.
 - An incident is always raised, with the `Self Terminate` field in the incident table being true if this is the policy's second time executing since it was applied.
 - Cloud Workflow is automatically kicked off.
-  - If this is the policy's second time executing, the policy takes no action against Billing Centers and instead terminates itself as a failsafe in case it is applied and forgotten about by the user.
+  - If this is the policy's second time executing, the policy takes no action against Billing Centers and instead terminates itself as a failsafe in case it was applied and forgotten about by the user.
   - If this is the policy's first time executing, deletes all of the Billing Centers in the Flexera organization.
 
 ## Prerequisites
@@ -19,8 +19,8 @@ This policy uses [credentials](https://docs.flexera.com/flexera/EN/Automation/Ma
 ### Credential configuration
 
 - [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
-  - `common:org:own`
-  - `optima:rule_based_dimension`
+  - `billing_center_admin`
+  - `policy_manager`
 
 The [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) page in the docs has detailed instructions for setting up Credentials for the most common providers.
 

--- a/automation/flexera/delete_all_billing_centers/delete_all_billing_centers.pt
+++ b/automation/flexera/delete_all_billing_centers/delete_all_billing_centers.pt
@@ -53,11 +53,10 @@ script "js_second_execution", type: "javascript" do
   result = [{ id: false }]
 
   now = new Date()
-  created_at = ds_applied_policy['created_at']
-  difference = now - created_at
+  created_at = new Date(ds_applied_policy['created_at'])
 
   // If applied policy was created over 5 minutes ago, assume this is the second time it is running
-  if (difference > 300000) { result = [{ id: true }] }
+  if (now - created_at > 300000) { result = [{ id: true }] }
 EOS
 end
 

--- a/automation/flexera/delete_all_billing_centers/delete_all_billing_centers.pt
+++ b/automation/flexera/delete_all_billing_centers/delete_all_billing_centers.pt
@@ -50,13 +50,50 @@ script "js_second_execution", type: "javascript" do
   parameters "ds_applied_policy"
   result "result"
   code <<-'EOS'
-  result = [{ id: false }]
+  result = [{ id: ds_applied_policy['href'], terminate: false }]
 
   now = new Date()
   created_at = new Date(ds_applied_policy['created_at'])
 
-  // If applied policy was created over 5 minutes ago, assume this is the second time it is running
-  if (now - created_at > 300000) { result = [{ id: true }] }
+  // If applied policy was created over 1 minute ago, assume this is the second time it is running
+  if (now - created_at > 60000) { result[0]['terminate'] = true }
+EOS
+end
+
+datasource "ds_self_terminate_boolean" do
+  run_script $js_self_terminate_boolean, $ds_second_execution
+end
+
+script "js_self_terminate_boolean", type: "javascript" do
+  parameters "ds_second_execution"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_second_execution[0]['terminate']) { result = ds_second_execution }
+EOS
+end
+
+datasource "ds_self_terminate" do
+  iterate $ds_self_terminate_boolean
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    verb "DELETE"
+    path val(iter_item, 'id')
+    header "Api-Version", "1.0"
+  end
+end
+
+datasource "ds_incident" do
+  run_script $js_incident, $ds_second_execution, $ds_self_terminate
+end
+
+script "js_incident", type: "javascript" do
+  parameters "ds_second_execution", "ds_self_terminate"
+  result "result"
+  code <<-'EOS'
+  result = ds_second_execution
 EOS
 end
 
@@ -65,13 +102,16 @@ end
 ###############################################################################
 
 policy "pol_delete_bcs" do
-  validate_each $ds_second_execution do
+  validate_each $ds_incident do
     summary_template "Deleting Billing Centers"
     check eq(0, 1)
     escalate $esc_delete_billing_centers
     export do
       resource_level true
       field "id" do
+        label "Policy HREF"
+      end
+      field "terminate" do
         label "Self Terminate"
       end
     end
@@ -86,20 +126,18 @@ escalation "esc_delete_billing_centers" do
   automatic true
   label "Delete Billing Centers"
   description "Approval to delete all billing centers"
-  run "delete_billing_centers", data, policy_id, rs_org_id, rs_project_id, rs_optima_host, rs_governance_host
+  run "delete_billing_centers", data, rs_org_id, rs_optima_host
 end
 
 ###############################################################################
 # Cloud Workflow
 ###############################################################################
 
-define delete_billing_centers($data, $policy_id, $rs_org_id, $rs_project_id, $rs_optima_host, $rs_governance_host) return $all_responses do
+define delete_billing_centers($data, $rs_org_id, $rs_optima_host) return $all_responses do
   $$all_responses = []
 
-  # Policy purposely self-terminates on second run in case someone applied it and forgot about it
-  if $data[0]["id"]
-    call self_terminate($policy_id, $rs_project_id, $rs_governance_host) retrieve $terminate_response
-  else
+  # Policy will only run if it isn't self-terminating
+  if $data[0]["terminate"] == false
     call list_childless_billing_centers($rs_org_id, $rs_optima_host) retrieve $billing_centers
 
     while size($billing_centers) > 0 do
@@ -113,31 +151,6 @@ define delete_billing_centers($data, $policy_id, $rs_org_id, $rs_project_id, $rs
 
       call list_childless_billing_centers($rs_org_id, $rs_optima_host) retrieve $billing_centers
     end
-  end
-end
-
-define self_terminate($policy_id, $rs_project_id, $rs_governance_host) return $response do
-  task_label("Delete Applied Policy: " + $policy_id)
-
-  $response = http_request(
-    auth: $$auth_flexera,
-    https: true,
-    verb: "delete",
-    href: "/api/governance/projects/" + $rs_project_id + "/applied_policies/" + $policy_id,
-    host: $rs_governance_host,
-    headers: {
-      "Api-Version": "1.0",
-      "User-Agent": "RS Policies"
-    }
-  )
-
-  task_label("Delete Applied Policy response: " + $policy_id + " " + to_json($response))
-  $$all_responses << to_json({"req": "DELETE /applied_policies/" + $policy_id, "resp": $response})
-
-  if $response["code"] != 204 && $response["code"] != 202 && $response["code"] != 200
-    raise "Unexpected response Deleting Applied Policy: " + $policy_id + " " + to_json($response)
-  else
-    task_label("Delete Applied Policy successful: " + $policy_id)
   end
 end
 

--- a/automation/flexera/delete_all_billing_centers/delete_all_billing_centers.pt
+++ b/automation/flexera/delete_all_billing_centers/delete_all_billing_centers.pt
@@ -1,0 +1,221 @@
+name "Flexera CCO Delete All Billing Centers"
+rs_pt_ver 20180301
+type "policy"
+short_description "Deletes all Billing Centers in the Flexera organization. See the [README](https://github.com/flexera-public/policy_templates/tree/master/automation/flexera/delete_all_billing_centers) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+long_description ""
+severity "high"
+category "Cost"
+default_frequency "15 minutes"
+info(
+  version: "1.0",
+  provider: "Flexera",
+  service: "Optima",
+  policy_set: "Automation",
+  publish: "false"
+)
+
+###############################################################################
+# Parameters
+###############################################################################
+
+###############################################################################
+# Authentication
+###############################################################################
+
+credentials "auth_flexera" do
+  schemes "oauth2"
+  label "Flexera"
+  description "Select FlexeraOne OAuth2 credential."
+  tags "provider=flexera"
+end
+
+###############################################################################
+# Datasources & Scripts
+###############################################################################
+
+datasource "ds_applied_policy" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    header "Api-Version", "1.0"
+  end
+end
+
+datasource "ds_second_execution" do
+  run_script $js_second_execution, $ds_applied_policy
+end
+
+script "js_second_execution", type: "javascript" do
+  parameters "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = [{ id: false }]
+
+  now = new Date()
+  created_at = ds_applied_policy['created_at']
+  difference = now - created_at
+
+  // If applied policy was created over 5 minutes ago, assume this is the second time it is running
+  if (difference > 300000) { result = [{ id: true }] }
+EOS
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "pol_delete_bcs" do
+  validate_each $ds_second_execution do
+    summary_template "Deleting Billing Centers"
+    check eq(0, 1)
+    escalate $esc_delete_billing_centers
+    export do
+      resource_level true
+      field "id" do
+        label "Self Terminate"
+      end
+    end
+  end
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
+escalation "esc_delete_billing_centers" do
+  automatic true
+  label "Delete Billing Centers"
+  description "Approval to delete all billing centers"
+  run "delete_billing_centers", data, policy_id, rs_org_id, rs_project_id, rs_optima_host, rs_governance_host
+end
+
+###############################################################################
+# Cloud Workflow
+###############################################################################
+
+define delete_billing_centers($data, $policy_id, $rs_org_id, $rs_project_id, $rs_optima_host, $rs_governance_host) return $all_responses do
+  $$all_responses = []
+
+  # Policy purposely self-terminates on second run in case someone applied it and forgot about it
+  if $data[0]["id"]
+    call self_terminate($policy_id, $rs_project_id, $rs_governance_host) retrieve $terminate_response
+  else
+    call list_childless_billing_centers($rs_org_id, $rs_optima_host) retrieve $billing_centers
+
+    while size($billing_centers) > 0 do
+      foreach $billing_center in $billing_centers do
+        sub on_error: handle_error() do
+          call delete_billing_center($billing_center, $rs_org_id, $rs_optima_host) retrieve $delete_response
+        end
+      end
+
+      sleep(10)
+
+      call list_childless_billing_centers($rs_org_id, $rs_optima_host) retrieve $billing_centers
+    end
+  end
+end
+
+define self_terminate($policy_id, $rs_project_id, $rs_governance_host) return $response do
+  task_label("Delete Applied Policy: " + $policy_id)
+
+  $response = http_request(
+    auth: $$auth_flexera,
+    https: true,
+    verb: "delete",
+    href: "/api/governance/projects/" + $rs_project_id + "/applied_policies/" + $policy_id,
+    host: $rs_governance_host,
+    headers: {
+      "Api-Version": "1.0",
+      "User-Agent": "RS Policies"
+    }
+  )
+
+  task_label("Delete Applied Policy response: " + $policy_id + " " + to_json($response))
+  $$all_responses << to_json({"req": "DELETE /applied_policies/" + $policy_id, "resp": $response})
+
+  if $response["code"] != 204 && $response["code"] != 202 && $response["code"] != 200
+    raise "Unexpected response Deleting Applied Policy: " + $policy_id + " " + to_json($response)
+  else
+    task_label("Delete Applied Policy successful: " + $policy_id)
+  end
+end
+
+define list_childless_billing_centers($rs_org_id, $rs_optima_host) return $billing_centers do
+  $billing_centers = []
+
+  task_label("Listing All Billing Centers")
+
+  $response = http_request(
+    auth: $$auth_flexera,
+    https: true,
+    verb: "get",
+    href: "/analytics/orgs/" + $rs_org_id + "/billing_centers",
+    host: $rs_optima_host,
+    headers: {
+      "Api-Version": "1.0",
+      "User-Agent": "RS Policies"
+    }
+  )
+
+  task_label("Listing All Billing Centers response: " + to_json($response))
+  $$all_responses << to_json({"req": "GET /billing_centers", "resp": $response})
+
+  if $response["code"] != 204 && $response["code"] != 202 && $response["code"] != 200
+    raise "Unexpected response Listing All Billing Centers: " + to_json($response)
+  else
+    task_label("Listing All Billing Centers successful")
+
+    $parent_ids = []
+
+    foreach $item in $response["body"] do
+      if $item["name"] != "Unallocated" && $item["parent_id"] != null && $item["parent_id"] != ""
+        $parent_ids << $item["parent_id"]
+      end
+    end
+
+    foreach $item in $response["body"] do
+      if $item["name"] != "Unallocated" && contains?($parent_ids, [ $item["id"] ]) == false
+        $billing_centers << $item
+      end
+    end
+  end
+end
+
+define delete_billing_center($billing_center, $rs_org_id, $rs_optima_host) return $response do
+  $bc_label = $billing_center["name"] + " (" + $billing_center["id"] + ")"
+
+  task_label("Delete Billing Center: " + $bc_label)
+
+  $response = http_request(
+    auth: $$auth_flexera,
+    https: true,
+    verb: "delete",
+    href: "/analytics/orgs/" + $rs_org_id + "/billing_centers/" + $billing_center["id"],
+    host: $rs_optima_host,
+    headers: {
+      "Api-Version": "1.0",
+      "User-Agent": "RS Policies"
+    }
+  )
+
+  task_label("Delete Billing Center response: " + $bc_label + " " + to_json($response))
+  $$all_responses << to_json({"req": "DELETE /billing_centers/" + $billing_center["id"], "resp": $response})
+
+  if $response["code"] != 204 && $response["code"] != 202 && $response["code"] != 200
+    raise "Unexpected response Deleting Billing Centers: " + $bc_label + " " + to_json($response)
+  else
+    task_label("Delete Billing Center successful: " + $bc_label)
+  end
+end
+
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  # We check for errors at the end, and raise them all together
+  # Skip errors handled by this definition
+  $_error_behavior = "skip"
+end

--- a/data/policy_permissions_list/master_policy_permissions_list.json
+++ b/data/policy_permissions_list/master_policy_permissions_list.json
@@ -1,6 +1,28 @@
 {
   "values": [
     {
+      "id": "./automation/flexera/delete_all_billing_centers/delete_all_billing_centers.pt",
+      "name": "Flexera CCO Delete All Billing Centers",
+      "version": "1.0",
+      "providers": [
+        {
+          "name": "flexera",
+          "permissions": [
+            {
+              "name": "billing_center_admin",
+              "read_only": true,
+              "required": true
+            },
+            {
+              "name": "policy_manager",
+              "read_only": true,
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "./automation/flexera/outdated_applied_policies/outdated_applied_policies.pt",
       "name": "Flexera Automation Outdated Applied Policies",
       "version": "0.1",

--- a/data/policy_permissions_list/master_policy_permissions_list.yaml
+++ b/data/policy_permissions_list/master_policy_permissions_list.yaml
@@ -1,5 +1,17 @@
 ---
 :values:
+- id: "./automation/flexera/delete_all_billing_centers/delete_all_billing_centers.pt"
+  name: Flexera CCO Delete All Billing Centers
+  version: '1.0'
+  :providers:
+  - :name: flexera
+    :permissions:
+    - name: billing_center_admin
+      read_only: true
+      required: true
+    - name: policy_manager
+      read_only: true
+      required: true
 - id: "./automation/flexera/outdated_applied_policies/outdated_applied_policies.pt"
   name: Flexera Automation Outdated Applied Policies
   version: '0.1'

--- a/tools/policy_master_permission_generation/validated_policy_templates.yaml
+++ b/tools/policy_master_permission_generation/validated_policy_templates.yaml
@@ -80,5 +80,6 @@ validated_policy_templates:
 -  "./cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations.pt"
 -  "./cost/google/schedule_instance/google_schedule_instance.pt"
 # Flexera
+-  "./automation/flexera/delete_all_billing_centers/delete_all_billing_centers.pt"
 -  "./automation/flexera/outdated_applied_policies/outdated_applied_policies.pt"
 -  "./cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt"


### PR DESCRIPTION
### Description

This policy deletes all Billing Centers in the Flexera organization it is executed within. The policy will automatically self-terminate the second time it runs to avoid accidental future deletion of Billing Centers.

This policy is unpublished and primarily intended for internal use.

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/projects/7954/policy-templates/65df998bdc59260001cddad8

The policy has been tested, but the nature of this policy means it can't be left applied to demonstrate that it works. To test it, create some billing centers in org 6 and then apply the policy.
- The first time the policy executes, it should delete all of the billing centers.
- The second time the policy executes, it should self-terminate.

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
