### PR TITLE
Fix Issues with moved Policy Parser file

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'rubygems'
 require 'json'
 require 'fileutils'
-require_relative 'tools/lib/policy_parser'
+require_relative '.dangerfile/policy_parser'
 
 # the list of policies is consumed by the tools/policy_sync/policy_sync.pt
 # and the docs.rightscale.com build to generate the policies/user/policy_list.html

--- a/tools/readme_policy_table_of_contents/generate_readme_policy_table_of_contents.rb
+++ b/tools/readme_policy_table_of_contents/generate_readme_policy_table_of_contents.rb
@@ -1,6 +1,6 @@
 require 'uri'
 require 'yaml'
-require_relative '../lib/policy_parser'
+require_relative '../../.dangerfile/policy_parser'
 
 
 pp = PolicyParser.new
@@ -167,4 +167,3 @@ puts pt_stats.to_yaml
 puts "-->"
 puts "<!-- End Policy Template Stats -->"
 puts ""
-


### PR DESCRIPTION
### Description

Moving the policy parser file inadvertently broke other automation. This is the fix.
