### PR TITLE
POL-1172 Update AWS CloudFormation Template for Policies

### DIFF
--- a/operational/aws/tag_cardinality/README.md
+++ b/operational/aws/tag_cardinality/README.md
@@ -1,12 +1,12 @@
 # AWS Tag Cardinality Report
 
-## What it does
+## What It Does
 
 This Policy Template is used to generate a tag cardinality (how many unique values each tag key has) report for AWS, along with a list of those unique values for each tag key. The report includes cardinality for all tag values for both AWS Accounts and Resources.
 
-> *NOTE: This Policy Template must be appled to the **AWS Organization Master Payer** account.*
+> *NOTE: This Policy Template must be applied to the **AWS Organization Master Payer** account.*
 
-## Functional Details
+## How It Works
 
 This policy performs the following action:
 

--- a/operational/aws/tag_cardinality/README.md
+++ b/operational/aws/tag_cardinality/README.md
@@ -30,7 +30,7 @@ This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Auto
 - [**AWS Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1121575) (*provider=aws*) which has the following permissions:
   - `tag:GetResources`
   - `ec2:DescribeRegions`
-  - `eorganizations:ListAccounts`
+  - `organizations:ListAccounts`
   - `organizations:ListTagsForResource`
 
   Example IAM Permission Policy:

--- a/tools/cloudformation-template/FlexeraAutomationPolicies.template
+++ b/tools/cloudformation-template/FlexeraAutomationPolicies.template
@@ -25,11 +25,11 @@ Metadata:
           #### For each policy template append:
           # - paramPerms<PolicyTemplateNameNoSpaces>
           - paramPermsAWSUnusedVolumes
-          - paramPermsAWSUnusedRDS
+          - paramPermsAWSRightsizeRDSInstances
           - paramPermsAWSUnusedIPAddresses
           - paramPermsAWSOldSnapshots
-          - paramPermsAWSIdleComputeInstances
           - paramPermsAWSRightsizeEC2Instances
+          - paramPermsAWSSupersededEC2Instances
           - paramPermsAWSReservedInstancesRecommendation
           - paramPermsAWSObjectStorageOptimization
           - paramPermsAWSExpiringSavingsPlans
@@ -56,16 +56,16 @@ Metadata:
       #   default: "Permissions for Policy Template: <Policy Template Name>"
       paramPermsAWSUnusedVolumes:
         default: "Permissions for Policy Template: AWS Unused Volumes"
-      paramPermsAWSUnusedRDS:
-        default: "Permissions for Policy Template: AWS Unused RDS"
+      paramPermsAWSRightsizeRDSInstances:
+        default: "Permissions for Policy Template: AWS Rightsize RDS Instances"
       paramPermsAWSUnusedIPAddresses:
         default: "Permissions for Policy Template: AWS Unused IP Addresses"
       paramPermsAWSOldSnapshots:
         default: "Permissions for Policy Template: AWS Old Snapshots"
-      paramPermsAWSIdleComputeInstances:
-        default: "Permissions for Policy Template: AWS Idle Compute Instances"
       paramPermsAWSRightsizeEC2Instances:
         default: "Permissions for Policy Template: AWS Rightsize EC2 Instances"
+      paramPermsAWSSupersededEC2Instances:
+        default: "Permissions for Policy Template: AWS Superseded EC2 Instances"
       paramPermsAWSReservedInstancesRecommendation:
         default: "Permissions for Policy Template: AWS Reserved Instances Recommendation"
       paramPermsAWSObjectStorageOptimization:
@@ -134,13 +134,14 @@ Parameters:
       - No Access
       - Read Only
       - Read and Take Action
-  paramPermsAWSUnusedRDS:
-    Description: 'What permissions should policies using "AWS Unused RDS" Policy Template be granted on the IAM Role that will be created?'
+  paramPermsAWSRightsizeRDSInstances:
+    Description: 'What permissions should policies using "AWS Rightsize RDS Instances" Policy Template be granted on the IAM Role that will be created?'
     Type: String
     Default: Read Only
     AllowedValues:
       - No Access
       - Read Only
+      - Read and Take Action
   paramPermsAWSUnusedIPAddresses:
     Description: 'What permissions should policies using "AWS Unused IP Addresses" Policy Template be granted on the IAM Role that will be created?'
     Type: String
@@ -157,15 +158,16 @@ Parameters:
       - No Access
       - Read Only
       - Read and Take Action
-  paramPermsAWSIdleComputeInstances:
-    Description: 'What permissions should policies using "AWS Idle Compute Instances" Policy Template be granted on the IAM Role that will be created?'
+  paramPermsAWSRightsizeEC2Instances:
+    Description: 'What permissions should policies using "AWS Rightsize EC2 Instances" Policy Template be granted on the IAM Role that will be created?'
     Type: String
     Default: Read Only
     AllowedValues:
       - No Access
       - Read Only
-  paramPermsAWSRightsizeEC2Instances:
-    Description: 'What permissions should policies using "AWS Rightsize EC2 Instances" Policy Template be granted on the IAM Role that will be created?'
+      - Read and Take Action
+  paramPermsAWSSupersededEC2Instances:
+    Description: 'What permissions should policies using "AWS Superseded EC2 Instances" Policy Template be granted on the IAM Role that will be created?'
     Type: String
     Default: Read Only
     AllowedValues:
@@ -253,14 +255,13 @@ Conditions:
   CreatePolicyAWSUnusedVolumesAction: !Equals
     - !Ref paramPermsAWSUnusedVolumes
     - Read and Take Action
-  CreatePolicyAWSUnusedRDSRead: !Not
+  CreatePolicyAWSRightsizeRDSInstancesRead: !Not
     - !Equals
-      - !Ref paramPermsAWSUnusedRDS
+      - !Ref paramPermsAWSRightsizeRDSInstances
       - No Access
-  # Policy has no actions currently, commenting out to prevent cfn-lint W8001 Error Condition not used
-  # CreatePolicyAWSUnusedRDSAction: !Equals
-  #   - !Ref paramPermsAWSUnusedRDS
-  #   - Read and Take Action
+  CreatePolicyAWSRightsizeRDSInstancesAction: !Equals
+    - !Ref paramPermsAWSRightsizeRDSInstances
+    - Read and Take Action
   CreatePolicyAWSUnusedIPAddressesRead: !Not
     - !Equals
       - !Ref paramPermsAWSUnusedIPAddresses
@@ -275,20 +276,19 @@ Conditions:
   CreatePolicyAWSOldSnapshotsAction: !Equals
     - !Ref paramPermsAWSOldSnapshots
     - Read and Take Action
-  CreatePolicyAWSIdleComputeInstancesRead: !Not
-    - !Equals
-      - !Ref paramPermsAWSIdleComputeInstances
-      - No Access
-  # Policy has no actions currently, commenting out to prevent cfn-lint W8001 Error Condition not used
-  # CreatePolicyAWSIdleComputeInstancesAction: !Equals
-  #   - !Ref paramPermsAWSIdleComputeInstances
-  #   - Read and Take Action
   CreatePolicyAWSRightsizeEC2InstancesRead: !Not
     - !Equals
       - !Ref paramPermsAWSRightsizeEC2Instances
       - No Access
   CreatePolicyAWSRightsizeEC2InstancesAction: !Equals
     - !Ref paramPermsAWSRightsizeEC2Instances
