### PR TITLE
POL-1156 Deprecate "Policy Update Notification" Policy

### DIFF
--- a/compliance/policy_update_notification/CHANGELOG.md
+++ b/compliance/policy_update_notification/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1
+
+- Deprecated: This policy is no longer being updated. Please see policy README for more information.
+
 ## v2.0
 
 - Policy now works in all Flexera orgs regardless of zone

--- a/compliance/policy_update_notification/README.md
+++ b/compliance/policy_update_notification/README.md
@@ -1,5 +1,9 @@
 # Policy Update Notification
 
+## Deprecated
+
+This policy is no longer being updated. The [Flexera Automation Outdated Applied Policies](https://github.com/flexera-public/policy_templates/tree/master/automation/flexera/outdated_applied_policies/) policy has superseded this one and includes significantly more functionality.
+
 ## What It Does
 
 This Policy Template scans all applied policies in a Flexera account and finds ones that are using an outdated version of a policy template from the Flexera catalog. An incident is raised, and optionally an email is sent, containing a list of these outdated applied policies.

--- a/compliance/policy_update_notification/policy_update_notification.pt
+++ b/compliance/policy_update_notification/policy_update_notification.pt
@@ -1,13 +1,13 @@
 name "Policy Update Notification"
 rs_pt_ver 20180301
 type "policy"
-short_description "Checks for applied policies that use outdated policy catalog templates. See the [README](https://github.com/flexera-public/policy_templates/tree/master/compliance/policy_update_notification/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "**Deprecated: This policy is no longer being updated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/compliance/policy_update_notification/) for more details.**  Checks for applied policies that use outdated policy catalog templates. See the [README](https://github.com/flexera-public/policy_templates/tree/master/compliance/policy_update_notification/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 severity "low"
 category "Compliance"
 default_frequency "weekly"
 info(
-  version: "2.0",
+  version: "2.1",
   provider: "Flexera Cloud Management",
   service: "",
   policy_set: ""


### PR DESCRIPTION
### Description

This deprecates the Policy Update Notification policy and directs users to the more up to date and functional Flexera Automation Outdated Applied Policies policy.

### Contribution Check List

- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
