### PR TITLE
Add links to documentation in the policy short description

### DIFF
--- a/cost/budget_v_actual_spend_report/CHANGELOG.md
+++ b/cost/budget_v_actual_spend_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1
+
+- Added links to documentation in the policy short description
+
 ## v2.0
 
 - initial release

--- a/cost/budget_v_actual_spend_report/CHANGELOG.md
+++ b/cost/budget_v_actual_spend_report/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.1
 
 - Added links to documentation in the policy short description
+- Added default values ​​and descriptions for all policy parameters
 
 ## v2.0
 

--- a/cost/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
+++ b/cost/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
@@ -25,7 +25,6 @@ parameter "param_budget_name_id" do
   type "string"
   constraint_description "Budget Name or ID is a required field"
   category "Policy Settings"
-  default ""
 end
 
 parameter "param_filter" do

--- a/cost/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
+++ b/cost/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
@@ -2,6 +2,7 @@ name "Budget vs Actual Spend Report"
 rs_pt_ver 20180301
 type "policy"
 short_description "Emails a report comparing budget vs actual spend to stakeholders. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/budget_v_actual_spend_report/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+long_description ""
 severity "medium"
 category "Cost"
 tenancy "single"
@@ -23,25 +24,33 @@ parameter "param_budget_name_id" do
   min_length 1
   type "string"
   constraint_description "Budget Name or ID is a required field"
+  category "Policy Settings"
+  default ""
 end
 
 parameter "param_filter" do
   type "list"
   label "Filter Group By Dimension(s)"
   description "Enable budget tracking for specific dimensions and values. Only dimensions previously defined in the budget are supported"
+  category "Policy Settings"
+  default []
 end
 
 parameter "param_unbudgeted" do
   label "Unbudgeted spend"
   type "string"
   allowed_values "Exclude unbudgeted spend","Include unbudgeted spend"
+  description "Specify whether to consider or ignore spend that was not included in the initial budget planning."
+  category "Policy Settings"
   default "Exclude unbudgeted spend"
 end
 
 parameter "param_email" do
-  label "Email addresses"
+  label "Email Addresses"
   type "list"
   description "A list of email addresses to notify"
+  category "Policy Settings"
+  default []
 end
 
 ###############################################################################

--- a/cost/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
+++ b/cost/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
@@ -1,7 +1,7 @@
 name "Budget vs Actual Spend Report"
 rs_pt_ver 20180301
 type "policy"
-short_description "Emails a report comparing budget vs actual spend to stakeholders"
+short_description "Emails a report comparing budget vs actual spend to stakeholders. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/budget_v_actual_spend_report/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 severity "medium"
 category "Cost"
 tenancy "single"

--- a/cost/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
+++ b/cost/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
@@ -7,7 +7,7 @@ category "Cost"
 tenancy "single"
 default_frequency "daily"
 info(
-  version: "2.0",
+  version: "2.1",
   provider: "Flexera Optima",
   service: "",
   policy_set: ""


### PR DESCRIPTION
### Description

Add links to documentation in the "Budget vs Actual Spend Report" policy short description

### Contribution Check List

- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