+    - Read and Take Action
+  CreatePolicyAWSSupersededEC2InstancesRead: !Not
+    - !Equals
+      - !Ref paramPermsAWSSupersededEC2Instances
+      - No Access
+  CreatePolicyAWSSupersededEC2InstancesAction: !Equals
+    - !Ref paramPermsAWSSupersededEC2Instances
     - Read and Take Action
   CreatePolicyAWSReservedInstancesRecommendationRead: !Not
     - !Equals
@@ -370,7 +370,7 @@ Mappings:
     #   action:
     #     - "<IAM Permission>"
     AWSUnusedVolumes:
-      read:
+        read:
         - "ec2:DescribeRegions"
         - "ec2:DescribeVolumes"
         - "ec2:DescribeSnapshots"
@@ -381,21 +381,25 @@ Mappings:
         - "ec2:CreateSnapshot"
         - "ec2:DetachVolume"
         - "ec2:DeleteVolume"
-    AWSUnusedRDS:
+    AWSRightsizeRDSInstances:
       read:
-        - "ec2:DescribeRegions"
+        - "sts:GetCallerIdentity"
         - "cloudwatch:GetMetricStatistics"
         - "cloudwatch:GetMetricData"
-        - "cloudwatch:ListMetrics"
+        - "ec2:DescribeRegions"
         - "rds:DescribeDBInstances"
         - "rds:ListTagsForResource"
-        - "sts:GetCallerIdentity"
-      action: []
+        - "rds:DescribeOrderableDBInstanceOptions"
+      action:
+        - "rds:ModifyDBInstance"
+        - "rds:DeleteDBInstance"
     AWSUnusedIPAddresses:
       read:
         - "ec2:DescribeRegions"
         - "ec2:DescribeAddresses"
         - "pricing:GetProducts"
+        - "sts:GetCallerIdentity"
+        - "cloudtrail:LookupEvents"
       action:
         - "ec2:ReleaseAddress"
     AWSOldSnapshots:
@@ -403,46 +407,50 @@ Mappings:
         - "ec2:DescribeRegions"
         - "ec2:DescribeImages"
         - "ec2:DescribeSnapshots"
-        - "cloudtrail:LookupEvents"
         - "rds:DescribeDBInstances"
         - "rds:DescribeDBSnapshots"
         - "rds:DescribeDBClusters"
         - "rds:DescribeDBClusterSnapshots"
         - "sts:GetCallerIdentity"
+        - "cloudtrail:LookupEvents"
       action:
         - "ec2:DeregisterImage"
         - "ec2:DeleteSnapshot"
-        - "rds:DeleteDBSnapshot"
         - "rds:DeleteDBClusterSnapshot"
-    AWSIdleComputeInstances:
-      read:
-        - "ec2:DescribeRegions"
-        - "ec2:DescribeInstances"
-        - "ec2:DescribeTags"
-        - "cloudwatch:GetMetricStatistics"
-        - "cloudwatch:GetMetricData"
-        - "cloudwatch:ListMetrics"
-      action: []
+        - "rds:DeleteDBSnapshot"
     AWSRightsizeEC2Instances:
       read:
-        - "ec2:DescribeInstanceStatus"
         - "ec2:DescribeRegions"
         - "ec2:DescribeInstances"
         - "ec2:DescribeTags"
         - "cloudwatch:GetMetricStatistics"
         - "cloudwatch:GetMetricData"
         - "cloudwatch:ListMetrics"
+        - "sts:GetCallerIdentity"
       action:
+        - "ec2:DescribeInstanceStatus"
         - "ec2:ModifyInstanceAttribute"
         - "ec2:StartInstances"
         - "ec2:StopInstances"
         - "ec2:TerminateInstances"
+    AWSSupersededEC2Instances:
+      read:
+        - "ec2:DescribeRegions"
+        - "ec2:DescribeInstances"
+        - "ec2:DescribeTags"
+        - "sts:GetCallerIdentity"
+      action:
+        - "ec2:DescribeInstanceStatus"
+        - "ec2:ModifyInstanceAttribute"
+        - "ec2:StartInstances"
+        - "ec2:StopInstances"
     AWSReservedInstancesRecommendation:
       read:
         - "ce:GetReservationPurchaseRecommendation"
       action: []
     AWSObjectStorageOptimization:
       read:
+        - "sts:GetCallerIdentity"
         - "s3:ListAllMyBuckets"
         - "s3:GetBucketLocation"
         - "s3:ListBucket"
@@ -462,23 +470,25 @@ Mappings:
     AWSSavingsPlanUtilization:
       read:
         - "ce:GetSavingsPlansUtilization"
+        - "savingsplans:DescribeSavingsPlans"
       action: []
     AWSTagCardinalityReport:
       read:
         - "tag:GetResources"
         - "ec2:DescribeRegions"
-        - "organizations:ListAccounts"
+        - "eorganizations:ListAccounts"
         - "organizations:ListTagsForResource"
       action: []
     AWSUntaggedResources:
       read:
-        - "tag:GetResources"
-        - "ec2:DescribeRegions"
-      action:
-        - "tag:TagResources"
-        - "ec2:CreateTags"
-        - "rds:AddTagsToResource"
+        - "sts:GetCallerIdentity"
         - "config:TagResource"
+        - "ec2:DescribeRegions"
+        - "tag:GetResources"
+      action:
+        - "ec2:CreateTags"
+        - "tag:TagResources"
+        - "rds:AddTagsToResources"
     # End for each policy template
 
 
@@ -594,15 +604,15 @@ Resources:
               - AWSUnusedVolumes
               - action
             Resource: "*"
-  ## AWS Unused RDS Permission Policies
-  iamPolicyAWSUnusedRDSRead:
+  ## AWS Rightsize RDS Instances Permission Policies
+  iamPolicyAWSRightsizeRDSInstancesRead:
     Type: "AWS::IAM::Policy"
-    Condition: CreatePolicyAWSUnusedRDSRead
+    Condition: CreatePolicyAWSRightsizeRDSInstancesRead
     Properties:
       PolicyName: !Join
         - "_"
         - - !Ref paramRoleName
-          - AWSUnusedRDSReadPermissionPolicy
+          - AWSRightsizeRDSInstancesReadPermissionPolicy
       Roles:
         - !Ref iamRole
       PolicyDocument:
@@ -611,8 +621,27 @@ Resources:
           - Effect: Allow
             Action: !FindInMap
               - PermissionMap
-              - AWSUnusedRDS
+              - AWSRightsizeRDSInstances
               - read
+            Resource: "*"
+  iamPolicyAWSRightsizeRDSInstancesAction:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSRightsizeRDSInstancesAction
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSRightsizeRDSInstancesActionPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSRightsizeRDSInstances
+              - action
             Resource: "*"
   iamPolicyAWSUnusedIPAddresses:
     Type: "AWS::IAM::Policy"
@@ -692,26 +721,6 @@ Resources:
               - AWSOldSnapshots
               - action
             Resource: "*"
-  ## AWS Idle Compute Instances Permission Policies
-  iamPolicyAWSIdleComputeInstances:
-    Type: "AWS::IAM::Policy"
-    Condition: CreatePolicyAWSIdleComputeInstancesRead
-    Properties:
-      PolicyName: !Join
-        - "_"
-        - - !Ref paramRoleName
-          - AWSIdleComputeInstancesReadPermissionPolicy
-      Roles:
-        - !Ref iamRole
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Action: !FindInMap
-              - PermissionMap
-              - AWSIdleComputeInstances
-              - read
-            Resource: "*"
   ## AWS Rightsize EC2 Instances Permission Policies
   iamPolicyAWSRightsizeEC2Instances:
     Type: "AWS::IAM::Policy"
@@ -749,6 +758,45 @@ Resources:
             Action: !FindInMap
               - PermissionMap
               - AWSRightsizeEC2Instances
