### PR TITLE
FOPTS-3569 Fix: empty bill_source_expressions

### DIFF
--- a/cost/azure/savings_realized/CHANGELOG.md
+++ b/cost/azure/savings_realized/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v3.7
 
-- Issue with `bill_source_expressions` fixed, in case that was empty, policy breaks on runtime since `or` condition doesn't support empty expressions, added an extra validation to get rid of that condition if `bill_source_expressions` is empty.
+- Added support for organizations with no Microsoft Azure Enterprise Agreement (Legacy) bill connects
 
 ## v3.6
 

--- a/cost/azure/savings_realized/CHANGELOG.md
+++ b/cost/azure/savings_realized/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.7
+
+- Issue with empty `bill_source_expressions` fixed.
+
 ## v3.6
 
 - Incident subject is now the name of the applied policy

--- a/cost/azure/savings_realized/CHANGELOG.md
+++ b/cost/azure/savings_realized/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v3.7
 
-- Issue with empty `bill_source_expressions` fixed.
+- Issue with `bill_source_expressions` fixed, in case that was empty, policy breaks on runtime since `or` condition doesn't support empty expressions, added an extra validation to get rid of that condition if `bill_source_expressions` is empty.
 
 ## v3.6
 

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -473,7 +473,9 @@ script "js_get_aggregated_costs", type: "javascript" do
     return { "dimension": "bill_source", "type": "equal", "value": bill_source }
   })
 
-  filter["expressions"].push({ "type": "or", "expressions": bill_source_expressions })
+  if (bill_source_expressions.length  > 0) {
+    filter["expressions"].push({ "type": "or", "expressions": bill_source_expressions })
+  }
 
   payload = {
     "billing_center_ids": ds_filtered_bcs,

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -152,9 +152,9 @@ datasource "ds_billing_centers" do
     auth $auth_flexera
     host rs_optima_host
     path join(["/analytics/orgs/", rs_org_id, "/billing_centers"])
+    query "view", "allocation_table"
     header "Api-Version", "1.0"
     header "User-Agent", "RS Policies"
-    query "view", "allocation_table"
     ignore_status [403]
   end
   result do
@@ -730,7 +730,7 @@ end
 # Policy
 ###############################################################################
 
-policy "policy_purchase_option_by_inst_type_and_region" do
+policy "pol_purchase_option_by_inst_type_and_region" do
   validate_each $ds_chart_data do
     summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}"
     detail_template <<-'EOS'

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -473,7 +473,7 @@ script "js_get_aggregated_costs", type: "javascript" do
     return { "dimension": "bill_source", "type": "equal", "value": bill_source }
   })
 
-  if (bill_source_expressions.length  > 0) {
+  if (bill_source_expressions.length > 0) {
     filter["expressions"].push({ "type": "or", "expressions": bill_source_expressions })
   }
 

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "monthly"
 info(
-  version: "3.6",
+  version: "3.7",
   provider: "Azure",
   service: "Compute",
   policy_set: "Savings Realized"


### PR DESCRIPTION
### Description

Currently when `bill_source_expressions` is empty it creates an `or` condition with empty expressions, it causes that policy breaks in runtime, specifically with this error message:

`Invalid filter: invalid #4 AND expression: attribute 'expressions' must contain at least one expression for type \\\"or\\\": invalid argument\`

So we added a condition to validate if `bill_source_expressions` is empty, if so get rid to create that `or` condition.

SQ link: https://flexera.atlassian.net/browse/SQ-7053
CLONE link: https://flexera.atlassian.net/browse/FOPTS-3569

### Issues Resolved

- Bug on empty `bill_source_expressions`.

### Link to Example Applied Policy

[Previous version](https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/60073?policyId=65f9bf71d8f0b2e49c9c96f6)
[With error](https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/60073?policyId=65f9bf02d8f0b2e49c9c96f5)
[New version](https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/60073?policyId=65f9bc241909b512219a67ff)

### Contribution Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
