### PR TITLE
POL-1129 Dangerfile Improvements/Normalization

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -101,7 +101,7 @@ def bad_urls?(file)
   fail_message = ""
 
   if diff && diff.patch =~ regex
-    diff.patch.each_line do |line, index|
+    diff.patch.each_line.with_index do |line, index|
       line_number = index + 1
 
       if line =~ regex
@@ -267,7 +267,7 @@ def sections_out_of_order?(file)
   # Failsafe for meta policy code which won't be in the correct order by design
   found_meta = false
 
-  policy_code.each_line do |line, index|
+  policy_code.each_line.with_index do |line, index|
     line_number = index + 1
 
     found_meta = true if line.strip.start_with?('# Meta Policy [alpha]')
@@ -349,7 +349,7 @@ def blocks_ungrouped?(file)
     # Failsafe for meta policy code which won't be in the correct order by design
     found_meta = false
 
-    policy_code.each_line do |line, index|
+    policy_code.each_line.with_index do |line, index|
       line_number = index + 1
 
       found_meta = true if line.strip.start_with?('# Meta Policy [alpha]')
@@ -478,7 +478,7 @@ def bad_block_name?(file, block_name)
     block_regex = /.*/
   end
 
-  policy_code.each_line do |line, index|
+  policy_code.each_line.with_index do |line, index|
     line_number = index + 1
     fail_message += "Line #{line_number.to_s}\n" if block_regex.match?(line)
   end
@@ -500,7 +500,7 @@ def deprecated_code_blocks?(file, block_name)
 
   fail_message = ""
 
-  policy_code.each_line do |line, index|
+  policy_code.each_line.with_index do |line, index|
     line_number = index + 1
     fail_message += "Line #{line_number.to_s}: Permission block found\n" if permission_regex.match?(line)
     fail_message += "Line #{line_number.to_s}: Resources block found\n" if resources_regex.match?(line)
@@ -523,7 +523,7 @@ def block_missing_field?(file, block_name, field_name)
   present = false
   line_number = nil
 
-  policy_code.each_line do |line, index|
+  policy_code.each_line.with_index do |line, index|
     # Check if we're entering the block
     if line.strip.start_with?(block_name + ' ') && line.strip.end_with?('do')
       present = false
@@ -557,7 +557,7 @@ def ds_js_name_mismatch?(file)
   js_name = nil
   line_number = nil
 
-  policy_code.each_line do |line, index|
+  policy_code.each_line.with_index do |line, index|
     case line
     # Stop doing the check once we hit the Meta Policy section
     when line.strip.start_with?('# Meta Policy [alpha]')
@@ -600,7 +600,7 @@ def run_script_incorrect_order?(file)
   fail_message = ""
   ds_name = nil
 
-  policy_code.each_line do |line, index|
+  policy_code.each_line.with_index do |line, index|
     line_number = index + 1
 
     # Stop doing the check if we've reached the meta policy section

--- a/Dangerfile
+++ b/Dangerfile
@@ -448,6 +448,8 @@ def bad_block_name?(file, block_name)
   # Store contents of file for direct analysis
   policy_code = File.read(file)
 