+              - action
+            Resource: "*"
+  ## AWS Superseded EC2 Instances Permission Policies
+  iamPolicyAWSSupersededEC2Instances:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSSupersededEC2InstancesRead
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSSupersededEC2InstancesReadPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSSupersededEC2Instances
+              - read
+            Resource: "*"
+  iamPolicyAWSSupersededEC2InstancesAction:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSSupersededEC2InstancesAction
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSSupersededEC2InstancesActionPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSSupersededEC2Instances
               - action
             Resource: "*"
   ## AWS Reserved Instances Recommendation

--- a/tools/cloudformation-template/FlexeraAutomationPolicies.template
+++ b/tools/cloudformation-template/FlexeraAutomationPolicies.template
@@ -528,7 +528,7 @@ Mappings:
       read:
         - "tag:GetResources"
         - "ec2:DescribeRegions"
-        - "eorganizations:ListAccounts"
+        - "organizations:ListAccounts"
         - "organizations:ListTagsForResource"
       action: []
     AWSUntaggedResources:

--- a/tools/cloudformation-template/FlexeraAutomationPolicies.template
+++ b/tools/cloudformation-template/FlexeraAutomationPolicies.template
@@ -27,6 +27,7 @@ Metadata:
           - paramPermsAWSUnusedVolumes
           - paramPermsAWSRightsizeRDSInstances
           - paramPermsAWSUnusedIPAddresses
+          - paramPermsAWSUnusedCLBs
           - paramPermsAWSOldSnapshots
           - paramPermsAWSRightsizeEC2Instances
           - paramPermsAWSSupersededEC2Instances
@@ -60,6 +61,8 @@ Metadata:
         default: "Permissions for Policy Template: AWS Rightsize RDS Instances"
       paramPermsAWSUnusedIPAddresses:
         default: "Permissions for Policy Template: AWS Unused IP Addresses"
+      paramPermsAWSUnusedCLBs:
+        default: "Permissions for Policy Template: AWS Unused Classic Load Balancers"
       paramPermsAWSOldSnapshots:
         default: "Permissions for Policy Template: AWS Old Snapshots"
       paramPermsAWSRightsizeEC2Instances:
@@ -144,6 +147,14 @@ Parameters:
       - Read and Take Action
   paramPermsAWSUnusedIPAddresses:
     Description: 'What permissions should policies using "AWS Unused IP Addresses" Policy Template be granted on the IAM Role that will be created?'
+    Type: String
+    Default: Read Only
+    AllowedValues:
+      - No Access
+      - Read Only
+      - Read and Take Action
+  paramPermsAWSUnusedCLBs:
+    Description: 'What permissions should policies using "AWS Unused Classic Load Balancers" Policy Template be granted on the IAM Role that will be created?'
     Type: String
     Default: Read Only
     AllowedValues:
@@ -268,6 +279,13 @@ Conditions:
       - No Access
   CreatePolicyAWSUnusedIPAddressesAction: !Equals
     - !Ref paramPermsAWSUnusedIPAddresses
+    - Read and Take Action
+  CreatePolicyAWSUnusedCLBsRead: !Not
+  - !Equals
+    - !Ref paramPermsAWSUnusedCLBs
+    - No Access
+  CreatePolicyAWSUnusedCLBsAction: !Equals
+    - !Ref paramPermsAWSUnusedCLBs
     - Read and Take Action
   CreatePolicyAWSOldSnapshotsRead: !Not
     - !Equals
@@ -402,6 +420,15 @@ Mappings:
         - "cloudtrail:LookupEvents"
       action:
         - "ec2:ReleaseAddress"
+    AWSUnusedCLBs:
+      read:
+        - `sts:GetCallerIdentity`
+        - `ec2:DescribeRegions`
+        - `elasticloadbalancing:DescribeLoadBalancers`
+        - `elasticloadbalancing:DescribeInstanceHealth`
+        - `elasticloadbalancing:DescribeTags`
+      action:
+        - `elasticloadbalancing:DeleteLoadBalancer`
     AWSOldSnapshots:
       read:
         - "ec2:DescribeRegions"
@@ -643,7 +670,8 @@ Resources:
               - AWSRightsizeRDSInstances
               - action
             Resource: "*"
-  iamPolicyAWSUnusedIPAddresses:
+  ## AWS Unused IP Addresses Permission Policies
+  iamPolicyAWSUnusedIPAddressesRead:
     Type: "AWS::IAM::Policy"
     Condition: CreatePolicyAWSUnusedIPAddressesRead
     Properties:
@@ -662,7 +690,6 @@ Resources:
               - AWSUnusedIPAddresses
               - read
             Resource: "*"
-  ## AWS Unused IP Addresses Permission Policies
   iamPolicyAWSUnusedIPAddressesAction:
     Type: "AWS::IAM::Policy"
     Condition: CreatePolicyAWSUnusedIPAddressesAction
@@ -680,6 +707,45 @@ Resources:
             Action: !FindInMap
               - PermissionMap
               - AWSUnusedIPAddresses
+              - action
+            Resource: "*"
+  ## AWS Unused Classic Load Balancers Policies
+  iamPolicyAWSUnusedCLBsRead:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSUnusedCLBsRead
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSUnusedCLBsReadPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSUnusedCLBs
+              - read
+            Resource: "*"
+  iamPolicyAWSUnusedCLBsAction:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSUnusedCLBsAction
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSUnusedCLBsActionPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSUnusedCLBs
               - action
             Resource: "*"
   ## AWS Old Snapshots Permission Policies

--- a/tools/cloudformation-template/FlexeraAutomationPolicies.template
+++ b/tools/cloudformation-template/FlexeraAutomationPolicies.template
@@ -25,6 +25,7 @@ Metadata:
           #### For each policy template append:
           # - paramPerms<PolicyTemplateNameNoSpaces>
           - paramPermsAWSUnusedVolumes
+          - paramPermsAWSRightsizeEBSVolumes
           - paramPermsAWSRightsizeRDSInstances
           - paramPermsAWSUnusedIPAddresses
           - paramPermsAWSUnusedCLBs
@@ -57,6 +58,8 @@ Metadata:
       #   default: "Permissions for Policy Template: <Policy Template Name>"
       paramPermsAWSUnusedVolumes:
         default: "Permissions for Policy Template: AWS Unused Volumes"
+      paramPermsAWSRightsizeEBSVolumes:
+        default: "Permissions for Policy Template: AWS Rightsize EBS Volumes"
       paramPermsAWSRightsizeRDSInstances:
         default: "Permissions for Policy Template: AWS Rightsize RDS Instances"
       paramPermsAWSUnusedIPAddresses:
@@ -131,6 +134,14 @@ Parameters:
   #     - Read and Take Action
   paramPermsAWSUnusedVolumes:
     Description: 'What permissions should policies using "AWS Unused Volumes" Policy Template be granted on the IAM Role that will be created?'
+    Type: String
+    Default: Read Only
+    AllowedValues:
+      - No Access
+      - Read Only
+      - Read and Take Action
+  paramPermsAWSRightsizeEBSVolumes:
+    Description: 'What permissions should policies using "AWS Rightsize EBS Volumes" Policy Template be granted on the IAM Role that will be created?'
     Type: String
     Default: Read Only
     AllowedValues:
@@ -266,6 +277,13 @@ Conditions:
   CreatePolicyAWSUnusedVolumesAction: !Equals
     - !Ref paramPermsAWSUnusedVolumes
     - Read and Take Action
