### PR TITLE
POL-1140 Dangerfile Additions: Code Block Field Order and Recommendations Export

### DIFF
--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -745,7 +745,7 @@ def policy_missing_recommendation_fields?(file, field_type)
     end
   end
 
-  fail_message = "**#{file}**\nRecommendation policy has export that is missing #{field_type} fields:\n\n" + fail_message if !fail_message.empty?
+  fail_message = "**#{file}**\nRecommendation policy has export that is missing #{field_type} fields. These fields are scraped by the Flexera platform for dashboards:\n\n" + fail_message if !fail_message.empty?
 
   return fail_message.strip if !fail_message.empty?
   return false

--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -638,8 +638,11 @@ def policy_block_fields_incorrect_order?(file, block_type)
           order_indices = filtered_list.map { |item| correct_order.index(item) }
 
           if order_indices != order_indices.sort
-            block_id = policy_id if policy_id
-            fail_message += "Line #{block_line_number.to_s}: #{block_name} \"#{block_id}\"\n"
+            if policy_id && block_type == "policy"
+              fail_message += "Line #{block_line_number.to_s}: policy \"#{policy_id}\"\n"
+            else
+              fail_message += "Line #{block_line_number.to_s}: #{block_name} \"#{block_id}\"\n"
+            end
           end
 
           testing_block = false

--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -712,7 +712,7 @@ def policy_missing_recommendation_fields?(file, field_type)
         export_line = line_number
       end
 