+  fail_message = ""
+
   # Set values based on which section we're checking.
   # proper_name: Correct prefix that block name ought to have
   # block_regex: Test for presence of block with an invalid name

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -8,7 +8,6 @@ severity "low"
 default_frequency "weekly"
 info(
   version: "8.0",
-  provider: "AWS",
   service: "Storage",
   policy_set: "Old Snapshots",
   recommendation_type: "Usage Reduction"
@@ -124,7 +123,6 @@ end
 
 parameter "param_automatic_action" do
   type "list"
-  category "Actions"
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action."
   allowed_values ["Delete Snapshots"]
@@ -192,20 +190,6 @@ pagination "pagination_aws_describe_db_snapshots_xml" do
   end
 end
 
-# https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBClusterSnapshots.html
-pagination "pagination_aws_describe_db_cluster_snapshots_xml" do
-  get_page_marker do
-    body_path "//DescribeDBClusterSnapshotsResponse/DescribeDBClusterSnapshotsResult/Marker"
-  end
-  set_page_marker do
-    query "Marker"
-  end
-end
-
-###############################################################################
-# Datasources & Scripts
-###############################################################################
-
 # Get applied policy metadata for use later
 datasource "ds_applied_policy" do
   request do
@@ -213,6 +197,16 @@ datasource "ds_applied_policy" do
     host rs_governance_host
     path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
     header "Api-Version", "1.0"
+  end
+end
+
+# https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBClusterSnapshots.html
+pagination "pagination_aws_describe_db_cluster_snapshots_xml" do
+  get_page_marker do
+    body_path "//DescribeDBClusterSnapshotsResponse/DescribeDBClusterSnapshotsResult/Marker"
+  end
+  set_page_marker do
+    query "Marker"
   end
 end
 
@@ -879,10 +873,10 @@ EOS
 end
 
 datasource "ds_snapshot_costs_grouped" do
-  run_script $js_snapshot_costs_grouped, $ds_snapshot_costs
+  run_script $js_snapshot_costs_grouped_lolol, $ds_snapshot_costs
 end
 
-script "js_snapshot_costs_grouped", type: "javascript" do
+script "js_snapshot_costs_grouped_lolol", type: "javascript" do
   parameters "ds_snapshot_costs"
   result "result"
   code <<-EOS
@@ -903,11 +897,11 @@ EOS
 end
 
 datasource "ds_snapshots_cost_mapping" do
-  run_script $js_snapshots_cost_mapping, $ds_filter_ami_snapshots, $ds_snapshot_costs_grouped, $ds_snapshots_combined, $ds_currency, $ds_applied_policy, $ds_aws_account, $param_min_savings, $param_snapshot_age, $param_snapshot_include_ami
+  run_script $js_snapshots_cost_mapping, $param_snapshot_include_ami, $ds_filter_ami_snapshots, $ds_snapshot_costs_grouped, $ds_snapshots_combined, $ds_currency, $ds_applied_policy, $ds_aws_account, $param_min_savings, $param_snapshot_age
 end
 
 script "js_snapshots_cost_mapping", type: "javascript" do
-  parameters "ds_filter_ami_snapshots", "ds_snapshot_costs_grouped", "ds_snapshots_combined", "ds_currency", "ds_applied_policy", "ds_aws_account", "param_min_savings", "param_snapshot_age", "param_snapshot_include_ami"
+  parameters "param_snapshot_include_ami", "ds_filter_ami_snapshots", "ds_snapshot_costs_grouped", "ds_snapshots_combined", "ds_currency", "ds_applied_policy", "ds_aws_account", "param_min_savings", "param_snapshot_age"
   result "result"
   code <<-'EOS'
   // Function for formatting currency numbers later
@@ -1030,10 +1024,28 @@ EOS
 end
 
 ###############################################################################
+# Escalations
+###############################################################################
+
+escalation "email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
+
+escalation "esc_delete_snapshot" do
+  automatic contains($param_automatic_action, "Delete Snapshots")
+  label "Delete Snapshots"
+  description "Approval to delete all selected snapshots"
+  run "delete_snapshots", data, $param_snapshot_include_ami
+end
+
+###############################################################################
 # Policy
 ###############################################################################
 
-policy "pol_utilization" do
+policy "utilization" do
   validate_each $ds_snapshots_cost_mapping do
     summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} AWS Old Snapshots Found"
     detail_template <<-'EOS'
@@ -1043,7 +1055,7 @@ policy "pol_utilization" do
     EOS
     # Policy check fails and incident is created only if data is not empty and the Parent Policy has not been terminated
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
-    escalate $esc_email
+    escalate $email
     escalate $esc_delete_snapshot
     hash_exclude "total_savings", "message", "tags", "age", "savings", "savingsCurrency"
     export do
@@ -1117,24 +1129,6 @@ policy "pol_utilization" do
       end
     end
   end
-end
-
-###############################################################################
-# Escalations
-###############################################################################
-
-escalation "esc_email" do
-  automatic true
-  label "Send Email"
-  description "Send incident email"
-  email $param_email
-end
-
-escalation "esc_delete_snapshot" do
-  automatic contains($param_automatic_action, "Delete Snapshots")
-  label "Delete Snapshots"
-  description "Approval to delete all selected snapshots"
-  run "delete_snapshots", data, $param_snapshot_include_ami
 end
 
 ###############################################################################

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -25,7 +25,7 @@ parameter "param_email" do
   default []
 end
 
-parameter "param_aws_account_number" do
+parameter "paramaws_account_number" do
   type "string"
   category "Policy Settings"
   label "Account Number"
@@ -138,7 +138,7 @@ credentials "auth_aws" do
   label "AWS"
   description "Select the AWS Credential from the list"
   tags "provider=aws"
-  aws_account_number $param_aws_account_number
+  aws_account_number $paramaws_account_number
 end
 
 credentials "auth_flexera" do


### PR DESCRIPTION
### Description

This update adds two new tests to the Dangerfile:

- Test whether datasource and javascript block names match
- Test whether the parameters of a run_script block are in the preferred order

Additionally, significant improvements have been made to policy tests more generally:

- Standardization of formatting for output of warnings/errors.
- Inclusion of line numbers where appropriate.
- Inclusion of multiple results when multiple offenses are found for a single test.

The following bugs have also been fixed:

- Bug fix for block grouping test. It should no longer return false positives.

### Link to Example



### Contribution Check List

- [X] New functionality includes testing.
