### PR TITLE
SQ-6941 Sort the dimensions shown in the report

### DIFF
--- a/cost/cloud_cost_anomaly_alerts/CHANGELOG.md
+++ b/cost/cloud_cost_anomaly_alerts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2
+
+- Fixed bug where incident showed dimensions from column `Grouping Dimensions` in random order
+
 ## v3.1
 
 - Fixed bug where incident link would render incorrectly if spaces were present in filter value

--- a/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
+++ b/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1",
+  version: "3.2",
   provider: "Flexera",
   service: "Optima",
   policy_set: ""
@@ -428,7 +428,8 @@ script "js_filter_anomalies", type: "javascript" do
     })
 
     if (anomalous.length > 0) {
-      dimension_key = _.map(_.keys(timeSeries['dimensions']), function(key) {
+      dimensions = _.pick(timeSeries['dimensions'], _.keys(timeSeries['dimensions']).sort())
+      dimension_key = _.map(_.keys(dimensions), function(key) {
         if (key == "billing_center_id") {
           billing_center = _.find(billing_centers, function(bc) {
             return bc['id'] == timeSeries['dimensions'][key]

--- a/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
+++ b/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
@@ -428,16 +428,16 @@ script "js_filter_anomalies", type: "javascript" do
     })
 
     if (anomalous.length > 0) {
-      dimensions = _.pick(timeSeries['dimensions'], _.keys(timeSeries['dimensions']).sort())
-      dimension_key = _.map(_.keys(dimensions), function(key) {
-        if (key == "billing_center_id") {
-          billing_center = _.find(billing_centers, function(bc) {
-            return bc['id'] == timeSeries['dimensions'][key]
-          })
+      dimension_key = _.map(ds_filter_dimensions['ids'], function(id) {
+        var dimensionValue = timeSeries['dimensions'][id]
+        if (id == "billing_center_id") {
+            var billing_center = _.find(ds_billing_centers, function(bc) {
+                return bc['id'] == dimensionValue
+            })
 
-          return billing_center['name']
+            return billing_center['name']
         } else {
-          return timeSeries['dimensions'][key]
+            return dimensionValue
         }
       }).join('; ')
 
@@ -562,3 +562,4 @@ escalation "esc_email" do
   description "Send incident email"
   email $param_email
 end
+

--- a/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
+++ b/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
@@ -431,13 +431,12 @@ script "js_filter_anomalies", type: "javascript" do
       dimension_key = _.map(ds_filter_dimensions['ids'], function(id) {
         var dimensionValue = timeSeries['dimensions'][id]
         if (id == "billing_center_id") {
-            var billing_center = _.find(ds_billing_centers, function(bc) {
-                return bc['id'] == dimensionValue
-            })
-
-            return billing_center['name']
+          var billing_center = _.find(ds_billing_centers, function(bc) {
+            return bc['id'] == dimensionValue
+          })
+          return billing_center['name']
         } else {
-            return dimensionValue
+          return dimensionValue
         }
       }).join('; ')
 

--- a/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
+++ b/cost/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
@@ -561,4 +561,3 @@ escalation "esc_email" do
   description "Send incident email"
   email $param_email
 end
-


### PR DESCRIPTION
### Description

Fixed bug where incident showed dimensions from column `Grouping Dimensions` in random order.

### Issues Resolved

https://flexera.atlassian.net/browse/SQ-6941

### Link to Example Applied Policy

Latest version 3.1:
![image](https://github.com/flexera-public/policy_templates/assets/54189123/81d0c76b-c412-4d19-b0bf-dd909f36db75)
As you can see sometimes Azure appears at the beginning and sometimes at the middle


Incoming version 3.2:
![image](https://github.com/flexera-public/policy_templates/assets/54189123/6b606d9d-8e00-4591-a435-fb8c49457fbc)
Now they appear in the order specified by user.
https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/60073?policyId=65efef161909b512219a676e

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