-      if !field_block && line.strip.start_with?("end")
+      if export_block && !field_block && line.strip.start_with?("end")
         export_block = false
 
         export_info << {

--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -600,6 +600,7 @@ def policy_block_fields_incorrect_order?(file, block_type)
   block_line_number = 0
   block_names = [ block_type ]
   block_id = ""
+  policy_id = nil
 
   case block_type
   when "parameter"
@@ -626,6 +627,8 @@ def policy_block_fields_incorrect_order?(file, block_type)
 
         break if line.strip.start_with?('# Meta Policy [alpha]')
 
+        policy_id = line.split('"')[1] if line.start_with?("policy ")
+
         if testing_block && !sub_block && !export_block && !line.strip.start_with?("end") && !line.strip.start_with?("request do")
           sub_block = true if line.strip.end_with?(" do") || line.include?("<<-")
           export_block = true if line.strip == "export do"
@@ -635,6 +638,7 @@ def policy_block_fields_incorrect_order?(file, block_type)
           order_indices = filtered_list.map { |item| correct_order.index(item) }
 
           if order_indices != order_indices.sort
+            block_id = policy_id if policy_id
             fail_message += "Line #{block_line_number.to_s}: #{block_name} \"#{block_id}\"\n"
           end
 

--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -639,15 +639,13 @@ def policy_block_fields_incorrect_order?(file, block_type)
 
           if order_indices != order_indices.sort
             if policy_id && block_type == "policy"
-              fail_message += "Line #{block_line_number.to_s}: policy \"#{policy_id}\"\n"
+              fail_message += "Line #{block_line_number.to_s}: policy \"#{policy_id}\" #{block_name.strip}\n"
             else
               fail_message += "Line #{block_line_number.to_s}: #{block_name} \"#{block_id}\"\n"
             end
           end
 
           testing_block = false
-          sub_block = false
-          field_list = []
         elsif sub_block && !export_block && (line.strip.start_with?("end") || line.include?("EOS") || line.include?("EOF"))
           sub_block = false
         elsif export_block
@@ -658,6 +656,10 @@ def policy_block_fields_incorrect_order?(file, block_type)
 
         if line.start_with?(block_name + " ") && line.strip.end_with?(" do")
           testing_block = true
+          sub_block = false
+          export_block = false
+          field_list = []
+
           block_line_number = line_number
           block_id = line.split('"')[1]
         end

--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -624,6 +624,8 @@ def policy_block_fields_incorrect_order?(file, block_type)
       policy_code.each_line.with_index do |line, index|
         line_number = index + 1
 
+        break if line.strip.start_with?('# Meta Policy [alpha]')
+
         if testing_block && !sub_block && !export_block && !line.strip.start_with?("end") && !line.strip.start_with?("request do")
           sub_block = true if line.strip.end_with?(" do") || line.include?("<<-")
           export_block = true if line.strip == "export do"
@@ -647,7 +649,7 @@ def policy_block_fields_incorrect_order?(file, block_type)
           field_block = false if line.strip.start_with?("end") && field_block
         end
 
-        if line.start_with?(block_name + " ") && line.end_with?(" do")
+        if line.start_with?(block_name + " ") && line.strip.end_with?(" do")
           testing_block = true
           block_line_number = line_number
           block_id = line.split('"')[1]

--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -544,16 +544,19 @@ def policy_run_script_incorrect_order?(file)
       # Remove the first item because it's just the name of the script itself
       script_name = parameters.shift
 
-      ds_found = false       # Whether we've found a datasource parameter
-      param_found = false    # Whether we've found a parameter parameter
-      constant_found = false # Whether we've found a constant, like rs_org_id
-      value_found = false    # Whether we've found a raw value, like a number or string
+      iter_found = false      # Whether we've found a val(iter_item, "") parameter
+      ds_found = false        # Whether we've found a datasource parameter
+      param_found = false     # Whether we've found a parameter parameter
+      constant_found = false  # Whether we've found a constant, like rs_org_id
+      value_found = false     # Whether we've found a raw value, like a number or string
 
       parameters.each do |parameter|
-        if parameter.start_with?('$ds')
+        if parameter.include?("iter_item")
+          iter_found = true
+          disordered = true if ds_found || param_found || constant_found || value_found
+        elsif parameter.start_with?('$ds')
           ds_found = true
           disordered = true if param_found || constant_found || value_found
-          puts parameter
         elsif parameter.start_with?('$param')
           param_found = true
           disordered = true if constant_found || value_found
@@ -569,7 +572,7 @@ def policy_run_script_incorrect_order?(file)
     fail_message += "Line #{line_number.to_s}: #{ds_name} / run_script #{script_name}\n" if disordered
   end
 
-  fail_message = "**#{file}**\nrun_script statements found whose parameters are not in the correct order. run_script parameters should be in the following order: script, datasources, parameters, variables, raw values:\n\n" + fail_message if !fail_message.empty?
+  fail_message = "**#{file}**\nrun_script statements found whose parameters are not in the correct order. run_script parameters should be in the following order: script, val(iter_item, *string*), datasources, parameters, variables, raw values:\n\n" + fail_message if !fail_message.empty?
 
   return fail_message.strip if !fail_message.empty?
   return false

--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -551,7 +551,7 @@ def policy_run_script_incorrect_order?(file)
       value_found = false     # Whether we've found a raw value, like a number or string
 
       parameters.each do |parameter|
-        if parameter.include?("iter_item")
+        if parameter.start_with?('val(') && parameter.include?("iter_item")
           iter_found = true
           disordered = true if ds_found || param_found || constant_found || value_found
         elsif parameter.start_with?('$ds')

--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -736,11 +736,11 @@ def policy_missing_recommendation_fields?(file, field_type)
       missing_fields = []
 
       required_fields.each do |field|
-        missing_fields << field if !export["list"].include?(field)
+        missing_fields << field if !export[:list].include?(field)
       end
 
       if missing_fields.length > 0
-        fail_message += "Line #{export["line"].to_s}: " + missing_fields.join(", ") + "\n"
+        fail_message += "Line #{export[:line].to_s}: " + missing_fields.join(", ") + "\n"
       end
     end
   end

--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -599,6 +599,7 @@ def policy_block_fields_incorrect_order?(file, block_type)
   field_block = false
   block_line_number = 0
   block_names = [ block_type ]
+  block_id = ""
 
   case block_type
   when "parameter"
@@ -608,7 +609,7 @@ def policy_block_fields_incorrect_order?(file, block_type)
   when "pagination"
     correct_order = [ "get_page_marker", "set_page_marker" ]
   when "datasource"
-    correct_order = [ "auth", "pagination", "verb", "scheme", "host", "path", "header", "query", "body", "body_field", "ignore_status" ]
+    correct_order = [ "auth", "pagination", "verb", "scheme", "host", "path", "query", "header", "body", "body_field", "ignore_status" ]
   when "script"
     correct_order = [ "parameters", "result", "code" ]
   when "policy"
@@ -632,7 +633,7 @@ def policy_block_fields_incorrect_order?(file, block_type)
           order_indices = filtered_list.map { |item| correct_order.index(item) }
 
           if order_indices != order_indices.sort
-            fail_message += "Line #{block_line_number.to_s}\n"
+            fail_message += "Line #{block_line_number.to_s}: #{block_name} \"#{block_id}\"\n"
           end
 
           testing_block = false
@@ -649,6 +650,7 @@ def policy_block_fields_incorrect_order?(file, block_type)
         if line.start_with?(block_name + " ") && line.end_with?(" do")
           testing_block = true
           block_line_number = line_number
+          block_id = line.split('"')[1]
         end
       end
     end

--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -551,7 +551,7 @@ def policy_run_script_incorrect_order?(file)
       value_found = false     # Whether we've found a raw value, like a number or string
 
       parameters.each do |parameter|
-        if parameter.start_with?('val(') && parameter.include?("iter_item")
+        if parameter.start_with?("val(") && parameter.include?("iter_item")
           iter_found = true
           disordered = true if ds_found || param_found || constant_found || value_found
         elsif parameter.start_with?('$ds')

--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -536,7 +536,7 @@ def policy_run_script_incorrect_order?(file)
     end
 
     disordered = false
-    iter_index = nil
+    iter_index = -5
 
     if line.strip.start_with?("run_script")
       # Store a list of all of the parameters for the run_script

--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -646,6 +646,9 @@ def policy_block_fields_incorrect_order?(file, block_type)
           end
 
           testing_block = false
+          sub_block = false
+          export_block = false
+          field_list = []
         elsif sub_block && !export_block && (line.strip.start_with?("end") || line.include?("EOS") || line.include?("EOF"))
           sub_block = false
         elsif export_block

--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -629,7 +629,7 @@ def policy_block_fields_incorrect_order?(file, block_type)
 
         policy_id = line.split('"')[1] if line.start_with?("policy ")
 
-        if testing_block && !sub_block && !export_block && !line.strip.start_with?("end") && !line.strip.start_with?("request do")
+        if testing_block && !sub_block && !export_block && !line.strip.start_with?("end") && !line.strip.start_with?("request do") && !line.strip.start_with?("result do")
           sub_block = true if line.strip.end_with?(" do") || line.include?("<<-")
           export_block = true if line.strip == "export do"
           field_list << line.strip.split(" ")[0]

--- a/Dangerfile
+++ b/Dangerfile
@@ -254,6 +254,15 @@ changed_pt_files.each do |file|
   # Raise error if run_script statements with incorrect parameter ordering are found
   test = policy_run_script_incorrect_order?(file); fail test if test
 
+  # Raise error if code blocks have fields in improper order
+  test = policy_block_fields_incorrect_order?(file, "parameter"); fail test if test
+  test = policy_block_fields_incorrect_order?(file, "credentials"); fail test if test
+  test = policy_block_fields_incorrect_order?(file, "pagination"); fail test if test
+  test = policy_block_fields_incorrect_order?(file, "datasource"); fail test if test
+  test = policy_block_fields_incorrect_order?(file, "script"); fail test if test
+  test = policy_block_fields_incorrect_order?(file, "policy"); fail test if test
+  test = policy_block_fields_incorrect_order?(file, "escalation"); fail test if test
+
   # Raise error if policy is not in the master permissions file.
   # Raise warning if policy is in this file, but datasources have been added.
   test = policy_missing_master_permissions?(file, permissions_yaml); fail test if test

--- a/Dangerfile
+++ b/Dangerfile
@@ -263,6 +263,12 @@ changed_pt_files.each do |file|
   test = policy_block_fields_incorrect_order?(file, "policy"); fail test if test
   test = policy_block_fields_incorrect_order?(file, "escalation"); fail test if test
 
+  # Raise error if recommendation policy is missing required export fields
+  test = policy_missing_recommendation_fields?(file, "required"); fail test if test
+
+  # Raise warning if recommendation policy is missing recommended export fields
+  test = policy_missing_recommendation_fields?(file, "recommended"); warn test if test
+
   # Raise error if policy is not in the master permissions file.
   # Raise warning if policy is in this file, but datasources have been added.
   test = policy_missing_master_permissions?(file, permissions_yaml); fail test if test

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -1267,9 +1267,6 @@ policy "pol_utilization" do
       field "lookbackPeriod" do
         label "Look Back Period (Days)"
       end
-      field "service" do
-        label "Service"
-      end
       field "id" do
         label "ID"
         path "resourceID"
@@ -1291,9 +1288,6 @@ policy "pol_utilization" do
     hash_exclude "underutil_message", "idle_message", "underutil_total_savings", "idle_total_savings", "tags", "savings", "savingsCurrency", "cpu_maximum", "cpu_minimum", "cpu_average", "mem_maximum", "mem_minimum", "mem_average"
     export do
       resource_level true
-      field "accountID" do
-        label "Subscription ID"
-      end
       field "accountName" do
         label "Subscription Name"
       end

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -20,7 +20,7 @@ info(
 
 parameter "param_email" do
   type "list"
-  category "Policy Settingss"
+  category "Policy Settings"
   label "Email addresses"
   description "A list of email addresses to notify."
   default []
@@ -1267,6 +1267,9 @@ policy "pol_utilization" do
       field "lookbackPeriod" do
         label "Look Back Period (Days)"
       end
+      field "service" do
+        label "Service"
+      end
       field "id" do
         label "ID"
         path "resourceID"
@@ -1288,6 +1291,9 @@ policy "pol_utilization" do
     hash_exclude "underutil_message", "idle_message", "underutil_total_savings", "idle_total_savings", "tags", "savings", "savingsCurrency", "cpu_maximum", "cpu_minimum", "cpu_average", "mem_maximum", "mem_minimum", "mem_average"
     export do
       resource_level true
+      field "accountID" do
+        label "Subscription ID"
+      end
       field "accountName" do
         label "Subscription Name"
       end

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -22,7 +22,7 @@ parameter "param_email" do
   type "list"
   category "Policy Settings"
   label "Email addresses"
-  description "A list of email addresses to notify."
+  description "A list of email aaddresses to notify."
   default []
 end
 

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -19,11 +19,11 @@ info(
 ###############################################################################
 
 parameter "param_email" do
-  type "list"
-  category "Policy Settings"
   label "Email addresses"
   description "A list of email aaddresses to notify."
   default []
+  type "list"
+  category "Policy Settings"
 end
 
 parameter "param_azure_endpoint" do
@@ -193,10 +193,10 @@ credentials "auth_azure" do
 end
 
 credentials "auth_flexera" do
-  schemes "oauth2"
-  label "Flexera"
   description "Select Flexera One OAuth2 credentials"
   tags "provider=flexera"
+  schemes "oauth2"
+  label "Flexera"
 end
 
 ###############################################################################
@@ -320,12 +320,12 @@ end
 
 datasource "ds_azure_subscriptions" do
   request do
+    query "api-version", "2020-01-01"
+    header "User-Agent", "RS Policies"
     auth $auth_azure
     pagination $pagination_azure
     host $param_azure_endpoint
     path "/subscriptions/"
-    query "api-version", "2020-01-01"
-    header "User-Agent", "RS Policies"
     # Header X-Meta-Flexera has no affect on datasource query, but is required for Meta Policies
     # Forces `ds_is_deleted` datasource to run first during policy execution
     header "Meta-Flexera", val($ds_is_deleted, "path")
@@ -478,8 +478,8 @@ datasource "ds_azure_instances_region_filtered" do
 end
 
 script "js_azure_instances_region_filtered", type: "javascript" do
-  parameters "ds_azure_instances_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
+  parameters "ds_azure_instances_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   code <<-EOS
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_instances_tag_filtered, function(vm) {
@@ -1285,10 +1285,10 @@ policy "pol_utilization" do
     EOS
     # Policy check fails and incident is created only if data is not empty and the Parent Policy has not been terminated
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
+    hash_exclude "underutil_message", "idle_message", "underutil_total_savings", "idle_total_savings", "tags", "savings", "savingsCurrency", "cpu_maximum", "cpu_minimum", "cpu_average", "mem_maximum", "mem_minimum", "mem_average"
     escalate $esc_email
     escalate $esc_poweroff_instances
     escalate $esc_delete_instances
-    hash_exclude "underutil_message", "idle_message", "underutil_total_savings", "idle_total_savings", "tags", "savings", "savingsCurrency", "cpu_maximum", "cpu_minimum", "cpu_average", "mem_maximum", "mem_minimum", "mem_average"
     export do
       resource_level true
       field "accountID" do
@@ -1404,9 +1404,9 @@ end
 
 escalation "esc_delete_instances" do
   automatic contains($param_automatic_action, "Delete Idle Instances")
+  run "delete_instances", data, $param_azure_endpoint
   label "Delete Idle Instances"
   description "Approval to delete all selected instances"
-  run "delete_instances", data, $param_azure_endpoint
 end
 
 ###############################################################################

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -19,11 +19,11 @@ info(
 ###############################################################################
 
 parameter "param_email" do
-  label "Email addresses"
-  description "A list of email aaddresses to notify."
-  default []
   type "list"
-  category "Policy Settings"
+  category "Policy Settingss"
+  label "Email addresses"
+  description "A list of email addresses to notify."
+  default []
 end
 
 parameter "param_azure_endpoint" do
@@ -193,10 +193,10 @@ credentials "auth_azure" do
 end
 
 credentials "auth_flexera" do
-  description "Select Flexera One OAuth2 credentials"
-  tags "provider=flexera"
   schemes "oauth2"
   label "Flexera"
+  description "Select Flexera One OAuth2 credentials"
+  tags "provider=flexera"
 end
 
 ###############################################################################
@@ -320,12 +320,12 @@ end
 
 datasource "ds_azure_subscriptions" do
   request do
-    query "api-version", "2020-01-01"
-    header "User-Agent", "RS Policies"
     auth $auth_azure
     pagination $pagination_azure
     host $param_azure_endpoint
     path "/subscriptions/"
+    query "api-version", "2020-01-01"
+    header "User-Agent", "RS Policies"
     # Header X-Meta-Flexera has no affect on datasource query, but is required for Meta Policies
     # Forces `ds_is_deleted` datasource to run first during policy execution
     header "Meta-Flexera", val($ds_is_deleted, "path")
@@ -478,8 +478,8 @@ datasource "ds_azure_instances_region_filtered" do
 end
 
 script "js_azure_instances_region_filtered", type: "javascript" do
-  result "result"
   parameters "ds_azure_instances_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
+  result "result"
   code <<-EOS
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_instances_tag_filtered, function(vm) {
@@ -1285,10 +1285,10 @@ policy "pol_utilization" do
     EOS
     # Policy check fails and incident is created only if data is not empty and the Parent Policy has not been terminated
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
-    hash_exclude "underutil_message", "idle_message", "underutil_total_savings", "idle_total_savings", "tags", "savings", "savingsCurrency", "cpu_maximum", "cpu_minimum", "cpu_average", "mem_maximum", "mem_minimum", "mem_average"
     escalate $esc_email
     escalate $esc_poweroff_instances
     escalate $esc_delete_instances
+    hash_exclude "underutil_message", "idle_message", "underutil_total_savings", "idle_total_savings", "tags", "savings", "savingsCurrency", "cpu_maximum", "cpu_minimum", "cpu_average", "mem_maximum", "mem_minimum", "mem_average"
     export do
       resource_level true
       field "accountID" do
@@ -1404,9 +1404,9 @@ end
 
 escalation "esc_delete_instances" do
   automatic contains($param_automatic_action, "Delete Idle Instances")
-  run "delete_instances", data, $param_azure_endpoint
   label "Delete Idle Instances"
   description "Approval to delete all selected instances"
+  run "delete_instances", data, $param_azure_endpoint
 end
 
 ###############################################################################


### PR DESCRIPTION
### Description

The following tests have been added to the Dangerfile:
- Tests for whether the ordering of fields within a code block is correct.
- Test for whether recommendation policies have all of the required and recommended fields in the export block

The following bugs have been fixed:
- run_script order test now correctly expects val(iter_item, *string*) to come before other parameters. This is mostly revelent when run_script occurs within a request block.

### Contribution Check List

- [X] New functionality includes testing.