+  CreatePolicyAWSRightsizeEBSVolumesRead: !Not
+    - !Equals
+      - !Ref paramPermsAWSRightsizeEBSVolumes
+      - No Access
+  CreatePolicyAWSRightsizeEBSVolumesAction: !Equals
+    - !Ref paramPermsAWSRightsizeEBSVolumes
+    - Read and Take Action
   CreatePolicyAWSRightsizeRDSInstancesRead: !Not
     - !Equals
       - !Ref paramPermsAWSRightsizeRDSInstances
@@ -388,7 +406,7 @@ Mappings:
     #   action:
     #     - "<IAM Permission>"
     AWSUnusedVolumes:
-        read:
+      read:
         - "ec2:DescribeRegions"
         - "ec2:DescribeVolumes"
         - "ec2:DescribeSnapshots"
@@ -399,6 +417,13 @@ Mappings:
         - "ec2:CreateSnapshot"
         - "ec2:DetachVolume"
         - "ec2:DeleteVolume"
+    AWSRightsizeEBSVolumes:
+      read:
+        - "ec2:DescribeRegions"
+        - "ec2:DescribeVolumes"
+        - "pricing:GetProducts"
+      action:
+        - "ec2:ModifyVolume"
     AWSRightsizeRDSInstances:
       read:
         - "sts:GetCallerIdentity"
@@ -422,13 +447,13 @@ Mappings:
         - "ec2:ReleaseAddress"
     AWSUnusedCLBs:
       read:
-        - `sts:GetCallerIdentity`
-        - `ec2:DescribeRegions`
-        - `elasticloadbalancing:DescribeLoadBalancers`
-        - `elasticloadbalancing:DescribeInstanceHealth`
-        - `elasticloadbalancing:DescribeTags`
+        - "sts:GetCallerIdentity"
+        - "ec2:DescribeRegions"
+        - "elasticloadbalancing:DescribeLoadBalancers"
+        - "elasticloadbalancing:DescribeInstanceHealth"
+        - "elasticloadbalancing:DescribeTags"
       action:
-        - `elasticloadbalancing:DeleteLoadBalancer`
+        - "elasticloadbalancing:DeleteLoadBalancer"
     AWSOldSnapshots:
       read:
         - "ec2:DescribeRegions"
@@ -629,6 +654,45 @@ Resources:
             Action: !FindInMap
               - PermissionMap
               - AWSUnusedVolumes
+              - action
+            Resource: "*"
+  ## AWS Rightsize EBS Volumes Permission Policies
+  iamPolicyAWSRightsizeEBSVolumesRead:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSRightsizeEBSVolumesRead
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSRightsizeEBSVolumesReadPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSRightsizeEBSVolumes
+              - read
+            Resource: "*"
+  iamPolicyAWSRightsizeEBSVolumesAction:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSRightsizeEBSVolumesAction
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSRightsizeEBSVolumesActionPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSRightsizeEBSVolumes
               - action
             Resource: "*"
   ## AWS Rightsize RDS Instances Permission Policies

--- a/tools/cloudformation-template/releases/FlexeraAutomationPolicies_v0.8.0.template
+++ b/tools/cloudformation-template/releases/FlexeraAutomationPolicies_v0.8.0.template
@@ -528,7 +528,7 @@ Mappings:
       read:
         - "tag:GetResources"
         - "ec2:DescribeRegions"
-        - "eorganizations:ListAccounts"
+        - "organizations:ListAccounts"
         - "organizations:ListTagsForResource"
       action: []
     AWSUntaggedResources:

--- a/tools/cloudformation-template/releases/FlexeraAutomationPolicies_v0.8.0.template
+++ b/tools/cloudformation-template/releases/FlexeraAutomationPolicies_v0.8.0.template
@@ -1,0 +1,1113 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: "CloudFormation Stack with IAM Role and IAM Permission Policy used by Flexera Automation. Official Docs: https://docs.flexera.com/"
+
+Metadata:
+  # AWS::CloudFormation::Interface is a metadata key that defines how parameters are grouped and sorted in the AWS CloudFormation console.
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html
+  AWS::CloudFormation::Interface:
+    # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudformation-interface-parametergroup.html
+    ParameterGroups:
+      # ParameterGroup with paramFlexeraOrgId should be first.
+      # paramFlexeraOrgId only param that is actually required (if Org is on app.flexera.com)
+      - Label:
+          default: "Parameters related to your Organization on the Flexera Platform"
+        Parameters:
+          - paramFlexeraOrgId
+          - paramFlexeraZone
+      - Label:
+          default: "Parameters related to the IAM Role that is created"
+        Parameters:
+          - paramRoleName
+          - paramRolePath
+      - Label:
+          default: "Parameters related to Policy Template permissions on the IAM Role that is created"
+        Parameters:
+          #### For each policy template append:
+          # - paramPerms<PolicyTemplateNameNoSpaces>
+          - paramPermsAWSUnusedVolumes
+          - paramPermsAWSRightsizeEBSVolumes
+          - paramPermsAWSRightsizeRDSInstances
+          - paramPermsAWSUnusedIPAddresses
+          - paramPermsAWSUnusedCLBs
+          - paramPermsAWSOldSnapshots
+          - paramPermsAWSRightsizeEC2Instances
+          - paramPermsAWSSupersededEC2Instances
+          - paramPermsAWSReservedInstancesRecommendation
+          - paramPermsAWSObjectStorageOptimization
+          - paramPermsAWSExpiringSavingsPlans
+          - paramPermsAWSSavingsPlanRecommendations
+          - paramPermsAWSSavingsPlanUtilization
+          - paramPermsAWSTagCardinalityReport
+          - paramPermsAWSUntaggedResources
+          # End for each policy template
+          - paramPermsAttachExistingPolicies
+    # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudformation-interface-parameterlabel.html
+    ParameterLabels:
+      paramRoleName:
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudformation-interface-label.html
+        # The default label that the CloudFormation console uses to name a parameter group or parameter.
+        default: "IAM Role Name"
+      paramRolePath:
+        default: "IAM Role Path"
+      paramFlexeraOrgId:
+        default: "Flexera Organization ID"
+      paramFlexeraZone:
+        default: "Flexera Zone"
+      #### For each policy template append:
+      # paramPerms<PolicyTemplateNameNoSpaces>:
+      #   default: "Permissions for Policy Template: <Policy Template Name>"
+      paramPermsAWSUnusedVolumes:
+        default: "Permissions for Policy Template: AWS Unused Volumes"
+      paramPermsAWSRightsizeEBSVolumes:
+        default: "Permissions for Policy Template: AWS Rightsize EBS Volumes"
+      paramPermsAWSRightsizeRDSInstances:
+        default: "Permissions for Policy Template: AWS Rightsize RDS Instances"
+      paramPermsAWSUnusedIPAddresses:
+        default: "Permissions for Policy Template: AWS Unused IP Addresses"
+      paramPermsAWSUnusedCLBs:
+        default: "Permissions for Policy Template: AWS Unused Classic Load Balancers"
+      paramPermsAWSOldSnapshots:
+        default: "Permissions for Policy Template: AWS Old Snapshots"
+      paramPermsAWSRightsizeEC2Instances:
+        default: "Permissions for Policy Template: AWS Rightsize EC2 Instances"
+      paramPermsAWSSupersededEC2Instances:
+        default: "Permissions for Policy Template: AWS Superseded EC2 Instances"
+      paramPermsAWSReservedInstancesRecommendation:
+        default: "Permissions for Policy Template: AWS Reserved Instances Recommendation"
+      paramPermsAWSObjectStorageOptimization:
+        default: "Permissions for Policy Template: AWS Object Storage Optimization"
+      paramPermsAWSExpiringSavingsPlans:
+        default: "Permissions for Policy Template: AWS Expiring Savings Plans"
+      paramPermsAWSSavingsPlanRecommendations:
+        default: "Permissions for Policy Template: AWS Savings Plan Recommendations"
+      paramPermsAWSSavingsPlanUtilization:
+        default: "Permissions for Policy Template: AWS Savings Plan Utilization"
+      paramPermsAWSTagCardinalityReport:
+        default: "Permissions for Policy Template: AWS Tag Cardinality Report"
+      paramPermsAWSUntaggedResources:
+        default: "Permissions for Policy Template: AWS Untagged Resources"
+      # End for each policy template
+      paramPermsAttachExistingPolicies:
+        default: "Additional IAM Permission Policies for IAM Role"
+
+Parameters:
+  # ParameterGroup: Parameters related to your Organization on the Flexera Platform
+  paramFlexeraOrgId:
+    Description: >-
+      The Organization ID in Flexera which trust will be granted to use the IAM Role that will be created
+    Type: String
+    AllowedPattern: "[0-9]+"
+    MinLength: 1
+    ConstraintDescription: Organization ID must be provided and match regex [0-9]+
+  paramFlexeraZone:
+    Description: >-
+      The Flexera Zone which trust will be granted to.  The Organization ID should be located in this Flexera Zone.
+    Type: String
+    Default: app.flexera.com
+    AllowedValues:
+      - app.flexera.com
+      - app.flexera.eu
+      - app.flexera.au
+      - app.flexeratest.com
+
+  # ParameterGroup: Parameters for the IAM Role that is created
+  paramRoleName:
+    Description: Name of the the IAM Role that will be created. If you plan to create more than one IAM Role (i.e. one for each Policy Template, or to trust multiple Orgs) you will need to modify this to prevent naming conflict.
+    Type: String
+    Default: FlexeraAutomationAccessRole
+    # IAM Role Name Max Length is 64chars
+    MaxLength: 64
+  paramRolePath:
+    Description: Path for the IAM Role that will be created. Generally does not need to be modified.
+    Type: String
+    Default: /
+
+  # ParameterGroup: Parameters to define Policy Template permissions on the IAM Role that is created
+  #### For each policy template append:
+  # paramPerms<PolicyTemplateNameNoSpaces>:
+  #   Description: 'What permissions should policies using "<Policy Template Name>" Policy Template be granted on the IAM Role that will be created?'
+  #   Type: String
+  #   Default: Read Only
+  #   AllowedValues:
+  #     - No Access
+  #     - Read Only
+  #     - Read and Take Action
+  paramPermsAWSUnusedVolumes:
+    Description: 'What permissions should policies using "AWS Unused Volumes" Policy Template be granted on the IAM Role that will be created?'
+    Type: String
+    Default: Read Only
+    AllowedValues:
+      - No Access
+      - Read Only
+      - Read and Take Action
+  paramPermsAWSRightsizeEBSVolumes:
+    Description: 'What permissions should policies using "AWS Rightsize EBS Volumes" Policy Template be granted on the IAM Role that will be created?'
+    Type: String
+    Default: Read Only
+    AllowedValues:
+      - No Access
+      - Read Only
+      - Read and Take Action
+  paramPermsAWSRightsizeRDSInstances:
+    Description: 'What permissions should policies using "AWS Rightsize RDS Instances" Policy Template be granted on the IAM Role that will be created?'
+    Type: String
+    Default: Read Only
+    AllowedValues:
+      - No Access
+      - Read Only
+      - Read and Take Action
+  paramPermsAWSUnusedIPAddresses:
+    Description: 'What permissions should policies using "AWS Unused IP Addresses" Policy Template be granted on the IAM Role that will be created?'
+    Type: String
+    Default: Read Only
+    AllowedValues:
+      - No Access
+      - Read Only
+      - Read and Take Action
+  paramPermsAWSUnusedCLBs:
+    Description: 'What permissions should policies using "AWS Unused Classic Load Balancers" Policy Template be granted on the IAM Role that will be created?'
+    Type: String
+    Default: Read Only
+    AllowedValues:
+      - No Access
+      - Read Only
+      - Read and Take Action
+  paramPermsAWSOldSnapshots:
+    Description: 'What permissions should policies using "AWS Old Snapshots" Policy Template be granted on the IAM Role that will be created?'
+    Type: String
+    Default: Read Only
+    AllowedValues:
+      - No Access
+      - Read Only
+      - Read and Take Action
+  paramPermsAWSRightsizeEC2Instances:
+    Description: 'What permissions should policies using "AWS Rightsize EC2 Instances" Policy Template be granted on the IAM Role that will be created?'
+    Type: String
+    Default: Read Only
+    AllowedValues:
+      - No Access
+      - Read Only
+      - Read and Take Action
+  paramPermsAWSSupersededEC2Instances:
+    Description: 'What permissions should policies using "AWS Superseded EC2 Instances" Policy Template be granted on the IAM Role that will be created?'
+    Type: String
+    Default: Read Only
+    AllowedValues:
+      - No Access
+      - Read Only
+      - Read and Take Action
+  paramPermsAWSReservedInstancesRecommendation:
+    Description: 'What permissions should policies using "AWS Reserved Instances Recommendation" Policy Template be granted on the IAM Role that will be created?'
+    Type: String
+    Default: Read Only
+    AllowedValues:
+      - No Access
+      - Read Only
+      # - Read and Take Action
+  paramPermsAWSObjectStorageOptimization:
+    Description: 'What permissions should policies using "AWS Object Storage Optimization" Policy Template be granted on the IAM Role that will be created?'
+    Type: String
+    Default: Read Only
+    AllowedValues:
+      - No Access
+      - Read Only
+      - Read and Take Action
+  paramPermsAWSExpiringSavingsPlans:
+    Description: 'What permissions should policies using "AWS Expiring Savings Plans" Policy Template be granted on the IAM Role that will be created?'
+    Type: String
+    Default: Read Only
+    AllowedValues:
+      - No Access
+      - Read Only
+      # - Read and Take Action
+  paramPermsAWSSavingsPlanRecommendations:
+    Description: 'What permissions should policies using "AWS Savings Plan Recommendations" Policy Template be granted on the IAM Role that will be created?'
+    Type: String
+    Default: Read Only
+    AllowedValues:
+      - No Access
+      - Read Only
+      # - Read and Take Action
+  paramPermsAWSSavingsPlanUtilization:
+    Description: 'What permissions should policies using "AWS Savings Plan Utilization" Policy Template be granted on the IAM Role that will be created?'
+    Type: String
+    Default: Read Only
+    AllowedValues:
+      - No Access
+      - Read Only
+      # - Read and Take Action
+  paramPermsAWSTagCardinalityReport:
+    Description: 'What permissions should policies using "AWS Tag Cardinality Report" Policy Template be granted on the IAM Role that will be created?'
+    Type: String
+    Default: Read Only
+    AllowedValues:
+      - No Access
+      - Read Only
+      # - Read and Take Action
+  paramPermsAWSUntaggedResources:
+    Description: 'What permissions should policies using "AWS Untagged Resources" Policy Template be granted on the IAM Role that will be created?'
+    Type: String
+    Default: Read Only
+    AllowedValues:
+      - No Access
+      - Read Only
+      - Read and Take Action
+  # End for each policy template
+  paramPermsAttachExistingPolicies:
+    Description: 'Existing IAM Permission Policies to attach to the IAM Role that will be created. Optional, comma separated list of IAM Policy ARNs -- i.e. arn:aws:iam::aws:policy/ReadOnlyAccess'
+    Type: String
+    #  AWS Managed Policy ARN:      arn:aws:iam::aws:policy/ReadOnlyAccess
+    #  Customer Managed Policy ARN: arn:aws:iam::123456789012:policy/CustomPolicy
+    AllowedPattern: '^((arn:aws:iam::(\d{12}|aws)?:policy\/[\w+=,.@-]{1,128})(,)?)*$'
+    ConstraintDescription: 'Malformed IAM Policy ARN.  Must match pattern ^((arn:aws:iam::(\d{12}|aws)?:policy\/[\w+=,.@-]{1,128})(,)?)*$'
+
+Conditions:
+  #### For each policy template append:
+  # CreatePolicy<PolicyTemplateNameNoSpaces>Read: !Not
+  #   - !Equals
+  #     - !Ref paramPerms<PolicyTemplateNameNoSpaces>
+  #     - No Access
+  # CreatePolicy<PolicyTemplateNameNoSpaces>Action: !Equals
+  #   - !Ref paramPerms<PolicyTemplateNameNoSpaces>
+  #   - Read and Take Action
+  CreatePolicyAWSUnusedVolumesRead: !Not
+    - !Equals
+      - !Ref paramPermsAWSUnusedVolumes
+      - No Access
+  CreatePolicyAWSUnusedVolumesAction: !Equals
+    - !Ref paramPermsAWSUnusedVolumes
+    - Read and Take Action
+  CreatePolicyAWSRightsizeEBSVolumesRead: !Not
+    - !Equals
+      - !Ref paramPermsAWSRightsizeEBSVolumes
+      - No Access
+  CreatePolicyAWSRightsizeEBSVolumesAction: !Equals
+    - !Ref paramPermsAWSRightsizeEBSVolumes
+    - Read and Take Action
+  CreatePolicyAWSRightsizeRDSInstancesRead: !Not
+    - !Equals
+      - !Ref paramPermsAWSRightsizeRDSInstances
+      - No Access
+  CreatePolicyAWSRightsizeRDSInstancesAction: !Equals
+    - !Ref paramPermsAWSRightsizeRDSInstances
+    - Read and Take Action
+  CreatePolicyAWSUnusedIPAddressesRead: !Not
+    - !Equals
+      - !Ref paramPermsAWSUnusedIPAddresses
+      - No Access
+  CreatePolicyAWSUnusedIPAddressesAction: !Equals
+    - !Ref paramPermsAWSUnusedIPAddresses
+    - Read and Take Action
+  CreatePolicyAWSUnusedCLBsRead: !Not
+  - !Equals
+    - !Ref paramPermsAWSUnusedCLBs
+    - No Access
+  CreatePolicyAWSUnusedCLBsAction: !Equals
+    - !Ref paramPermsAWSUnusedCLBs
+    - Read and Take Action
+  CreatePolicyAWSOldSnapshotsRead: !Not
+    - !Equals
+      - !Ref paramPermsAWSOldSnapshots
+      - No Access
+  CreatePolicyAWSOldSnapshotsAction: !Equals
+    - !Ref paramPermsAWSOldSnapshots
+    - Read and Take Action
+  CreatePolicyAWSRightsizeEC2InstancesRead: !Not
+    - !Equals
+      - !Ref paramPermsAWSRightsizeEC2Instances
+      - No Access
+  CreatePolicyAWSRightsizeEC2InstancesAction: !Equals
+    - !Ref paramPermsAWSRightsizeEC2Instances
+    - Read and Take Action
+  CreatePolicyAWSSupersededEC2InstancesRead: !Not
+    - !Equals
+      - !Ref paramPermsAWSSupersededEC2Instances
+      - No Access
+  CreatePolicyAWSSupersededEC2InstancesAction: !Equals
+    - !Ref paramPermsAWSSupersededEC2Instances
+    - Read and Take Action
+  CreatePolicyAWSReservedInstancesRecommendationRead: !Not
+    - !Equals
+      - !Ref paramPermsAWSReservedInstancesRecommendation
+      - No Access
+  # Policy has no actions currently, commenting out to prevent cfn-lint W8001 Error Condition not used
+  # CreatePolicyAWSReservedInstancesRecommendationAction: !Equals
+  #   - !Ref paramPermsAWSReservedInstancesRecommendation
+  #   - Read and Take Action
+  CreatePolicyAWSObjectStorageOptimizationRead: !Not
+    - !Equals
+      - !Ref paramPermsAWSObjectStorageOptimization
+      - No Access
+  CreatePolicyAWSObjectStorageOptimizationAction: !Equals
+    - !Ref paramPermsAWSObjectStorageOptimization
+    - Read and Take Action
+  CreatePolicyAWSExpiringSavingsPlansRead: !Not
+    - !Equals
+      - !Ref paramPermsAWSExpiringSavingsPlans
+      - No Access
+  # Policy has no actions currently, commenting out to prevent cfn-lint W8001 Error Condition not used
+  # CreatePolicyAWSExpiringSavingsPlansAction: !Equals
+  #   - !Ref paramPermsAWSExpiringSavingsPlans
+  #   - Read and Take Action
+  CreatePolicyAWSSavingsPlanRecommendationsRead: !Not
+    - !Equals
+      - !Ref paramPermsAWSSavingsPlanRecommendations
+      - No Access
+  # Policy has no actions currently, commenting out to prevent cfn-lint W8001 Error Condition not used
+  # CreatePolicyAWSSavingsPlanRecommendationsAction: !Equals
+  #   - !Ref paramPermsAWSSavingsPlanRecommendations
+  #   - Read and Take Action
+  CreatePolicyAWSSavingsPlanUtilizationRead: !Not
+    - !Equals
+      - !Ref paramPermsAWSSavingsPlanUtilization
+      - No Access
+  # Policy has no actions currently, commenting out to prevent cfn-lint W8001 Error Condition not used
+  # CreatePolicyAWSSavingsPlanUtilizationAction: !Equals
+  #   - !Ref paramPermsAWSSavingsPlanUtilization
+  #   - Read and Take Action
+  CreatePolicyAWSTagCardinalityReportRead: !Not
+    - !Equals
+      - !Ref paramPermsAWSTagCardinalityReport
+      - No Access
+  # Policy has no actions currently, commenting out to prevent cfn-lint W8001 Error Condition not used
+  # CreatePolicyAWSTagCardinalityReportAction: !Equals
+  #   - !Ref paramPermsAWSTagCardinalityReport
+  #   - Read and Take Action
+  CreatePolicyAWSUntaggedResourcesRead: !Not
+    - !Equals
+      - !Ref paramPermsAWSUntaggedResources
+      - No Access
+  CreatePolicyAWSUntaggedResourcesAction: !Equals
+    - !Ref paramPermsAWSUntaggedResources
+    - Read and Take Action
+  # End for each policy template
+  ValueProvidedparamPermsAttachExistingPolicies: !Not
+    - !Equals
+      - !Ref paramPermsAttachExistingPolicies
+      - ""
+
+Mappings:
+  TrustedRoleMap:
+    app.flexera.com:
+      roleArn: "arn:aws:iam::451234325714:role/production_customer_access"
+    app.flexera.eu:
+      roleArn: "arn:aws:iam::451234325714:role/production_eu_customer_access"
+    app.flexera.au:
+      roleArn: "arn:aws:iam::451234325714:role/production_apac_customer_access"
+    app.flexeratest.com:
+      roleArn: "arn:aws:iam::274571843445:role/staging_customer_access"
+  PermissionMap:
+    # Begin IAM Permissions Map
+    # Expect 2 lists for each Policy Template (read and action)
+    #### For each policy template append:
+    # <PolicyTemplateNameNoSpaces>:
+    #   read:
+    #     - "<IAM Permission>"
+    #   action:
+    #     - "<IAM Permission>"
+    AWSUnusedVolumes:
+      read:
+        - "ec2:DescribeRegions"
+        - "ec2:DescribeVolumes"
+        - "ec2:DescribeSnapshots"
+        - "cloudwatch:GetMetricStatistics"
+        - "cloudwatch:GetMetricData"
+      action:
+        - "ec2:CreateTags"
+        - "ec2:CreateSnapshot"
+        - "ec2:DetachVolume"
+        - "ec2:DeleteVolume"
+    AWSRightsizeEBSVolumes:
+      read:
+        - "ec2:DescribeRegions"
+        - "ec2:DescribeVolumes"
+        - "pricing:GetProducts"
+      action:
+        - "ec2:ModifyVolume"
+    AWSRightsizeRDSInstances:
+      read:
+        - "sts:GetCallerIdentity"
+        - "cloudwatch:GetMetricStatistics"
+        - "cloudwatch:GetMetricData"
+        - "ec2:DescribeRegions"
+        - "rds:DescribeDBInstances"
+        - "rds:ListTagsForResource"
+        - "rds:DescribeOrderableDBInstanceOptions"
+      action:
+        - "rds:ModifyDBInstance"
+        - "rds:DeleteDBInstance"
+    AWSUnusedIPAddresses:
+      read:
+        - "ec2:DescribeRegions"
+        - "ec2:DescribeAddresses"
+        - "pricing:GetProducts"
+        - "sts:GetCallerIdentity"
+        - "cloudtrail:LookupEvents"
+      action:
+        - "ec2:ReleaseAddress"
+    AWSUnusedCLBs:
+      read:
+        - "sts:GetCallerIdentity"
+        - "ec2:DescribeRegions"
+        - "elasticloadbalancing:DescribeLoadBalancers"
+        - "elasticloadbalancing:DescribeInstanceHealth"
+        - "elasticloadbalancing:DescribeTags"
+      action:
+        - "elasticloadbalancing:DeleteLoadBalancer"
+    AWSOldSnapshots:
+      read:
+        - "ec2:DescribeRegions"
+        - "ec2:DescribeImages"
+        - "ec2:DescribeSnapshots"
+        - "rds:DescribeDBInstances"
+        - "rds:DescribeDBSnapshots"
+        - "rds:DescribeDBClusters"
+        - "rds:DescribeDBClusterSnapshots"
+        - "sts:GetCallerIdentity"
+        - "cloudtrail:LookupEvents"
+      action:
+        - "ec2:DeregisterImage"
+        - "ec2:DeleteSnapshot"
+        - "rds:DeleteDBClusterSnapshot"
+        - "rds:DeleteDBSnapshot"
+    AWSRightsizeEC2Instances:
+      read:
+        - "ec2:DescribeRegions"
+        - "ec2:DescribeInstances"
+        - "ec2:DescribeTags"
+        - "cloudwatch:GetMetricStatistics"
+        - "cloudwatch:GetMetricData"
+        - "cloudwatch:ListMetrics"
+        - "sts:GetCallerIdentity"
+      action:
+        - "ec2:DescribeInstanceStatus"
+        - "ec2:ModifyInstanceAttribute"
+        - "ec2:StartInstances"
+        - "ec2:StopInstances"
+        - "ec2:TerminateInstances"
+    AWSSupersededEC2Instances:
+      read:
+        - "ec2:DescribeRegions"
+        - "ec2:DescribeInstances"
+        - "ec2:DescribeTags"
+        - "sts:GetCallerIdentity"
+      action:
+        - "ec2:DescribeInstanceStatus"
+        - "ec2:ModifyInstanceAttribute"
+        - "ec2:StartInstances"
+        - "ec2:StopInstances"
+    AWSReservedInstancesRecommendation:
+      read:
+        - "ce:GetReservationPurchaseRecommendation"
+      action: []
+    AWSObjectStorageOptimization:
+      read:
+        - "sts:GetCallerIdentity"
+        - "s3:ListAllMyBuckets"
+        - "s3:GetBucketLocation"
+        - "s3:ListBucket"
+        - "s3:GetObject"
+        - "s3:GetObjectTagging"
+      action:
+        - "s3:PutObject"
+        - "s3:DeleteObject"
+    AWSExpiringSavingsPlans:
+      read:
+        - "savingsplans:DescribeSavingsPlans"
+      action: []
+    AWSSavingsPlanRecommendations:
+      read:
+        - "ce:GetSavingsPlansPurchaseRecommendation"
+      action: []
+    AWSSavingsPlanUtilization:
+      read:
+        - "ce:GetSavingsPlansUtilization"
+        - "savingsplans:DescribeSavingsPlans"
+      action: []
+    AWSTagCardinalityReport:
+      read:
+        - "tag:GetResources"
+        - "ec2:DescribeRegions"
+        - "eorganizations:ListAccounts"
+        - "organizations:ListTagsForResource"
+      action: []
+    AWSUntaggedResources:
+      read:
+        - "sts:GetCallerIdentity"
+        - "config:TagResource"
+        - "ec2:DescribeRegions"
+        - "tag:GetResources"
+      action:
+        - "ec2:CreateTags"
+        - "tag:TagResources"
+        - "rds:AddTagsToResources"
+    # End for each policy template
+
+
+Resources:
+  # IAM Role Resource
+  iamRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: !Ref paramRoleName
+      Description: !Join
+        - " "
+        - - "Allows access from Flexera Platform. This IAM Role and the attached permission policies were created and are managed by CloudFormation Stack:"
+          - !Ref AWS::StackId
+      Path: !Ref paramRolePath
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !FindInMap
+                - TrustedRoleMap
+                - !Ref paramFlexeraZone
+                - roleArn
+            Action: "sts:AssumeRole"
+            Condition:
+              StringEquals:
+                "sts:ExternalId": !Ref paramFlexeraOrgId
+      # ManagedPolicyArns value is conditional based on input paramPermsAttachExistingPolicies
+      ManagedPolicyArns: !If
+        - ValueProvidedparamPermsAttachExistingPolicies
+        # If value is provided for paramPermsAttachExistingPolicies, split that comma-separated list into a list object
+        - !Split [ ",", !Ref paramPermsAttachExistingPolicies ]
+        # Provide a null value if nothing provided for paramPermsAttachExistingPolicies
+        - !Ref AWS::NoValue
+  # Begin IAM Permission Policy Resources
+  # 1 or 2 Permission Policies per Policy Template (read and action)
+  # Policy create/attachment is conditional based on parameter input for each policy
+  #### For each policy template append:
+  # iamPolicy<PolicyTemplateNameNoSpaces>Read:
+  #   Type: "AWS::IAM::Policy"
+  #   Condition: CreatePolicy<PolicyTemplateNameNoSpaces>Read
+  #   Properties:
+  #     PolicyName: !Join
+  #       - "_"
+  #       - - !Ref paramRoleName
+  #         - <PolicyTemplateNameNoSpaces>ReadPermissionPolicy
+  #     Roles:
+  #       - !Ref iamRole
+  #     PolicyDocument:
+  #       Version: 2012-10-17
+  #       Statement:
+  #         - Effect: Allow
+  #           Action: !FindInMap
+  #             - PermissionMap
+  #             - <PolicyTemplateNameNoSpaces>
+  #             - read
+  #           Resource: "*"
+  # iamPolicy<PolicyTemplateNameNoSpaces>Action:
+  #   Type: "AWS::IAM::Policy"
+  #   Condition: CreatePolicy<PolicyTemplateNameNoSpaces>Action
+  #   Properties:
+  #     PolicyName: !Join
+  #       - "_"
+  #       - - !Ref paramRoleName
+  #         - <PolicyTemplateNameNoSpaces>ActionPermissionPolicy
+  #     Roles:
+  #       - !Ref iamRole
+  #     PolicyDocument:
+  #       Version: 2012-10-17
+  #       Statement:
+  #         - Effect: Allow
+  #           Action: !FindInMap
+  #             - PermissionMap
+  #             - <PolicyTemplateNameNoSpaces>
+  #             - action
+  #           Resource: "*"
+  ## AWS Unused Volumes Permission Policies
+  iamPolicyAWSUnusedVolumesRead:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSUnusedVolumesRead
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSUnusedVolumesReadPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSUnusedVolumes
+              - read
+            Resource: "*"
+  iamPolicyAWSUnusedVolumesAction:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSUnusedVolumesAction
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSUnusedVolumesActionPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSUnusedVolumes
+              - action
+            Resource: "*"
+  ## AWS Rightsize EBS Volumes Permission Policies
+  iamPolicyAWSRightsizeEBSVolumesRead:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSRightsizeEBSVolumesRead
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSRightsizeEBSVolumesReadPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSRightsizeEBSVolumes
+              - read
+            Resource: "*"
+  iamPolicyAWSRightsizeEBSVolumesAction:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSRightsizeEBSVolumesAction
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSRightsizeEBSVolumesActionPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSRightsizeEBSVolumes
+              - action
+            Resource: "*"
+  ## AWS Rightsize RDS Instances Permission Policies
+  iamPolicyAWSRightsizeRDSInstancesRead:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSRightsizeRDSInstancesRead
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSRightsizeRDSInstancesReadPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSRightsizeRDSInstances
+              - read
+            Resource: "*"
+  iamPolicyAWSRightsizeRDSInstancesAction:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSRightsizeRDSInstancesAction
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSRightsizeRDSInstancesActionPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSRightsizeRDSInstances
+              - action
+            Resource: "*"
+  ## AWS Unused IP Addresses Permission Policies
+  iamPolicyAWSUnusedIPAddressesRead:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSUnusedIPAddressesRead
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSUnusedIPAddressesReadPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSUnusedIPAddresses
+              - read
+            Resource: "*"
+  iamPolicyAWSUnusedIPAddressesAction:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSUnusedIPAddressesAction
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSUnusedIPAddressesActionPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSUnusedIPAddresses
+              - action
+            Resource: "*"
+  ## AWS Unused Classic Load Balancers Policies
+  iamPolicyAWSUnusedCLBsRead:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSUnusedCLBsRead
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSUnusedCLBsReadPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSUnusedCLBs
+              - read
+            Resource: "*"
+  iamPolicyAWSUnusedCLBsAction:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSUnusedCLBsAction
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSUnusedCLBsActionPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSUnusedCLBs
+              - action
+            Resource: "*"
+  ## AWS Old Snapshots Permission Policies
+  iamPolicyAWSOldSnapshots:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSOldSnapshotsRead
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSOldSnapshotsReadPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSOldSnapshots
+              - read
+            Resource: "*"
+  iamPolicyAWSOldSnapshotsAction:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSOldSnapshotsAction
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSOldSnapshotsActionPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSOldSnapshots
+              - action
+            Resource: "*"
+  ## AWS Rightsize EC2 Instances Permission Policies
+  iamPolicyAWSRightsizeEC2Instances:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSRightsizeEC2InstancesRead
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSRightsizeEC2InstancesReadPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSRightsizeEC2Instances
+              - read
+            Resource: "*"
+  iamPolicyAWSRightsizeEC2InstancesAction:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSRightsizeEC2InstancesAction
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSRightsizeEC2InstancesActionPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSRightsizeEC2Instances
+              - action
+            Resource: "*"
+  ## AWS Superseded EC2 Instances Permission Policies
+  iamPolicyAWSSupersededEC2Instances:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSSupersededEC2InstancesRead
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSSupersededEC2InstancesReadPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSSupersededEC2Instances
+              - read
+            Resource: "*"
+  iamPolicyAWSSupersededEC2InstancesAction:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSSupersededEC2InstancesAction
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSSupersededEC2InstancesActionPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSSupersededEC2Instances
+              - action
+            Resource: "*"
+  ## AWS Reserved Instances Recommendation
+  iamPolicyAWSReservedInstancesRecommendation:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSReservedInstancesRecommendationRead
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSReservedInstancesRecommendationReadPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSReservedInstancesRecommendation
+              - read
+            Resource: "*"
+  iamPolicyAWSObjectStorageOptimizationRead:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSObjectStorageOptimizationRead
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSObjectStorageOptimizationReadPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSObjectStorageOptimization
+              - read
+            Resource: "*"
+  iamPolicyAWSObjectStorageOptimizationAction:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSObjectStorageOptimizationAction
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSObjectStorageOptimizationActionPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSObjectStorageOptimization
+              - action
+            Resource: "*"
+  iamPolicyAWSExpiringSavingsPlans:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSExpiringSavingsPlansRead
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSExpiringSavingsPlansReadPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSExpiringSavingsPlans
+              - read
+            Resource: "*"
+  iamPolicyAWSSavingsPlanRecommendations:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSSavingsPlanRecommendationsRead
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSSavingsPlanRecommendationsReadPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSSavingsPlanRecommendations
+              - read
+            Resource: "*"
+  iamPolicyAWSSavingsPlanUtilization:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSSavingsPlanUtilizationRead
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSSavingsPlanUtilizationReadPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSSavingsPlanUtilization
+              - read
+            Resource: "*"
+  iamPolicyAWSTagCardinalityReport:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSTagCardinalityReportRead
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSTagCardinalityReportReadPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSTagCardinalityReport
+              - read
+            Resource: "*"
+  iamPolicyAWSUntaggedResourcesRead:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSUntaggedResourcesRead
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSUntaggedResourcesReadPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSUntaggedResources
+              - read
+            Resource: "*"
+  iamPolicyAWSUntaggedResourcesAction:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSUntaggedResourcesAction
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSUntaggedResourcesActionPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSUntaggedResources
+              - action
+            Resource: "*"
+  # End for each policy template
+
+  # End IAM Permission Policy Resources
+
+Outputs:
+  iamRoleArn:
+    Description: The ARN of the IAM Role that was created
+    Value: !GetAtt
+      - iamRole
+      - Arn


### PR DESCRIPTION
### Description

This is an update to the AWS CloudFormation Template for Policies. The following changes were made:
- Updated permissions across the board to match our current documentation.
- Removed: Idle Compute policy since this policy is deprecated. 
- Removed: Unused RDS policy since this policy is deprecated. 
- Added: Rightsize RDS Instances
- Added: Rightsize EBS Volumes
- Added: Superseded Instances
- Added: Unused Classic Load Balancers (CLBs)

During review for this, a typo was discovered in the permissions for the AWS Tag Cardinality Report README. This has been fixed, as well as all other linting errors for this file.

### Example

This is the result of running this CFT, selecting for actions when possible, in our sales-sandbox account:

https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/roles/details/TestRole908734205?section=permissions

### Contribution Check List

- [X] New functionality includes testing.
