### PR TITLE
POL-1173 Update AWS Instance Types JSON to include Memory

### DIFF
--- a/data/aws/instance_types.json
+++ b/data/aws/instance_types.json
@@ -1,6403 +1,6403 @@
 {
-    "a1.medium": {
-        "up": "a1.large",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "1",
-        "nfu": "2",
-        "memory": "2"
-    },
-    "a1.large": {
-        "up": "a1.xlarge",
-        "down": "a1.medium",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "4"
-    },
-    "a1.xlarge": {
-        "up": "a1.2xlarge",
-        "down": "a1.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "8"
-    },
-    "a1.2xlarge": {
-        "up": "a1.4xlarge",
-        "down": "a1.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "16"
-    },
-    "a1.4xlarge": {
-        "up": null,
-        "down": "a1.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "32"
-    },
-    "a1.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "memory": "32"
-    },
-    "c1.medium": {
-        "up": "c1.xlarge",
-        "down": null,
-        "superseded": {
-            "regular": "c5.large",
-            "next_gen": "",
-            "burstable": "",
-            "amd": ""
-        },
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "2",
-        "nfu": "2",
-        "memory": "1.7"
-    },
-    "c1.xlarge": {
-        "up": null,
-        "down": "c1.medium",
-        "superseded": {
-            "regular": "c5.xlarge",
-            "next_gen": "",
-            "burstable": "",
-            "amd": ""
-        },
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "8",
-        "nfu": "8",
-        "memory": "7"
-    },
-    "c3.large": {
-        "up": "c3.xlarge",
-        "down": null,
-        "superseded": {
-            "regular": "c5.large",
-            "next_gen": "",
-            "burstable": "",
-            "amd": ""
-        },
-        "ec2_classic": true,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "3.75"
-    },
-    "c3.xlarge": {
-        "up": "c3.2xlarge",
-        "down": "c3.large",
-        "superseded": {
-            "regular": "c5.xlarge",
-            "next_gen": "",
-            "burstable": "",
-            "amd": ""
-        },
-        "ec2_classic": true,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "7.5"
-    },
-    "c3.2xlarge": {
-        "up": "c3.4xlarge",
-        "down": "c3.xlarge",
-        "superseded": {
-            "regular": "c5.2xlarge",
-            "next_gen": "",
-            "burstable": "",
-            "amd": ""
-        },
-        "ec2_classic": true,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "15"
-    },
-    "c3.4xlarge": {
-        "up": "c3.8xlarge",
-        "down": "c3.2xlarge",
-        "superseded": {
-            "regular": "c5.4xlarge",
-            "next_gen": "",
-            "burstable": "",
-            "amd": ""
-        },
-        "ec2_classic": true,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "30"
-    },
-    "c3.8xlarge": {
-        "up": null,
-        "down": "c3.4xlarge",
-        "superseded": {
-            "regular": "c5.9xlarge",
-            "next_gen": "",
-            "burstable": "",
-            "amd": ""
-        },
-        "ec2_classic": true,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "60"
-    },
-    "c4.large": {
-        "up": "c4.xlarge",
-        "down": null,
-        "superseded": {
-            "regular": "c5.large",
-            "next_gen": "",
-            "burstable": "",
-            "amd": ""
-        },
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "3.75"
-    },
-    "c4.xlarge": {
-        "up": "c4.2xlarge",
-        "down": "c4.large",
-        "superseded": {
-            "regular": "c5.xlarge",
-            "next_gen": "",
-            "burstable": "",
-            "amd": ""
-        },
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "7.5"
-    },
-    "c4.2xlarge": {
-        "up": "c4.4xlarge",
-        "down": "c4.xlarge",
-        "superseded": {
-            "regular": "c5.2xlarge",
-            "next_gen": "",
-            "burstable": "",
-            "amd": ""
-        },
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "15"
-    },
-    "c4.4xlarge": {
-        "up": "c4.8xlarge",
-        "down": "c4.2xlarge",
-        "superseded": {
-            "regular": "c5.4xlarge",
-            "next_gen": "",
-            "burstable": "",
-            "amd": ""
-        },
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "30"
-    },
-    "c4.8xlarge": {
-        "up": null,
-        "down": "c4.4xlarge",
-        "superseded": {
-            "regular": "c5.9xlarge",
-            "next_gen": "",
-            "burstable": "",
-            "amd": ""
-        },
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "36",
-        "nfu": "64",
-        "memory": "60"
-    },
-    "c5.large": {
-        "up": "c5.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "4"
-    },
-    "c5.xlarge": {
-        "up": "c5.2xlarge",
-        "down": "c5.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "8"
-    },
-    "c5.2xlarge": {
-        "up": "c5.4xlarge",
-        "down": "c5.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "16"
-    },
-    "c5.4xlarge": {
-        "up": "c5.9xlarge",
-        "down": "c5.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "32"
-    },
-    "c5.9xlarge": {
-        "up": "c5.12xlarge",
-        "down": "c5.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "36",
-        "nfu": "72",
-        "memory": "72"
-    },
-    "c5.12xlarge": {
-        "up": "c5.18xlarge",
-        "down": "c5.9xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "96"
-    },
-    "c5.18xlarge": {
-        "up": "c5.24xlarge",
-        "down": "c5.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "72",
-        "nfu": "144",
-        "memory": "144"
-    },
-    "c5.24xlarge": {
-        "up": null,
-        "down": "c18.18xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "192"
-    },
-    "c5.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "memory": "192"
-    },
-    "c5a.large": {
-        "up": "c5a.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "4"
-    },
-    "c5a.xlarge": {
-        "up": "c5a.2xlarge",
-        "down": "c5a.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "8"
-    },
-    "c5a.2xlarge": {
-        "up": "c5a.4xlarge",
-        "down": "c5a.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "16"
-    },
-    "c5a.4xlarge": {
-        "up": "c5a.8xlarge",
-        "down": "c5a.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "32"
-    },
-    "c5a.8xlarge": {
-        "up": "c5a.12xlarge",
-        "down": "c5a.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "64"
-    },
-    "c5a.12xlarge": {
-        "up": "c5a.16xlarge",
-        "down": "c5a.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "96"
-    },
-    "c5a.16xlarge": {
-        "up": "c5a.24xlarge",
-        "down": "c5a.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "128"
-    },
-    "c5a.24xlarge": {
-        "up": null,
-        "down": "c18.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "192"
-    },
-    "c5d.large": {
-        "up": "c5d.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "4"
-    },
-    "c5d.xlarge": {
-        "up": "c5d.2xlarge",
-        "down": "c5d.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "8"
-    },
-    "c5d.2xlarge": {
-        "up": "c5d.4xlarge",
-        "down": "c5d.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "16"
-    },
-    "c5d.4xlarge": {
-        "up": "c5d.9xlarge",
-        "down": "c5d.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "32"
-    },
-    "c5d.9xlarge": {
-        "up": "c5d.12xlarge",
-        "down": "c5d.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "36",
-        "nfu": "72",
-        "memory": "72"
-    },
-    "c5d.12xlarge": {
-        "up": "c5d.18xlarge",
-        "down": "c5d.9xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "96"
-    },
-    "c5d.18xlarge": {
-        "up": "c5d.24xlarge",
-        "down": "c5d.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "72",
-        "nfu": "144",
-        "memory": "144"
-    },
-    "c5d.24xlarge": {
-        "up": null,
-        "down": "c5d.18xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "192"
-    },
-    "c5d.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "memory": "192"
-    },
-    "c5ad.large": {
-        "up": "c5ad.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "4"
-    },
-    "c5ad.xlarge": {
-        "up": "c5ad.2xlarge",
-        "down": "c5ad.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "8"
-    },
-    "c5ad.2xlarge": {
-        "up": "c5ad.4xlarge",
-        "down": "c5ad.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "16"
-    },
-    "c5ad.4xlarge": {
-        "up": "c5ad.8xlarge",
-        "down": "c5ad.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "32"
-    },
-    "c5ad.8xlarge": {
-        "up": "c5ad.12xlarge",
-        "down": "c5ad.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "64"
-    },
-    "c5ad.12xlarge": {
-        "up": "c5ad.16xlarge",
-        "down": "c5ad.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "96"
-    },
-    "c5ad.16xlarge": {
-        "up": "c5ad.24xlarge",
-        "down": "c5ad.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "128"
-    },
-    "c5ad.24xlarge": {
-        "up": null,
-        "down": "c5ad.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "192"
-    },
-    "c5n.large": {
-        "up": "c5n.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "5.25"
-    },
-    "c5n.xlarge": {
-        "up": "c5n.2xlarge",
-        "down": "c5n.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "10.5"
-    },
-    "c5n.2xlarge": {
-        "up": "c5n.4xlarge",
-        "down": "c5n.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "21"
-    },
-    "c5n.4xlarge": {
-        "up": "c5n.9xlarge",
-        "down": "c5n.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "42"
-    },
-    "c5n.9xlarge": {
-        "up": "c5n.18xlarge",
-        "down": "c5n.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "36",
-        "nfu": "72",
-        "memory": "96"
-    },
-    "c5n.18xlarge": {
-        "up": null,
-        "down": "c5n.9xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "72",
-        "nfu": "144",
-        "memory": "192"
-    },
-    "c5n.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "72",
-        "memory": "192"
-    },
-    "c6a.large": {
-        "up": "c6a.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "4"
-    },
-    "c6a.xlarge": {
-        "up": "c6a.2xlarge",
-        "down": "c6a.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "8"
-    },
-    "c6a.2xlarge": {
-        "up": "c6a.4xlarge",
-        "down": "c6a.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "16"
-    },
-    "c6a.4xlarge": {
-        "up": "c6a.8xlarge",
-        "down": "c6a.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "32"
-    },
-    "c6a.8xlarge": {
-        "up": "c6a.12xlarge",
-        "down": "c6a.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "64"
-    },
-    "c6a.12xlarge": {
-        "up": "c6a.16xlarge",
-        "down": "c6a.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "96"
-    },
-    "c6a.16xlarge": {
-        "up": "c6a.24xlarge",
-        "down": "c6a.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "128"
-    },
-    "c6a.24xlarge": {
-        "up": "c6a.32xlarge",
-        "down": "c6a.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "192"
-    },
-    "c6a.32xlarge": {
-        "up": "c6a.48xlarge",
-        "down": "c6a.24xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "128",
-        "nfu": "256",
-        "memory": "256"
-    },
-    "c6a.48xlarge": {
-        "up": null,
-        "down": "c6a.32xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "192",
-        "nfu": "384",
-        "memory": "384"
-    },
-    "c6a.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "192",
-        "nfu": "384",
-        "memory": "384"
-    },
-    "c6g.medium": {
-        "up": "c6g.large",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "1",
-        "nfu": "2",
-        "memory": "2"
-    },
-    "c6g.large": {
-        "up": "c6g.xlarge",
-        "down": "c6g.medium",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "4"
-    },
-    "c6g.xlarge": {
-        "up": "c6g.2xlarge",
-        "down": "c6g.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "8"
-    },
-    "c6g.2xlarge": {
-        "up": "c6g.4xlarge",
-        "down": "c6g.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "16"
-    },
-    "c6g.4xlarge": {
-        "up": "c6g.8xlarge",
-        "down": "c6g.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "32"
-    },
-    "c6g.8xlarge": {
-        "up": "c6g.12xlarge",
-        "down": "c6g.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "64"
-    },
-    "c6g.12xlarge": {
-        "up": "c6g.16xlarge",
-        "down": "c6g.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "96"
-    },
-    "c6g.16xlarge": {
-        "up": null,
-        "down": "c6g.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "128"
-    },
-    "c6g.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "memory": "128"
-    },
-    "c6gd.medium": {
-        "up": "c6gd.large",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "1",
-        "nfu": "2",
-        "memory": "2"
-    },
-    "c6gd.large": {
-        "up": "c6gd.xlarge",
-        "down": "c6gd.medium",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "4"
-    },
-    "c6gd.xlarge": {
-        "up": "c6gd.2xlarge",
-        "down": "c6gd.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "8"
-    },
-    "c6gd.2xlarge": {
-        "up": "c6gd.4xlarge",
-        "down": "c6gd.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "16"
-    },
-    "c6gd.4xlarge": {
-        "up": "c6gd.8xlarge",
-        "down": "c6gd.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "32"
-    },
-    "c6gd.8xlarge": {
-        "up": "c6gd.12xlarge",
-        "down": "c6gd.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "64"
-    },
-    "c6gd.12xlarge": {
-        "up": "c6gd.16xlarge",
-        "down": "c6gd.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "96"
-    },
-    "c6gd.16xlarge": {
-        "up": null,
-        "down": "c6gd.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "128"
-    },
-    "c6gd.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "memory": "128"
-    },
-    "c6gn.medium": {
-        "up": "c6gn.large",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "1",
-        "nfu": "2",
-        "memory": "2"
-    },
-    "c6gn.large": {
-        "up": "c6gn.xlarge",
-        "down": "c6gn.medium",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "4"
-    },
-    "c6gn.xlarge": {
-        "up": "c6gn.2xlarge",
-        "down": "c6gn.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "8"
-    },
-    "c6gn.2xlarge": {
-        "up": "c6gn.4xlarge",
-        "down": "c6gn.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "16"
-    },
-    "c6gn.4xlarge": {
-        "up": "c6gn.8xlarge",
-        "down": "c6gn.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "32"
-    },
-    "c6gn.8xlarge": {
-        "up": "c6gn.12xlarge",
-        "down": "c6gn.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "64"
-    },
-    "c6gn.12xlarge": {
-        "up": "c6gn.16xlarge",
-        "down": "c6gn.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "96"
-    },
-    "c6gn.16xlarge": {
-        "up": null,
-        "down": "c6gn.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "128"
-    },
-    "c6i.large": {
-        "up": "c6i.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "4"
-    },
-    "c6i.xlarge": {
-        "up": "c6i.2xlarge",
-        "down": "c6i.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "8"
-    },
-    "c6i.2xlarge": {
-        "up": "c6i.4xlarge",
-        "down": "c6i.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "16"
-    },
-    "c6i.4xlarge": {
-        "up": "c6i.8xlarge",
-        "down": "c6i.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "32"
-    },
-    "c6i.8xlarge": {
-        "up": "c6i.12xlarge",
-        "down": "c6i.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "64"
-    },
-    "c6i.12xlarge": {
-        "up": "c6i.16xlarge",
-        "down": "c6i.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "96"
-    },
-    "c6i.16xlarge": {
-        "up": "c6i.24xlarge",
-        "down": "c6i.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "128"
-    },
-    "c6i.24xlarge": {
-        "up": "c6i.32xlarge",
-        "down": "c6i.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "192"
-    },
-    "c6i.32xlarge": {
-        "up": null,
-        "down": "c6i.24xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "128",
-        "nfu": "256",
-        "memory": "256"
-    },
-    "c6i.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "128",
-        "nfu": "256",
-        "memory": "256"
-    },
-    "c6id.large": {
-        "up": "c6id.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "4"
-    },
-    "c6id.xlarge": {
-        "up": "c6id.2xlarge",
-        "down": "c6id.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "8"
-    },
-    "c6id.2xlarge": {
-        "up": "c6id.4xlarge",
-        "down": "c6id.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "16"
-    },
-    "c6id.4xlarge": {
-        "up": "c6id.8xlarge",
-        "down": "c6id.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "32"
-    },
-    "c6id.8xlarge": {
-        "up": "c6id.12xlarge",
-        "down": "c6id.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "64"
-    },
-    "c6id.12xlarge": {
-        "up": "c6id.16xlarge",
-        "down": "c6id.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "96"
-    },
-    "c6id.16xlarge": {
-        "up": "c6id.24xlarge",
-        "down": "c6id.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "128"
-    },
-    "c6id.24xlarge": {
-        "up": "c6id.32xlarge",
-        "down": "c6id.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "192"
-    },
-    "c6id.32xlarge": {
-        "up": null,
-        "down": "c6id.24xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "128",
-        "nfu": "256",
-        "memory": "256"
-    },
-    "c6id.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "128",
-        "nfu": "256",
-        "memory": "256"
-    },
-    "c7g.medium": {
-        "up": "c7g.large",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "1",
-        "nfu": "2",
-        "memory": "2"
-    },
-    "c7g.large": {
-        "up": "c7g.xlarge",
-        "down": "c7g.medium",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "4"
-    },
-    "c7g.xlarge": {
-        "up": "c7g.2xlarge",
-        "down": "c7g.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "8"
-    },
-    "c7g.2xlarge": {
-        "up": "c7g.4xlarge",
-        "down": "c7g.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "16"
-    },
-    "c7g.4xlarge": {
-        "up": "c7g.8xlarge",
-        "down": "c7g.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "32"
-    },
-    "c7g.8xlarge": {
-        "up": "c7g.12xlarge",
-        "down": "c7g.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "64"
-    },
-    "c7g.12xlarge": {
-        "up": "c7g.16xlarge",
-        "down": "c7g.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "96"
-    },
-    "c7g.16xlarge": {
-        "up": null,
-        "down": "c7g.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "128"
-    },
-    "cc1.4xlarge": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "nfu": "32"
-    },
-    "cc2.8xlarge": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "60.5"
-    },
-    "cg1.4xlarge": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "nfu": "32"
-    },
-    "cr1.8xlarge": {
-        "up": null,
-        "down": null,
-        "superseded": {
-            "regular": "r3.8xlarge",
-            "next_gen": "r4.8xlarge",
-            "burstable": "",
-            "amd": ""
-        },
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "244"
-    },
-    "d2.xlarge": {
-        "up": "d2.2xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "30.5"
-    },
-    "d2.2xlarge": {
-        "up": "d2.4xlarge",
-        "down": "d2.xlarge",
-        "superseded": null,
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "61"
-    },
-    "d2.4xlarge": {
-        "up": "d2.8xlarge",
-        "down": "d2.2xlarge",
-        "superseded": null,
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "122"
-    },
-    "d2.8xlarge": {
-        "up": null,
-        "down": "d2.4xlarge",
-        "superseded": null,
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "36",
-        "nfu": "64",
-        "memory": "244"
-    },
-    "d3.xlarge": {
-        "up": "d3.2xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "32"
-    },
-    "d3.2xlarge": {
-        "up": "d3.4xlarge",
-        "down": "d3.xlarge",
-        "superseded": null,
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "64"
-    },
-    "d3.4xlarge": {
-        "up": "d3.8xlarge",
-        "down": "d3.2xlarge",
-        "superseded": null,
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "128"
-    },
-    "d3.8xlarge": {
-        "up": null,
-        "down": "d3.4xlarge",
-        "superseded": null,
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "256"
-    },
-    "d3en.xlarge": {
-        "up": "d3en.2xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "d3en.2xlarge": {
-        "up": "d3en.4xlarge",
-        "down": "d3en.xlarge",
-        "superseded": null,
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "d3en.4xlarge": {
-        "up": "d3en.6xlarge",
-        "down": "d3en.2xlarge",
-        "superseded": null,
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "64"
-    },
-    "d3en.6xlarge": {
-        "up": "d3en.8xlarge",
-        "down": "d3en.4xlarge",
-        "superseded": null,
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "24",
-        "nfu": "48",
-        "memory": "96"
-    },
-    "d3en.8xlarge": {
-        "up": "d3en.12xlarge",
-        "down": "d3en.6xlarge",
-        "superseded": null,
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "128"
-    },
-    "d3en.12xlarge": {
-        "up": null,
-        "down": "d3en.8xlarge",
-        "superseded": null,
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "192"
-    },
-    "p2.xlarge": {
-        "up": "p2.8xlarge",
-        "down": null,
-        "superseded": {
-            "regular": "p3.xlarge",
-            "next_gen": null,
-            "burstable": "",
-            "amd": ""
-        },
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "61"
-    },
-    "p2.8xlarge": {
-        "up": "p2.16xlarge",
-        "down": "p2.xlarge",
-        "superseded": {
-            "regular": "p3.8xlarge",
-            "next_gen": null,
-            "burstable": "",
-            "amd": ""
-        },
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "488"
-    },
-    "p2.16xlarge": {
-        "up": null,
-        "down": "p2.8xlarge",
-        "superseded": {
-            "regular": "p3.16xlarge",
-            "next_gen": null,
-            "burstable": "",
-            "amd": ""
-        },
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "732"
-    },
-    "p3.2xlarge": {
-        "up": "p3.8xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "61"
-    },
-    "p3.8xlarge": {
-        "up": "p3.16xlarge",
-        "down": "p3.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "244"
-    },
-    "p3.16xlarge": {
-        "up": "p3dn.24xlarge",
-        "down": "p3.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "488"
-    },
-    "p3dn.24xlarge": {
-        "up": null,
-        "down": "p3.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "768"
-    },
-    "inf1.xlarge": {
-        "up": "inf1.2xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "8"
-    },
-    "inf1.2xlarge": {
-        "up": "inf1.6xlarge",
-        "down": "inf1.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "16"
-    },
-    "inf1.6xlarge": {
-        "up": "inf1.24xlarge",
-        "down": "inf1.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "24",
-        "nfu": "48",
-        "memory": "48"
-    },
-    "inf1.24xlarge": {
-        "up": null,
-        "down": "inf1.6xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "192"
-    },
-    "g2.2xlarge": {
-        "up": "g2.8xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "15"
-    },
-    "g2.8xlarge": {
-        "up": null,
-        "down": "g2.2xlarge",
-        "superseded": null,
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "60"
-    },
-    "g3s.xlarge": {
-        "up": "g3.4xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "30.5"
-    },
-    "g3.4xlarge": {
-        "up": "g3.8xlarge",
-        "down": "g3s.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "122"
-    },
-    "g3.8xlarge": {
-        "up": "g3.16xlarge",
-        "down": "g3.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "244"
-    },
-    "g3.16xlarge": {
-        "up": null,
-        "down": "g3.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "488"
-    },
-    "g4.large": {
-        "up": "g4.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "nfu": "4"
-    },
-    "g4.2xlarge": {
-        "up": "g4.4xlarge",
-        "down": "g4.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "nfu": "16"
-    },
-    "g4.4xlarge": {
-        "up": "g4.8xlarge",
-        "down": "g4.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "nfu": "32"
-    },
-    "g4.8xlarge": {
-        "up": "g4.16xlarge",
-        "down": "g4.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "nfu": "64"
-    },
-    "g4.16xlarge": {
-        "up": null,
-        "down": "g4.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "nfu": "128"
-    },
-    "g4dn.12xlarge": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "192"
-    },
-    "g4dn.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "memory": "384"
-    },
-    "g4ad.4xlarge": {
-        "up": "g4ad.8xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "64"
-    },
-    "g4ad.8xlarge": {
-        "up": "g4ad.16xlarge",
-        "down": "g4ad.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "128"
-    },
-    "g4ad.16xlarge": {
-        "up": null,
-        "down": "g4ad.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "256"
-    },
-    "g4dn.xlarge": {
-        "up": "g4dn.2xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "g4dn.2xlarge": {
-        "up": "g4dn.4xlarge",
-        "down": "g4dn.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "g4dn.4xlarge": {
-        "up": "g4dn.8xlarge",
-        "down": "g4dn.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "64"
-    },
-    "g4dn.8xlarge": {
-        "up": "g4dn.16xlarge",
-        "down": "g4dn.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "128"
-    },
-    "g4dn.16xlarge": {
-        "up": null,
-        "down": "g4dn.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "256"
-    },
-    "g5g.xlarge": {
-        "up": "g5g.2xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": false,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "8"
-    },
-    "g5g.2xlarge": {
-        "up": "g5g.4xlarge",
-        "down": "g5g.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": false,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "16"
-    },
-    "g5g.4xlarge": {
-        "up": "g5g.8xlarge",
-        "down": "g5g.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": false,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "32"
-    },
-    "g5g.8xlarge": {
-        "up": "g5g.16xlarge",
-        "down": "g5g.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": false,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "64"
-    },
-    "g5g.16xlarge": {
-        "up": "g5g.metal",
-        "down": "g5g.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": false,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "128"
-    },
-    "g5g.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": false,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "128"
-    },
-    "f1.2xlarge": {
-        "up": "f1.4xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "122"
-    },
-    "f1.4xlarge": {
-        "up": "f1.16xlarge",
-        "down": "f1.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "244"
-    },
-    "f1.16xlarge": {
-        "up": null,
-        "down": "f1.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "976"
-    },
-    "h1.2xlarge": {
-        "up": "h1.4xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "h1.4xlarge": {
-        "up": "h1.8xlarge",
-        "down": "h1.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "64"
-    },
-    "h1.8xlarge": {
-        "up": "h1.16xlarge",
-        "down": "h1.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "128"
-    },
-    "h1.16xlarge": {
-        "up": null,
-        "down": "h1.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "256"
-    },
-    "hi1.4xlarge": {
-        "up": "hs1.8xlarge",
-        "down": null,
-        "superseded": {
-            "regular": "i3.4xlarge",
-            "next_gen": "",
-            "burstable": "",
-            "amd": ""
-        },
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "nfu": "32"
-    },
-    "hs1.8xlarge": {
-        "up": null,
-        "down": "hi1.4xlarge",
-        "superseded": {
-            "regular": "d2.8xlarge",
-            "next_gen": "",
-            "burstable": "",
-            "amd": ""
-        },
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "16",
-        "nfu": "64",
-        "memory": "117"
-    },
-    "i2.xlarge": {
-        "up": "i2.2xlarge",
-        "down": null,
-        "superseded": {
-            "regular": "i3.xlarge",
-            "next_gen": "",
-            "burstable": "",
-            "amd": ""
-        },
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "30.5"
-    },
-    "i2.2xlarge": {
-        "up": "i2.4xlarge",
-        "down": "i2.xlarge",
-        "superseded": {
-            "regular": "i3.2xlarge",
-            "next_gen": "",
-            "burstable": "",
-            "amd": ""
-        },
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "61"
-    },
-    "i2.4xlarge": {
-        "up": "i2.8xlarge",
-        "down": "i2.2xlarge",
-        "superseded": {
-            "regular": "i3.4xlarge",
-            "next_gen": "",
-            "burstable": "",
-            "amd": ""
-        },
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "122"
-    },
-    "i2.8xlarge": {
-        "up": null,
-        "down": "i2.4xlarge",
-        "superseded": {
-            "regular": "i3.8xlarge",
-            "next_gen": "",
-            "burstable": "",
-            "amd": ""
-        },
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "244"
-    },
-    "i3.large": {
-        "up": "i3.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "15.25"
-    },
-    "i3.xlarge": {
-        "up": "i3.2xlarge",
-        "down": "i3.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "30.5"
-    },
-    "i3.2xlarge": {
-        "up": "i3.4xlarge",
-        "down": "i3.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "61"
-    },
-    "i3.4xlarge": {
-        "up": "i3.8xlarge",
-        "down": "i3.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "122"
-    },
-    "i3.8xlarge": {
-        "up": "i3.16xlarge",
-        "down": "i3.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "244"
-    },
-    "i3.16xlarge": {
-        "up": null,
-        "down": "i3.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "488"
-    },
-    "i3.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "memory": "512"
-    },
-    "i3en.large": {
-        "up": "i3en.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "16"
-    },
-    "i3en.xlarge": {
-        "up": "i3en.2xlarge",
-        "down": "i3en.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "32"
-    },
-    "i3en.2xlarge": {
-        "up": "i3en.3xlarge",
-        "down": "i3en.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "64"
-    },
-    "i3en.3xlarge": {
-        "up": "i3en.6xlarge",
-        "down": "i3en.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "12",
-        "nfu": "24",
-        "memory": "96"
-    },
-    "i3en.6xlarge": {
-        "up": "i3en.12xlarge",
-        "down": "i3en.3xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "24",
-        "nfu": "48",
-        "memory": "192"
-    },
-    "i3en.12xlarge": {
-        "up": "i3en.24xlarge",
-        "down": "i3en.6xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "384"
-    },
-    "i3en.24xlarge": {
-        "up": null,
-        "down": "i3en.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "768"
-    },
-    "i3en.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "memory": "768"
-    },
-    "im4gn.large": {
-        "up": "im4gn.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "8",
-        "memory": "8"
-    },
-    "im4gn.xlarge": {
-        "up": "im4gn.2xlarge",
-        "down": "im4gn.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "16",
-        "memory": "16"
-    },
-    "im4gn.2xlarge": {
-        "up": "im4gn.4xlarge",
-        "down": "im4gn.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "32",
-        "memory": "32"
-    },
-    "im4gn.4xlarge": {
-        "up": "im4gn.8xlarge",
-        "down": "im4gn.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "64",
-        "memory": "64"
-    },
-    "im4gn.8xlarge": {
-        "up": "im4gn.16xlarge",
-        "down": "im4gn.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "128",
-        "memory": "128"
-    },
-    "im4gn.16xlarge": {
-        "up": null,
-        "down": "im4gn.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "256",
-        "memory": "256"
-    },
-    "is4gen.medium": {
-        "up": "is4gen.large",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "1",
-        "nfu": "6",
-        "memory": "6"
-    },
-    "is4gen.large": {
-        "up": "is4gen.xlarge",
-        "down": "is4gen.medium",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "12",
-        "memory": "12"
-    },
-    "is4gen.xlarge": {
-        "up": "is4gen.2xlarge",
-        "down": "is4gen.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "24",
-        "memory": "24"
-    },
-    "is4gen.2xlarge": {
-        "up": "is4gen.4xlarge",
-        "down": "is4gen.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "48",
-        "memory": "48"
-    },
-    "is4gen.4xlarge": {
-        "up": "is4gen.8xlarge",
-        "down": "is4gen.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "96",
-        "memory": "96"
-    },
-    "is4gen.8xlarge": {
-        "up": null,
-        "down": "is4gen.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "192",
-        "memory": "192"
-    },
-    "m1.small": {
-        "up": "m1.medium",
-        "down": null,
-        "superseded": {
-            "regular": "t3.large",
-            "next_gen": "",
-            "burstable": "t3.large",
-            "amd": "m5a.large"
-        },
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "1",
-        "nfu": "1",
-        "memory": "1.7"
-    },
-    "m1.medium": {
-        "up": "m1.large",
-        "down": "m1.small",
-        "superseded": {
-            "regular": "m5.large",
-            "next_gen": "",
-            "burstable": "t3.large",
-            "amd": "m5a.large"
-        },
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "1",
-        "nfu": "2",
-        "memory": "3.75"
-    },
-    "m1.large": {
-        "up": "m1.xlarge",
-        "down": "m1.medium",
-        "superseded": {
-            "regular": "m5.large",
-            "next_gen": "",
-            "burstable": "t3.xlarge",
-            "amd": "m5a.large"
-        },
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "7.5"
-    },
-    "m1.xlarge": {
-        "up": null,
-        "down": "m1.large",
-        "superseded": {
-            "regular": "m5.xlarge",
-            "next_gen": "",
-            "burstable": "t3.2xlarge",
-            "amd": "m5a.xlarge"
-        },
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "15"
-    },
-    "m2.xlarge": {
-        "up": "m2.2xlarge",
-        "down": null,
-        "superseded": {
-            "regular": "r3.large",
-            "next_gen": "r5.large",
-            "burstable": "",
-            "amd": "r5a.large"
-        },
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "2",
-        "nfu": "8",
-        "memory": "17.1"
-    },
-    "m2.2xlarge": {
-        "up": "m2.4xlarge",
-        "down": "m2.xlarge",
-        "superseded": {
-            "regular": "r3.xlarge",
-            "next_gen": "r5.xlarge",
-            "burstable": "",
-            "amd": "r5a.xlarge"
-        },
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "4",
-        "nfu": "16",
-        "memory": "34.2"
-    },
-    "m2.4xlarge": {
-        "up": null,
-        "down": "m2.2xlarge",
-        "superseded": {
-            "regular": "r3.2xlarge",
-            "next_gen": "r5.2xlarge",
-            "burstable": "",
-            "amd": "r5a.2xlarge"
-        },
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "8",
-        "nfu": "32",
-        "memory": "68.4"
-    },
-    "m3.medium": {
-        "up": "m3.large",
-        "down": null,
-        "superseded": {
-            "regular": "m5.large",
-            "next_gen": "",
-            "burstable": "t3.large",
-            "amd": "m5a.large"
-        },
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "1",
-        "nfu": "2",
-        "memory": "3.75"
-    },
-    "m3.large": {
-        "up": "m3.xlarge",
-        "down": "m3.medium",
-        "superseded": {
-            "regular": "m5.large",
-            "next_gen": "",
-            "burstable": "t3.xlarge",
-            "amd": "m5a.large"
-        },
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "7.5"
-    },
-    "m3.xlarge": {
-        "up": "m3.2xlarge",
-        "down": "m3.large",
-        "superseded": {
-            "regular": "m5.xlarge",
-            "next_gen": "",
-            "burstable": "t3.2xlarge",
-            "amd": "m5a.xlarge"
-        },
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "15"
-    },
-    "m3.2xlarge": {
-        "up": null,
-        "down": "m3.xlarge",
-        "superseded": {
-            "regular": "m5.2xlarge",
-            "next_gen": "",
-            "burstable": "",
-            "amd": "m5a.2xlarge"
-        },
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "30"
-    },
-    "m4.large": {
-        "up": "m4.xlarge",
-        "down": null,
-        "superseded": {
-            "regular": "m5.large",
-            "next_gen": "",
-            "burstable": "t3.xlarge",
-            "amd": "m5a.large"
-        },
-        "ec2_classic": false,
-        "enhanced_networking": false,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "8"
-    },
-    "m4.xlarge": {
-        "up": "m4.2xlarge",
-        "down": "m4.large",
-        "superseded": {
-            "regular": "m5.xlarge",
-            "next_gen": "",
-            "burstable": "t3.2xlarge",
-            "amd": "m5a.xlarge"
-        },
-        "ec2_classic": false,
-        "enhanced_networking": false,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "m4.2xlarge": {
-        "up": "m4.4xlarge",
-        "down": "m4.xlarge",
-        "superseded": {
-            "regular": "m5.2xlarge",
-            "next_gen": "",
-            "burstable": "",
-            "amd": "m5a.2xlarge"
-        },
-        "ec2_classic": false,
-        "enhanced_networking": false,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "m4.4xlarge": {
-        "up": "m4.10xlarge",
-        "down": "m4.2xlarge",
-        "superseded": {
-            "regular": "m5.4xlarge",
-            "next_gen": "",
-            "burstable": "",
-            "amd": "m5a.4xlarge"
-        },
-        "ec2_classic": false,
-        "enhanced_networking": false,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "64"
-    },
-    "m4.10xlarge": {
-        "up": "m4.16xlarge",
-        "down": "m4.4xlarge",
-        "superseded": {
-            "regular": "m5.12xlarge",
-            "next_gen": "",
-            "burstable": "",
-            "amd": "m5a.12xlarge"
-        },
-        "ec2_classic": false,
-        "enhanced_networking": false,
-        "vcpu": "40",
-        "nfu": "80",
-        "memory": "160"
-    },
-    "m4.16xlarge": {
-        "up": null,
-        "down": "m4.10xlarge",
-        "superseded": {
-            "regular": "m5.16xlarge",
-            "next_gen": "",
-            "burstable": "",
-            "amd": "m5a.16xlarge"
-        },
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "256"
-    },
-    "m5.large": {
-        "up": "m5.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "8"
-    },
-    "m5.xlarge": {
-        "up": "m5.2xlarge",
-        "down": "m5.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "m5.2xlarge": {
-        "up": "m5.4xlarge",
-        "down": "m5.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "m5.4xlarge": {
-        "up": "m5.8xlarge",
-        "down": "m5.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "64"
-    },
-    "m5.8xlarge": {
-        "up": "m5.12xlarge",
-        "down": "m5.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "128"
-    },
-    "m5.12xlarge": {
-        "up": "m5.16xlarge",
-        "down": "m5.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "192"
-    },
-    "m5.16xlarge": {
-        "up": "m5.24xlarge",
-        "down": "m5.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "256"
-    },
-    "m5.24xlarge": {
-        "up": null,
-        "down": "m5.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "384"
-    },
-    "m5.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "memory": "384"
-    },
-    "m5n.large": {
-        "up": "m5n.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "8"
-    },
-    "m5n.xlarge": {
-        "up": "m5n.2xlarge",
-        "down": "m5n.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "m5n.2xlarge": {
-        "up": "m5n.4xlarge",
-        "down": "m5n.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "m5n.4xlarge": {
-        "up": "m5n.8xlarge",
-        "down": "m5n.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "64"
-    },
-    "m5n.8xlarge": {
-        "up": "m5n.12xlarge",
-        "down": "m5n.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "128"
-    },
-    "m5n.12xlarge": {
-        "up": "m5n.16xlarge",
-        "down": "m5n.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "192"
-    },
-    "m5n.16xlarge": {
-        "up": "m5n.24xlarge",
-        "down": "m5n.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "256"
-    },
-    "m5n.24xlarge": {
-        "up": null,
-        "down": "m5n.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "384"
-    },
-    "m5n.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "memory": "384"
-    },
-    "m5dn.large": {
-        "up": "m5dn.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "8"
-    },
-    "m5dn.xlarge": {
-        "up": "m5dn.2xlarge",
-        "down": "m5dn.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "m5dn.2xlarge": {
-        "up": "m5dn.4xlarge",
-        "down": "m5dn.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "m5dn.4xlarge": {
-        "up": "m5dn.8xlarge",
-        "down": "m5dn.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "64"
-    },
-    "m5dn.8xlarge": {
-        "up": "m5dn.12xlarge",
-        "down": "m5dn.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "128"
-    },
-    "m5dn.12xlarge": {
-        "up": "m5dn.16xlarge",
-        "down": "m5dn.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "192"
-    },
-    "m5dn.16xlarge": {
-        "up": "m5dn.24xlarge",
-        "down": "m5dn.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "256"
-    },
-    "m5dn.24xlarge": {
-        "up": null,
-        "down": "m5dn.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "384"
-    },
-    "m5dn.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "memory": "384"
-    },
-    "m5zn.large": {
-        "up": "m5zn.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "8"
-    },
-    "m5zn.xlarge": {
-        "up": "m5zn.2xlarge",
-        "down": "m5zn.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "m5zn.2xlarge": {
-        "up": "m5zn.3xlarge",
-        "down": "m5zn.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "m5zn.3xlarge": {
-        "up": "m5zn.6xlarge",
-        "down": "m5zn.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "12",
-        "nfu": "24",
-        "memory": "48"
-    },
-    "m5zn.6xlarge": {
-        "up": "m5zn.12xlarge",
-        "down": "m5zn.3xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "24",
-        "nfu": "48",
-        "memory": "96"
-    },
-    "m5zn.12xlarge": {
-        "up": null,
-        "down": "m5zn.6xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "192"
-    },
-    "m5zn.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "memory": "192"
-    },
-    "mac1.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "12",
-        "memory": "32"
-    },
-    "p4d.24xlarge": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "1152"
-    },
-    "m6a.large": {
-        "up": "m6a.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "8"
-    },
-    "m6a.xlarge": {
-        "up": "m6a.2xlarge",
-        "down": "m6a.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "m6a.2xlarge": {
-        "up": "m6a.4xlarge",
-        "down": "m6a.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "m6a.4xlarge": {
-        "up": "m6a.8xlarge",
-        "down": "m6a.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "64"
-    },
-    "m6a.8xlarge": {
-        "up": "m6a.12xlarge",
-        "down": "m6a.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "128"
-    },
-    "m6a.12xlarge": {
-        "up": "m6a.16xlarge",
-        "down": "m6a.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "192"
-    },
-    "m6a.16xlarge": {
-        "up": "m6a.24xlarge",
-        "down": "m6a.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "256"
-    },
-    "m6a.24xlarge": {
-        "up": "m6a.32xlarge",
-        "down": "m6a.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "384"
-    },
-    "m6a.32xlarge": {
-        "up": "m6a.48xlarge",
-        "down": "m6a.24xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "128",
-        "nfu": "256",
-        "memory": "512"
-    },
-    "m6a.48xlarge": {
-        "up": null,
-        "down": "m6a.32xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "192",
-        "nfu": "384",
-        "memory": "768"
-    },
-    "m6a.metal": {
-        "up": null,
-        "down": "m6a.32xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "192",
-        "nfu": "384",
-        "memory": "768"
-    },
-    "m6g.medium": {
-        "up": "m6g.large",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "1",
-        "nfu": "2",
-        "memory": "4"
-    },
-    "m6g.large": {
-        "up": "m6g.xlarge",
-        "down": "m6g.medium",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "8"
-    },
-    "m6g.xlarge": {
-        "up": "m6g.2xlarge",
-        "down": "m6g.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "m6g.2xlarge": {
-        "up": "m6g.4xlarge",
-        "down": "m6g.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "m6g.4xlarge": {
-        "up": "m6g.8xlarge",
-        "down": "m6g.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "64"
-    },
-    "m6g.8xlarge": {
-        "up": "m6g.12xlarge",
-        "down": "m6g.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "128"
-    },
-    "m6g.12xlarge": {
-        "up": "m6g.16xlarge",
-        "down": "m6g.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "192"
-    },
-    "m6g.16xlarge": {
-        "up": "m6g.24xlarge",
-        "down": "m6g.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "256"
-    },
-    "m6g.24xlarge": {
-        "up": null,
-        "down": "m6g.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "nfu": "192"
-    },
-    "m6g.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "memory": "256"
-    },
-    "m6gd.medium": {
-        "up": "m6gd.large",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "1",
-        "nfu": "2",
-        "memory": "4"
-    },
-    "m6gd.large": {
-        "up": "m6gd.xlarge",
-        "down": "m6gd.medium",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "8"
-    },
-    "m6gd.xlarge": {
-        "up": "m6gd.2xlarge",
-        "down": "m6gd.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "m6gd.2xlarge": {
-        "up": "m6gd.4xlarge",
-        "down": "m6gd.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "m6gd.4xlarge": {
-        "up": "m6gd.8xlarge",
-        "down": "m6gd.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "64"
-    },
-    "m6gd.8xlarge": {
-        "up": "m6gd.12xlarge",
-        "down": "m6gd.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "128"
-    },
-    "m6gd.12xlarge": {
-        "up": "m6gd.16xlarge",
-        "down": "m6gd.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "192"
-    },
-    "m6gd.16xlarge": {
-        "up": "m6gd.24xlarge",
-        "down": "m6gd.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "256"
-    },
-    "m6gd.24xlarge": {
-        "up": null,
-        "down": "m6gd.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "nfu": "192"
-    },
-    "m6gd.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "memory": "256"
-    },
-    "m6i.large": {
-        "up": "m6i.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "8"
-    },
-    "m6i.xlarge": {
-        "up": "m6i.2xlarge",
-        "down": "m6i.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "m6i.2xlarge": {
-        "up": "m6i.4xlarge",
-        "down": "m6i.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "m6i.4xlarge": {
-        "up": "m6i.8xlarge",
-        "down": "m6i.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "64"
-    },
-    "m6i.8xlarge": {
-        "up": "m6i.12xlarge",
-        "down": "m6i.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "128"
-    },
-    "m6i.12xlarge": {
-        "up": "m6i.16xlarge",
-        "down": "m6i.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "192"
-    },
-    "m6i.16xlarge": {
-        "up": "m6i.24xlarge",
-        "down": "m6i.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "256"
-    },
-    "m6i.24xlarge": {
-        "up": "m6i.32xlarge",
-        "down": "m6i.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "384"
-    },
-    "m6i.32xlarge": {
-        "up": null,
-        "down": "m6i.24xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "128",
-        "nfu": "256",
-        "memory": "512"
-    },
-    "m6i.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "128",
-        "nfu": "256",
-        "memory": "512"
-    },
-    "m6id.large": {
-        "up": "m6id.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "8"
-    },
-    "m6id.xlarge": {
-        "up": "m6id.2xlarge",
-        "down": "m6id.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "m6id.2xlarge": {
-        "up": "m6id.4xlarge",
-        "down": "m6id.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "m6id.4xlarge": {
-        "up": "m6id.8xlarge",
-        "down": "m6id.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "64"
-    },
-    "m6id.8xlarge": {
-        "up": "m6id.12xlarge",
-        "down": "m6id.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "128"
-    },
-    "m6id.12xlarge": {
-        "up": "m6id.16xlarge",
-        "down": "m6id.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "192"
-    },
-    "m6id.16xlarge": {
-        "up": "m6id.24xlarge",
-        "down": "m6id.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "256"
-    },
-    "m6id.24xlarge": {
-        "up": "m6id.32xlarge",
-        "down": "m6id.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "384"
-    },
-    "m6id.32xlarge": {
-        "up": null,
-        "down": "m6id.24xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "128",
-        "nfu": "256",
-        "memory": "512"
-    },
-    "m6id.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "128",
-        "nfu": "256",
-        "memory": "512"
-    },
-    "m5a.large": {
-        "up": "m5a.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "8"
-    },
-    "m5a.xlarge": {
-        "up": "m5a.2xlarge",
-        "down": "m5a.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "m5a.2xlarge": {
-        "up": "m5a.4xlarge",
-        "down": "m5a.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "m5a.4xlarge": {
-        "up": "m5a.8xlarge",
-        "down": "m5a.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "64"
-    },
-    "m5a.8xlarge": {
-        "up": "m5a.12xlarge",
-        "down": "m5a.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "128"
-    },
-    "m5a.12xlarge": {
-        "up": "m5a.16xlarge",
-        "down": "m5a.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "192"
-    },
-    "m5a.16xlarge": {
-        "up": "m5a.24xlarge",
-        "down": "m5a.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "256"
-    },
-    "m5a.24xlarge": {
-        "up": null,
-        "down": "m5a.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "384"
-    },
-    "m5ad.large": {
-        "up": "m5ad.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "8"
-    },
-    "m5ad.xlarge": {
-        "up": "m5ad.2xlarge",
-        "down": "m5ad.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "m5ad.2xlarge": {
-        "up": "m5ad.4xlarge",
-        "down": "m5ad.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "m5ad.4xlarge": {
-        "up": "m5ad.8xlarge",
-        "down": "m5ad.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "64"
-    },
-    "m5ad.8xlarge": {
-        "up": "m5ad.12xlarge",
-        "down": "m5ad.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "128"
-    },
-    "m5ad.12xlarge": {
-        "up": "m5ad.16xlarge",
-        "down": "m5ad.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "192"
-    },
-    "m5ad.16xlarge": {
-        "up": "m5ad.24xlarge",
-        "down": "m5ad.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "256"
-    },
-    "m5ad.24xlarge": {
-        "up": null,
-        "down": "m5ad.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "384"
-    },
-    "m5d.large": {
-        "up": "m5d.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "8"
-    },
-    "m5d.xlarge": {
-        "up": "m5d.2xlarge",
-        "down": "m5d.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "m5d.2xlarge": {
-        "up": "m5d.4xlarge",
-        "down": "m5d.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "m5d.4xlarge": {
-        "up": "m5d.8xlarge",
-        "down": "m5d.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "64"
-    },
-    "m5d.8xlarge": {
-        "up": "m5d.12xlarge",
-        "down": "m5d.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "128"
-    },
-    "m5d.12xlarge": {
-        "up": "m5d.16xlarge",
-        "down": "m5d.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "192"
-    },
-    "m5d.16xlarge": {
-        "up": "m5d.24xlarge",
-        "down": "m5d.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "256"
-    },
-    "m5d.24xlarge": {
-        "up": null,
-        "down": "m5d.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "384"
-    },
-    "m5d.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "memory": "384"
-    },
-    "r3.large": {
-        "up": "r3.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "15.25"
-    },
-    "r3.xlarge": {
-        "up": "r3.2xlarge",
-        "down": "r3.large",
-        "superseded": null,
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "30.5"
-    },
-    "r3.2xlarge": {
-        "up": "r3.4xlarge",
-        "down": "r3.xlarge",
-        "superseded": null,
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "61"
-    },
-    "r3.4xlarge": {
-        "up": "r3.8xlarge",
-        "down": "r3.2xlarge",
-        "superseded": null,
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "122"
-    },
-    "r3.8xlarge": {
-        "up": null,
-        "down": "r3.4xlarge",
-        "superseded": null,
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "244"
-    },
-    "r4.large": {
-        "up": "r4.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "15.25"
-    },
-    "r4.xlarge": {
-        "up": "r4.2xlarge",
-        "down": "r4.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "30.5"
-    },
-    "r4.2xlarge": {
-        "up": "r4.4xlarge",
-        "down": "r4.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "61"
-    },
-    "r4.4xlarge": {
-        "up": "r4.8xlarge",
-        "down": "r4.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "122"
-    },
-    "r4.8xlarge": {
-        "up": "r4.16xlarge",
-        "down": "r4.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "244"
-    },
-    "r4.16xlarge": {
-        "up": null,
-        "down": "r4.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "488"
-    },
-    "r5.large": {
-        "up": "r5.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "16"
-    },
-    "r5.xlarge": {
-        "up": "r5.2xlarge",
-        "down": "r5.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "32"
-    },
-    "r5.2xlarge": {
-        "up": "r5.4xlarge",
-        "down": "r5.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "64"
-    },
-    "r5.4xlarge": {
-        "up": "r5.8xlarge",
-        "down": "r5.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "128"
-    },
-    "r5.8xlarge": {
-        "up": "r5.12xlarge",
-        "down": "r5.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "256"
-    },
-    "r5.12xlarge": {
-        "up": "r5.16xlarge",
-        "down": "r5.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "384"
-    },
-    "r5.16xlarge": {
-        "up": "r5.24xlarge",
-        "down": "r5.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "512"
-    },
-    "r5.24xlarge": {
-        "up": null,
-        "down": "r5.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "768"
-    },
-    "r5.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "memory": "768"
-    },
-    "r5a.large": {
-        "up": "r5a.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "16"
-    },
-    "r5a.xlarge": {
-        "up": "r5a.2xlarge",
-        "down": "r5a.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "32"
-    },
-    "r5a.2xlarge": {
-        "up": "r5a.4xlarge",
-        "down": "r5a.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "64"
-    },
-    "r5a.4xlarge": {
-        "up": "r5a.8xlarge",
-        "down": "r5a.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "128"
-    },
-    "r5a.8xlarge": {
-        "up": "r5a.12xlarge",
-        "down": "r5a.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "256"
-    },
-    "r5a.12xlarge": {
-        "up": "r5a.16xlarge",
-        "down": "r5a.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "384"
-    },
-    "r5a.16xlarge": {
-        "up": "r5a.24xlarge",
-        "down": "r5a.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "512"
-    },
-    "r5a.24xlarge": {
-        "up": null,
-        "down": "r5a.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "768"
-    },
-    "r5b.large": {
-        "up": "r5b.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "16"
-    },
-    "r5b.xlarge": {
-        "up": "r5b.2xlarge",
-        "down": "r5b.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "32"
-    },
-    "r5b.2xlarge": {
-        "up": "r5b.4xlarge",
-        "down": "r5b.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "64"
-    },
-    "r5b.4xlarge": {
-        "up": "r5b.8xlarge",
-        "down": "r5b.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "128"
-    },
-    "r5b.8xlarge": {
-        "up": "r5b.12xlarge",
-        "down": "r5b.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "256"
-    },
-    "r5b.12xlarge": {
-        "up": "r5b.16xlarge",
-        "down": "r5b.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "384"
-    },
-    "r5b.16xlarge": {
-        "up": "r5b.24xlarge",
-        "down": "r5b.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "512"
-    },
-    "r5b.24xlarge": {
-        "up": null,
-        "down": "r5b.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "768"
-    },
-    "r5b.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "memory": "768"
-    },
-    "r5ad.large": {
-        "up": "r5ad.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "16"
-    },
-    "r5ad.xlarge": {
-        "up": "r5ad.2xlarge",
-        "down": "r5ad.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "32"
-    },
-    "r5ad.2xlarge": {
-        "up": "r5ad.4xlarge",
-        "down": "r5ad.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "64"
-    },
-    "r5ad.4xlarge": {
-        "up": "r5ad.8xlarge",
-        "down": "r5ad.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "128"
-    },
-    "r5ad.8xlarge": {
-        "up": "r5ad.12xlarge",
-        "down": "r5ad.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "256"
-    },
-    "r5ad.12xlarge": {
-        "up": "r5ad.16xlarge",
-        "down": "r5ad.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "384"
-    },
-    "r5ad.16xlarge": {
-        "up": "r5ad.24xlarge",
-        "down": "r5ad.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "512"
-    },
-    "r5ad.24xlarge": {
-        "up": null,
-        "down": "r5ad.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "768"
-    },
-    "r5n.large": {
-        "up": "r5n.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "16"
-    },
-    "r5n.xlarge": {
-        "up": "r5n.2xlarge",
-        "down": "r5n.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "32"
-    },
-    "r5n.2xlarge": {
-        "up": "r5n.4xlarge",
-        "down": "r5n.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "64"
-    },
-    "r5n.4xlarge": {
-        "up": "r5n.8xlarge",
-        "down": "r5n.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "128"
-    },
-    "r5n.8xlarge": {
-        "up": "r5n.12xlarge",
-        "down": "r5n.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "256"
-    },
-    "r5n.12xlarge": {
-        "up": "r5n.16xlarge",
-        "down": "r5n.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "384"
-    },
-    "r5n.16xlarge": {
-        "up": "r5n.24xlarge",
-        "down": "r5n.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "512"
-    },
-    "r5n.24xlarge": {
-        "up": null,
-        "down": "r5n.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "768"
-    },
-    "r5n.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "memory": "768"
-    },
-    "r5dn.large": {
-        "up": "r5dn.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "16"
-    },
-    "r5dn.xlarge": {
-        "up": "r5dn.2xlarge",
-        "down": "r5dn.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "32"
-    },
-    "r5dn.2xlarge": {
-        "up": "r5dn.4xlarge",
-        "down": "r5dn.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "64"
-    },
-    "r5dn.4xlarge": {
-        "up": "r5dn.8xlarge",
-        "down": "r5dn.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "128"
-    },
-    "r5dn.8xlarge": {
-        "up": "r5dn.12xlarge",
-        "down": "r5dn.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "256"
-    },
-    "r5dn.12xlarge": {
-        "up": "r5dn.16xlarge",
-        "down": "r5dn.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "384"
-    },
-    "r5dn.16xlarge": {
-        "up": "r5dn.24xlarge",
-        "down": "r5dn.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "512"
-    },
-    "r5dn.24xlarge": {
-        "up": null,
-        "down": "r5dn.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "768"
-    },
-    "r5dn.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "memory": "768"
-    },
-    "r5d.large": {
-        "up": "r5d.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "16"
-    },
-    "r5d.xlarge": {
-        "up": "r5d.2xlarge",
-        "down": "r5d.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "32"
-    },
-    "r5d.2xlarge": {
-        "up": "r5d.4xlarge",
-        "down": "r5d.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "64"
-    },
-    "r5d.4xlarge": {
-        "up": "r5d.8xlarge",
-        "down": "r5d.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "128"
-    },
-    "r5d.8xlarge": {
-        "up": "r5d.12xlarge",
-        "down": "r5d.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "256"
-    },
-    "r5d.12xlarge": {
-        "up": "r5d.16xlarge",
-        "down": "r5d.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "384"
-    },
-    "r5d.16xlarge": {
-        "up": "r5d.24xlarge",
-        "down": "r5d.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "512"
-    },
-    "r5d.24xlarge": {
-        "up": null,
-        "down": "r5d.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "768"
-    },
-    "r5d.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "memory": "768"
-    },
-    "r6a.large": {
-        "up": "r6a.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "16"
-    },
-    "r6a.xlarge": {
-        "up": "r6a.2xlarge",
-        "down": "r6a.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "32"
-    },
-    "r6a.2xlarge": {
-        "up": "r6a.4xlarge",
-        "down": "r6a.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "64"
-    },
-    "r6a.4xlarge": {
-        "up": "r6a.8xlarge",
-        "down": "r6a.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "128"
-    },
-    "r6a.8xlarge": {
-        "up": "r6a.12xlarge",
-        "down": "r6a.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "256"
-    },
-    "r6a.12xlarge": {
-        "up": "r6a.16xlarge",
-        "down": "r6a.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "384"
-    },
-    "r6a.16xlarge": {
-        "up": "r6a.24xlarge",
-        "down": "r6a.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "512"
-    },
-    "r6a.24xlarge": {
-        "up": "r6a.32xlarge",
-        "down": "r6a.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "768"
-    },
-    "r6a.32xlarge": {
-        "up": "r6a.48xlarge",
-        "down": "r6a.24xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "128",
-        "nfu": "256",
-        "memory": "1024"
-    },
-    "r6a.48xlarge": {
-        "up": null,
-        "down": "r6a.32xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "192",
-        "nfu": "384",
-        "memory": "1536"
-    },
-    "r6a.metal": {
-        "up": null,
-        "down": "r6a.32xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "192",
-        "nfu": "384",
-        "memory": "1536"
-    },
-    "r6g.medium": {
-        "up": "r6g.large",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "1",
-        "nfu": "2",
-        "memory": "8"
-    },
-    "r6g.large": {
-        "up": "r6g.xlarge",
-        "down": "r6g.medium",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "16"
-    },
-    "r6g.xlarge": {
-        "up": "r6g.2xlarge",
-        "down": "r6g.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "32"
-    },
-    "r6g.2xlarge": {
-        "up": "r6g.4xlarge",
-        "down": "r6g.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "64"
-    },
-    "r6g.4xlarge": {
-        "up": "r6g.8xlarge",
-        "down": "r6g.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "128"
-    },
-    "r6g.8xlarge": {
-        "up": "r6g.12xlarge",
-        "down": "r6g.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "256"
-    },
-    "r6g.12xlarge": {
-        "up": "r6g.16xlarge",
-        "down": "r6g.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "384"
-    },
-    "r6g.16xlarge": {
-        "up": null,
-        "down": "r6g.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "512"
-    },
-    "r6g.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "memory": "512"
-    },
-    "r6gd.medium": {
-        "up": "r6gd.large",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "1",
-        "nfu": "2",
-        "memory": "8"
-    },
-    "r6gd.large": {
-        "up": "r6gd.xlarge",
-        "down": "r6gd.medium",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "16"
-    },
-    "r6gd.xlarge": {
-        "up": "r6gd.2xlarge",
-        "down": "r6gd.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "32"
-    },
-    "r6gd.2xlarge": {
-        "up": "r6gd.4xlarge",
-        "down": "r6gd.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "64"
-    },
-    "r6gd.4xlarge": {
-        "up": "r6gd.8xlarge",
-        "down": "r6gd.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "128"
-    },
-    "r6gd.8xlarge": {
-        "up": "r6gd.12xlarge",
-        "down": "r6gd.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "256"
-    },
-    "r6gd.12xlarge": {
-        "up": "r6gd.16xlarge",
-        "down": "r6gd.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "384"
-    },
-    "r6gd.16xlarge": {
-        "up": null,
-        "down": "r6gd.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "512"
-    },
-    "r6gd.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "memory": "512"
-    },
-    "r6i.large": {
-        "up": "r6i.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "16"
-    },
-    "r6i.xlarge": {
-        "up": "r6i.2xlarge",
-        "down": "r6i.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "32"
-    },
-    "r6i.2xlarge": {
-        "up": "r6i.4xlarge",
-        "down": "r6i.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "64"
-    },
-    "r6i.4xlarge": {
-        "up": "r6i.8xlarge",
-        "down": "r6i.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "128"
-    },
-    "r6i.8xlarge": {
-        "up": "r6i.12xlarge",
-        "down": "r6i.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "256"
-    },
-    "r6i.12xlarge": {
-        "up": "r6i.16xlarge",
-        "down": "r6i.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "384"
-    },
-    "r6i.16xlarge": {
-        "up": "r6i.24xlarge",
-        "down": "r6i.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "512"
-    },
-    "r6i.24xlarge": {
-        "up": "r6i.32xlarge",
-        "down": "r6i.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "768"
-    },
-    "r6i.32xlarge": {
-        "up": null,
-        "down": "r6i.24xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "128",
-        "nfu": "256",
-        "memory": "1024"
-    },
-    "r6i.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "128",
-        "nfu": "256",
-        "memory": "1024"
-    },
-    "r6id.large": {
-        "up": "r6id.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "16"
-    },
-    "r6id.xlarge": {
-        "up": "r6id.2xlarge",
-        "down": "r6id.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "32"
-    },
-    "r6id.2xlarge": {
-        "up": "r6id.4xlarge",
-        "down": "r6id.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "64"
-    },
-    "r6id.4xlarge": {
-        "up": "r6id.8xlarge",
-        "down": "r6id.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "128"
-    },
-    "r6id.8xlarge": {
-        "up": "r6id.12xlarge",
-        "down": "r6id.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "256"
-    },
-    "r6id.12xlarge": {
-        "up": "r6id.16xlarge",
-        "down": "r6id.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "384"
-    },
-    "r6id.16xlarge": {
-        "up": "r6id.24xlarge",
-        "down": "r6id.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "512"
-    },
-    "r6id.24xlarge": {
-        "up": "r6id.32xlarge",
-        "down": "r6id.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "768"
-    },
-    "r6id.32xlarge": {
-        "up": null,
-        "down": "r6id.24xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "128",
-        "nfu": "256",
-        "memory": "1024"
-    },
-    "r6id.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "128",
-        "nfu": "256",
-        "memory": "1024"
-    },
-    "x1.16xlarge": {
-        "up": "x1.32xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "976"
-    },
-    "x1.32xlarge": {
-        "up": null,
-        "down": "x1.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "128",
-        "nfu": "256",
-        "memory": "1952"
-    },
-    "x1e.xlarge": {
-        "up": "x1e.2xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "122"
-    },
-    "x1e.2xlarge": {
-        "up": "x1e.4xlarge",
-        "down": "x1e.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "244"
-    },
-    "x1e.4xlarge": {
-        "up": "x1e.8xlarge",
-        "down": "x1e.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "488"
-    },
-    "x1e.8xlarge": {
-        "up": "x1e.16xlarge",
-        "down": "x1e.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "976"
-    },
-    "x1e.16xlarge": {
-        "up": "x1e.32xlarge",
-        "down": "x1e.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "1952"
-    },
-    "x1e.32xlarge": {
-        "up": null,
-        "down": "x1e.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "128",
-        "nfu": "256",
-        "memory": "3904"
-    },
-    "x2gd.medium": {
-        "up": "x2gd.large",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "1",
-        "nfu": "16",
-        "memory": "16"
-    },
-    "x2gd.large": {
-        "up": "x2gd.xlarge",
-        "down": "x2gd.medium",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "32",
-        "memory": "32"
-    },
-    "x2gd.xlarge": {
-        "up": "x2gd.2xlarge",
-        "down": "x2gd.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "64",
-        "memory": "64"
-    },
-    "x2gd.2xlarge": {
-        "up": "x2gd.4xlarge",
-        "down": "x2gd.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "128",
-        "memory": "128"
-    },
-    "x2gd.4xlarge": {
-        "up": "x2gd.8xlarge",
-        "down": "x2gd.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "256",
-        "memory": "256"
-    },
-    "x2gd.8xlarge": {
-        "up": "x2gd.12xlarge",
-        "down": "x2gd.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "512",
-        "memory": "512"
-    },
-    "x2gd.12xlarge": {
-        "up": "x2gd.16xlarge",
-        "down": "x2gd.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "768",
-        "memory": "768"
-    },
-    "x2gd.16xlarge": {
-        "up": "x2gd.metal",
-        "down": "x2gd.12xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "1024",
-        "memory": "1024"
-    },
-    "x2gd.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "1024",
-        "memory": "1024"
-    },
-    "x2idn.16xlarge": {
-        "up": "x2idn.24xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "1024"
-    },
-    "x2idn.24xlarge": {
-        "up": "x2idn.32xlarge",
-        "down": "x2idn.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "1536"
-    },
-    "x2idn.32xlarge": {
-        "up": null,
-        "down": "x2idn.24xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "128",
-        "nfu": "256",
-        "memory": "2048"
-    },
-    "x2idn.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "128",
-        "nfu": "256",
-        "memory": "2048"
-    },
-    "x2iedn.xlarge": {
-        "up": "x2iedn.2xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "128"
-    },
-    "x2iedn.2xlarge": {
-        "up": "x2iedn.4xlarge",
-        "down": "x2iedn.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "256"
-    },
-    "x2iedn.4xlarge": {
-        "up": "x2iedn.8xlarge",
-        "down": "x2iedn.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "512"
-    },
-    "x2iedn.8xlarge": {
-        "up": "x2iedn.16xlarge",
-        "down": "x2iedn.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "1024"
-    },
-    "x2iedn.16xlarge": {
-        "up": "x2iedn.24xlarge",
-        "down": "x2iedn.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "64",
-        "nfu": "128",
-        "memory": "2048"
-    },
-    "x2iedn.24xlarge": {
-        "up": "x2iedn.32xlarge",
-        "down": "x2iedn.16xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "96",
-        "nfu": "192",
-        "memory": "3072"
-    },
-    "x2iedn.32xlarge": {
-        "up": null,
-        "down": "x2iedn.24xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "128",
-        "nfu": "256",
-        "memory": "4096"
-    },
-    "x2iedn.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "128",
-        "nfu": "256",
-        "memory": "4096"
-    },
-    "x2iezn.2xlarge": {
-        "up": "x2iezn.4xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "256"
-    },
-    "x2iezn.4xlarge": {
-        "up": "x2iezn.6xlarge",
-        "down": "x2iezn.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "16",
-        "nfu": "32",
-        "memory": "512"
-    },
-    "x2iezn.6xlarge": {
-        "up": "x2iezn.8xlarge",
-        "down": "x2iezn.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "24",
-        "nfu": "46",
-        "memory": "768"
-    },
-    "x2iezn.8xlarge": {
-        "up": "x2iezn.12xlarge",
-        "down": "x2iezn.4xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "32",
-        "nfu": "64",
-        "memory": "1024"
-    },
-    "x2iezn.12xlarge": {
-        "up": null,
-        "down": "x2iezn.8xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "1536"
-    },
-    "x2iezn.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "1536"
-    },
-    "z1d.large": {
-        "up": "z1d.xlarge",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "16"
-    },
-    "z1d.xlarge": {
-        "up": "z1d.2xlarge",
-        "down": "z1d.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "32"
-    },
-    "z1d.2xlarge": {
-        "up": "z1d.3xlarge",
-        "down": "z1d.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "64"
-    },
-    "z1d.3xlarge": {
-        "up": "z1d.6xlarge",
-        "down": "z1d.2xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "12",
-        "nfu": "24",
-        "memory": "96"
-    },
-    "z1d.6xlarge": {
-        "up": "z1d.12xlarge",
-        "down": "z1d.3xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "24",
-        "nfu": "48",
-        "memory": "192"
-    },
-    "z1d.12xlarge": {
-        "up": null,
-        "down": "z1d.6xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "nfu": "96",
-        "memory": "384"
-    },
-    "z1d.metal": {
-        "up": null,
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "48",
-        "memory": "384"
-    },
-    "u-6tb1.metal": {
-        "up": "u-9tb1.metal",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "448",
-        "memory": "6144"
-    },
-    "u-9tb1.metal": {
-        "up": "u-12tb1.metal",
-        "down": "u-6tb1.metal",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "448",
-        "memory": "9216"
-    },
-    "u-12tb1.metal": {
-        "up": "u-18tb1.metal",
-        "down": "u-9tb1.metal",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "448",
-        "memory": "12288"
-    },
-    "u-18tb1.metal": {
-        "up": "u-24tb1.metal",
-        "down": "u-12tb1.metal",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "448",
-        "memory": "18432"
-    },
-    "u-24tb1.metal": {
-        "up": null,
-        "down": "u-18tb1.metal",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "vcpu": "448",
-        "memory": "24576"
-    },
-    "t1.micro": {
-        "up": null,
-        "down": null,
-        "superseded": {
-            "regular": "t2.micro",
-            "next_gen": "t3.micro",
-            "burstable": "",
-            "amd": "t3a.micro"
-        },
-        "ec2_classic": true,
-        "enhanced_networking": false,
-        "vcpu": "1",
-        "nfu": "0.5",
-        "memory": "0.613"
-    },
-    "t2.nano": {
-        "up": "t2.micro",
-        "down": null,
-        "superseded": {
-            "regular": "t3.nano",
-            "next_gen": "",
-            "burstable": "",
-            "amd": "t3a.nano"
-        },
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 3,
-            "max_earnable_credits": 72
-        },
-        "vcpu": "1",
-        "nfu": "0.25",
-        "memory": "0.5"
-    },
-    "t2.micro": {
-        "up": "t2.small",
-        "down": "t2.nano",
-        "superseded": {
-            "regular": "t3.micro",
-            "next_gen": "",
-            "burstable": "",
-            "amd": "t3a.micro"
-        },
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 6,
-            "max_earnable_credits": 144
-        },
-        "vcpu": "1",
-        "nfu": "0.5",
-        "memory": "1"
-    },
-    "t2.small": {
-        "up": "t2.medium",
-        "down": "t2.micro",
-        "superseded": {
-            "regular": "t3.small",
-            "next_gen": "",
-            "burstable": "",
-            "amd": "t3a.small"
-        },
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 12,
-            "max_earnable_credits": 288
-        },
-        "vcpu": "1",
-        "nfu": "1",
-        "memory": "2"
-    },
-    "t2.medium": {
-        "up": "t2.large",
-        "down": "t2.small",
-        "superseded": {
-            "regular": "t3.medium",
-            "next_gen": "",
-            "burstable": "",
-            "amd": "t3a.medium"
-        },
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 24,
-            "max_earnable_credits": 576
-        },
-        "vcpu": "2",
-        "nfu": "2",
-        "memory": "4"
-    },
-    "t2.large": {
-        "up": "t2.xlarge",
-        "down": "t2.medium",
-        "superseded": {
-            "regular": "t3.large",
-            "next_gen": "",
-            "burstable": "",
-            "amd": "t3a.large"
-        },
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 36,
-            "max_earnable_credits": 864
-        },
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "8"
-    },
-    "t2.xlarge": {
-        "up": "t2.2xlarge",
-        "down": "t2.large",
-        "superseded": {
-            "regular": "t3.xlarge",
-            "next_gen": "",
-            "burstable": "",
-            "amd": "t3a.xlarge"
-        },
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 54,
-            "max_earnable_credits": 1296
-        },
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "t2.2xlarge": {
-        "up": null,
-        "down": "t2.xlarge",
-        "superseded": {
-            "regular": "t3.2xlarge",
-            "next_gen": "",
-            "burstable": "",
-            "amd": "t3a.2xlarge"
-        },
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 81.6,
-            "max_earnable_credits": 1958.4
-        },
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "t3.nano": {
-        "up": "t3.micro",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 6,
-            "max_earnable_credits": 144
-        },
-        "vcpu": "2",
-        "nfu": "0.25",
-        "memory": "0.5"
-    },
-    "t3.micro": {
-        "up": "t3.small",
-        "down": "t3.nano",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 12,
-            "max_earnable_credits": 288
-        },
-        "vcpu": "2",
-        "nfu": "0.5",
-        "memory": "1"
-    },
-    "t3.small": {
-        "up": "t3.medium",
-        "down": "t3.micro",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 24,
-            "max_earnable_credits": 576
-        },
-        "vcpu": "2",
-        "nfu": "1",
-        "memory": "2"
-    },
-    "t3.medium": {
-        "up": "t3.large",
-        "down": "t3.small",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 24,
-            "max_earnable_credits": 576
-        },
-        "vcpu": "2",
-        "nfu": "2",
-        "memory": "4"
-    },
-    "t3.large": {
-        "up": "t3.xlarge",
-        "down": "t3.medium",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 36,
-            "max_earnable_credits": 864
-        },
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "8"
-    },
-    "t3.xlarge": {
-        "up": "t3.2xlarge",
-        "down": "t3.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 96,
-            "max_earnable_credits": 2304
-        },
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "t3.2xlarge": {
-        "up": null,
-        "down": "t3.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 192,
-            "max_earnable_credits": 4608
-        },
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "t3a.nano": {
-        "up": "t3.micro",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 6,
-            "max_earnable_credits": 144
-        },
-        "vcpu": "2",
-        "nfu": "0.25",
-        "memory": "0.5"
-    },
-    "t3a.micro": {
-        "up": "t3.small",
-        "down": "t3.nano",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 12,
-            "max_earnable_credits": 288
-        },
-        "vcpu": "2",
-        "nfu": "0.5",
-        "memory": "1"
-    },
-    "t3a.small": {
-        "up": "t3.medium",
-        "down": "t3.micro",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 24,
-            "max_earnable_credits": 576
-        },
-        "vcpu": "2",
-        "nfu": "1",
-        "memory": "2"
-    },
-    "t3a.medium": {
-        "up": "t3.large",
-        "down": "t3.small",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 24,
-            "max_earnable_credits": 576
-        },
-        "vcpu": "2",
-        "nfu": "2",
-        "memory": "4"
-    },
-    "t3a.large": {
-        "up": "t3.xlarge",
-        "down": "t3.medium",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 36,
-            "max_earnable_credits": 864
-        },
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "8"
-    },
-    "t3a.xlarge": {
-        "up": "t3.2xlarge",
-        "down": "t3.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 96,
-            "max_earnable_credits": 2304
-        },
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "t3a.2xlarge": {
-        "up": null,
-        "down": "t3.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 192,
-            "max_earnable_credits": 4608
-        },
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "t4g.nano": {
-        "up": "t4g.micro",
-        "down": null,
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 6,
-            "max_earnable_credits": 144
-        },
-        "vcpu": "2",
-        "nfu": "0.25",
-        "memory": "0.5"
-    },
-    "t4g.micro": {
-        "up": "t4g.small",
-        "down": "t4g.nano",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 12,
-            "max_earnable_credits": 288
-        },
-        "vcpu": "2",
-        "nfu": "0.5",
-        "memory": "1"
-    },
-    "t4g.small": {
-        "up": "t4g.medium",
-        "down": "t4g.micro",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 24,
-            "max_earnable_credits": 576
-        },
-        "vcpu": "2",
-        "nfu": "1",
-        "memory": "2"
-    },
-    "t4g.medium": {
-        "up": "t4g.large",
-        "down": "t4g.small",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 24,
-            "max_earnable_credits": 576
-        },
-        "vcpu": "2",
-        "nfu": "2",
-        "memory": "4"
-    },
-    "t4g.large": {
-        "up": "t4g.xlarge",
-        "down": "t4g.medium",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 26,
-            "max_earnable_credits": 864
-        },
-        "vcpu": "2",
-        "nfu": "4",
-        "memory": "8"
-    },
-    "t4g.xlarge": {
-        "up": "t4g.2xlarge",
-        "down": "t4g.large",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 96,
-            "max_earnable_credits": 2304
-        },
-        "vcpu": "4",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "t4g.2xlarge": {
-        "up": null,
-        "down": "t4g.xlarge",
-        "superseded": null,
-        "ec2_classic": false,
-        "enhanced_networking": true,
-        "burst_info": {
-            "credits_per_hour": 192,
-            "max_earnable_credits": 4608
-        },
-        "vcpu": "8",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "db.t1.micro": {
-        "vcpu": "1",
-        "up": null,
-        "down": null,
-        "nfu": "0.5",
-        "memory": "0.613"
-    },
-    "db.t2.micro": {
-        "vcpu": "1",
-        "up": "db.t2.small",
-        "down": null,
-        "nfu": "0.5",
-        "memory": "1"
-    },
-    "db.t2.small": {
-        "vcpu": "1",
-        "up": "db.t2.medium",
-        "down": "db.t2.micro",
-        "nfu": "1",
-        "memory": "2"
-    },
-    "db.t2.medium": {
-        "vcpu": "2",
-        "up": "db.t2.large",
-        "down": "db.t2.small",
-        "nfu": "2",
-        "memory": "4"
-    },
-    "db.t2.large": {
-        "vcpu": "2",
-        "up": "db.t2.xlarge",
-        "down": "db.t2.medium",
-        "nfu": "4",
-        "memory": "8"
-    },
-    "db.t2.xlarge": {
-        "vcpu": "4",
-        "up": "db.t2.2xlarge",
-        "down": "db.t2.large",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "db.t2.2xlarge": {
-        "vcpu": "8",
-        "up": null,
-        "down": "db.t2.xlarge",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "db.t3.micro": {
-        "vcpu": "2",
-        "up": "db.t3.small",
-        "down": null,
-        "nfu": "0.5",
-        "memory": "1"
-    },
-    "db.t3.small": {
-        "vcpu": "2",
-        "up": "db.t3.medium",
-        "down": "db.t3.micro",
-        "nfu": "1",
-        "memory": "2"
-    },
-    "db.t3.medium": {
-        "vcpu": "2",
-        "up": "db.t3.large",
-        "down": "db.t3.small",
-        "nfu": "2",
-        "memory": "4"
-    },
-    "db.t3.large": {
-        "vcpu": "2",
-        "up": "db.t3.xlarge",
-        "down": "db.t3.medium",
-        "nfu": "4",
-        "memory": "8"
-    },
-    "db.t3.xlarge": {
-        "vcpu": "4",
-        "up": "db.t3.2xlarge",
-        "down": "db.t3.large",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "db.t3.2xlarge": {
-        "vcpu": "8",
-        "up": null,
-        "down": "db.t3.xlarge",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "db.t4g.micro": {
-        "vcpu": "2",
-        "up": "db.t4g.small",
-        "down": null,
-        "nfu": "0.5",
-        "memory": "1"
-    },
-    "db.t4g.small": {
-        "vcpu": "2",
-        "up": "db.t4g.medium",
-        "down": "db.t4g.micro",
-        "nfu": "1",
-        "memory": "2"
-    },
-    "db.t4g.medium": {
-        "vcpu": "2",
-        "up": "db.t4g.large",
-        "down": "db.t4g.small",
-        "nfu": "2",
-        "memory": "4"
-    },
-    "db.t4g.large": {
-        "vcpu": "2",
-        "up": "db.t4g.xlarge",
-        "down": "db.t4g.medium",
-        "nfu": "4",
-        "memory": "8"
-    },
-    "db.t4g.xlarge": {
-        "vcpu": "4",
-        "up": "db.t4g.2xlarge",
-        "down": "db.t4g.large",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "db.t4g.2xlarge": {
-        "vcpu": "8",
-        "up": null,
-        "down": "db.t4g.xlarge",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "db.m4.large": {
-        "vcpu": "2",
-        "up": "db.m4.xlarge",
-        "down": null,
-        "nfu": "4",
-        "memory": "8"
-    },
-    "db.m4.xlarge": {
-        "vcpu": "4",
-        "up": "db.m4.2xlarge",
-        "down": "db.m4.large",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "db.m4.2xlarge": {
-        "vcpu": "8",
-        "up": "db.m4.4xlarge",
-        "down": "db.m4.xlarge",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "db.m4.4xlarge": {
-        "vcpu": "16",
-        "up": "db.m4.10xlarge",
-        "down": "db.m4.2xlarge",
-        "nfu": "32",
-        "memory": "64"
-    },
-    "db.m4.10xlarge": {
-        "vcpu": "40",
-        "up": "db.m4.16xlarge",
-        "down": "db.m4.4xlarge",
-        "nfu": "80",
-        "memory": "160"
-    },
-    "db.m4.16xlarge": {
-        "vcpu": "64",
-        "up": null,
-        "down": "db.m4.10xlarge",
-        "nfu": "128",
-        "memory": "256"
-    },
-    "db.m5.large": {
-        "vcpu": "2",
-        "up": "db.m5.xlarge",
-        "down": null,
-        "nfu": "4",
-        "memory": "8"
-    },
-    "db.m5.xlarge": {
-        "vcpu": "4",
-        "up": "db.m5.2xlarge",
-        "down": "db.m5.large",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "db.m5.2xlarge": {
-        "vcpu": "8",
-        "up": "db.m5.4xlarge",
-        "down": "db.m5.xlarge",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "db.m5.4xlarge": {
-        "vcpu": "16",
-        "up": "db.m5.12xlarge",
-        "down": "db.m5.2xlarge",
-        "nfu": "32",
-        "memory": "64"
-    },
-    "db.m5.12xlarge": {
-        "vcpu": "48",
-        "up": "db.m5.16xlarge",
-        "down": "db.m5.4xlarge",
-        "nfu": "96",
-        "memory": "192"
-    },
-    "db.m5.16xlarge": {
-        "vcpu": "64",
-        "up": "db.m5.24xlarge",
-        "down": "db.m5.12xlarge",
-        "nfu": "128",
-        "memory": "256"
-    },
-    "db.m5.24xlarge": {
-        "vcpu": "96",
-        "up": null,
-        "down": "db.m5.16xlarge",
-        "nfu": "192",
-        "memory": "384"
-    },
-    "db.m6g.large": {
-        "vcpu": "2",
-        "up": "db.m6g.xlarge",
-        "down": null,
-        "nfu": "4",
-        "memory": "8"
-    },
-    "db.m6g.xlarge": {
-        "vcpu": "4",
-        "up": "db.m6g.2xlarge",
-        "down": "db.m6g.large",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "db.m6g.2xlarge": {
-        "vcpu": "8",
-        "up": "db.m6g.4xlarge",
-        "down": "db.m6g.xlarge",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "db.m6g.4xlarge": {
-        "vcpu": "16",
-        "up": "db.m6g.8xlarge",
-        "down": "db.m6g.2xlarge",
-        "nfu": "32",
-        "memory": "64"
-    },
-    "db.m6g.8xlarge": {
-        "vcpu": "32",
-        "up": "db.m6g.16xlarge",
-        "down": "db.m6g.4xlarge",
-        "nfu": "64",
-        "memory": "128"
-    },
-    "db.m6g.12xlarge": {
-        "vcpu": "48",
-        "up": "db.m6g.16xlarge",
-        "down": "db.m6g.8xlarge",
-        "nfu": "96",
-        "memory": "192"
-    },
-    "db.m6g.16xlarge": {
-        "vcpu": "64",
-        "up": null,
-        "down": "db.m6g.12xlarge",
-        "nfu": "128",
-        "memory": "256"
-    },
-    "db.m6i.large": {
-        "vcpu": "2",
-        "up": "db.m6i.xlarge",
-        "down": null,
-        "nfu": "4",
-        "memory": "8"
-    },
-    "db.m6i.xlarge": {
-        "vcpu": "4",
-        "up": "db.m6i.2xlarge",
-        "down": "db.m6i.large",
-        "nfu": "8",
-        "memory": "16"
-    },
-    "db.m6i.2xlarge": {
-        "vcpu": "8",
-        "up": "db.m6i.4xlarge",
-        "down": "db.m6i.xlarge",
-        "nfu": "16",
-        "memory": "32"
-    },
-    "db.m6i.4xlarge": {
-        "vcpu": "16",
-        "up": "db.m6i.8xlarge",
-        "down": "db.m6i.2xlarge",
-        "nfu": "32",
-        "memory": "64"
-    },
-    "db.m6i.8xlarge": {
-        "vcpu": "32",
-        "up": "db.m6i.12xlarge",
-        "down": "db.m6i.4xlarge",
-        "nfu": "64",
-        "memory": "128"
-    },
-    "db.m6i.12xlarge": {
-        "vcpu": "48",
-        "up": "db.m6i.16xlarge",
-        "down": "db.m6i.8xlarge",
-        "nfu": "96",
-        "memory": "192"
-    },
-    "db.m6i.16xlarge": {
-        "vcpu": "64",
-        "up": "db.m6i.24xlarge",
-        "down": "db.m6i.12xlarge",
-        "nfu": "128",
-        "memory": "256"
-    },
-    "db.m6i.24xlarge": {
-        "vcpu": "96",
-        "up": "db.m6i.32xlarge",
-        "down": "db.m6i.16xlarge",
-        "nfu": "192",
-        "memory": "384"
-    },
-    "db.m6i.32xlarge": {
-        "vcpu": "128",
-        "up": null,
-        "down": "db.m6i.24xlarge",
-        "nfu": "256",
-        "memory": "512"
-    },
-    "db.r6g.large": {
-        "vcpu": "2",
-        "up": "db.r6g.xlarge",
-        "down": null,
-        "nfu": "4",
-        "memory": "16"
-    },
-    "db.r6g.xlarge": {
-        "vcpu": "4",
-        "up": "db.r6g.2xlarge",
-        "down": "db.r6g.large",
-        "nfu": "8",
-        "memory": "32"
-    },
-    "db.r6g.2xlarge": {
-        "vcpu": "8",
-        "up": "db.r6g.4xlarge",
-        "down": "db.r6g.xlarge",
-        "nfu": "16",
-        "memory": "64"
-    },
-    "db.r6g.4xlarge": {
-        "vcpu": "16",
-        "up": "db.r6g.8xlarge",
-        "down": "db.r6g.2xlarge",
-        "nfu": "32",
-        "memory": "128"
-    },
-    "db.r6g.8xlarge": {
-        "vcpu": "32",
-        "up": "db.r6g.16xlarge",
-        "down": "db.r6g.4xlarge",
-        "nfu": "64",
-        "memory": "256"
-    },
-    "db.r6g.12xlarge": {
-        "vcpu": "48",
-        "up": "db.r6g.16xlarge",
-        "down": "db.r6g.8xlarge",
-        "nfu": "96",
-        "memory": "384"
-    },
-    "db.r6g.16xlarge": {
-        "vcpu": "64",
-        "up": null,
-        "down": "db.r6g.12xlarge",
-        "nfu": "128",
-        "memory": "512"
-    },
-    "db.r4.large": {
-        "vcpu": "2",
-        "up": "db.r4.xlarge",
-        "down": null,
-        "nfu": "4",
-        "memory": "15.25"
-    },
-    "db.r4.xlarge": {
-        "vcpu": "4",
-        "up": "db.r4.2xlarge",
-        "down": "db.r4.large",
-        "nfu": "8",
-        "memory": "30.5"
-    },
-    "db.r4.2xlarge": {
-        "vcpu": "8",
-        "up": "db.r4.4xlarge",
-        "down": "db.r4.xlarge",
-        "nfu": "16",
-        "memory": "61"
-    },
-    "db.r4.4xlarge": {
-        "vcpu": "16",
-        "up": "db.r4.8xlarge",
-        "down": "db.r4.2xlarge",
-        "nfu": "32",
-        "memory": "122"
-    },
-    "db.r4.8xlarge": {
-        "vcpu": "32",
-        "up": "db.r4.16xlarge",
-        "down": "db.r4.4xlarge",
-        "nfu": "64",
-        "memory": "244"
-    },
-    "db.r4.16xlarge": {
-        "vcpu": "64",
-        "up": null,
-        "down": "db.r4.8xlarge",
-        "nfu": "128",
-        "memory": "488"
-    },
-    "db.r5.large": {
-        "vcpu": "2",
-        "up": "db.r5.xlarge",
-        "down": null,
-        "nfu": "4",
-        "memory": "16"
-    },
-    "db.r5.xlarge": {
-        "vcpu": "4",
-        "up": "db.r5.2xlarge",
-        "down": "db.r5.large",
-        "nfu": "8",
-        "memory": "32"
-    },
-    "db.r5.2xlarge": {
-        "vcpu": "8",
-        "up": "db.r5.4xlarge",
-        "down": "db.r5.xlarge",
-        "nfu": "16",
-        "memory": "64"
-    },
-    "db.r5.4xlarge": {
-        "vcpu": "16",
-        "up": "db.r5.8xlarge",
-        "down": "db.r5.2xlarge",
-        "nfu": "32",
-        "memory": "128"
-    },
-    "db.r5.8xlarge": {
-        "vcpu": "32",
-        "up": "db.r5.12xlarge",
-        "down": "db.r5.4xlarge",
-        "nfu": "64",
-        "memory": "256"
-    },
-    "db.r5.12xlarge": {
-        "vcpu": "48",
-        "up": "db.r5.24xlarge",
-        "down": "db.r5.4xlarge",
-        "nfu": "96",
-        "memory": "384"
-    },
-    "db.r5.24xlarge": {
-        "vcpu": "64",
-        "up": null,
-        "down": "db.r5.12xlarge",
-        "nfu": "192",
-        "memory": "768"
-    },
-    "db.x1e.xlarge": {
-        "vcpu": "4",
-        "up": "db.x1e.2xlarge",
-        "down": null,
-        "nfu": "8",
-        "memory": "122"
-    },
-    "db.x1e.2xlarge": {
-        "vcpu": "8",
-        "up": "db.x1e.4xlarge",
-        "down": "db.x1e.xlarge",
-        "nfu": "16",
-        "memory": "244"
-    },
-    "db.x1e.4xlarge": {
-        "vcpu": "16",
-        "up": "db.x1e.8xlarge",
-        "down": "db.x1e.2xlarge",
-        "nfu": "32",
-        "memory": "488"
-    },
-    "db.x1e.8xlarge": {
-        "vcpu": "32",
-        "up": "db.x1e.16xlarge",
-        "down": "db.x1e.4xlarge",
-        "nfu": "64",
-        "memory": "976"
-    },
-    "db.x1e.16xlarge": {
-        "vcpu": "64",
-        "up": "db.x1e.32xlarge",
-        "down": "db.x1e.8xlarge",
-        "nfu": "128",
-        "memory": "1952"
-    },
-    "db.x1e.32xlarge": {
-        "vcpu": "128",
-        "up": null,
-        "down": "db.x1e.16xlarge",
-        "nfu": "256",
-        "memory": "3904"
-    },
-    "db.x1.16xlarge": {
-        "vcpu": "64",
-        "up": "db.x1.32xlarge",
-        "down": null,
-        "nfu": "128",
-        "memory": "976"
-    },
-    "db.x1.32xlarge": {
-        "vcpu": "128",
-        "up": null,
-        "down": "db.x1.16xlarge",
-        "nfu": "256",
-        "memory": "1952"
-    },
-    "db.m1.small": {
-        "vcpu": "1",
-        "up": "db.m1.medium",
-        "down": null,
-        "nfu": "1",
-        "memory": "1.7"
-    },
-    "db.m1.medium": {
-        "vcpu": "1",
-        "up": "db.m1.large",
-        "down": "db.m1.small",
-        "nfu": "2",
-        "memory": "3.75"
-    },
-    "db.m1.large": {
-        "vcpu": "2",
-        "up": "db.m1.xlarge",
-        "down": "db.m1.medium",
-        "nfu": "4",
-        "memory": "7.5"
-    },
-    "db.m1.xlarge": {
-        "vcpu": "4",
-        "up": null,
-        "down": "db.m1.large",
-        "nfu": "8",
-        "memory": "15"
-    },
-    "db.m3.medium": {
-        "vcpu": "1",
-        "up": "db.m3.large",
-        "down": null,
-        "nfu": "2",
-        "memory": "3.75"
-    },
-    "db.m3.large": {
-        "vcpu": "2",
-        "up": "db.m3.xlarge",
-        "down": "db.m3.medium",
-        "nfu": "4",
-        "memory": "7.5"
-    },
-    "db.m3.xlarge": {
-        "vcpu": "4",
-        "up": "db.m3.2xlarge",
-        "down": "db.m3.large",
-        "nfu": "8",
-        "memory": "15"
-    },
-    "db.m3.2xlarge": {
-        "vcpu": "8",
-        "up": null,
-        "down": "db.m3.xlarge",
-        "nfu": "16",
-        "memory": "30"
-    },
-    "db.m2.xlarge": {
-        "vcpu": "2",
-        "up": "db.m2.2xlarge",
-        "down": null,
-        "nfu": "8",
-        "memory": "17.1"
-    },
-    "db.m2.2xlarge": {
-        "vcpu": "4",
-        "up": "db.m2.4xlarge",
-        "down": "db.m2.xlarge",
-        "nfu": "16",
-        "memory": "34.2"
-    },
-    "db.m2.4xlarge": {
-        "vcpu": "8",
-        "up": null,
-        "down": "db.m2.2xlarge",
-        "nfu": "32",
-        "memory": "68.4"
-    },
-    "db.r3.large": {
-        "vcpu": "2",
-        "up": "db.r3.xlarge",
-        "down": null,
-        "nfu": "4",
-        "memory": "15.25"
-    },
-    "db.r3.xlarge": {
-        "vcpu": "4",
-        "up": "db.r3.2xlarge",
-        "down": "db.r3.large",
-        "nfu": "8",
-        "memory": "30.5"
-    },
-    "db.r3.2xlarge": {
-        "vcpu": "8",
-        "up": "db.r3.4xlarge",
-        "down": "db.r3.xlarge",
-        "nfu": "16",
-        "memory": "61"
-    },
-    "db.r3.4xlarge": {
-        "vcpu": "16",
-        "up": "db.r3.8xlarge",
-        "down": "db.r3.2xlarge",
-        "nfu": "32",
-        "memory": "122"
-    },
-    "db.r3.8xlarge": {
-        "vcpu": "32",
-        "up": null,
-        "down": "db.r3.4xlarge",
-        "nfu": "64",
-        "memory": "244"
-    }
+	"a1.medium": {
+		"up": "a1.large",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "1",
+		"nfu": "2",
+		"memory": "2"
+	},
+	"a1.large": {
+		"up": "a1.xlarge",
+		"down": "a1.medium",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "4"
+	},
+	"a1.xlarge": {
+		"up": "a1.2xlarge",
+		"down": "a1.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "8"
+	},
+	"a1.2xlarge": {
+		"up": "a1.4xlarge",
+		"down": "a1.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "16"
+	},
+	"a1.4xlarge": {
+		"up": null,
+		"down": "a1.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "32"
+	},
+	"a1.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"memory": "32"
+	},
+	"c1.medium": {
+		"up": "c1.xlarge",
+		"down": null,
+		"superseded": {
+			"regular": "c5.large",
+			"next_gen": "",
+			"burstable": "",
+			"amd": ""
+		},
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "2",
+		"nfu": "2",
+		"memory": "1.7"
+	},
+	"c1.xlarge": {
+		"up": null,
+		"down": "c1.medium",
+		"superseded": {
+			"regular": "c5.xlarge",
+			"next_gen": "",
+			"burstable": "",
+			"amd": ""
+		},
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "8",
+		"nfu": "8",
+		"memory": "7"
+	},
+	"c3.large": {
+		"up": "c3.xlarge",
+		"down": null,
+		"superseded": {
+			"regular": "c5.large",
+			"next_gen": "",
+			"burstable": "",
+			"amd": ""
+		},
+		"ec2_classic": true,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "3.75"
+	},
+	"c3.xlarge": {
+		"up": "c3.2xlarge",
+		"down": "c3.large",
+		"superseded": {
+			"regular": "c5.xlarge",
+			"next_gen": "",
+			"burstable": "",
+			"amd": ""
+		},
+		"ec2_classic": true,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "7.5"
+	},
+	"c3.2xlarge": {
+		"up": "c3.4xlarge",
+		"down": "c3.xlarge",
+		"superseded": {
+			"regular": "c5.2xlarge",
+			"next_gen": "",
+			"burstable": "",
+			"amd": ""
+		},
+		"ec2_classic": true,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "15"
+	},
+	"c3.4xlarge": {
+		"up": "c3.8xlarge",
+		"down": "c3.2xlarge",
+		"superseded": {
+			"regular": "c5.4xlarge",
+			"next_gen": "",
+			"burstable": "",
+			"amd": ""
+		},
+		"ec2_classic": true,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "30"
+	},
+	"c3.8xlarge": {
+		"up": null,
+		"down": "c3.4xlarge",
+		"superseded": {
+			"regular": "c5.9xlarge",
+			"next_gen": "",
+			"burstable": "",
+			"amd": ""
+		},
+		"ec2_classic": true,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "60"
+	},
+	"c4.large": {
+		"up": "c4.xlarge",
+		"down": null,
+		"superseded": {
+			"regular": "c5.large",
+			"next_gen": "",
+			"burstable": "",
+			"amd": ""
+		},
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "3.75"
+	},
+	"c4.xlarge": {
+		"up": "c4.2xlarge",
+		"down": "c4.large",
+		"superseded": {
+			"regular": "c5.xlarge",
+			"next_gen": "",
+			"burstable": "",
+			"amd": ""
+		},
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "7.5"
+	},
+	"c4.2xlarge": {
+		"up": "c4.4xlarge",
+		"down": "c4.xlarge",
+		"superseded": {
+			"regular": "c5.2xlarge",
+			"next_gen": "",
+			"burstable": "",
+			"amd": ""
+		},
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "15"
+	},
+	"c4.4xlarge": {
+		"up": "c4.8xlarge",
+		"down": "c4.2xlarge",
+		"superseded": {
+			"regular": "c5.4xlarge",
+			"next_gen": "",
+			"burstable": "",
+			"amd": ""
+		},
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "30"
+	},
+	"c4.8xlarge": {
+		"up": null,
+		"down": "c4.4xlarge",
+		"superseded": {
+			"regular": "c5.9xlarge",
+			"next_gen": "",
+			"burstable": "",
+			"amd": ""
+		},
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "36",
+		"nfu": "64",
+		"memory": "60"
+	},
+	"c5.large": {
+		"up": "c5.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "4"
+	},
+	"c5.xlarge": {
+		"up": "c5.2xlarge",
+		"down": "c5.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "8"
+	},
+	"c5.2xlarge": {
+		"up": "c5.4xlarge",
+		"down": "c5.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "16"
+	},
+	"c5.4xlarge": {
+		"up": "c5.9xlarge",
+		"down": "c5.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "32"
+	},
+	"c5.9xlarge": {
+		"up": "c5.12xlarge",
+		"down": "c5.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "36",
+		"nfu": "72",
+		"memory": "72"
+	},
+	"c5.12xlarge": {
+		"up": "c5.18xlarge",
+		"down": "c5.9xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "96"
+	},
+	"c5.18xlarge": {
+		"up": "c5.24xlarge",
+		"down": "c5.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "72",
+		"nfu": "144",
+		"memory": "144"
+	},
+	"c5.24xlarge": {
+		"up": null,
+		"down": "c18.18xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "192"
+	},
+	"c5.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"memory": "192"
+	},
+	"c5a.large": {
+		"up": "c5a.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "4"
+	},
+	"c5a.xlarge": {
+		"up": "c5a.2xlarge",
+		"down": "c5a.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "8"
+	},
+	"c5a.2xlarge": {
+		"up": "c5a.4xlarge",
+		"down": "c5a.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "16"
+	},
+	"c5a.4xlarge": {
+		"up": "c5a.8xlarge",
+		"down": "c5a.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "32"
+	},
+	"c5a.8xlarge": {
+		"up": "c5a.12xlarge",
+		"down": "c5a.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "64"
+	},
+	"c5a.12xlarge": {
+		"up": "c5a.16xlarge",
+		"down": "c5a.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "96"
+	},
+	"c5a.16xlarge": {
+		"up": "c5a.24xlarge",
+		"down": "c5a.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "128"
+	},
+	"c5a.24xlarge": {
+		"up": null,
+		"down": "c18.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "192"
+	},
+	"c5d.large": {
+		"up": "c5d.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "4"
+	},
+	"c5d.xlarge": {
+		"up": "c5d.2xlarge",
+		"down": "c5d.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "8"
+	},
+	"c5d.2xlarge": {
+		"up": "c5d.4xlarge",
+		"down": "c5d.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "16"
+	},
+	"c5d.4xlarge": {
+		"up": "c5d.9xlarge",
+		"down": "c5d.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "32"
+	},
+	"c5d.9xlarge": {
+		"up": "c5d.12xlarge",
+		"down": "c5d.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "36",
+		"nfu": "72",
+		"memory": "72"
+	},
+	"c5d.12xlarge": {
+		"up": "c5d.18xlarge",
+		"down": "c5d.9xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "96"
+	},
+	"c5d.18xlarge": {
+		"up": "c5d.24xlarge",
+		"down": "c5d.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "72",
+		"nfu": "144",
+		"memory": "144"
+	},
+	"c5d.24xlarge": {
+		"up": null,
+		"down": "c5d.18xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "192"
+	},
+	"c5d.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"memory": "192"
+	},
+	"c5ad.large": {
+		"up": "c5ad.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "4"
+	},
+	"c5ad.xlarge": {
+		"up": "c5ad.2xlarge",
+		"down": "c5ad.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "8"
+	},
+	"c5ad.2xlarge": {
+		"up": "c5ad.4xlarge",
+		"down": "c5ad.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "16"
+	},
+	"c5ad.4xlarge": {
+		"up": "c5ad.8xlarge",
+		"down": "c5ad.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "32"
+	},
+	"c5ad.8xlarge": {
+		"up": "c5ad.12xlarge",
+		"down": "c5ad.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "64"
+	},
+	"c5ad.12xlarge": {
+		"up": "c5ad.16xlarge",
+		"down": "c5ad.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "96"
+	},
+	"c5ad.16xlarge": {
+		"up": "c5ad.24xlarge",
+		"down": "c5ad.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "128"
+	},
+	"c5ad.24xlarge": {
+		"up": null,
+		"down": "c5ad.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "192"
+	},
+	"c5n.large": {
+		"up": "c5n.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "5.25"
+	},
+	"c5n.xlarge": {
+		"up": "c5n.2xlarge",
+		"down": "c5n.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "10.5"
+	},
+	"c5n.2xlarge": {
+		"up": "c5n.4xlarge",
+		"down": "c5n.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "21"
+	},
+	"c5n.4xlarge": {
+		"up": "c5n.9xlarge",
+		"down": "c5n.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "42"
+	},
+	"c5n.9xlarge": {
+		"up": "c5n.18xlarge",
+		"down": "c5n.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "36",
+		"nfu": "72",
+		"memory": "96"
+	},
+	"c5n.18xlarge": {
+		"up": null,
+		"down": "c5n.9xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "72",
+		"nfu": "144",
+		"memory": "192"
+	},
+	"c5n.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "72",
+		"memory": "192"
+	},
+	"c6a.large": {
+		"up": "c6a.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "4"
+	},
+	"c6a.xlarge": {
+		"up": "c6a.2xlarge",
+		"down": "c6a.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "8"
+	},
+	"c6a.2xlarge": {
+		"up": "c6a.4xlarge",
+		"down": "c6a.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "16"
+	},
+	"c6a.4xlarge": {
+		"up": "c6a.8xlarge",
+		"down": "c6a.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "32"
+	},
+	"c6a.8xlarge": {
+		"up": "c6a.12xlarge",
+		"down": "c6a.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "64"
+	},
+	"c6a.12xlarge": {
+		"up": "c6a.16xlarge",
+		"down": "c6a.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "96"
+	},
+	"c6a.16xlarge": {
+		"up": "c6a.24xlarge",
+		"down": "c6a.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "128"
+	},
+	"c6a.24xlarge": {
+		"up": "c6a.32xlarge",
+		"down": "c6a.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "192"
+	},
+	"c6a.32xlarge": {
+		"up": "c6a.48xlarge",
+		"down": "c6a.24xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "128",
+		"nfu": "256",
+		"memory": "256"
+	},
+	"c6a.48xlarge": {
+		"up": null,
+		"down": "c6a.32xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "192",
+		"nfu": "384",
+		"memory": "384"
+	},
+	"c6a.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "192",
+		"nfu": "384",
+		"memory": "384"
+	},
+	"c6g.medium": {
+		"up": "c6g.large",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "1",
+		"nfu": "2",
+		"memory": "2"
+	},
+	"c6g.large": {
+		"up": "c6g.xlarge",
+		"down": "c6g.medium",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "4"
+	},
+	"c6g.xlarge": {
+		"up": "c6g.2xlarge",
+		"down": "c6g.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "8"
+	},
+	"c6g.2xlarge": {
+		"up": "c6g.4xlarge",
+		"down": "c6g.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "16"
+	},
+	"c6g.4xlarge": {
+		"up": "c6g.8xlarge",
+		"down": "c6g.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "32"
+	},
+	"c6g.8xlarge": {
+		"up": "c6g.12xlarge",
+		"down": "c6g.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "64"
+	},
+	"c6g.12xlarge": {
+		"up": "c6g.16xlarge",
+		"down": "c6g.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "96"
+	},
+	"c6g.16xlarge": {
+		"up": null,
+		"down": "c6g.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "128"
+	},
+	"c6g.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"memory": "128"
+	},
+	"c6gd.medium": {
+		"up": "c6gd.large",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "1",
+		"nfu": "2",
+		"memory": "2"
+	},
+	"c6gd.large": {
+		"up": "c6gd.xlarge",
+		"down": "c6gd.medium",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "4"
+	},
+	"c6gd.xlarge": {
+		"up": "c6gd.2xlarge",
+		"down": "c6gd.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "8"
+	},
+	"c6gd.2xlarge": {
+		"up": "c6gd.4xlarge",
+		"down": "c6gd.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "16"
+	},
+	"c6gd.4xlarge": {
+		"up": "c6gd.8xlarge",
+		"down": "c6gd.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "32"
+	},
+	"c6gd.8xlarge": {
+		"up": "c6gd.12xlarge",
+		"down": "c6gd.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "64"
+	},
+	"c6gd.12xlarge": {
+		"up": "c6gd.16xlarge",
+		"down": "c6gd.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "96"
+	},
+	"c6gd.16xlarge": {
+		"up": null,
+		"down": "c6gd.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "128"
+	},
+	"c6gd.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"memory": "128"
+	},
+	"c6gn.medium": {
+		"up": "c6gn.large",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "1",
+		"nfu": "2",
+		"memory": "2"
+	},
+	"c6gn.large": {
+		"up": "c6gn.xlarge",
+		"down": "c6gn.medium",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "4"
+	},
+	"c6gn.xlarge": {
+		"up": "c6gn.2xlarge",
+		"down": "c6gn.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "8"
+	},
+	"c6gn.2xlarge": {
+		"up": "c6gn.4xlarge",
+		"down": "c6gn.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "16"
+	},
+	"c6gn.4xlarge": {
+		"up": "c6gn.8xlarge",
+		"down": "c6gn.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "32"
+	},
+	"c6gn.8xlarge": {
+		"up": "c6gn.12xlarge",
+		"down": "c6gn.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "64"
+	},
+	"c6gn.12xlarge": {
+		"up": "c6gn.16xlarge",
+		"down": "c6gn.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "96"
+	},
+	"c6gn.16xlarge": {
+		"up": null,
+		"down": "c6gn.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "128"
+	},
+	"c6i.large": {
+		"up": "c6i.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "4"
+	},
+	"c6i.xlarge": {
+		"up": "c6i.2xlarge",
+		"down": "c6i.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "8"
+	},
+	"c6i.2xlarge": {
+		"up": "c6i.4xlarge",
+		"down": "c6i.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "16"
+	},
+	"c6i.4xlarge": {
+		"up": "c6i.8xlarge",
+		"down": "c6i.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "32"
+	},
+	"c6i.8xlarge": {
+		"up": "c6i.12xlarge",
+		"down": "c6i.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "64"
+	},
+	"c6i.12xlarge": {
+		"up": "c6i.16xlarge",
+		"down": "c6i.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "96"
+	},
+	"c6i.16xlarge": {
+		"up": "c6i.24xlarge",
+		"down": "c6i.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "128"
+	},
+	"c6i.24xlarge": {
+		"up": "c6i.32xlarge",
+		"down": "c6i.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "192"
+	},
+	"c6i.32xlarge": {
+		"up": null,
+		"down": "c6i.24xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "128",
+		"nfu": "256",
+		"memory": "256"
+	},
+	"c6i.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "128",
+		"nfu": "256",
+		"memory": "256"
+	},
+	"c6id.large": {
+		"up": "c6id.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "4"
+	},
+	"c6id.xlarge": {
+		"up": "c6id.2xlarge",
+		"down": "c6id.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "8"
+	},
+	"c6id.2xlarge": {
+		"up": "c6id.4xlarge",
+		"down": "c6id.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "16"
+	},
+	"c6id.4xlarge": {
+		"up": "c6id.8xlarge",
+		"down": "c6id.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "32"
+	},
+	"c6id.8xlarge": {
+		"up": "c6id.12xlarge",
+		"down": "c6id.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "64"
+	},
+	"c6id.12xlarge": {
+		"up": "c6id.16xlarge",
+		"down": "c6id.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "96"
+	},
+	"c6id.16xlarge": {
+		"up": "c6id.24xlarge",
+		"down": "c6id.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "128"
+	},
+	"c6id.24xlarge": {
+		"up": "c6id.32xlarge",
+		"down": "c6id.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "192"
+	},
+	"c6id.32xlarge": {
+		"up": null,
+		"down": "c6id.24xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "128",
+		"nfu": "256",
+		"memory": "256"
+	},
+	"c6id.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "128",
+		"nfu": "256",
+		"memory": "256"
+	},
+	"c7g.medium": {
+		"up": "c7g.large",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "1",
+		"nfu": "2",
+		"memory": "2"
+	},
+	"c7g.large": {
+		"up": "c7g.xlarge",
+		"down": "c7g.medium",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "4"
+	},
+	"c7g.xlarge": {
+		"up": "c7g.2xlarge",
+		"down": "c7g.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "8"
+	},
+	"c7g.2xlarge": {
+		"up": "c7g.4xlarge",
+		"down": "c7g.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "16"
+	},
+	"c7g.4xlarge": {
+		"up": "c7g.8xlarge",
+		"down": "c7g.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "32"
+	},
+	"c7g.8xlarge": {
+		"up": "c7g.12xlarge",
+		"down": "c7g.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "64"
+	},
+	"c7g.12xlarge": {
+		"up": "c7g.16xlarge",
+		"down": "c7g.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "96"
+	},
+	"c7g.16xlarge": {
+		"up": null,
+		"down": "c7g.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "128"
+	},
+	"cc1.4xlarge": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"nfu": "32"
+	},
+	"cc2.8xlarge": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "60.5"
+	},
+	"cg1.4xlarge": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"nfu": "32"
+	},
+	"cr1.8xlarge": {
+		"up": null,
+		"down": null,
+		"superseded": {
+			"regular": "r3.8xlarge",
+			"next_gen": "r4.8xlarge",
+			"burstable": "",
+			"amd": ""
+		},
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "244"
+	},
+	"d2.xlarge": {
+		"up": "d2.2xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "30.5"
+	},
+	"d2.2xlarge": {
+		"up": "d2.4xlarge",
+		"down": "d2.xlarge",
+		"superseded": null,
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "61"
+	},
+	"d2.4xlarge": {
+		"up": "d2.8xlarge",
+		"down": "d2.2xlarge",
+		"superseded": null,
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "122"
+	},
+	"d2.8xlarge": {
+		"up": null,
+		"down": "d2.4xlarge",
+		"superseded": null,
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "36",
+		"nfu": "64",
+		"memory": "244"
+	},
+	"d3.xlarge": {
+		"up": "d3.2xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "32"
+	},
+	"d3.2xlarge": {
+		"up": "d3.4xlarge",
+		"down": "d3.xlarge",
+		"superseded": null,
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "64"
+	},
+	"d3.4xlarge": {
+		"up": "d3.8xlarge",
+		"down": "d3.2xlarge",
+		"superseded": null,
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "128"
+	},
+	"d3.8xlarge": {
+		"up": null,
+		"down": "d3.4xlarge",
+		"superseded": null,
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "256"
+	},
+	"d3en.xlarge": {
+		"up": "d3en.2xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"d3en.2xlarge": {
+		"up": "d3en.4xlarge",
+		"down": "d3en.xlarge",
+		"superseded": null,
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"d3en.4xlarge": {
+		"up": "d3en.6xlarge",
+		"down": "d3en.2xlarge",
+		"superseded": null,
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "64"
+	},
+	"d3en.6xlarge": {
+		"up": "d3en.8xlarge",
+		"down": "d3en.4xlarge",
+		"superseded": null,
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "24",
+		"nfu": "48",
+		"memory": "96"
+	},
+	"d3en.8xlarge": {
+		"up": "d3en.12xlarge",
+		"down": "d3en.6xlarge",
+		"superseded": null,
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "128"
+	},
+	"d3en.12xlarge": {
+		"up": null,
+		"down": "d3en.8xlarge",
+		"superseded": null,
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "192"
+	},
+	"p2.xlarge": {
+		"up": "p2.8xlarge",
+		"down": null,
+		"superseded": {
+			"regular": "p3.xlarge",
+			"next_gen": null,
+			"burstable": "",
+			"amd": ""
+		},
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "61"
+	},
+	"p2.8xlarge": {
+		"up": "p2.16xlarge",
+		"down": "p2.xlarge",
+		"superseded": {
+			"regular": "p3.8xlarge",
+			"next_gen": null,
+			"burstable": "",
+			"amd": ""
+		},
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "488"
+	},
+	"p2.16xlarge": {
+		"up": null,
+		"down": "p2.8xlarge",
+		"superseded": {
+			"regular": "p3.16xlarge",
+			"next_gen": null,
+			"burstable": "",
+			"amd": ""
+		},
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "732"
+	},
+	"p3.2xlarge": {
+		"up": "p3.8xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "61"
+	},
+	"p3.8xlarge": {
+		"up": "p3.16xlarge",
+		"down": "p3.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "244"
+	},
+	"p3.16xlarge": {
+		"up": "p3dn.24xlarge",
+		"down": "p3.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "488"
+	},
+	"p3dn.24xlarge": {
+		"up": null,
+		"down": "p3.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "768"
+	},
+	"inf1.xlarge": {
+		"up": "inf1.2xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "8"
+	},
+	"inf1.2xlarge": {
+		"up": "inf1.6xlarge",
+		"down": "inf1.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "16"
+	},
+	"inf1.6xlarge": {
+		"up": "inf1.24xlarge",
+		"down": "inf1.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "24",
+		"nfu": "48",
+		"memory": "48"
+	},
+	"inf1.24xlarge": {
+		"up": null,
+		"down": "inf1.6xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "192"
+	},
+	"g2.2xlarge": {
+		"up": "g2.8xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "15"
+	},
+	"g2.8xlarge": {
+		"up": null,
+		"down": "g2.2xlarge",
+		"superseded": null,
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "60"
+	},
+	"g3s.xlarge": {
+		"up": "g3.4xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "30.5"
+	},
+	"g3.4xlarge": {
+		"up": "g3.8xlarge",
+		"down": "g3s.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "122"
+	},
+	"g3.8xlarge": {
+		"up": "g3.16xlarge",
+		"down": "g3.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "244"
+	},
+	"g3.16xlarge": {
+		"up": null,
+		"down": "g3.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "488"
+	},
+	"g4.large": {
+		"up": "g4.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"nfu": "4"
+	},
+	"g4.2xlarge": {
+		"up": "g4.4xlarge",
+		"down": "g4.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"nfu": "16"
+	},
+	"g4.4xlarge": {
+		"up": "g4.8xlarge",
+		"down": "g4.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"nfu": "32"
+	},
+	"g4.8xlarge": {
+		"up": "g4.16xlarge",
+		"down": "g4.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"nfu": "64"
+	},
+	"g4.16xlarge": {
+		"up": null,
+		"down": "g4.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"nfu": "128"
+	},
+	"g4dn.12xlarge": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "192"
+	},
+	"g4dn.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"memory": "384"
+	},
+	"g4ad.4xlarge": {
+		"up": "g4ad.8xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "64"
+	},
+	"g4ad.8xlarge": {
+		"up": "g4ad.16xlarge",
+		"down": "g4ad.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "128"
+	},
+	"g4ad.16xlarge": {
+		"up": null,
+		"down": "g4ad.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "256"
+	},
+	"g4dn.xlarge": {
+		"up": "g4dn.2xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"g4dn.2xlarge": {
+		"up": "g4dn.4xlarge",
+		"down": "g4dn.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"g4dn.4xlarge": {
+		"up": "g4dn.8xlarge",
+		"down": "g4dn.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "64"
+	},
+	"g4dn.8xlarge": {
+		"up": "g4dn.16xlarge",
+		"down": "g4dn.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "128"
+	},
+	"g4dn.16xlarge": {
+		"up": null,
+		"down": "g4dn.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "256"
+	},
+	"g5g.xlarge": {
+		"up": "g5g.2xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": false,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "8"
+	},
+	"g5g.2xlarge": {
+		"up": "g5g.4xlarge",
+		"down": "g5g.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": false,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "16"
+	},
+	"g5g.4xlarge": {
+		"up": "g5g.8xlarge",
+		"down": "g5g.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": false,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "32"
+	},
+	"g5g.8xlarge": {
+		"up": "g5g.16xlarge",
+		"down": "g5g.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": false,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "64"
+	},
+	"g5g.16xlarge": {
+		"up": "g5g.metal",
+		"down": "g5g.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": false,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "128"
+	},
+	"g5g.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": false,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "128"
+	},
+	"f1.2xlarge": {
+		"up": "f1.4xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "122"
+	},
+	"f1.4xlarge": {
+		"up": "f1.16xlarge",
+		"down": "f1.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "244"
+	},
+	"f1.16xlarge": {
+		"up": null,
+		"down": "f1.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "976"
+	},
+	"h1.2xlarge": {
+		"up": "h1.4xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"h1.4xlarge": {
+		"up": "h1.8xlarge",
+		"down": "h1.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "64"
+	},
+	"h1.8xlarge": {
+		"up": "h1.16xlarge",
+		"down": "h1.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "128"
+	},
+	"h1.16xlarge": {
+		"up": null,
+		"down": "h1.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "256"
+	},
+	"hi1.4xlarge": {
+		"up": "hs1.8xlarge",
+		"down": null,
+		"superseded": {
+			"regular": "i3.4xlarge",
+			"next_gen": "",
+			"burstable": "",
+			"amd": ""
+		},
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"nfu": "32"
+	},
+	"hs1.8xlarge": {
+		"up": null,
+		"down": "hi1.4xlarge",
+		"superseded": {
+			"regular": "d2.8xlarge",
+			"next_gen": "",
+			"burstable": "",
+			"amd": ""
+		},
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "16",
+		"nfu": "64",
+		"memory": "117"
+	},
+	"i2.xlarge": {
+		"up": "i2.2xlarge",
+		"down": null,
+		"superseded": {
+			"regular": "i3.xlarge",
+			"next_gen": "",
+			"burstable": "",
+			"amd": ""
+		},
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "30.5"
+	},
+	"i2.2xlarge": {
+		"up": "i2.4xlarge",
+		"down": "i2.xlarge",
+		"superseded": {
+			"regular": "i3.2xlarge",
+			"next_gen": "",
+			"burstable": "",
+			"amd": ""
+		},
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "61"
+	},
+	"i2.4xlarge": {
+		"up": "i2.8xlarge",
+		"down": "i2.2xlarge",
+		"superseded": {
+			"regular": "i3.4xlarge",
+			"next_gen": "",
+			"burstable": "",
+			"amd": ""
+		},
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "122"
+	},
+	"i2.8xlarge": {
+		"up": null,
+		"down": "i2.4xlarge",
+		"superseded": {
+			"regular": "i3.8xlarge",
+			"next_gen": "",
+			"burstable": "",
+			"amd": ""
+		},
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "244"
+	},
+	"i3.large": {
+		"up": "i3.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "15.25"
+	},
+	"i3.xlarge": {
+		"up": "i3.2xlarge",
+		"down": "i3.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "30.5"
+	},
+	"i3.2xlarge": {
+		"up": "i3.4xlarge",
+		"down": "i3.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "61"
+	},
+	"i3.4xlarge": {
+		"up": "i3.8xlarge",
+		"down": "i3.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "122"
+	},
+	"i3.8xlarge": {
+		"up": "i3.16xlarge",
+		"down": "i3.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "244"
+	},
+	"i3.16xlarge": {
+		"up": null,
+		"down": "i3.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "488"
+	},
+	"i3.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"memory": "512"
+	},
+	"i3en.large": {
+		"up": "i3en.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "16"
+	},
+	"i3en.xlarge": {
+		"up": "i3en.2xlarge",
+		"down": "i3en.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "32"
+	},
+	"i3en.2xlarge": {
+		"up": "i3en.3xlarge",
+		"down": "i3en.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "64"
+	},
+	"i3en.3xlarge": {
+		"up": "i3en.6xlarge",
+		"down": "i3en.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "12",
+		"nfu": "24",
+		"memory": "96"
+	},
+	"i3en.6xlarge": {
+		"up": "i3en.12xlarge",
+		"down": "i3en.3xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "24",
+		"nfu": "48",
+		"memory": "192"
+	},
+	"i3en.12xlarge": {
+		"up": "i3en.24xlarge",
+		"down": "i3en.6xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "384"
+	},
+	"i3en.24xlarge": {
+		"up": null,
+		"down": "i3en.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "768"
+	},
+	"i3en.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"memory": "768"
+	},
+	"im4gn.large": {
+		"up": "im4gn.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "8",
+		"memory": "8"
+	},
+	"im4gn.xlarge": {
+		"up": "im4gn.2xlarge",
+		"down": "im4gn.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "16",
+		"memory": "16"
+	},
+	"im4gn.2xlarge": {
+		"up": "im4gn.4xlarge",
+		"down": "im4gn.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "32",
+		"memory": "32"
+	},
+	"im4gn.4xlarge": {
+		"up": "im4gn.8xlarge",
+		"down": "im4gn.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "64",
+		"memory": "64"
+	},
+	"im4gn.8xlarge": {
+		"up": "im4gn.16xlarge",
+		"down": "im4gn.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "128",
+		"memory": "128"
+	},
+	"im4gn.16xlarge": {
+		"up": null,
+		"down": "im4gn.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "256",
+		"memory": "256"
+	},
+	"is4gen.medium": {
+		"up": "is4gen.large",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "1",
+		"nfu": "6",
+		"memory": "6"
+	},
+	"is4gen.large": {
+		"up": "is4gen.xlarge",
+		"down": "is4gen.medium",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "12",
+		"memory": "12"
+	},
+	"is4gen.xlarge": {
+		"up": "is4gen.2xlarge",
+		"down": "is4gen.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "24",
+		"memory": "24"
+	},
+	"is4gen.2xlarge": {
+		"up": "is4gen.4xlarge",
+		"down": "is4gen.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "48",
+		"memory": "48"
+	},
+	"is4gen.4xlarge": {
+		"up": "is4gen.8xlarge",
+		"down": "is4gen.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "96",
+		"memory": "96"
+	},
+	"is4gen.8xlarge": {
+		"up": null,
+		"down": "is4gen.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "192",
+		"memory": "192"
+	},
+	"m1.small": {
+		"up": "m1.medium",
+		"down": null,
+		"superseded": {
+			"regular": "t3.large",
+			"next_gen": "",
+			"burstable": "t3.large",
+			"amd": "m5a.large"
+		},
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "1",
+		"nfu": "1",
+		"memory": "1.7"
+	},
+	"m1.medium": {
+		"up": "m1.large",
+		"down": "m1.small",
+		"superseded": {
+			"regular": "m5.large",
+			"next_gen": "",
+			"burstable": "t3.large",
+			"amd": "m5a.large"
+		},
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "1",
+		"nfu": "2",
+		"memory": "3.75"
+	},
+	"m1.large": {
+		"up": "m1.xlarge",
+		"down": "m1.medium",
+		"superseded": {
+			"regular": "m5.large",
+			"next_gen": "",
+			"burstable": "t3.xlarge",
+			"amd": "m5a.large"
+		},
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "7.5"
+	},
+	"m1.xlarge": {
+		"up": null,
+		"down": "m1.large",
+		"superseded": {
+			"regular": "m5.xlarge",
+			"next_gen": "",
+			"burstable": "t3.2xlarge",
+			"amd": "m5a.xlarge"
+		},
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "15"
+	},
+	"m2.xlarge": {
+		"up": "m2.2xlarge",
+		"down": null,
+		"superseded": {
+			"regular": "r3.large",
+			"next_gen": "r5.large",
+			"burstable": "",
+			"amd": "r5a.large"
+		},
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "2",
+		"nfu": "8",
+		"memory": "17.1"
+	},
+	"m2.2xlarge": {
+		"up": "m2.4xlarge",
+		"down": "m2.xlarge",
+		"superseded": {
+			"regular": "r3.xlarge",
+			"next_gen": "r5.xlarge",
+			"burstable": "",
+			"amd": "r5a.xlarge"
+		},
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "4",
+		"nfu": "16",
+		"memory": "34.2"
+	},
+	"m2.4xlarge": {
+		"up": null,
+		"down": "m2.2xlarge",
+		"superseded": {
+			"regular": "r3.2xlarge",
+			"next_gen": "r5.2xlarge",
+			"burstable": "",
+			"amd": "r5a.2xlarge"
+		},
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "8",
+		"nfu": "32",
+		"memory": "68.4"
+	},
+	"m3.medium": {
+		"up": "m3.large",
+		"down": null,
+		"superseded": {
+			"regular": "m5.large",
+			"next_gen": "",
+			"burstable": "t3.large",
+			"amd": "m5a.large"
+		},
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "1",
+		"nfu": "2",
+		"memory": "3.75"
+	},
+	"m3.large": {
+		"up": "m3.xlarge",
+		"down": "m3.medium",
+		"superseded": {
+			"regular": "m5.large",
+			"next_gen": "",
+			"burstable": "t3.xlarge",
+			"amd": "m5a.large"
+		},
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "7.5"
+	},
+	"m3.xlarge": {
+		"up": "m3.2xlarge",
+		"down": "m3.large",
+		"superseded": {
+			"regular": "m5.xlarge",
+			"next_gen": "",
+			"burstable": "t3.2xlarge",
+			"amd": "m5a.xlarge"
+		},
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "15"
+	},
+	"m3.2xlarge": {
+		"up": null,
+		"down": "m3.xlarge",
+		"superseded": {
+			"regular": "m5.2xlarge",
+			"next_gen": "",
+			"burstable": "",
+			"amd": "m5a.2xlarge"
+		},
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "30"
+	},
+	"m4.large": {
+		"up": "m4.xlarge",
+		"down": null,
+		"superseded": {
+			"regular": "m5.large",
+			"next_gen": "",
+			"burstable": "t3.xlarge",
+			"amd": "m5a.large"
+		},
+		"ec2_classic": false,
+		"enhanced_networking": false,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "8"
+	},
+	"m4.xlarge": {
+		"up": "m4.2xlarge",
+		"down": "m4.large",
+		"superseded": {
+			"regular": "m5.xlarge",
+			"next_gen": "",
+			"burstable": "t3.2xlarge",
+			"amd": "m5a.xlarge"
+		},
+		"ec2_classic": false,
+		"enhanced_networking": false,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"m4.2xlarge": {
+		"up": "m4.4xlarge",
+		"down": "m4.xlarge",
+		"superseded": {
+			"regular": "m5.2xlarge",
+			"next_gen": "",
+			"burstable": "",
+			"amd": "m5a.2xlarge"
+		},
+		"ec2_classic": false,
+		"enhanced_networking": false,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"m4.4xlarge": {
+		"up": "m4.10xlarge",
+		"down": "m4.2xlarge",
+		"superseded": {
+			"regular": "m5.4xlarge",
+			"next_gen": "",
+			"burstable": "",
+			"amd": "m5a.4xlarge"
+		},
+		"ec2_classic": false,
+		"enhanced_networking": false,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "64"
+	},
+	"m4.10xlarge": {
+		"up": "m4.16xlarge",
+		"down": "m4.4xlarge",
+		"superseded": {
+			"regular": "m5.12xlarge",
+			"next_gen": "",
+			"burstable": "",
+			"amd": "m5a.12xlarge"
+		},
+		"ec2_classic": false,
+		"enhanced_networking": false,
+		"vcpu": "40",
+		"nfu": "80",
+		"memory": "160"
+	},
+	"m4.16xlarge": {
+		"up": null,
+		"down": "m4.10xlarge",
+		"superseded": {
+			"regular": "m5.16xlarge",
+			"next_gen": "",
+			"burstable": "",
+			"amd": "m5a.16xlarge"
+		},
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "256"
+	},
+	"m5.large": {
+		"up": "m5.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "8"
+	},
+	"m5.xlarge": {
+		"up": "m5.2xlarge",
+		"down": "m5.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"m5.2xlarge": {
+		"up": "m5.4xlarge",
+		"down": "m5.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"m5.4xlarge": {
+		"up": "m5.8xlarge",
+		"down": "m5.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "64"
+	},
+	"m5.8xlarge": {
+		"up": "m5.12xlarge",
+		"down": "m5.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "128"
+	},
+	"m5.12xlarge": {
+		"up": "m5.16xlarge",
+		"down": "m5.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "192"
+	},
+	"m5.16xlarge": {
+		"up": "m5.24xlarge",
+		"down": "m5.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "256"
+	},
+	"m5.24xlarge": {
+		"up": null,
+		"down": "m5.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "384"
+	},
+	"m5.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"memory": "384"
+	},
+	"m5n.large": {
+		"up": "m5n.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "8"
+	},
+	"m5n.xlarge": {
+		"up": "m5n.2xlarge",
+		"down": "m5n.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"m5n.2xlarge": {
+		"up": "m5n.4xlarge",
+		"down": "m5n.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"m5n.4xlarge": {
+		"up": "m5n.8xlarge",
+		"down": "m5n.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "64"
+	},
+	"m5n.8xlarge": {
+		"up": "m5n.12xlarge",
+		"down": "m5n.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "128"
+	},
+	"m5n.12xlarge": {
+		"up": "m5n.16xlarge",
+		"down": "m5n.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "192"
+	},
+	"m5n.16xlarge": {
+		"up": "m5n.24xlarge",
+		"down": "m5n.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "256"
+	},
+	"m5n.24xlarge": {
+		"up": null,
+		"down": "m5n.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "384"
+	},
+	"m5n.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"memory": "384"
+	},
+	"m5dn.large": {
+		"up": "m5dn.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "8"
+	},
+	"m5dn.xlarge": {
+		"up": "m5dn.2xlarge",
+		"down": "m5dn.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"m5dn.2xlarge": {
+		"up": "m5dn.4xlarge",
+		"down": "m5dn.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"m5dn.4xlarge": {
+		"up": "m5dn.8xlarge",
+		"down": "m5dn.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "64"
+	},
+	"m5dn.8xlarge": {
+		"up": "m5dn.12xlarge",
+		"down": "m5dn.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "128"
+	},
+	"m5dn.12xlarge": {
+		"up": "m5dn.16xlarge",
+		"down": "m5dn.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "192"
+	},
+	"m5dn.16xlarge": {
+		"up": "m5dn.24xlarge",
+		"down": "m5dn.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "256"
+	},
+	"m5dn.24xlarge": {
+		"up": null,
+		"down": "m5dn.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "384"
+	},
+	"m5dn.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"memory": "384"
+	},
+	"m5zn.large": {
+		"up": "m5zn.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "8"
+	},
+	"m5zn.xlarge": {
+		"up": "m5zn.2xlarge",
+		"down": "m5zn.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"m5zn.2xlarge": {
+		"up": "m5zn.3xlarge",
+		"down": "m5zn.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"m5zn.3xlarge": {
+		"up": "m5zn.6xlarge",
+		"down": "m5zn.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "12",
+		"nfu": "24",
+		"memory": "48"
+	},
+	"m5zn.6xlarge": {
+		"up": "m5zn.12xlarge",
+		"down": "m5zn.3xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "24",
+		"nfu": "48",
+		"memory": "96"
+	},
+	"m5zn.12xlarge": {
+		"up": null,
+		"down": "m5zn.6xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "192"
+	},
+	"m5zn.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"memory": "192"
+	},
+	"mac1.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "12",
+		"memory": "32"
+	},
+	"p4d.24xlarge": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "1152"
+	},
+	"m6a.large": {
+		"up": "m6a.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "8"
+	},
+	"m6a.xlarge": {
+		"up": "m6a.2xlarge",
+		"down": "m6a.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"m6a.2xlarge": {
+		"up": "m6a.4xlarge",
+		"down": "m6a.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"m6a.4xlarge": {
+		"up": "m6a.8xlarge",
+		"down": "m6a.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "64"
+	},
+	"m6a.8xlarge": {
+		"up": "m6a.12xlarge",
+		"down": "m6a.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "128"
+	},
+	"m6a.12xlarge": {
+		"up": "m6a.16xlarge",
+		"down": "m6a.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "192"
+	},
+	"m6a.16xlarge": {
+		"up": "m6a.24xlarge",
+		"down": "m6a.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "256"
+	},
+	"m6a.24xlarge": {
+		"up": "m6a.32xlarge",
+		"down": "m6a.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "384"
+	},
+	"m6a.32xlarge": {
+		"up": "m6a.48xlarge",
+		"down": "m6a.24xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "128",
+		"nfu": "256",
+		"memory": "512"
+	},
+	"m6a.48xlarge": {
+		"up": null,
+		"down": "m6a.32xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "192",
+		"nfu": "384",
+		"memory": "768"
+	},
+	"m6a.metal": {
+		"up": null,
+		"down": "m6a.32xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "192",
+		"nfu": "384",
+		"memory": "768"
+	},
+	"m6g.medium": {
+		"up": "m6g.large",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "1",
+		"nfu": "2",
+		"memory": "4"
+	},
+	"m6g.large": {
+		"up": "m6g.xlarge",
+		"down": "m6g.medium",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "8"
+	},
+	"m6g.xlarge": {
+		"up": "m6g.2xlarge",
+		"down": "m6g.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"m6g.2xlarge": {
+		"up": "m6g.4xlarge",
+		"down": "m6g.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"m6g.4xlarge": {
+		"up": "m6g.8xlarge",
+		"down": "m6g.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "64"
+	},
+	"m6g.8xlarge": {
+		"up": "m6g.12xlarge",
+		"down": "m6g.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "128"
+	},
+	"m6g.12xlarge": {
+		"up": "m6g.16xlarge",
+		"down": "m6g.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "192"
+	},
+	"m6g.16xlarge": {
+		"up": "m6g.24xlarge",
+		"down": "m6g.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "256"
+	},
+	"m6g.24xlarge": {
+		"up": null,
+		"down": "m6g.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"nfu": "192"
+	},
+	"m6g.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"memory": "256"
+	},
+	"m6gd.medium": {
+		"up": "m6gd.large",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "1",
+		"nfu": "2",
+		"memory": "4"
+	},
+	"m6gd.large": {
+		"up": "m6gd.xlarge",
+		"down": "m6gd.medium",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "8"
+	},
+	"m6gd.xlarge": {
+		"up": "m6gd.2xlarge",
+		"down": "m6gd.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"m6gd.2xlarge": {
+		"up": "m6gd.4xlarge",
+		"down": "m6gd.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"m6gd.4xlarge": {
+		"up": "m6gd.8xlarge",
+		"down": "m6gd.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "64"
+	},
+	"m6gd.8xlarge": {
+		"up": "m6gd.12xlarge",
+		"down": "m6gd.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "128"
+	},
+	"m6gd.12xlarge": {
+		"up": "m6gd.16xlarge",
+		"down": "m6gd.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "192"
+	},
+	"m6gd.16xlarge": {
+		"up": "m6gd.24xlarge",
+		"down": "m6gd.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "256"
+	},
+	"m6gd.24xlarge": {
+		"up": null,
+		"down": "m6gd.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"nfu": "192"
+	},
+	"m6gd.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"memory": "256"
+	},
+	"m6i.large": {
+		"up": "m6i.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "8"
+	},
+	"m6i.xlarge": {
+		"up": "m6i.2xlarge",
+		"down": "m6i.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"m6i.2xlarge": {
+		"up": "m6i.4xlarge",
+		"down": "m6i.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"m6i.4xlarge": {
+		"up": "m6i.8xlarge",
+		"down": "m6i.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "64"
+	},
+	"m6i.8xlarge": {
+		"up": "m6i.12xlarge",
+		"down": "m6i.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "128"
+	},
+	"m6i.12xlarge": {
+		"up": "m6i.16xlarge",
+		"down": "m6i.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "192"
+	},
+	"m6i.16xlarge": {
+		"up": "m6i.24xlarge",
+		"down": "m6i.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "256"
+	},
+	"m6i.24xlarge": {
+		"up": "m6i.32xlarge",
+		"down": "m6i.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "384"
+	},
+	"m6i.32xlarge": {
+		"up": null,
+		"down": "m6i.24xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "128",
+		"nfu": "256",
+		"memory": "512"
+	},
+	"m6i.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "128",
+		"nfu": "256",
+		"memory": "512"
+	},
+	"m6id.large": {
+		"up": "m6id.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "8"
+	},
+	"m6id.xlarge": {
+		"up": "m6id.2xlarge",
+		"down": "m6id.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"m6id.2xlarge": {
+		"up": "m6id.4xlarge",
+		"down": "m6id.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"m6id.4xlarge": {
+		"up": "m6id.8xlarge",
+		"down": "m6id.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "64"
+	},
+	"m6id.8xlarge": {
+		"up": "m6id.12xlarge",
+		"down": "m6id.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "128"
+	},
+	"m6id.12xlarge": {
+		"up": "m6id.16xlarge",
+		"down": "m6id.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "192"
+	},
+	"m6id.16xlarge": {
+		"up": "m6id.24xlarge",
+		"down": "m6id.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "256"
+	},
+	"m6id.24xlarge": {
+		"up": "m6id.32xlarge",
+		"down": "m6id.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "384"
+	},
+	"m6id.32xlarge": {
+		"up": null,
+		"down": "m6id.24xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "128",
+		"nfu": "256",
+		"memory": "512"
+	},
+	"m6id.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "128",
+		"nfu": "256",
+		"memory": "512"
+	},
+	"m5a.large": {
+		"up": "m5a.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "8"
+	},
+	"m5a.xlarge": {
+		"up": "m5a.2xlarge",
+		"down": "m5a.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"m5a.2xlarge": {
+		"up": "m5a.4xlarge",
+		"down": "m5a.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"m5a.4xlarge": {
+		"up": "m5a.8xlarge",
+		"down": "m5a.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "64"
+	},
+	"m5a.8xlarge": {
+		"up": "m5a.12xlarge",
+		"down": "m5a.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "128"
+	},
+	"m5a.12xlarge": {
+		"up": "m5a.16xlarge",
+		"down": "m5a.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "192"
+	},
+	"m5a.16xlarge": {
+		"up": "m5a.24xlarge",
+		"down": "m5a.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "256"
+	},
+	"m5a.24xlarge": {
+		"up": null,
+		"down": "m5a.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "384"
+	},
+	"m5ad.large": {
+		"up": "m5ad.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "8"
+	},
+	"m5ad.xlarge": {
+		"up": "m5ad.2xlarge",
+		"down": "m5ad.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"m5ad.2xlarge": {
+		"up": "m5ad.4xlarge",
+		"down": "m5ad.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"m5ad.4xlarge": {
+		"up": "m5ad.8xlarge",
+		"down": "m5ad.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "64"
+	},
+	"m5ad.8xlarge": {
+		"up": "m5ad.12xlarge",
+		"down": "m5ad.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "128"
+	},
+	"m5ad.12xlarge": {
+		"up": "m5ad.16xlarge",
+		"down": "m5ad.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "192"
+	},
+	"m5ad.16xlarge": {
+		"up": "m5ad.24xlarge",
+		"down": "m5ad.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "256"
+	},
+	"m5ad.24xlarge": {
+		"up": null,
+		"down": "m5ad.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "384"
+	},
+	"m5d.large": {
+		"up": "m5d.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "8"
+	},
+	"m5d.xlarge": {
+		"up": "m5d.2xlarge",
+		"down": "m5d.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"m5d.2xlarge": {
+		"up": "m5d.4xlarge",
+		"down": "m5d.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"m5d.4xlarge": {
+		"up": "m5d.8xlarge",
+		"down": "m5d.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "64"
+	},
+	"m5d.8xlarge": {
+		"up": "m5d.12xlarge",
+		"down": "m5d.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "128"
+	},
+	"m5d.12xlarge": {
+		"up": "m5d.16xlarge",
+		"down": "m5d.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "192"
+	},
+	"m5d.16xlarge": {
+		"up": "m5d.24xlarge",
+		"down": "m5d.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "256"
+	},
+	"m5d.24xlarge": {
+		"up": null,
+		"down": "m5d.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "384"
+	},
+	"m5d.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"memory": "384"
+	},
+	"r3.large": {
+		"up": "r3.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "15.25"
+	},
+	"r3.xlarge": {
+		"up": "r3.2xlarge",
+		"down": "r3.large",
+		"superseded": null,
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "30.5"
+	},
+	"r3.2xlarge": {
+		"up": "r3.4xlarge",
+		"down": "r3.xlarge",
+		"superseded": null,
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "61"
+	},
+	"r3.4xlarge": {
+		"up": "r3.8xlarge",
+		"down": "r3.2xlarge",
+		"superseded": null,
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "122"
+	},
+	"r3.8xlarge": {
+		"up": null,
+		"down": "r3.4xlarge",
+		"superseded": null,
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "244"
+	},
+	"r4.large": {
+		"up": "r4.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "15.25"
+	},
+	"r4.xlarge": {
+		"up": "r4.2xlarge",
+		"down": "r4.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "30.5"
+	},
+	"r4.2xlarge": {
+		"up": "r4.4xlarge",
+		"down": "r4.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "61"
+	},
+	"r4.4xlarge": {
+		"up": "r4.8xlarge",
+		"down": "r4.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "122"
+	},
+	"r4.8xlarge": {
+		"up": "r4.16xlarge",
+		"down": "r4.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "244"
+	},
+	"r4.16xlarge": {
+		"up": null,
+		"down": "r4.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "488"
+	},
+	"r5.large": {
+		"up": "r5.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "16"
+	},
+	"r5.xlarge": {
+		"up": "r5.2xlarge",
+		"down": "r5.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "32"
+	},
+	"r5.2xlarge": {
+		"up": "r5.4xlarge",
+		"down": "r5.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "64"
+	},
+	"r5.4xlarge": {
+		"up": "r5.8xlarge",
+		"down": "r5.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "128"
+	},
+	"r5.8xlarge": {
+		"up": "r5.12xlarge",
+		"down": "r5.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "256"
+	},
+	"r5.12xlarge": {
+		"up": "r5.16xlarge",
+		"down": "r5.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "384"
+	},
+	"r5.16xlarge": {
+		"up": "r5.24xlarge",
+		"down": "r5.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "512"
+	},
+	"r5.24xlarge": {
+		"up": null,
+		"down": "r5.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "768"
+	},
+	"r5.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"memory": "768"
+	},
+	"r5a.large": {
+		"up": "r5a.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "16"
+	},
+	"r5a.xlarge": {
+		"up": "r5a.2xlarge",
+		"down": "r5a.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "32"
+	},
+	"r5a.2xlarge": {
+		"up": "r5a.4xlarge",
+		"down": "r5a.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "64"
+	},
+	"r5a.4xlarge": {
+		"up": "r5a.8xlarge",
+		"down": "r5a.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "128"
+	},
+	"r5a.8xlarge": {
+		"up": "r5a.12xlarge",
+		"down": "r5a.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "256"
+	},
+	"r5a.12xlarge": {
+		"up": "r5a.16xlarge",
+		"down": "r5a.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "384"
+	},
+	"r5a.16xlarge": {
+		"up": "r5a.24xlarge",
+		"down": "r5a.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "512"
+	},
+	"r5a.24xlarge": {
+		"up": null,
+		"down": "r5a.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "768"
+	},
+	"r5b.large": {
+		"up": "r5b.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "16"
+	},
+	"r5b.xlarge": {
+		"up": "r5b.2xlarge",
+		"down": "r5b.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "32"
+	},
+	"r5b.2xlarge": {
+		"up": "r5b.4xlarge",
+		"down": "r5b.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "64"
+	},
+	"r5b.4xlarge": {
+		"up": "r5b.8xlarge",
+		"down": "r5b.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "128"
+	},
+	"r5b.8xlarge": {
+		"up": "r5b.12xlarge",
+		"down": "r5b.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "256"
+	},
+	"r5b.12xlarge": {
+		"up": "r5b.16xlarge",
+		"down": "r5b.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "384"
+	},
+	"r5b.16xlarge": {
+		"up": "r5b.24xlarge",
+		"down": "r5b.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "512"
+	},
+	"r5b.24xlarge": {
+		"up": null,
+		"down": "r5b.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "768"
+	},
+	"r5b.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"memory": "768"
+	},
+	"r5ad.large": {
+		"up": "r5ad.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "16"
+	},
+	"r5ad.xlarge": {
+		"up": "r5ad.2xlarge",
+		"down": "r5ad.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "32"
+	},
+	"r5ad.2xlarge": {
+		"up": "r5ad.4xlarge",
+		"down": "r5ad.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "64"
+	},
+	"r5ad.4xlarge": {
+		"up": "r5ad.8xlarge",
+		"down": "r5ad.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "128"
+	},
+	"r5ad.8xlarge": {
+		"up": "r5ad.12xlarge",
+		"down": "r5ad.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "256"
+	},
+	"r5ad.12xlarge": {
+		"up": "r5ad.16xlarge",
+		"down": "r5ad.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "384"
+	},
+	"r5ad.16xlarge": {
+		"up": "r5ad.24xlarge",
+		"down": "r5ad.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "512"
+	},
+	"r5ad.24xlarge": {
+		"up": null,
+		"down": "r5ad.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "768"
+	},
+	"r5n.large": {
+		"up": "r5n.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "16"
+	},
+	"r5n.xlarge": {
+		"up": "r5n.2xlarge",
+		"down": "r5n.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "32"
+	},
+	"r5n.2xlarge": {
+		"up": "r5n.4xlarge",
+		"down": "r5n.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "64"
+	},
+	"r5n.4xlarge": {
+		"up": "r5n.8xlarge",
+		"down": "r5n.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "128"
+	},
+	"r5n.8xlarge": {
+		"up": "r5n.12xlarge",
+		"down": "r5n.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "256"
+	},
+	"r5n.12xlarge": {
+		"up": "r5n.16xlarge",
+		"down": "r5n.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "384"
+	},
+	"r5n.16xlarge": {
+		"up": "r5n.24xlarge",
+		"down": "r5n.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "512"
+	},
+	"r5n.24xlarge": {
+		"up": null,
+		"down": "r5n.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "768"
+	},
+	"r5n.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"memory": "768"
+	},
+	"r5dn.large": {
+		"up": "r5dn.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "16"
+	},
+	"r5dn.xlarge": {
+		"up": "r5dn.2xlarge",
+		"down": "r5dn.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "32"
+	},
+	"r5dn.2xlarge": {
+		"up": "r5dn.4xlarge",
+		"down": "r5dn.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "64"
+	},
+	"r5dn.4xlarge": {
+		"up": "r5dn.8xlarge",
+		"down": "r5dn.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "128"
+	},
+	"r5dn.8xlarge": {
+		"up": "r5dn.12xlarge",
+		"down": "r5dn.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "256"
+	},
+	"r5dn.12xlarge": {
+		"up": "r5dn.16xlarge",
+		"down": "r5dn.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "384"
+	},
+	"r5dn.16xlarge": {
+		"up": "r5dn.24xlarge",
+		"down": "r5dn.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "512"
+	},
+	"r5dn.24xlarge": {
+		"up": null,
+		"down": "r5dn.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "768"
+	},
+	"r5dn.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"memory": "768"
+	},
+	"r5d.large": {
+		"up": "r5d.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "16"
+	},
+	"r5d.xlarge": {
+		"up": "r5d.2xlarge",
+		"down": "r5d.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "32"
+	},
+	"r5d.2xlarge": {
+		"up": "r5d.4xlarge",
+		"down": "r5d.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "64"
+	},
+	"r5d.4xlarge": {
+		"up": "r5d.8xlarge",
+		"down": "r5d.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "128"
+	},
+	"r5d.8xlarge": {
+		"up": "r5d.12xlarge",
+		"down": "r5d.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "256"
+	},
+	"r5d.12xlarge": {
+		"up": "r5d.16xlarge",
+		"down": "r5d.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "384"
+	},
+	"r5d.16xlarge": {
+		"up": "r5d.24xlarge",
+		"down": "r5d.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "512"
+	},
+	"r5d.24xlarge": {
+		"up": null,
+		"down": "r5d.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "768"
+	},
+	"r5d.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"memory": "768"
+	},
+	"r6a.large": {
+		"up": "r6a.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "16"
+	},
+	"r6a.xlarge": {
+		"up": "r6a.2xlarge",
+		"down": "r6a.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "32"
+	},
+	"r6a.2xlarge": {
+		"up": "r6a.4xlarge",
+		"down": "r6a.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "64"
+	},
+	"r6a.4xlarge": {
+		"up": "r6a.8xlarge",
+		"down": "r6a.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "128"
+	},
+	"r6a.8xlarge": {
+		"up": "r6a.12xlarge",
+		"down": "r6a.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "256"
+	},
+	"r6a.12xlarge": {
+		"up": "r6a.16xlarge",
+		"down": "r6a.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "384"
+	},
+	"r6a.16xlarge": {
+		"up": "r6a.24xlarge",
+		"down": "r6a.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "512"
+	},
+	"r6a.24xlarge": {
+		"up": "r6a.32xlarge",
+		"down": "r6a.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "768"
+	},
+	"r6a.32xlarge": {
+		"up": "r6a.48xlarge",
+		"down": "r6a.24xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "128",
+		"nfu": "256",
+		"memory": "1024"
+	},
+	"r6a.48xlarge": {
+		"up": null,
+		"down": "r6a.32xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "192",
+		"nfu": "384",
+		"memory": "1536"
+	},
+	"r6a.metal": {
+		"up": null,
+		"down": "r6a.32xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "192",
+		"nfu": "384",
+		"memory": "1536"
+	},
+	"r6g.medium": {
+		"up": "r6g.large",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "1",
+		"nfu": "2",
+		"memory": "8"
+	},
+	"r6g.large": {
+		"up": "r6g.xlarge",
+		"down": "r6g.medium",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "16"
+	},
+	"r6g.xlarge": {
+		"up": "r6g.2xlarge",
+		"down": "r6g.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "32"
+	},
+	"r6g.2xlarge": {
+		"up": "r6g.4xlarge",
+		"down": "r6g.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "64"
+	},
+	"r6g.4xlarge": {
+		"up": "r6g.8xlarge",
+		"down": "r6g.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "128"
+	},
+	"r6g.8xlarge": {
+		"up": "r6g.12xlarge",
+		"down": "r6g.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "256"
+	},
+	"r6g.12xlarge": {
+		"up": "r6g.16xlarge",
+		"down": "r6g.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "384"
+	},
+	"r6g.16xlarge": {
+		"up": null,
+		"down": "r6g.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "512"
+	},
+	"r6g.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"memory": "512"
+	},
+	"r6gd.medium": {
+		"up": "r6gd.large",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "1",
+		"nfu": "2",
+		"memory": "8"
+	},
+	"r6gd.large": {
+		"up": "r6gd.xlarge",
+		"down": "r6gd.medium",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "16"
+	},
+	"r6gd.xlarge": {
+		"up": "r6gd.2xlarge",
+		"down": "r6gd.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "32"
+	},
+	"r6gd.2xlarge": {
+		"up": "r6gd.4xlarge",
+		"down": "r6gd.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "64"
+	},
+	"r6gd.4xlarge": {
+		"up": "r6gd.8xlarge",
+		"down": "r6gd.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "128"
+	},
+	"r6gd.8xlarge": {
+		"up": "r6gd.12xlarge",
+		"down": "r6gd.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "256"
+	},
+	"r6gd.12xlarge": {
+		"up": "r6gd.16xlarge",
+		"down": "r6gd.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "384"
+	},
+	"r6gd.16xlarge": {
+		"up": null,
+		"down": "r6gd.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "512"
+	},
+	"r6gd.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"memory": "512"
+	},
+	"r6i.large": {
+		"up": "r6i.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "16"
+	},
+	"r6i.xlarge": {
+		"up": "r6i.2xlarge",
+		"down": "r6i.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "32"
+	},
+	"r6i.2xlarge": {
+		"up": "r6i.4xlarge",
+		"down": "r6i.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "64"
+	},
+	"r6i.4xlarge": {
+		"up": "r6i.8xlarge",
+		"down": "r6i.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "128"
+	},
+	"r6i.8xlarge": {
+		"up": "r6i.12xlarge",
+		"down": "r6i.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "256"
+	},
+	"r6i.12xlarge": {
+		"up": "r6i.16xlarge",
+		"down": "r6i.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "384"
+	},
+	"r6i.16xlarge": {
+		"up": "r6i.24xlarge",
+		"down": "r6i.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "512"
+	},
+	"r6i.24xlarge": {
+		"up": "r6i.32xlarge",
+		"down": "r6i.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "768"
+	},
+	"r6i.32xlarge": {
+		"up": null,
+		"down": "r6i.24xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "128",
+		"nfu": "256",
+		"memory": "1024"
+	},
+	"r6i.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "128",
+		"nfu": "256",
+		"memory": "1024"
+	},
+	"r6id.large": {
+		"up": "r6id.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "16"
+	},
+	"r6id.xlarge": {
+		"up": "r6id.2xlarge",
+		"down": "r6id.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "32"
+	},
+	"r6id.2xlarge": {
+		"up": "r6id.4xlarge",
+		"down": "r6id.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "64"
+	},
+	"r6id.4xlarge": {
+		"up": "r6id.8xlarge",
+		"down": "r6id.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "128"
+	},
+	"r6id.8xlarge": {
+		"up": "r6id.12xlarge",
+		"down": "r6id.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "256"
+	},
+	"r6id.12xlarge": {
+		"up": "r6id.16xlarge",
+		"down": "r6id.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "384"
+	},
+	"r6id.16xlarge": {
+		"up": "r6id.24xlarge",
+		"down": "r6id.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "512"
+	},
+	"r6id.24xlarge": {
+		"up": "r6id.32xlarge",
+		"down": "r6id.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "768"
+	},
+	"r6id.32xlarge": {
+		"up": null,
+		"down": "r6id.24xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "128",
+		"nfu": "256",
+		"memory": "1024"
+	},
+	"r6id.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "128",
+		"nfu": "256",
+		"memory": "1024"
+	},
+	"x1.16xlarge": {
+		"up": "x1.32xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "976"
+	},
+	"x1.32xlarge": {
+		"up": null,
+		"down": "x1.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "128",
+		"nfu": "256",
+		"memory": "1952"
+	},
+	"x1e.xlarge": {
+		"up": "x1e.2xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "122"
+	},
+	"x1e.2xlarge": {
+		"up": "x1e.4xlarge",
+		"down": "x1e.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "244"
+	},
+	"x1e.4xlarge": {
+		"up": "x1e.8xlarge",
+		"down": "x1e.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "488"
+	},
+	"x1e.8xlarge": {
+		"up": "x1e.16xlarge",
+		"down": "x1e.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "976"
+	},
+	"x1e.16xlarge": {
+		"up": "x1e.32xlarge",
+		"down": "x1e.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "1952"
+	},
+	"x1e.32xlarge": {
+		"up": null,
+		"down": "x1e.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "128",
+		"nfu": "256",
+		"memory": "3904"
+	},
+	"x2gd.medium": {
+		"up": "x2gd.large",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "1",
+		"nfu": "16",
+		"memory": "16"
+	},
+	"x2gd.large": {
+		"up": "x2gd.xlarge",
+		"down": "x2gd.medium",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "32",
+		"memory": "32"
+	},
+	"x2gd.xlarge": {
+		"up": "x2gd.2xlarge",
+		"down": "x2gd.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "64",
+		"memory": "64"
+	},
+	"x2gd.2xlarge": {
+		"up": "x2gd.4xlarge",
+		"down": "x2gd.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "128",
+		"memory": "128"
+	},
+	"x2gd.4xlarge": {
+		"up": "x2gd.8xlarge",
+		"down": "x2gd.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "256",
+		"memory": "256"
+	},
+	"x2gd.8xlarge": {
+		"up": "x2gd.12xlarge",
+		"down": "x2gd.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "512",
+		"memory": "512"
+	},
+	"x2gd.12xlarge": {
+		"up": "x2gd.16xlarge",
+		"down": "x2gd.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "768",
+		"memory": "768"
+	},
+	"x2gd.16xlarge": {
+		"up": "x2gd.metal",
+		"down": "x2gd.12xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "1024",
+		"memory": "1024"
+	},
+	"x2gd.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "1024",
+		"memory": "1024"
+	},
+	"x2idn.16xlarge": {
+		"up": "x2idn.24xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "1024"
+	},
+	"x2idn.24xlarge": {
+		"up": "x2idn.32xlarge",
+		"down": "x2idn.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "1536"
+	},
+	"x2idn.32xlarge": {
+		"up": null,
+		"down": "x2idn.24xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "128",
+		"nfu": "256",
+		"memory": "2048"
+	},
+	"x2idn.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "128",
+		"nfu": "256",
+		"memory": "2048"
+	},
+	"x2iedn.xlarge": {
+		"up": "x2iedn.2xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "128"
+	},
+	"x2iedn.2xlarge": {
+		"up": "x2iedn.4xlarge",
+		"down": "x2iedn.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "256"
+	},
+	"x2iedn.4xlarge": {
+		"up": "x2iedn.8xlarge",
+		"down": "x2iedn.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "512"
+	},
+	"x2iedn.8xlarge": {
+		"up": "x2iedn.16xlarge",
+		"down": "x2iedn.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "1024"
+	},
+	"x2iedn.16xlarge": {
+		"up": "x2iedn.24xlarge",
+		"down": "x2iedn.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "64",
+		"nfu": "128",
+		"memory": "2048"
+	},
+	"x2iedn.24xlarge": {
+		"up": "x2iedn.32xlarge",
+		"down": "x2iedn.16xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "96",
+		"nfu": "192",
+		"memory": "3072"
+	},
+	"x2iedn.32xlarge": {
+		"up": null,
+		"down": "x2iedn.24xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "128",
+		"nfu": "256",
+		"memory": "4096"
+	},
+	"x2iedn.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "128",
+		"nfu": "256",
+		"memory": "4096"
+	},
+	"x2iezn.2xlarge": {
+		"up": "x2iezn.4xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "256"
+	},
+	"x2iezn.4xlarge": {
+		"up": "x2iezn.6xlarge",
+		"down": "x2iezn.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "16",
+		"nfu": "32",
+		"memory": "512"
+	},
+	"x2iezn.6xlarge": {
+		"up": "x2iezn.8xlarge",
+		"down": "x2iezn.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "24",
+		"nfu": "46",
+		"memory": "768"
+	},
+	"x2iezn.8xlarge": {
+		"up": "x2iezn.12xlarge",
+		"down": "x2iezn.4xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "32",
+		"nfu": "64",
+		"memory": "1024"
+	},
+	"x2iezn.12xlarge": {
+		"up": null,
+		"down": "x2iezn.8xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "1536"
+	},
+	"x2iezn.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "1536"
+	},
+	"z1d.large": {
+		"up": "z1d.xlarge",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "16"
+	},
+	"z1d.xlarge": {
+		"up": "z1d.2xlarge",
+		"down": "z1d.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "32"
+	},
+	"z1d.2xlarge": {
+		"up": "z1d.3xlarge",
+		"down": "z1d.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "64"
+	},
+	"z1d.3xlarge": {
+		"up": "z1d.6xlarge",
+		"down": "z1d.2xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "12",
+		"nfu": "24",
+		"memory": "96"
+	},
+	"z1d.6xlarge": {
+		"up": "z1d.12xlarge",
+		"down": "z1d.3xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "24",
+		"nfu": "48",
+		"memory": "192"
+	},
+	"z1d.12xlarge": {
+		"up": null,
+		"down": "z1d.6xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"nfu": "96",
+		"memory": "384"
+	},
+	"z1d.metal": {
+		"up": null,
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "48",
+		"memory": "384"
+	},
+	"u-6tb1.metal": {
+		"up": "u-9tb1.metal",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "448",
+		"memory": "6144"
+	},
+	"u-9tb1.metal": {
+		"up": "u-12tb1.metal",
+		"down": "u-6tb1.metal",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "448",
+		"memory": "9216"
+	},
+	"u-12tb1.metal": {
+		"up": "u-18tb1.metal",
+		"down": "u-9tb1.metal",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "448",
+		"memory": "12288"
+	},
+	"u-18tb1.metal": {
+		"up": "u-24tb1.metal",
+		"down": "u-12tb1.metal",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "448",
+		"memory": "18432"
+	},
+	"u-24tb1.metal": {
+		"up": null,
+		"down": "u-18tb1.metal",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"vcpu": "448",
+		"memory": "24576"
+	},
+	"t1.micro": {
+		"up": null,
+		"down": null,
+		"superseded": {
+			"regular": "t2.micro",
+			"next_gen": "t3.micro",
+			"burstable": "",
+			"amd": "t3a.micro"
+		},
+		"ec2_classic": true,
+		"enhanced_networking": false,
+		"vcpu": "1",
+		"nfu": "0.5",
+		"memory": "0.613"
+	},
+	"t2.nano": {
+		"up": "t2.micro",
+		"down": null,
+		"superseded": {
+			"regular": "t3.nano",
+			"next_gen": "",
+			"burstable": "",
+			"amd": "t3a.nano"
+		},
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 3,
+			"max_earnable_credits": 72
+		},
+		"vcpu": "1",
+		"nfu": "0.25",
+		"memory": "0.5"
+	},
+	"t2.micro": {
+		"up": "t2.small",
+		"down": "t2.nano",
+		"superseded": {
+			"regular": "t3.micro",
+			"next_gen": "",
+			"burstable": "",
+			"amd": "t3a.micro"
+		},
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 6,
+			"max_earnable_credits": 144
+		},
+		"vcpu": "1",
+		"nfu": "0.5",
+		"memory": "1"
+	},
+	"t2.small": {
+		"up": "t2.medium",
+		"down": "t2.micro",
+		"superseded": {
+			"regular": "t3.small",
+			"next_gen": "",
+			"burstable": "",
+			"amd": "t3a.small"
+		},
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 12,
+			"max_earnable_credits": 288
+		},
+		"vcpu": "1",
+		"nfu": "1",
+		"memory": "2"
+	},
+	"t2.medium": {
+		"up": "t2.large",
+		"down": "t2.small",
+		"superseded": {
+			"regular": "t3.medium",
+			"next_gen": "",
+			"burstable": "",
+			"amd": "t3a.medium"
+		},
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 24,
+			"max_earnable_credits": 576
+		},
+		"vcpu": "2",
+		"nfu": "2",
+		"memory": "4"
+	},
+	"t2.large": {
+		"up": "t2.xlarge",
+		"down": "t2.medium",
+		"superseded": {
+			"regular": "t3.large",
+			"next_gen": "",
+			"burstable": "",
+			"amd": "t3a.large"
+		},
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 36,
+			"max_earnable_credits": 864
+		},
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "8"
+	},
+	"t2.xlarge": {
+		"up": "t2.2xlarge",
+		"down": "t2.large",
+		"superseded": {
+			"regular": "t3.xlarge",
+			"next_gen": "",
+			"burstable": "",
+			"amd": "t3a.xlarge"
+		},
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 54,
+			"max_earnable_credits": 1296
+		},
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"t2.2xlarge": {
+		"up": null,
+		"down": "t2.xlarge",
+		"superseded": {
+			"regular": "t3.2xlarge",
+			"next_gen": "",
+			"burstable": "",
+			"amd": "t3a.2xlarge"
+		},
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 81.6,
+			"max_earnable_credits": 1958.4
+		},
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"t3.nano": {
+		"up": "t3.micro",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 6,
+			"max_earnable_credits": 144
+		},
+		"vcpu": "2",
+		"nfu": "0.25",
+		"memory": "0.5"
+	},
+	"t3.micro": {
+		"up": "t3.small",
+		"down": "t3.nano",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 12,
+			"max_earnable_credits": 288
+		},
+		"vcpu": "2",
+		"nfu": "0.5",
+		"memory": "1"
+	},
+	"t3.small": {
+		"up": "t3.medium",
+		"down": "t3.micro",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 24,
+			"max_earnable_credits": 576
+		},
+		"vcpu": "2",
+		"nfu": "1",
+		"memory": "2"
+	},
+	"t3.medium": {
+		"up": "t3.large",
+		"down": "t3.small",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 24,
+			"max_earnable_credits": 576
+		},
+		"vcpu": "2",
+		"nfu": "2",
+		"memory": "4"
+	},
+	"t3.large": {
+		"up": "t3.xlarge",
+		"down": "t3.medium",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 36,
+			"max_earnable_credits": 864
+		},
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "8"
+	},
+	"t3.xlarge": {
+		"up": "t3.2xlarge",
+		"down": "t3.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 96,
+			"max_earnable_credits": 2304
+		},
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"t3.2xlarge": {
+		"up": null,
+		"down": "t3.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 192,
+			"max_earnable_credits": 4608
+		},
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"t3a.nano": {
+		"up": "t3.micro",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 6,
+			"max_earnable_credits": 144
+		},
+		"vcpu": "2",
+		"nfu": "0.25",
+		"memory": "0.5"
+	},
+	"t3a.micro": {
+		"up": "t3.small",
+		"down": "t3.nano",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 12,
+			"max_earnable_credits": 288
+		},
+		"vcpu": "2",
+		"nfu": "0.5",
+		"memory": "1"
+	},
+	"t3a.small": {
+		"up": "t3.medium",
+		"down": "t3.micro",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 24,
+			"max_earnable_credits": 576
+		},
+		"vcpu": "2",
+		"nfu": "1",
+		"memory": "2"
+	},
+	"t3a.medium": {
+		"up": "t3.large",
+		"down": "t3.small",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 24,
+			"max_earnable_credits": 576
+		},
+		"vcpu": "2",
+		"nfu": "2",
+		"memory": "4"
+	},
+	"t3a.large": {
+		"up": "t3.xlarge",
+		"down": "t3.medium",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 36,
+			"max_earnable_credits": 864
+		},
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "8"
+	},
+	"t3a.xlarge": {
+		"up": "t3.2xlarge",
+		"down": "t3.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 96,
+			"max_earnable_credits": 2304
+		},
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"t3a.2xlarge": {
+		"up": null,
+		"down": "t3.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 192,
+			"max_earnable_credits": 4608
+		},
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"t4g.nano": {
+		"up": "t4g.micro",
+		"down": null,
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 6,
+			"max_earnable_credits": 144
+		},
+		"vcpu": "2",
+		"nfu": "0.25",
+		"memory": "0.5"
+	},
+	"t4g.micro": {
+		"up": "t4g.small",
+		"down": "t4g.nano",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 12,
+			"max_earnable_credits": 288
+		},
+		"vcpu": "2",
+		"nfu": "0.5",
+		"memory": "1"
+	},
+	"t4g.small": {
+		"up": "t4g.medium",
+		"down": "t4g.micro",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 24,
+			"max_earnable_credits": 576
+		},
+		"vcpu": "2",
+		"nfu": "1",
+		"memory": "2"
+	},
+	"t4g.medium": {
+		"up": "t4g.large",
+		"down": "t4g.small",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 24,
+			"max_earnable_credits": 576
+		},
+		"vcpu": "2",
+		"nfu": "2",
+		"memory": "4"
+	},
+	"t4g.large": {
+		"up": "t4g.xlarge",
+		"down": "t4g.medium",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 26,
+			"max_earnable_credits": 864
+		},
+		"vcpu": "2",
+		"nfu": "4",
+		"memory": "8"
+	},
+	"t4g.xlarge": {
+		"up": "t4g.2xlarge",
+		"down": "t4g.large",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 96,
+			"max_earnable_credits": 2304
+		},
+		"vcpu": "4",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"t4g.2xlarge": {
+		"up": null,
+		"down": "t4g.xlarge",
+		"superseded": null,
+		"ec2_classic": false,
+		"enhanced_networking": true,
+		"burst_info": {
+			"credits_per_hour": 192,
+			"max_earnable_credits": 4608
+		},
+		"vcpu": "8",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"db.t1.micro": {
+		"vcpu": "1",
+		"up": null,
+		"down": null,
+		"nfu": "0.5",
+		"memory": "0.613"
+	},
+	"db.t2.micro": {
+		"vcpu": "1",
+		"up": "db.t2.small",
+		"down": null,
+		"nfu": "0.5",
+		"memory": "1"
+	},
+	"db.t2.small": {
+		"vcpu": "1",
+		"up": "db.t2.medium",
+		"down": "db.t2.micro",
+		"nfu": "1",
+		"memory": "2"
+	},
+	"db.t2.medium": {
+		"vcpu": "2",
+		"up": "db.t2.large",
+		"down": "db.t2.small",
+		"nfu": "2",
+		"memory": "4"
+	},
+	"db.t2.large": {
+		"vcpu": "2",
+		"up": "db.t2.xlarge",
+		"down": "db.t2.medium",
+		"nfu": "4",
+		"memory": "8"
+	},
+	"db.t2.xlarge": {
+		"vcpu": "4",
+		"up": "db.t2.2xlarge",
+		"down": "db.t2.large",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"db.t2.2xlarge": {
+		"vcpu": "8",
+		"up": null,
+		"down": "db.t2.xlarge",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"db.t3.micro": {
+		"vcpu": "2",
+		"up": "db.t3.small",
+		"down": null,
+		"nfu": "0.5",
+		"memory": "1"
+	},
+	"db.t3.small": {
+		"vcpu": "2",
+		"up": "db.t3.medium",
+		"down": "db.t3.micro",
+		"nfu": "1",
+		"memory": "2"
+	},
+	"db.t3.medium": {
+		"vcpu": "2",
+		"up": "db.t3.large",
+		"down": "db.t3.small",
+		"nfu": "2",
+		"memory": "4"
+	},
+	"db.t3.large": {
+		"vcpu": "2",
+		"up": "db.t3.xlarge",
+		"down": "db.t3.medium",
+		"nfu": "4",
+		"memory": "8"
+	},
+	"db.t3.xlarge": {
+		"vcpu": "4",
+		"up": "db.t3.2xlarge",
+		"down": "db.t3.large",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"db.t3.2xlarge": {
+		"vcpu": "8",
+		"up": null,
+		"down": "db.t3.xlarge",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"db.t4g.micro": {
+		"vcpu": "2",
+		"up": "db.t4g.small",
+		"down": null,
+		"nfu": "0.5",
+		"memory": "1"
+	},
+	"db.t4g.small": {
+		"vcpu": "2",
+		"up": "db.t4g.medium",
+		"down": "db.t4g.micro",
+		"nfu": "1",
+		"memory": "2"
+	},
+	"db.t4g.medium": {
+		"vcpu": "2",
+		"up": "db.t4g.large",
+		"down": "db.t4g.small",
+		"nfu": "2",
+		"memory": "4"
+	},
+	"db.t4g.large": {
+		"vcpu": "2",
+		"up": "db.t4g.xlarge",
+		"down": "db.t4g.medium",
+		"nfu": "4",
+		"memory": "8"
+	},
+	"db.t4g.xlarge": {
+		"vcpu": "4",
+		"up": "db.t4g.2xlarge",
+		"down": "db.t4g.large",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"db.t4g.2xlarge": {
+		"vcpu": "8",
+		"up": null,
+		"down": "db.t4g.xlarge",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"db.m4.large": {
+		"vcpu": "2",
+		"up": "db.m4.xlarge",
+		"down": null,
+		"nfu": "4",
+		"memory": "8"
+	},
+	"db.m4.xlarge": {
+		"vcpu": "4",
+		"up": "db.m4.2xlarge",
+		"down": "db.m4.large",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"db.m4.2xlarge": {
+		"vcpu": "8",
+		"up": "db.m4.4xlarge",
+		"down": "db.m4.xlarge",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"db.m4.4xlarge": {
+		"vcpu": "16",
+		"up": "db.m4.10xlarge",
+		"down": "db.m4.2xlarge",
+		"nfu": "32",
+		"memory": "64"
+	},
+	"db.m4.10xlarge": {
+		"vcpu": "40",
+		"up": "db.m4.16xlarge",
+		"down": "db.m4.4xlarge",
+		"nfu": "80",
+		"memory": "160"
+	},
+	"db.m4.16xlarge": {
+		"vcpu": "64",
+		"up": null,
+		"down": "db.m4.10xlarge",
+		"nfu": "128",
+		"memory": "256"
+	},
+	"db.m5.large": {
+		"vcpu": "2",
+		"up": "db.m5.xlarge",
+		"down": null,
+		"nfu": "4",
+		"memory": "8"
+	},
+	"db.m5.xlarge": {
+		"vcpu": "4",
+		"up": "db.m5.2xlarge",
+		"down": "db.m5.large",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"db.m5.2xlarge": {
+		"vcpu": "8",
+		"up": "db.m5.4xlarge",
+		"down": "db.m5.xlarge",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"db.m5.4xlarge": {
+		"vcpu": "16",
+		"up": "db.m5.12xlarge",
+		"down": "db.m5.2xlarge",
+		"nfu": "32",
+		"memory": "64"
+	},
+	"db.m5.12xlarge": {
+		"vcpu": "48",
+		"up": "db.m5.16xlarge",
+		"down": "db.m5.4xlarge",
+		"nfu": "96",
+		"memory": "192"
+	},
+	"db.m5.16xlarge": {
+		"vcpu": "64",
+		"up": "db.m5.24xlarge",
+		"down": "db.m5.12xlarge",
+		"nfu": "128",
+		"memory": "256"
+	},
+	"db.m5.24xlarge": {
+		"vcpu": "96",
+		"up": null,
+		"down": "db.m5.16xlarge",
+		"nfu": "192",
+		"memory": "384"
+	},
+	"db.m6g.large": {
+		"vcpu": "2",
+		"up": "db.m6g.xlarge",
+		"down": null,
+		"nfu": "4",
+		"memory": "8"
+	},
+	"db.m6g.xlarge": {
+		"vcpu": "4",
+		"up": "db.m6g.2xlarge",
+		"down": "db.m6g.large",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"db.m6g.2xlarge": {
+		"vcpu": "8",
+		"up": "db.m6g.4xlarge",
+		"down": "db.m6g.xlarge",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"db.m6g.4xlarge": {
+		"vcpu": "16",
+		"up": "db.m6g.8xlarge",
+		"down": "db.m6g.2xlarge",
+		"nfu": "32",
+		"memory": "64"
+	},
+	"db.m6g.8xlarge": {
+		"vcpu": "32",
+		"up": "db.m6g.16xlarge",
+		"down": "db.m6g.4xlarge",
+		"nfu": "64",
+		"memory": "128"
+	},
+	"db.m6g.12xlarge": {
+		"vcpu": "48",
+		"up": "db.m6g.16xlarge",
+		"down": "db.m6g.8xlarge",
+		"nfu": "96",
+		"memory": "192"
+	},
+	"db.m6g.16xlarge": {
+		"vcpu": "64",
+		"up": null,
+		"down": "db.m6g.12xlarge",
+		"nfu": "128",
+		"memory": "256"
+	},
+	"db.m6i.large": {
+		"vcpu": "2",
+		"up": "db.m6i.xlarge",
+		"down": null,
+		"nfu": "4",
+		"memory": "8"
+	},
+	"db.m6i.xlarge": {
+		"vcpu": "4",
+		"up": "db.m6i.2xlarge",
+		"down": "db.m6i.large",
+		"nfu": "8",
+		"memory": "16"
+	},
+	"db.m6i.2xlarge": {
+		"vcpu": "8",
+		"up": "db.m6i.4xlarge",
+		"down": "db.m6i.xlarge",
+		"nfu": "16",
+		"memory": "32"
+	},
+	"db.m6i.4xlarge": {
+		"vcpu": "16",
+		"up": "db.m6i.8xlarge",
+		"down": "db.m6i.2xlarge",
+		"nfu": "32",
+		"memory": "64"
+	},
+	"db.m6i.8xlarge": {
+		"vcpu": "32",
+		"up": "db.m6i.12xlarge",
+		"down": "db.m6i.4xlarge",
+		"nfu": "64",
+		"memory": "128"
+	},
+	"db.m6i.12xlarge": {
+		"vcpu": "48",
+		"up": "db.m6i.16xlarge",
+		"down": "db.m6i.8xlarge",
+		"nfu": "96",
+		"memory": "192"
+	},
+	"db.m6i.16xlarge": {
+		"vcpu": "64",
+		"up": "db.m6i.24xlarge",
+		"down": "db.m6i.12xlarge",
+		"nfu": "128",
+		"memory": "256"
+	},
+	"db.m6i.24xlarge": {
+		"vcpu": "96",
+		"up": "db.m6i.32xlarge",
+		"down": "db.m6i.16xlarge",
+		"nfu": "192",
+		"memory": "384"
+	},
+	"db.m6i.32xlarge": {
+		"vcpu": "128",
+		"up": null,
+		"down": "db.m6i.24xlarge",
+		"nfu": "256",
+		"memory": "512"
+	},
+	"db.r6g.large": {
+		"vcpu": "2",
+		"up": "db.r6g.xlarge",
+		"down": null,
+		"nfu": "4",
+		"memory": "16"
+	},
+	"db.r6g.xlarge": {
+		"vcpu": "4",
+		"up": "db.r6g.2xlarge",
+		"down": "db.r6g.large",
+		"nfu": "8",
+		"memory": "32"
+	},
+	"db.r6g.2xlarge": {
+		"vcpu": "8",
+		"up": "db.r6g.4xlarge",
+		"down": "db.r6g.xlarge",
+		"nfu": "16",
+		"memory": "64"
+	},
+	"db.r6g.4xlarge": {
+		"vcpu": "16",
+		"up": "db.r6g.8xlarge",
+		"down": "db.r6g.2xlarge",
+		"nfu": "32",
+		"memory": "128"
+	},
+	"db.r6g.8xlarge": {
+		"vcpu": "32",
+		"up": "db.r6g.16xlarge",
+		"down": "db.r6g.4xlarge",
+		"nfu": "64",
+		"memory": "256"
+	},
+	"db.r6g.12xlarge": {
+		"vcpu": "48",
+		"up": "db.r6g.16xlarge",
+		"down": "db.r6g.8xlarge",
+		"nfu": "96",
+		"memory": "384"
+	},
+	"db.r6g.16xlarge": {
+		"vcpu": "64",
+		"up": null,
+		"down": "db.r6g.12xlarge",
+		"nfu": "128",
+		"memory": "512"
+	},
+	"db.r4.large": {
+		"vcpu": "2",
+		"up": "db.r4.xlarge",
+		"down": null,
+		"nfu": "4",
+		"memory": "15.25"
+	},
+	"db.r4.xlarge": {
+		"vcpu": "4",
+		"up": "db.r4.2xlarge",
+		"down": "db.r4.large",
+		"nfu": "8",
+		"memory": "30.5"
+	},
+	"db.r4.2xlarge": {
+		"vcpu": "8",
+		"up": "db.r4.4xlarge",
+		"down": "db.r4.xlarge",
+		"nfu": "16",
+		"memory": "61"
+	},
+	"db.r4.4xlarge": {
+		"vcpu": "16",
+		"up": "db.r4.8xlarge",
+		"down": "db.r4.2xlarge",
+		"nfu": "32",
+		"memory": "122"
+	},
+	"db.r4.8xlarge": {
+		"vcpu": "32",
+		"up": "db.r4.16xlarge",
+		"down": "db.r4.4xlarge",
+		"nfu": "64",
+		"memory": "244"
+	},
+	"db.r4.16xlarge": {
+		"vcpu": "64",
+		"up": null,
+		"down": "db.r4.8xlarge",
+		"nfu": "128",
+		"memory": "488"
+	},
+	"db.r5.large": {
+		"vcpu": "2",
+		"up": "db.r5.xlarge",
+		"down": null,
+		"nfu": "4",
+		"memory": "16"
+	},
+	"db.r5.xlarge": {
+		"vcpu": "4",
+		"up": "db.r5.2xlarge",
+		"down": "db.r5.large",
+		"nfu": "8",
+		"memory": "32"
+	},
+	"db.r5.2xlarge": {
+		"vcpu": "8",
+		"up": "db.r5.4xlarge",
+		"down": "db.r5.xlarge",
+		"nfu": "16",
+		"memory": "64"
+	},
+	"db.r5.4xlarge": {
+		"vcpu": "16",
+		"up": "db.r5.8xlarge",
+		"down": "db.r5.2xlarge",
+		"nfu": "32",
+		"memory": "128"
+	},
+	"db.r5.8xlarge": {
+		"vcpu": "32",
+		"up": "db.r5.12xlarge",
+		"down": "db.r5.4xlarge",
+		"nfu": "64",
+		"memory": "256"
+	},
+	"db.r5.12xlarge": {
+		"vcpu": "48",
+		"up": "db.r5.24xlarge",
+		"down": "db.r5.4xlarge",
+		"nfu": "96",
+		"memory": "384"
+	},
+	"db.r5.24xlarge": {
+		"vcpu": "64",
+		"up": null,
+		"down": "db.r5.12xlarge",
+		"nfu": "192",
+		"memory": "768"
+	},
+	"db.x1e.xlarge": {
+		"vcpu": "4",
+		"up": "db.x1e.2xlarge",
+		"down": null,
+		"nfu": "8",
+		"memory": "122"
+	},
+	"db.x1e.2xlarge": {
+		"vcpu": "8",
+		"up": "db.x1e.4xlarge",
+		"down": "db.x1e.xlarge",
+		"nfu": "16",
+		"memory": "244"
+	},
+	"db.x1e.4xlarge": {
+		"vcpu": "16",
+		"up": "db.x1e.8xlarge",
+		"down": "db.x1e.2xlarge",
+		"nfu": "32",
+		"memory": "488"
+	},
+	"db.x1e.8xlarge": {
+		"vcpu": "32",
+		"up": "db.x1e.16xlarge",
+		"down": "db.x1e.4xlarge",
+		"nfu": "64",
+		"memory": "976"
+	},
+	"db.x1e.16xlarge": {
+		"vcpu": "64",
+		"up": "db.x1e.32xlarge",
+		"down": "db.x1e.8xlarge",
+		"nfu": "128",
+		"memory": "1952"
+	},
+	"db.x1e.32xlarge": {
+		"vcpu": "128",
+		"up": null,
+		"down": "db.x1e.16xlarge",
+		"nfu": "256",
+		"memory": "3904"
+	},
+	"db.x1.16xlarge": {
+		"vcpu": "64",
+		"up": "db.x1.32xlarge",
+		"down": null,
+		"nfu": "128",
+		"memory": "976"
+	},
+	"db.x1.32xlarge": {
+		"vcpu": "128",
+		"up": null,
+		"down": "db.x1.16xlarge",
+		"nfu": "256",
+		"memory": "1952"
+	},
+	"db.m1.small": {
+		"vcpu": "1",
+		"up": "db.m1.medium",
+		"down": null,
+		"nfu": "1",
+		"memory": "1.7"
+	},
+	"db.m1.medium": {
+		"vcpu": "1",
+		"up": "db.m1.large",
+		"down": "db.m1.small",
+		"nfu": "2",
+		"memory": "3.75"
+	},
+	"db.m1.large": {
+		"vcpu": "2",
+		"up": "db.m1.xlarge",
+		"down": "db.m1.medium",
+		"nfu": "4",
+		"memory": "7.5"
+	},
+	"db.m1.xlarge": {
+		"vcpu": "4",
+		"up": null,
+		"down": "db.m1.large",
+		"nfu": "8",
+		"memory": "15"
+	},
+	"db.m3.medium": {
+		"vcpu": "1",
+		"up": "db.m3.large",
+		"down": null,
+		"nfu": "2",
+		"memory": "3.75"
+	},
+	"db.m3.large": {
+		"vcpu": "2",
+		"up": "db.m3.xlarge",
+		"down": "db.m3.medium",
+		"nfu": "4",
+		"memory": "7.5"
+	},
+	"db.m3.xlarge": {
+		"vcpu": "4",
+		"up": "db.m3.2xlarge",
+		"down": "db.m3.large",
+		"nfu": "8",
+		"memory": "15"
+	},
+	"db.m3.2xlarge": {
+		"vcpu": "8",
+		"up": null,
+		"down": "db.m3.xlarge",
+		"nfu": "16",
+		"memory": "30"
+	},
+	"db.m2.xlarge": {
+		"vcpu": "2",
+		"up": "db.m2.2xlarge",
+		"down": null,
+		"nfu": "8",
+		"memory": "17.1"
+	},
+	"db.m2.2xlarge": {
+		"vcpu": "4",
+		"up": "db.m2.4xlarge",
+		"down": "db.m2.xlarge",
+		"nfu": "16",
+		"memory": "34.2"
+	},
+	"db.m2.4xlarge": {
+		"vcpu": "8",
+		"up": null,
+		"down": "db.m2.2xlarge",
+		"nfu": "32",
+		"memory": "68.4"
+	},
+	"db.r3.large": {
+		"vcpu": "2",
+		"up": "db.r3.xlarge",
+		"down": null,
+		"nfu": "4",
+		"memory": "15.25"
+	},
+	"db.r3.xlarge": {
+		"vcpu": "4",
+		"up": "db.r3.2xlarge",
+		"down": "db.r3.large",
+		"nfu": "8",
+		"memory": "30.5"
+	},
+	"db.r3.2xlarge": {
+		"vcpu": "8",
+		"up": "db.r3.4xlarge",
+		"down": "db.r3.xlarge",
+		"nfu": "16",
+		"memory": "61"
+	},
+	"db.r3.4xlarge": {
+		"vcpu": "16",
+		"up": "db.r3.8xlarge",
+		"down": "db.r3.2xlarge",
+		"nfu": "32",
+		"memory": "122"
+	},
+	"db.r3.8xlarge": {
+		"vcpu": "32",
+		"up": null,
+		"down": "db.r3.4xlarge",
+		"nfu": "64",
+		"memory": "244"
+	}
 }

--- a/data/aws/instance_types.json
+++ b/data/aws/instance_types.json
@@ -1,6403 +1,6403 @@
 {
-  "a1.medium": {
-    "up": "a1.large",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "1",
-    "nfu": "2",
-    "memory": "2.0"
-  },
-  "a1.large": {
-    "up": "a1.xlarge",
-    "down": "a1.medium",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "4.0"
-  },
-  "a1.xlarge": {
-    "up": "a1.2xlarge",
-    "down": "a1.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "8.0"
-  },
-  "a1.2xlarge": {
-    "up": "a1.4xlarge",
-    "down": "a1.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "16.0"
-  },
-  "a1.4xlarge": {
-    "up": null,
-    "down": "a1.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "32.0"
-  },
-  "a1.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "memory": "32.0"
-  },
-  "c1.medium": {
-    "up": "c1.xlarge",
-    "down": null,
-    "superseded": {
-      "regular": "c5.large",
-      "next_gen": "",
-      "burstable": "",
-      "amd": ""
-    },
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "2",
-    "nfu": "2",
-    "memory": "1.7"
-  },
-  "c1.xlarge": {
-    "up": null,
-    "down": "c1.medium",
-    "superseded": {
-      "regular": "c5.xlarge",
-      "next_gen": "",
-      "burstable": "",
-      "amd": ""
-    },
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "8",
-    "nfu": "8",
-    "memory": "7.0"
-  },
-  "c3.large": {
-    "up": "c3.xlarge",
-    "down": null,
-    "superseded": {
-      "regular": "c5.large",
-      "next_gen": "",
-      "burstable": "",
-      "amd": ""
-    },
-    "ec2_classic": true,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "3.75"
-  },
-  "c3.xlarge": {
-    "up": "c3.2xlarge",
-    "down": "c3.large",
-    "superseded": {
-      "regular": "c5.xlarge",
-      "next_gen": "",
-      "burstable": "",
-      "amd": ""
-    },
-    "ec2_classic": true,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "7.5"
-  },
-  "c3.2xlarge": {
-    "up": "c3.4xlarge",
-    "down": "c3.xlarge",
-    "superseded": {
-      "regular": "c5.2xlarge",
-      "next_gen": "",
-      "burstable": "",
-      "amd": ""
-    },
-    "ec2_classic": true,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "15.0"
-  },
-  "c3.4xlarge": {
-    "up": "c3.8xlarge",
-    "down": "c3.2xlarge",
-    "superseded": {
-      "regular": "c5.4xlarge",
-      "next_gen": "",
-      "burstable": "",
-      "amd": ""
-    },
-    "ec2_classic": true,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "30.0"
-  },
-  "c3.8xlarge": {
-    "up": null,
-    "down": "c3.4xlarge",
-    "superseded": {
-      "regular": "c5.9xlarge",
-      "next_gen": "",
-      "burstable": "",
-      "amd": ""
-    },
-    "ec2_classic": true,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "60.0"
-  },
-  "c4.large": {
-    "up": "c4.xlarge",
-    "down": null,
-    "superseded": {
-      "regular": "c5.large",
-      "next_gen": "",
-      "burstable": "",
-      "amd": ""
-    },
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "3.75"
-  },
-  "c4.xlarge": {
-    "up": "c4.2xlarge",
-    "down": "c4.large",
-    "superseded": {
-      "regular": "c5.xlarge",
-      "next_gen": "",
-      "burstable": "",
-      "amd": ""
-    },
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "7.5"
-  },
-  "c4.2xlarge": {
-    "up": "c4.4xlarge",
-    "down": "c4.xlarge",
-    "superseded": {
-      "regular": "c5.2xlarge",
-      "next_gen": "",
-      "burstable": "",
-      "amd": ""
-    },
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "15.0"
-  },
-  "c4.4xlarge": {
-    "up": "c4.8xlarge",
-    "down": "c4.2xlarge",
-    "superseded": {
-      "regular": "c5.4xlarge",
-      "next_gen": "",
-      "burstable": "",
-      "amd": ""
-    },
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "30.0"
-  },
-  "c4.8xlarge": {
-    "up": null,
-    "down": "c4.4xlarge",
-    "superseded": {
-      "regular": "c5.9xlarge",
-      "next_gen": "",
-      "burstable": "",
-      "amd": ""
-    },
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "36",
-    "nfu": "64",
-    "memory": "60.0"
-  },
-  "c5.large": {
-    "up": "c5.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "4.0"
-  },
-  "c5.xlarge": {
-    "up": "c5.2xlarge",
-    "down": "c5.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "8.0"
-  },
-  "c5.2xlarge": {
-    "up": "c5.4xlarge",
-    "down": "c5.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "16.0"
-  },
-  "c5.4xlarge": {
-    "up": "c5.9xlarge",
-    "down": "c5.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "32.0"
-  },
-  "c5.9xlarge": {
-    "up": "c5.12xlarge",
-    "down": "c5.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "36",
-    "nfu": "72",
-    "memory": "72.0"
-  },
-  "c5.12xlarge": {
-    "up": "c5.18xlarge",
-    "down": "c5.9xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "96.0"
-  },
-  "c5.18xlarge": {
-    "up": "c5.24xlarge",
-    "down": "c5.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "72",
-    "nfu": "144",
-    "memory": "144.0"
-  },
-  "c5.24xlarge": {
-    "up": null,
-    "down": "c18.18xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "192.0"
-  },
-  "c5.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "memory": "192.0"
-  },
-  "c5a.large": {
-    "up": "c5a.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "4.0"
-  },
-  "c5a.xlarge": {
-    "up": "c5a.2xlarge",
-    "down": "c5a.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "8.0"
-  },
-  "c5a.2xlarge": {
-    "up": "c5a.4xlarge",
-    "down": "c5a.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "16.0"
-  },
-  "c5a.4xlarge": {
-    "up": "c5a.8xlarge",
-    "down": "c5a.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "32.0"
-  },
-  "c5a.8xlarge": {
-    "up": "c5a.12xlarge",
-    "down": "c5a.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "64.0"
-  },
-  "c5a.12xlarge": {
-    "up": "c5a.16xlarge",
-    "down": "c5a.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "96.0"
-  },
-  "c5a.16xlarge": {
-    "up": "c5a.24xlarge",
-    "down": "c5a.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "128.0"
-  },
-  "c5a.24xlarge": {
-    "up": null,
-    "down": "c18.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "192.0"
-  },
-  "c5d.large": {
-    "up": "c5d.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "4.0"
-  },
-  "c5d.xlarge": {
-    "up": "c5d.2xlarge",
-    "down": "c5d.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "8.0"
-  },
-  "c5d.2xlarge": {
-    "up": "c5d.4xlarge",
-    "down": "c5d.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "16.0"
-  },
-  "c5d.4xlarge": {
-    "up": "c5d.9xlarge",
-    "down": "c5d.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "32.0"
-  },
-  "c5d.9xlarge": {
-    "up": "c5d.12xlarge",
-    "down": "c5d.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "36",
-    "nfu": "72",
-    "memory": "72.0"
-  },
-  "c5d.12xlarge": {
-    "up": "c5d.18xlarge",
-    "down": "c5d.9xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "96.0"
-  },
-  "c5d.18xlarge": {
-    "up": "c5d.24xlarge",
-    "down": "c5d.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "72",
-    "nfu": "144",
-    "memory": "144.0"
-  },
-  "c5d.24xlarge": {
-    "up": null,
-    "down": "c5d.18xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "192.0"
-  },
-  "c5d.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "memory": "192.0"
-  },
-  "c5ad.large": {
-    "up": "c5ad.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "4.0"
-  },
-  "c5ad.xlarge": {
-    "up": "c5ad.2xlarge",
-    "down": "c5ad.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "8.0"
-  },
-  "c5ad.2xlarge": {
-    "up": "c5ad.4xlarge",
-    "down": "c5ad.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "16.0"
-  },
-  "c5ad.4xlarge": {
-    "up": "c5ad.8xlarge",
-    "down": "c5ad.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "32.0"
-  },
-  "c5ad.8xlarge": {
-    "up": "c5ad.12xlarge",
-    "down": "c5ad.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "64.0"
-  },
-  "c5ad.12xlarge": {
-    "up": "c5ad.16xlarge",
-    "down": "c5ad.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "96.0"
-  },
-  "c5ad.16xlarge": {
-    "up": "c5ad.24xlarge",
-    "down": "c5ad.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "128.0"
-  },
-  "c5ad.24xlarge": {
-    "up": null,
-    "down": "c5ad.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "192.0"
-  },
-  "c5n.large": {
-    "up": "c5n.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "5.25"
-  },
-  "c5n.xlarge": {
-    "up": "c5n.2xlarge",
-    "down": "c5n.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "10.5"
-  },
-  "c5n.2xlarge": {
-    "up": "c5n.4xlarge",
-    "down": "c5n.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "21.0"
-  },
-  "c5n.4xlarge": {
-    "up": "c5n.9xlarge",
-    "down": "c5n.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "42.0"
-  },
-  "c5n.9xlarge": {
-    "up": "c5n.18xlarge",
-    "down": "c5n.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "36",
-    "nfu": "72",
-    "memory": "96.0"
-  },
-  "c5n.18xlarge": {
-    "up": null,
-    "down": "c5n.9xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "72",
-    "nfu": "144",
-    "memory": "192.0"
-  },
-  "c5n.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "72",
-    "memory": "192.0"
-  },
-  "c6a.large": {
-    "up": "c6a.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "4.0"
-  },
-  "c6a.xlarge": {
-    "up": "c6a.2xlarge",
-    "down": "c6a.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "8.0"
-  },
-  "c6a.2xlarge": {
-    "up": "c6a.4xlarge",
-    "down": "c6a.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "16.0"
-  },
-  "c6a.4xlarge": {
-    "up": "c6a.8xlarge",
-    "down": "c6a.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "32.0"
-  },
-  "c6a.8xlarge": {
-    "up": "c6a.12xlarge",
-    "down": "c6a.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "64.0"
-  },
-  "c6a.12xlarge": {
-    "up": "c6a.16xlarge",
-    "down": "c6a.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "96.0"
-  },
-  "c6a.16xlarge": {
-    "up": "c6a.24xlarge",
-    "down": "c6a.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "128.0"
-  },
-  "c6a.24xlarge": {
-    "up": "c6a.32xlarge",
-    "down": "c6a.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "192.0"
-  },
-  "c6a.32xlarge": {
-    "up": "c6a.48xlarge",
-    "down": "c6a.24xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "128",
-    "nfu": "256",
-    "memory": "256.0"
-  },
-  "c6a.48xlarge": {
-    "up": null,
-    "down": "c6a.32xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "192",
-    "nfu": "384",
-    "memory": "384.0"
-  },
-  "c6a.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "192",
-    "nfu": "384",
-    "memory": "384.0"
-  },
-  "c6g.medium": {
-    "up": "c6g.large",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "1",
-    "nfu": "2",
-    "memory": "2.0"
-  },
-  "c6g.large": {
-    "up": "c6g.xlarge",
-    "down": "c6g.medium",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "4.0"
-  },
-  "c6g.xlarge": {
-    "up": "c6g.2xlarge",
-    "down": "c6g.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "8.0"
-  },
-  "c6g.2xlarge": {
-    "up": "c6g.4xlarge",
-    "down": "c6g.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "16.0"
-  },
-  "c6g.4xlarge": {
-    "up": "c6g.8xlarge",
-    "down": "c6g.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "32.0"
-  },
-  "c6g.8xlarge": {
-    "up": "c6g.12xlarge",
-    "down": "c6g.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "64.0"
-  },
-  "c6g.12xlarge": {
-    "up": "c6g.16xlarge",
-    "down": "c6g.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "96.0"
-  },
-  "c6g.16xlarge": {
-    "up": null,
-    "down": "c6g.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "128.0"
-  },
-  "c6g.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "memory": "128.0"
-  },
-  "c6gd.medium": {
-    "up": "c6gd.large",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "1",
-    "nfu": "2",
-    "memory": "2.0"
-  },
-  "c6gd.large": {
-    "up": "c6gd.xlarge",
-    "down": "c6gd.medium",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "4.0"
-  },
-  "c6gd.xlarge": {
-    "up": "c6gd.2xlarge",
-    "down": "c6gd.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "8.0"
-  },
-  "c6gd.2xlarge": {
-    "up": "c6gd.4xlarge",
-    "down": "c6gd.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "16.0"
-  },
-  "c6gd.4xlarge": {
-    "up": "c6gd.8xlarge",
-    "down": "c6gd.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "32.0"
-  },
-  "c6gd.8xlarge": {
-    "up": "c6gd.12xlarge",
-    "down": "c6gd.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "64.0"
-  },
-  "c6gd.12xlarge": {
-    "up": "c6gd.16xlarge",
-    "down": "c6gd.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "96.0"
-  },
-  "c6gd.16xlarge": {
-    "up": null,
-    "down": "c6gd.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "128.0"
-  },
-  "c6gd.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "memory": "128.0"
-  },
-  "c6gn.medium": {
-    "up": "c6gn.large",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "1",
-    "nfu": "2",
-    "memory": "2.0"
-  },
-  "c6gn.large": {
-    "up": "c6gn.xlarge",
-    "down": "c6gn.medium",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "4.0"
-  },
-  "c6gn.xlarge": {
-    "up": "c6gn.2xlarge",
-    "down": "c6gn.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "8.0"
-  },
-  "c6gn.2xlarge": {
-    "up": "c6gn.4xlarge",
-    "down": "c6gn.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "16.0"
-  },
-  "c6gn.4xlarge": {
-    "up": "c6gn.8xlarge",
-    "down": "c6gn.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "32.0"
-  },
-  "c6gn.8xlarge": {
-    "up": "c6gn.12xlarge",
-    "down": "c6gn.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "64.0"
-  },
-  "c6gn.12xlarge": {
-    "up": "c6gn.16xlarge",
-    "down": "c6gn.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "96.0"
-  },
-  "c6gn.16xlarge": {
-    "up": null,
-    "down": "c6gn.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "128.0"
-  },
-  "c6i.large": {
-    "up": "c6i.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "4.0"
-  },
-  "c6i.xlarge": {
-    "up": "c6i.2xlarge",
-    "down": "c6i.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "8.0"
-  },
-  "c6i.2xlarge": {
-    "up": "c6i.4xlarge",
-    "down": "c6i.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "16.0"
-  },
-  "c6i.4xlarge": {
-    "up": "c6i.8xlarge",
-    "down": "c6i.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "32.0"
-  },
-  "c6i.8xlarge": {
-    "up": "c6i.12xlarge",
-    "down": "c6i.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "64.0"
-  },
-  "c6i.12xlarge": {
-    "up": "c6i.16xlarge",
-    "down": "c6i.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "96.0"
-  },
-  "c6i.16xlarge": {
-    "up": "c6i.24xlarge",
-    "down": "c6i.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "128.0"
-  },
-  "c6i.24xlarge": {
-    "up": "c6i.32xlarge",
-    "down": "c6i.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "192.0"
-  },
-  "c6i.32xlarge": {
-    "up": null,
-    "down": "c6i.24xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "128",
-    "nfu": "256",
-    "memory": "256.0"
-  },
-  "c6i.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "128",
-    "nfu": "256",
-    "memory": "256.0"
-  },
-  "c6id.large": {
-    "up": "c6id.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "4.0"
-  },
-  "c6id.xlarge": {
-    "up": "c6id.2xlarge",
-    "down": "c6id.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "8.0"
-  },
-  "c6id.2xlarge": {
-    "up": "c6id.4xlarge",
-    "down": "c6id.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "16.0"
-  },
-  "c6id.4xlarge": {
-    "up": "c6id.8xlarge",
-    "down": "c6id.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "32.0"
-  },
-  "c6id.8xlarge": {
-    "up": "c6id.12xlarge",
-    "down": "c6id.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "64.0"
-  },
-  "c6id.12xlarge": {
-    "up": "c6id.16xlarge",
-    "down": "c6id.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "96.0"
-  },
-  "c6id.16xlarge": {
-    "up": "c6id.24xlarge",
-    "down": "c6id.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "128.0"
-  },
-  "c6id.24xlarge": {
-    "up": "c6id.32xlarge",
-    "down": "c6id.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "192.0"
-  },
-  "c6id.32xlarge": {
-    "up": null,
-    "down": "c6id.24xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "128",
-    "nfu": "256",
-    "memory": "256.0"
-  },
-  "c6id.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "128",
-    "nfu": "256",
-    "memory": "256.0"
-  },
-  "c7g.medium": {
-    "up": "c7g.large",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "1",
-    "nfu": "2",
-    "memory": "2.0"
-  },
-  "c7g.large": {
-    "up": "c7g.xlarge",
-    "down": "c7g.medium",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "4.0"
-  },
-  "c7g.xlarge": {
-    "up": "c7g.2xlarge",
-    "down": "c7g.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "8.0"
-  },
-  "c7g.2xlarge": {
-    "up": "c7g.4xlarge",
-    "down": "c7g.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "16.0"
-  },
-  "c7g.4xlarge": {
-    "up": "c7g.8xlarge",
-    "down": "c7g.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "32.0"
-  },
-  "c7g.8xlarge": {
-    "up": "c7g.12xlarge",
-    "down": "c7g.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "64.0"
-  },
-  "c7g.12xlarge": {
-    "up": "c7g.16xlarge",
-    "down": "c7g.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "96.0"
-  },
-  "c7g.16xlarge": {
-    "up": null,
-    "down": "c7g.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "128.0"
-  },
-  "cc1.4xlarge": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "nfu": "32"
-  },
-  "cc2.8xlarge": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "60.5"
-  },
-  "cg1.4xlarge": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "nfu": "32"
-  },
-  "cr1.8xlarge": {
-    "up": null,
-    "down": null,
-    "superseded": {
-      "regular": "r3.8xlarge",
-      "next_gen": "r4.8xlarge",
-      "burstable": "",
-      "amd": ""
-    },
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "244.0"
-  },
-  "d2.xlarge": {
-    "up": "d2.2xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "30.5"
-  },
-  "d2.2xlarge": {
-    "up": "d2.4xlarge",
-    "down": "d2.xlarge",
-    "superseded": null,
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "61.0"
-  },
-  "d2.4xlarge": {
-    "up": "d2.8xlarge",
-    "down": "d2.2xlarge",
-    "superseded": null,
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "122.0"
-  },
-  "d2.8xlarge": {
-    "up": null,
-    "down": "d2.4xlarge",
-    "superseded": null,
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "36",
-    "nfu": "64",
-    "memory": "244.0"
-  },
-  "d3.xlarge": {
-    "up": "d3.2xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "32.0"
-  },
-  "d3.2xlarge": {
-    "up": "d3.4xlarge",
-    "down": "d3.xlarge",
-    "superseded": null,
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "64.0"
-  },
-  "d3.4xlarge": {
-    "up": "d3.8xlarge",
-    "down": "d3.2xlarge",
-    "superseded": null,
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "128.0"
-  },
-  "d3.8xlarge": {
-    "up": null,
-    "down": "d3.4xlarge",
-    "superseded": null,
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "256.0"
-  },
-  "d3en.xlarge": {
-    "up": "d3en.2xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "16.0"
-  },
-  "d3en.2xlarge": {
-    "up": "d3en.4xlarge",
-    "down": "d3en.xlarge",
-    "superseded": null,
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "32.0"
-  },
-  "d3en.4xlarge": {
-    "up": "d3en.6xlarge",
-    "down": "d3en.2xlarge",
-    "superseded": null,
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "64.0"
-  },
-  "d3en.6xlarge": {
-    "up": "d3en.8xlarge",
-    "down": "d3en.4xlarge",
-    "superseded": null,
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "24",
-    "nfu": "48",
-    "memory": "96.0"
-  },
-  "d3en.8xlarge": {
-    "up": "d3en.12xlarge",
-    "down": "d3en.6xlarge",
-    "superseded": null,
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "128.0"
-  },
-  "d3en.12xlarge": {
-    "up": null,
-    "down": "d3en.8xlarge",
-    "superseded": null,
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "192.0"
-  },
-  "p2.xlarge": {
-    "up": "p2.8xlarge",
-    "down": null,
-    "superseded": {
-      "regular": "p3.xlarge",
-      "next_gen": null,
-      "burstable": "",
-      "amd": ""
-    },
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "61.0"
-  },
-  "p2.8xlarge": {
-    "up": "p2.16xlarge",
-    "down": "p2.xlarge",
-    "superseded": {
-      "regular": "p3.8xlarge",
-      "next_gen": null,
-      "burstable": "",
-      "amd": ""
-    },
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "488.0"
-  },
-  "p2.16xlarge": {
-    "up": null,
-    "down": "p2.8xlarge",
-    "superseded": {
-      "regular": "p3.16xlarge",
-      "next_gen": null,
-      "burstable": "",
-      "amd": ""
-    },
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "732.0"
-  },
-  "p3.2xlarge": {
-    "up": "p3.8xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "61.0"
-  },
-  "p3.8xlarge": {
-    "up": "p3.16xlarge",
-    "down": "p3.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "244.0"
-  },
-  "p3.16xlarge": {
-    "up": "p3dn.24xlarge",
-    "down": "p3.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "488.0"
-  },
-  "p3dn.24xlarge": {
-    "up": null,
-    "down": "p3.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "768.0"
-  },
-  "inf1.xlarge": {
-    "up": "inf1.2xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "8.0"
-  },
-  "inf1.2xlarge": {
-    "up": "inf1.6xlarge",
-    "down": "inf1.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "16.0"
-  },
-  "inf1.6xlarge": {
-    "up": "inf1.24xlarge",
-    "down": "inf1.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "24",
-    "nfu": "48",
-    "memory": "48.0"
-  },
-  "inf1.24xlarge": {
-    "up": null,
-    "down": "inf1.6xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "192.0"
-  },
-  "g2.2xlarge": {
-    "up": "g2.8xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "15.0"
-  },
-  "g2.8xlarge": {
-    "up": null,
-    "down": "g2.2xlarge",
-    "superseded": null,
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "60.0"
-  },
-  "g3s.xlarge": {
-    "up": "g3.4xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "30.5"
-  },
-  "g3.4xlarge": {
-    "up": "g3.8xlarge",
-    "down": "g3s.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "122.0"
-  },
-  "g3.8xlarge": {
-    "up": "g3.16xlarge",
-    "down": "g3.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "244.0"
-  },
-  "g3.16xlarge": {
-    "up": null,
-    "down": "g3.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "488.0"
-  },
-  "g4.large": {
-    "up": "g4.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "nfu": "4"
-  },
-  "g4.2xlarge": {
-    "up": "g4.4xlarge",
-    "down": "g4.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "nfu": "16"
-  },
-  "g4.4xlarge": {
-    "up": "g4.8xlarge",
-    "down": "g4.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "nfu": "32"
-  },
-  "g4.8xlarge": {
-    "up": "g4.16xlarge",
-    "down": "g4.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "nfu": "64"
-  },
-  "g4.16xlarge": {
-    "up": null,
-    "down": "g4.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "nfu": "128"
-  },
-  "g4dn.12xlarge": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "192.0"
-  },
-  "g4dn.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "memory": "384.0"
-  },
-  "g4ad.4xlarge": {
-    "up": "g4ad.8xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "64.0"
-  },
-  "g4ad.8xlarge": {
-    "up": "g4ad.16xlarge",
-    "down": "g4ad.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "128.0"
-  },
-  "g4ad.16xlarge": {
-    "up": null,
-    "down": "g4ad.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "256.0"
-  },
-  "g4dn.xlarge": {
-    "up": "g4dn.2xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "16.0"
-  },
-  "g4dn.2xlarge": {
-    "up": "g4dn.4xlarge",
-    "down": "g4dn.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "32.0"
-  },
-  "g4dn.4xlarge": {
-    "up": "g4dn.8xlarge",
-    "down": "g4dn.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "64.0"
-  },
-  "g4dn.8xlarge": {
-    "up": "g4dn.16xlarge",
-    "down": "g4dn.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "128.0"
-  },
-  "g4dn.16xlarge": {
-    "up": null,
-    "down": "g4dn.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "256.0"
-  },
-  "g5g.xlarge": {
-    "up": "g5g.2xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": false,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "8.0"
-  },
-  "g5g.2xlarge": {
-    "up": "g5g.4xlarge",
-    "down": "g5g.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": false,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "16.0"
-  },
-  "g5g.4xlarge": {
-    "up": "g5g.8xlarge",
-    "down": "g5g.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": false,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "32.0"
-  },
-  "g5g.8xlarge": {
-    "up": "g5g.16xlarge",
-    "down": "g5g.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": false,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "64.0"
-  },
-  "g5g.16xlarge": {
-    "up": "g5g.metal",
-    "down": "g5g.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": false,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "128.0"
-  },
-  "g5g.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": false,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "128.0"
-  },
-  "f1.2xlarge": {
-    "up": "f1.4xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "122.0"
-  },
-  "f1.4xlarge": {
-    "up": "f1.16xlarge",
-    "down": "f1.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "244.0"
-  },
-  "f1.16xlarge": {
-    "up": null,
-    "down": "f1.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "976.0"
-  },
-  "h1.2xlarge": {
-    "up": "h1.4xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "32.0"
-  },
-  "h1.4xlarge": {
-    "up": "h1.8xlarge",
-    "down": "h1.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "64.0"
-  },
-  "h1.8xlarge": {
-    "up": "h1.16xlarge",
-    "down": "h1.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "128.0"
-  },
-  "h1.16xlarge": {
-    "up": null,
-    "down": "h1.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "256.0"
-  },
-  "hi1.4xlarge": {
-    "up": "hs1.8xlarge",
-    "down": null,
-    "superseded": {
-      "regular": "i3.4xlarge",
-      "next_gen": "",
-      "burstable": "",
-      "amd": ""
-    },
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "nfu": "32"
-  },
-  "hs1.8xlarge": {
-    "up": null,
-    "down": "hi1.4xlarge",
-    "superseded": {
-      "regular": "d2.8xlarge",
-      "next_gen": "",
-      "burstable": "",
-      "amd": ""
-    },
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "16",
-    "nfu": "64",
-    "memory": "117.0"
-  },
-  "i2.xlarge": {
-    "up": "i2.2xlarge",
-    "down": null,
-    "superseded": {
-      "regular": "i3.xlarge",
-      "next_gen": "",
-      "burstable": "",
-      "amd": ""
-    },
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "30.5"
-  },
-  "i2.2xlarge": {
-    "up": "i2.4xlarge",
-    "down": "i2.xlarge",
-    "superseded": {
-      "regular": "i3.2xlarge",
-      "next_gen": "",
-      "burstable": "",
-      "amd": ""
-    },
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "61.0"
-  },
-  "i2.4xlarge": {
-    "up": "i2.8xlarge",
-    "down": "i2.2xlarge",
-    "superseded": {
-      "regular": "i3.4xlarge",
-      "next_gen": "",
-      "burstable": "",
-      "amd": ""
-    },
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "122.0"
-  },
-  "i2.8xlarge": {
-    "up": null,
-    "down": "i2.4xlarge",
-    "superseded": {
-      "regular": "i3.8xlarge",
-      "next_gen": "",
-      "burstable": "",
-      "amd": ""
-    },
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "244.0"
-  },
-  "i3.large": {
-    "up": "i3.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "15.25"
-  },
-  "i3.xlarge": {
-    "up": "i3.2xlarge",
-    "down": "i3.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "30.5"
-  },
-  "i3.2xlarge": {
-    "up": "i3.4xlarge",
-    "down": "i3.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "61.0"
-  },
-  "i3.4xlarge": {
-    "up": "i3.8xlarge",
-    "down": "i3.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "122.0"
-  },
-  "i3.8xlarge": {
-    "up": "i3.16xlarge",
-    "down": "i3.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "244.0"
-  },
-  "i3.16xlarge": {
-    "up": null,
-    "down": "i3.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "488.0"
-  },
-  "i3.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "memory": "512.0"
-  },
-  "i3en.large": {
-    "up": "i3en.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "16.0"
-  },
-  "i3en.xlarge": {
-    "up": "i3en.2xlarge",
-    "down": "i3en.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "32.0"
-  },
-  "i3en.2xlarge": {
-    "up": "i3en.3xlarge",
-    "down": "i3en.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "64.0"
-  },
-  "i3en.3xlarge": {
-    "up": "i3en.6xlarge",
-    "down": "i3en.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "12",
-    "nfu": "24",
-    "memory": "96.0"
-  },
-  "i3en.6xlarge": {
-    "up": "i3en.12xlarge",
-    "down": "i3en.3xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "24",
-    "nfu": "48",
-    "memory": "192.0"
-  },
-  "i3en.12xlarge": {
-    "up": "i3en.24xlarge",
-    "down": "i3en.6xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "384.0"
-  },
-  "i3en.24xlarge": {
-    "up": null,
-    "down": "i3en.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "768.0"
-  },
-  "i3en.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "memory": "768.0"
-  },
-  "im4gn.large": {
-    "up": "im4gn.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "8",
-    "memory": "8.0"
-  },
-  "im4gn.xlarge": {
-    "up": "im4gn.2xlarge",
-    "down": "im4gn.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "16",
-    "memory": "16.0"
-  },
-  "im4gn.2xlarge": {
-    "up": "im4gn.4xlarge",
-    "down": "im4gn.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "32",
-    "memory": "32.0"
-  },
-  "im4gn.4xlarge": {
-    "up": "im4gn.8xlarge",
-    "down": "im4gn.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "64",
-    "memory": "64.0"
-  },
-  "im4gn.8xlarge": {
-    "up": "im4gn.16xlarge",
-    "down": "im4gn.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "128",
-    "memory": "128.0"
-  },
-  "im4gn.16xlarge": {
-    "up": null,
-    "down": "im4gn.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "256",
-    "memory": "256.0"
-  },
-  "is4gen.medium": {
-    "up": "is4gen.large",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "1",
-    "nfu": "6",
-    "memory": "6.0"
-  },
-  "is4gen.large": {
-    "up": "is4gen.xlarge",
-    "down": "is4gen.medium",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "12",
-    "memory": "12.0"
-  },
-  "is4gen.xlarge": {
-    "up": "is4gen.2xlarge",
-    "down": "is4gen.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "24",
-    "memory": "24.0"
-  },
-  "is4gen.2xlarge": {
-    "up": "is4gen.4xlarge",
-    "down": "is4gen.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "48",
-    "memory": "48.0"
-  },
-  "is4gen.4xlarge": {
-    "up": "is4gen.8xlarge",
-    "down": "is4gen.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "96",
-    "memory": "96.0"
-  },
-  "is4gen.8xlarge": {
-    "up": null,
-    "down": "is4gen.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "192",
-    "memory": "192.0"
-  },
-  "m1.small": {
-    "up": "m1.medium",
-    "down": null,
-    "superseded": {
-      "regular": "t3.large",
-      "next_gen": "",
-      "burstable": "t3.large",
-      "amd": "m5a.large"
-    },
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "1",
-    "nfu": "1",
-    "memory": "1.7"
-  },
-  "m1.medium": {
-    "up": "m1.large",
-    "down": "m1.small",
-    "superseded": {
-      "regular": "m5.large",
-      "next_gen": "",
-      "burstable": "t3.large",
-      "amd": "m5a.large"
-    },
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "1",
-    "nfu": "2",
-    "memory": "3.75"
-  },
-  "m1.large": {
-    "up": "m1.xlarge",
-    "down": "m1.medium",
-    "superseded": {
-      "regular": "m5.large",
-      "next_gen": "",
-      "burstable": "t3.xlarge",
-      "amd": "m5a.large"
-    },
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "7.5"
-  },
-  "m1.xlarge": {
-    "up": null,
-    "down": "m1.large",
-    "superseded": {
-      "regular": "m5.xlarge",
-      "next_gen": "",
-      "burstable": "t3.2xlarge",
-      "amd": "m5a.xlarge"
-    },
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "15.0"
-  },
-  "m2.xlarge": {
-    "up": "m2.2xlarge",
-    "down": null,
-    "superseded": {
-      "regular": "r3.large",
-      "next_gen": "r5.large",
-      "burstable": "",
-      "amd": "r5a.large"
-    },
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "2",
-    "nfu": "8",
-    "memory": "17.1"
-  },
-  "m2.2xlarge": {
-    "up": "m2.4xlarge",
-    "down": "m2.xlarge",
-    "superseded": {
-      "regular": "r3.xlarge",
-      "next_gen": "r5.xlarge",
-      "burstable": "",
-      "amd": "r5a.xlarge"
-    },
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "4",
-    "nfu": "16",
-    "memory": "34.2"
-  },
-  "m2.4xlarge": {
-    "up": null,
-    "down": "m2.2xlarge",
-    "superseded": {
-      "regular": "r3.2xlarge",
-      "next_gen": "r5.2xlarge",
-      "burstable": "",
-      "amd": "r5a.2xlarge"
-    },
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "8",
-    "nfu": "32",
-    "memory": "68.4"
-  },
-  "m3.medium": {
-    "up": "m3.large",
-    "down": null,
-    "superseded": {
-      "regular": "m5.large",
-      "next_gen": "",
-      "burstable": "t3.large",
-      "amd": "m5a.large"
-    },
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "1",
-    "nfu": "2",
-    "memory": "3.75"
-  },
-  "m3.large": {
-    "up": "m3.xlarge",
-    "down": "m3.medium",
-    "superseded": {
-      "regular": "m5.large",
-      "next_gen": "",
-      "burstable": "t3.xlarge",
-      "amd": "m5a.large"
-    },
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "7.5"
-  },
-  "m3.xlarge": {
-    "up": "m3.2xlarge",
-    "down": "m3.large",
-    "superseded": {
-      "regular": "m5.xlarge",
-      "next_gen": "",
-      "burstable": "t3.2xlarge",
-      "amd": "m5a.xlarge"
-    },
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "15.0"
-  },
-  "m3.2xlarge": {
-    "up": null,
-    "down": "m3.xlarge",
-    "superseded": {
-      "regular": "m5.2xlarge",
-      "next_gen": "",
-      "burstable": "",
-      "amd": "m5a.2xlarge"
-    },
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "30.0"
-  },
-  "m4.large": {
-    "up": "m4.xlarge",
-    "down": null,
-    "superseded": {
-      "regular": "m5.large",
-      "next_gen": "",
-      "burstable": "t3.xlarge",
-      "amd": "m5a.large"
-    },
-    "ec2_classic": false,
-    "enhanced_networking": false,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "8.0"
-  },
-  "m4.xlarge": {
-    "up": "m4.2xlarge",
-    "down": "m4.large",
-    "superseded": {
-      "regular": "m5.xlarge",
-      "next_gen": "",
-      "burstable": "t3.2xlarge",
-      "amd": "m5a.xlarge"
-    },
-    "ec2_classic": false,
-    "enhanced_networking": false,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "16.0"
-  },
-  "m4.2xlarge": {
-    "up": "m4.4xlarge",
-    "down": "m4.xlarge",
-    "superseded": {
-      "regular": "m5.2xlarge",
-      "next_gen": "",
-      "burstable": "",
-      "amd": "m5a.2xlarge"
-    },
-    "ec2_classic": false,
-    "enhanced_networking": false,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "32.0"
-  },
-  "m4.4xlarge": {
-    "up": "m4.10xlarge",
-    "down": "m4.2xlarge",
-    "superseded": {
-      "regular": "m5.4xlarge",
-      "next_gen": "",
-      "burstable": "",
-      "amd": "m5a.4xlarge"
-    },
-    "ec2_classic": false,
-    "enhanced_networking": false,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "64.0"
-  },
-  "m4.10xlarge": {
-    "up": "m4.16xlarge",
-    "down": "m4.4xlarge",
-    "superseded": {
-      "regular": "m5.12xlarge",
-      "next_gen": "",
-      "burstable": "",
-      "amd": "m5a.12xlarge"
-    },
-    "ec2_classic": false,
-    "enhanced_networking": false,
-    "vcpu": "40",
-    "nfu": "80",
-    "memory": "160.0"
-  },
-  "m4.16xlarge": {
-    "up": null,
-    "down": "m4.10xlarge",
-    "superseded": {
-      "regular": "m5.16xlarge",
-      "next_gen": "",
-      "burstable": "",
-      "amd": "m5a.16xlarge"
-    },
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "256.0"
-  },
-  "m5.large": {
-    "up": "m5.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "8.0"
-  },
-  "m5.xlarge": {
-    "up": "m5.2xlarge",
-    "down": "m5.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "16.0"
-  },
-  "m5.2xlarge": {
-    "up": "m5.4xlarge",
-    "down": "m5.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "32.0"
-  },
-  "m5.4xlarge": {
-    "up": "m5.8xlarge",
-    "down": "m5.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "64.0"
-  },
-  "m5.8xlarge": {
-    "up": "m5.12xlarge",
-    "down": "m5.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "128.0"
-  },
-  "m5.12xlarge": {
-    "up": "m5.16xlarge",
-    "down": "m5.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "192.0"
-  },
-  "m5.16xlarge": {
-    "up": "m5.24xlarge",
-    "down": "m5.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "256.0"
-  },
-  "m5.24xlarge": {
-    "up": null,
-    "down": "m5.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "384.0"
-  },
-  "m5.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "memory": "384.0"
-  },
-  "m5n.large": {
-    "up": "m5n.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "8.0"
-  },
-  "m5n.xlarge": {
-    "up": "m5n.2xlarge",
-    "down": "m5n.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "16.0"
-  },
-  "m5n.2xlarge": {
-    "up": "m5n.4xlarge",
-    "down": "m5n.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "32.0"
-  },
-  "m5n.4xlarge": {
-    "up": "m5n.8xlarge",
-    "down": "m5n.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "64.0"
-  },
-  "m5n.8xlarge": {
-    "up": "m5n.12xlarge",
-    "down": "m5n.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "128.0"
-  },
-  "m5n.12xlarge": {
-    "up": "m5n.16xlarge",
-    "down": "m5n.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "192.0"
-  },
-  "m5n.16xlarge": {
-    "up": "m5n.24xlarge",
-    "down": "m5n.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "256.0"
-  },
-  "m5n.24xlarge": {
-    "up": null,
-    "down": "m5n.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "384.0"
-  },
-  "m5n.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "memory": "384.0"
-  },
-  "m5dn.large": {
-    "up": "m5dn.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "8.0"
-  },
-  "m5dn.xlarge": {
-    "up": "m5dn.2xlarge",
-    "down": "m5dn.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "16.0"
-  },
-  "m5dn.2xlarge": {
-    "up": "m5dn.4xlarge",
-    "down": "m5dn.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "32.0"
-  },
-  "m5dn.4xlarge": {
-    "up": "m5dn.8xlarge",
-    "down": "m5dn.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "64.0"
-  },
-  "m5dn.8xlarge": {
-    "up": "m5dn.12xlarge",
-    "down": "m5dn.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "128.0"
-  },
-  "m5dn.12xlarge": {
-    "up": "m5dn.16xlarge",
-    "down": "m5dn.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "192.0"
-  },
-  "m5dn.16xlarge": {
-    "up": "m5dn.24xlarge",
-    "down": "m5dn.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "256.0"
-  },
-  "m5dn.24xlarge": {
-    "up": null,
-    "down": "m5dn.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "384.0"
-  },
-  "m5dn.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "memory": "384.0"
-  },
-  "m5zn.large": {
-    "up": "m5zn.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "8.0"
-  },
-  "m5zn.xlarge": {
-    "up": "m5zn.2xlarge",
-    "down": "m5zn.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "16.0"
-  },
-  "m5zn.2xlarge": {
-    "up": "m5zn.3xlarge",
-    "down": "m5zn.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "32.0"
-  },
-  "m5zn.3xlarge": {
-    "up": "m5zn.6xlarge",
-    "down": "m5zn.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "12",
-    "nfu": "24",
-    "memory": "48.0"
-  },
-  "m5zn.6xlarge": {
-    "up": "m5zn.12xlarge",
-    "down": "m5zn.3xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "24",
-    "nfu": "48",
-    "memory": "96.0"
-  },
-  "m5zn.12xlarge": {
-    "up": null,
-    "down": "m5zn.6xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "192.0"
-  },
-  "m5zn.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "memory": "192.0"
-  },
-  "mac1.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "12",
-    "memory": "32.0"
-  },
-  "p4d.24xlarge": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "1152.0"
-  },
-  "m6a.large": {
-    "up": "m6a.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "8.0"
-  },
-  "m6a.xlarge": {
-    "up": "m6a.2xlarge",
-    "down": "m6a.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "16.0"
-  },
-  "m6a.2xlarge": {
-    "up": "m6a.4xlarge",
-    "down": "m6a.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "32.0"
-  },
-  "m6a.4xlarge": {
-    "up": "m6a.8xlarge",
-    "down": "m6a.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "64.0"
-  },
-  "m6a.8xlarge": {
-    "up": "m6a.12xlarge",
-    "down": "m6a.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "128.0"
-  },
-  "m6a.12xlarge": {
-    "up": "m6a.16xlarge",
-    "down": "m6a.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "192.0"
-  },
-  "m6a.16xlarge": {
-    "up": "m6a.24xlarge",
-    "down": "m6a.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "256.0"
-  },
-  "m6a.24xlarge": {
-    "up": "m6a.32xlarge",
-    "down": "m6a.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "384.0"
-  },
-  "m6a.32xlarge": {
-    "up": "m6a.48xlarge",
-    "down": "m6a.24xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "128",
-    "nfu": "256",
-    "memory": "512.0"
-  },
-  "m6a.48xlarge": {
-    "up": null,
-    "down": "m6a.32xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "192",
-    "nfu": "384",
-    "memory": "768.0"
-  },
-  "m6a.metal": {
-    "up": null,
-    "down": "m6a.32xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "192",
-    "nfu": "384",
-    "memory": "768.0"
-  },
-  "m6g.medium": {
-    "up": "m6g.large",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "1",
-    "nfu": "2",
-    "memory": "4.0"
-  },
-  "m6g.large": {
-    "up": "m6g.xlarge",
-    "down": "m6g.medium",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "8.0"
-  },
-  "m6g.xlarge": {
-    "up": "m6g.2xlarge",
-    "down": "m6g.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "16.0"
-  },
-  "m6g.2xlarge": {
-    "up": "m6g.4xlarge",
-    "down": "m6g.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "32.0"
-  },
-  "m6g.4xlarge": {
-    "up": "m6g.8xlarge",
-    "down": "m6g.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "64.0"
-  },
-  "m6g.8xlarge": {
-    "up": "m6g.12xlarge",
-    "down": "m6g.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "128.0"
-  },
-  "m6g.12xlarge": {
-    "up": "m6g.16xlarge",
-    "down": "m6g.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "192.0"
-  },
-  "m6g.16xlarge": {
-    "up": "m6g.24xlarge",
-    "down": "m6g.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "256.0"
-  },
-  "m6g.24xlarge": {
-    "up": null,
-    "down": "m6g.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "nfu": "192"
-  },
-  "m6g.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "memory": "256.0"
-  },
-  "m6gd.medium": {
-    "up": "m6gd.large",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "1",
-    "nfu": "2",
-    "memory": "4.0"
-  },
-  "m6gd.large": {
-    "up": "m6gd.xlarge",
-    "down": "m6gd.medium",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "8.0"
-  },
-  "m6gd.xlarge": {
-    "up": "m6gd.2xlarge",
-    "down": "m6gd.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "16.0"
-  },
-  "m6gd.2xlarge": {
-    "up": "m6gd.4xlarge",
-    "down": "m6gd.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "32.0"
-  },
-  "m6gd.4xlarge": {
-    "up": "m6gd.8xlarge",
-    "down": "m6gd.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "64.0"
-  },
-  "m6gd.8xlarge": {
-    "up": "m6gd.12xlarge",
-    "down": "m6gd.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "128.0"
-  },
-  "m6gd.12xlarge": {
-    "up": "m6gd.16xlarge",
-    "down": "m6gd.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "192.0"
-  },
-  "m6gd.16xlarge": {
-    "up": "m6gd.24xlarge",
-    "down": "m6gd.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "256.0"
-  },
-  "m6gd.24xlarge": {
-    "up": null,
-    "down": "m6gd.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "nfu": "192"
-  },
-  "m6gd.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "memory": "256.0"
-  },
-  "m6i.large": {
-    "up": "m6i.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "8.0"
-  },
-  "m6i.xlarge": {
-    "up": "m6i.2xlarge",
-    "down": "m6i.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "16.0"
-  },
-  "m6i.2xlarge": {
-    "up": "m6i.4xlarge",
-    "down": "m6i.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "32.0"
-  },
-  "m6i.4xlarge": {
-    "up": "m6i.8xlarge",
-    "down": "m6i.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "64.0"
-  },
-  "m6i.8xlarge": {
-    "up": "m6i.12xlarge",
-    "down": "m6i.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "128.0"
-  },
-  "m6i.12xlarge": {
-    "up": "m6i.16xlarge",
-    "down": "m6i.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "192.0"
-  },
-  "m6i.16xlarge": {
-    "up": "m6i.24xlarge",
-    "down": "m6i.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "256.0"
-  },
-  "m6i.24xlarge": {
-    "up": "m6i.32xlarge",
-    "down": "m6i.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "384.0"
-  },
-  "m6i.32xlarge": {
-    "up": null,
-    "down": "m6i.24xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "128",
-    "nfu": "256",
-    "memory": "512.0"
-  },
-  "m6i.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "128",
-    "nfu": "256",
-    "memory": "512.0"
-  },
-  "m6id.large": {
-    "up": "m6id.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "8.0"
-  },
-  "m6id.xlarge": {
-    "up": "m6id.2xlarge",
-    "down": "m6id.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "16.0"
-  },
-  "m6id.2xlarge": {
-    "up": "m6id.4xlarge",
-    "down": "m6id.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "32.0"
-  },
-  "m6id.4xlarge": {
-    "up": "m6id.8xlarge",
-    "down": "m6id.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "64.0"
-  },
-  "m6id.8xlarge": {
-    "up": "m6id.12xlarge",
-    "down": "m6id.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "128.0"
-  },
-  "m6id.12xlarge": {
-    "up": "m6id.16xlarge",
-    "down": "m6id.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "192.0"
-  },
-  "m6id.16xlarge": {
-    "up": "m6id.24xlarge",
-    "down": "m6id.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "256.0"
-  },
-  "m6id.24xlarge": {
-    "up": "m6id.32xlarge",
-    "down": "m6id.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "384.0"
-  },
-  "m6id.32xlarge": {
-    "up": null,
-    "down": "m6id.24xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "128",
-    "nfu": "256",
-    "memory": "512.0"
-  },
-  "m6id.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "128",
-    "nfu": "256",
-    "memory": "512.0"
-  },
-  "m5a.large": {
-    "up": "m5a.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "8.0"
-  },
-  "m5a.xlarge": {
-    "up": "m5a.2xlarge",
-    "down": "m5a.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "16.0"
-  },
-  "m5a.2xlarge": {
-    "up": "m5a.4xlarge",
-    "down": "m5a.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "32.0"
-  },
-  "m5a.4xlarge": {
-    "up": "m5a.8xlarge",
-    "down": "m5a.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "64.0"
-  },
-  "m5a.8xlarge": {
-    "up": "m5a.12xlarge",
-    "down": "m5a.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "128.0"
-  },
-  "m5a.12xlarge": {
-    "up": "m5a.16xlarge",
-    "down": "m5a.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "192.0"
-  },
-  "m5a.16xlarge": {
-    "up": "m5a.24xlarge",
-    "down": "m5a.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "256.0"
-  },
-  "m5a.24xlarge": {
-    "up": null,
-    "down": "m5a.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "384.0"
-  },
-  "m5ad.large": {
-    "up": "m5ad.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "8.0"
-  },
-  "m5ad.xlarge": {
-    "up": "m5ad.2xlarge",
-    "down": "m5ad.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "16.0"
-  },
-  "m5ad.2xlarge": {
-    "up": "m5ad.4xlarge",
-    "down": "m5ad.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "32.0"
-  },
-  "m5ad.4xlarge": {
-    "up": "m5ad.8xlarge",
-    "down": "m5ad.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "64.0"
-  },
-  "m5ad.8xlarge": {
-    "up": "m5ad.12xlarge",
-    "down": "m5ad.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "128.0"
-  },
-  "m5ad.12xlarge": {
-    "up": "m5ad.16xlarge",
-    "down": "m5ad.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "192.0"
-  },
-  "m5ad.16xlarge": {
-    "up": "m5ad.24xlarge",
-    "down": "m5ad.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "256.0"
-  },
-  "m5ad.24xlarge": {
-    "up": null,
-    "down": "m5ad.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "384.0"
-  },
-  "m5d.large": {
-    "up": "m5d.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "8.0"
-  },
-  "m5d.xlarge": {
-    "up": "m5d.2xlarge",
-    "down": "m5d.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "16.0"
-  },
-  "m5d.2xlarge": {
-    "up": "m5d.4xlarge",
-    "down": "m5d.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "32.0"
-  },
-  "m5d.4xlarge": {
-    "up": "m5d.8xlarge",
-    "down": "m5d.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "64.0"
-  },
-  "m5d.8xlarge": {
-    "up": "m5d.12xlarge",
-    "down": "m5d.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "128.0"
-  },
-  "m5d.12xlarge": {
-    "up": "m5d.16xlarge",
-    "down": "m5d.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "192.0"
-  },
-  "m5d.16xlarge": {
-    "up": "m5d.24xlarge",
-    "down": "m5d.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "256.0"
-  },
-  "m5d.24xlarge": {
-    "up": null,
-    "down": "m5d.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "384.0"
-  },
-  "m5d.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "memory": "384.0"
-  },
-  "r3.large": {
-    "up": "r3.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "15.25"
-  },
-  "r3.xlarge": {
-    "up": "r3.2xlarge",
-    "down": "r3.large",
-    "superseded": null,
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "30.5"
-  },
-  "r3.2xlarge": {
-    "up": "r3.4xlarge",
-    "down": "r3.xlarge",
-    "superseded": null,
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "61.0"
-  },
-  "r3.4xlarge": {
-    "up": "r3.8xlarge",
-    "down": "r3.2xlarge",
-    "superseded": null,
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "122.0"
-  },
-  "r3.8xlarge": {
-    "up": null,
-    "down": "r3.4xlarge",
-    "superseded": null,
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "244.0"
-  },
-  "r4.large": {
-    "up": "r4.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "15.25"
-  },
-  "r4.xlarge": {
-    "up": "r4.2xlarge",
-    "down": "r4.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "30.5"
-  },
-  "r4.2xlarge": {
-    "up": "r4.4xlarge",
-    "down": "r4.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "61.0"
-  },
-  "r4.4xlarge": {
-    "up": "r4.8xlarge",
-    "down": "r4.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "122.0"
-  },
-  "r4.8xlarge": {
-    "up": "r4.16xlarge",
-    "down": "r4.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "244.0"
-  },
-  "r4.16xlarge": {
-    "up": null,
-    "down": "r4.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "488.0"
-  },
-  "r5.large": {
-    "up": "r5.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "16.0"
-  },
-  "r5.xlarge": {
-    "up": "r5.2xlarge",
-    "down": "r5.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "32.0"
-  },
-  "r5.2xlarge": {
-    "up": "r5.4xlarge",
-    "down": "r5.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "64.0"
-  },
-  "r5.4xlarge": {
-    "up": "r5.8xlarge",
-    "down": "r5.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "128.0"
-  },
-  "r5.8xlarge": {
-    "up": "r5.12xlarge",
-    "down": "r5.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "256.0"
-  },
-  "r5.12xlarge": {
-    "up": "r5.16xlarge",
-    "down": "r5.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "384.0"
-  },
-  "r5.16xlarge": {
-    "up": "r5.24xlarge",
-    "down": "r5.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "512.0"
-  },
-  "r5.24xlarge": {
-    "up": null,
-    "down": "r5.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "768.0"
-  },
-  "r5.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "memory": "768.0"
-  },
-  "r5a.large": {
-    "up": "r5a.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "16.0"
-  },
-  "r5a.xlarge": {
-    "up": "r5a.2xlarge",
-    "down": "r5a.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "32.0"
-  },
-  "r5a.2xlarge": {
-    "up": "r5a.4xlarge",
-    "down": "r5a.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "64.0"
-  },
-  "r5a.4xlarge": {
-    "up": "r5a.8xlarge",
-    "down": "r5a.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "128.0"
-  },
-  "r5a.8xlarge": {
-    "up": "r5a.12xlarge",
-    "down": "r5a.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "256.0"
-  },
-  "r5a.12xlarge": {
-    "up": "r5a.16xlarge",
-    "down": "r5a.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "384.0"
-  },
-  "r5a.16xlarge": {
-    "up": "r5a.24xlarge",
-    "down": "r5a.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "512.0"
-  },
-  "r5a.24xlarge": {
-    "up": null,
-    "down": "r5a.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "768.0"
-  },
-  "r5b.large": {
-    "up": "r5b.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "16.0"
-  },
-  "r5b.xlarge": {
-    "up": "r5b.2xlarge",
-    "down": "r5b.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "32.0"
-  },
-  "r5b.2xlarge": {
-    "up": "r5b.4xlarge",
-    "down": "r5b.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "64.0"
-  },
-  "r5b.4xlarge": {
-    "up": "r5b.8xlarge",
-    "down": "r5b.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "128.0"
-  },
-  "r5b.8xlarge": {
-    "up": "r5b.12xlarge",
-    "down": "r5b.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "256.0"
-  },
-  "r5b.12xlarge": {
-    "up": "r5b.16xlarge",
-    "down": "r5b.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "384.0"
-  },
-  "r5b.16xlarge": {
-    "up": "r5b.24xlarge",
-    "down": "r5b.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "512.0"
-  },
-  "r5b.24xlarge": {
-    "up": null,
-    "down": "r5b.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "768.0"
-  },
-  "r5b.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "memory": "768.0"
-  },
-  "r5ad.large": {
-    "up": "r5ad.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "16.0"
-  },
-  "r5ad.xlarge": {
-    "up": "r5ad.2xlarge",
-    "down": "r5ad.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "32.0"
-  },
-  "r5ad.2xlarge": {
-    "up": "r5ad.4xlarge",
-    "down": "r5ad.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "64.0"
-  },
-  "r5ad.4xlarge": {
-    "up": "r5ad.8xlarge",
-    "down": "r5ad.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "128.0"
-  },
-  "r5ad.8xlarge": {
-    "up": "r5ad.12xlarge",
-    "down": "r5ad.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "256.0"
-  },
-  "r5ad.12xlarge": {
-    "up": "r5ad.16xlarge",
-    "down": "r5ad.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "384.0"
-  },
-  "r5ad.16xlarge": {
-    "up": "r5ad.24xlarge",
-    "down": "r5ad.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "512.0"
-  },
-  "r5ad.24xlarge": {
-    "up": null,
-    "down": "r5ad.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "768.0"
-  },
-  "r5n.large": {
-    "up": "r5n.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "16.0"
-  },
-  "r5n.xlarge": {
-    "up": "r5n.2xlarge",
-    "down": "r5n.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "32.0"
-  },
-  "r5n.2xlarge": {
-    "up": "r5n.4xlarge",
-    "down": "r5n.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "64.0"
-  },
-  "r5n.4xlarge": {
-    "up": "r5n.8xlarge",
-    "down": "r5n.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "128.0"
-  },
-  "r5n.8xlarge": {
-    "up": "r5n.12xlarge",
-    "down": "r5n.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "256.0"
-  },
-  "r5n.12xlarge": {
-    "up": "r5n.16xlarge",
-    "down": "r5n.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "384.0"
-  },
-  "r5n.16xlarge": {
-    "up": "r5n.24xlarge",
-    "down": "r5n.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "512.0"
-  },
-  "r5n.24xlarge": {
-    "up": null,
-    "down": "r5n.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "768.0"
-  },
-  "r5n.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "memory": "768.0"
-  },
-  "r5dn.large": {
-    "up": "r5dn.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "16.0"
-  },
-  "r5dn.xlarge": {
-    "up": "r5dn.2xlarge",
-    "down": "r5dn.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "32.0"
-  },
-  "r5dn.2xlarge": {
-    "up": "r5dn.4xlarge",
-    "down": "r5dn.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "64.0"
-  },
-  "r5dn.4xlarge": {
-    "up": "r5dn.8xlarge",
-    "down": "r5dn.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "128.0"
-  },
-  "r5dn.8xlarge": {
-    "up": "r5dn.12xlarge",
-    "down": "r5dn.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "256.0"
-  },
-  "r5dn.12xlarge": {
-    "up": "r5dn.16xlarge",
-    "down": "r5dn.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "384.0"
-  },
-  "r5dn.16xlarge": {
-    "up": "r5dn.24xlarge",
-    "down": "r5dn.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "512.0"
-  },
-  "r5dn.24xlarge": {
-    "up": null,
-    "down": "r5dn.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "768.0"
-  },
-  "r5dn.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "memory": "768.0"
-  },
-  "r5d.large": {
-    "up": "r5d.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "16.0"
-  },
-  "r5d.xlarge": {
-    "up": "r5d.2xlarge",
-    "down": "r5d.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "32.0"
-  },
-  "r5d.2xlarge": {
-    "up": "r5d.4xlarge",
-    "down": "r5d.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "64.0"
-  },
-  "r5d.4xlarge": {
-    "up": "r5d.8xlarge",
-    "down": "r5d.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "128.0"
-  },
-  "r5d.8xlarge": {
-    "up": "r5d.12xlarge",
-    "down": "r5d.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "256.0"
-  },
-  "r5d.12xlarge": {
-    "up": "r5d.16xlarge",
-    "down": "r5d.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "384.0"
-  },
-  "r5d.16xlarge": {
-    "up": "r5d.24xlarge",
-    "down": "r5d.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "512.0"
-  },
-  "r5d.24xlarge": {
-    "up": null,
-    "down": "r5d.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "768.0"
-  },
-  "r5d.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "memory": "768.0"
-  },
-  "r6a.large": {
-    "up": "r6a.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "16.0"
-  },
-  "r6a.xlarge": {
-    "up": "r6a.2xlarge",
-    "down": "r6a.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "32.0"
-  },
-  "r6a.2xlarge": {
-    "up": "r6a.4xlarge",
-    "down": "r6a.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "64.0"
-  },
-  "r6a.4xlarge": {
-    "up": "r6a.8xlarge",
-    "down": "r6a.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "128.0"
-  },
-  "r6a.8xlarge": {
-    "up": "r6a.12xlarge",
-    "down": "r6a.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "256.0"
-  },
-  "r6a.12xlarge": {
-    "up": "r6a.16xlarge",
-    "down": "r6a.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "384.0"
-  },
-  "r6a.16xlarge": {
-    "up": "r6a.24xlarge",
-    "down": "r6a.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "512.0"
-  },
-  "r6a.24xlarge": {
-    "up": "r6a.32xlarge",
-    "down": "r6a.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "768.0"
-  },
-  "r6a.32xlarge": {
-    "up": "r6a.48xlarge",
-    "down": "r6a.24xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "128",
-    "nfu": "256",
-    "memory": "1024.0"
-  },
-  "r6a.48xlarge": {
-    "up": null,
-    "down": "r6a.32xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "192",
-    "nfu": "384",
-    "memory": "1536.0"
-  },
-  "r6a.metal": {
-    "up": null,
-    "down": "r6a.32xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "192",
-    "nfu": "384",
-    "memory": "1536.0"
-  },
-  "r6g.medium": {
-    "up": "r6g.large",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "1",
-    "nfu": "2",
-    "memory": "8.0"
-  },
-  "r6g.large": {
-    "up": "r6g.xlarge",
-    "down": "r6g.medium",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "16.0"
-  },
-  "r6g.xlarge": {
-    "up": "r6g.2xlarge",
-    "down": "r6g.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "32.0"
-  },
-  "r6g.2xlarge": {
-    "up": "r6g.4xlarge",
-    "down": "r6g.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "64.0"
-  },
-  "r6g.4xlarge": {
-    "up": "r6g.8xlarge",
-    "down": "r6g.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "128.0"
-  },
-  "r6g.8xlarge": {
-    "up": "r6g.12xlarge",
-    "down": "r6g.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "256.0"
-  },
-  "r6g.12xlarge": {
-    "up": "r6g.16xlarge",
-    "down": "r6g.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "384.0"
-  },
-  "r6g.16xlarge": {
-    "up": null,
-    "down": "r6g.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "512.0"
-  },
-  "r6g.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "memory": "512.0"
-  },
-  "r6gd.medium": {
-    "up": "r6gd.large",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "1",
-    "nfu": "2",
-    "memory": "8.0"
-  },
-  "r6gd.large": {
-    "up": "r6gd.xlarge",
-    "down": "r6gd.medium",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "16.0"
-  },
-  "r6gd.xlarge": {
-    "up": "r6gd.2xlarge",
-    "down": "r6gd.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "32.0"
-  },
-  "r6gd.2xlarge": {
-    "up": "r6gd.4xlarge",
-    "down": "r6gd.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "64.0"
-  },
-  "r6gd.4xlarge": {
-    "up": "r6gd.8xlarge",
-    "down": "r6gd.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "128.0"
-  },
-  "r6gd.8xlarge": {
-    "up": "r6gd.12xlarge",
-    "down": "r6gd.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "256.0"
-  },
-  "r6gd.12xlarge": {
-    "up": "r6gd.16xlarge",
-    "down": "r6gd.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "384.0"
-  },
-  "r6gd.16xlarge": {
-    "up": null,
-    "down": "r6gd.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "512.0"
-  },
-  "r6gd.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "memory": "512.0"
-  },
-  "r6i.large": {
-    "up": "r6i.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "16.0"
-  },
-  "r6i.xlarge": {
-    "up": "r6i.2xlarge",
-    "down": "r6i.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "32.0"
-  },
-  "r6i.2xlarge": {
-    "up": "r6i.4xlarge",
-    "down": "r6i.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "64.0"
-  },
-  "r6i.4xlarge": {
-    "up": "r6i.8xlarge",
-    "down": "r6i.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "128.0"
-  },
-  "r6i.8xlarge": {
-    "up": "r6i.12xlarge",
-    "down": "r6i.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "256.0"
-  },
-  "r6i.12xlarge": {
-    "up": "r6i.16xlarge",
-    "down": "r6i.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "384.0"
-  },
-  "r6i.16xlarge": {
-    "up": "r6i.24xlarge",
-    "down": "r6i.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "512.0"
-  },
-  "r6i.24xlarge": {
-    "up": "r6i.32xlarge",
-    "down": "r6i.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "768.0"
-  },
-  "r6i.32xlarge": {
-    "up": null,
-    "down": "r6i.24xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "128",
-    "nfu": "256",
-    "memory": "1024.0"
-  },
-  "r6i.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "128",
-    "nfu": "256",
-    "memory": "1024.0"
-  },
-  "r6id.large": {
-    "up": "r6id.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "16.0"
-  },
-  "r6id.xlarge": {
-    "up": "r6id.2xlarge",
-    "down": "r6id.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "32.0"
-  },
-  "r6id.2xlarge": {
-    "up": "r6id.4xlarge",
-    "down": "r6id.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "64.0"
-  },
-  "r6id.4xlarge": {
-    "up": "r6id.8xlarge",
-    "down": "r6id.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "128.0"
-  },
-  "r6id.8xlarge": {
-    "up": "r6id.12xlarge",
-    "down": "r6id.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "256.0"
-  },
-  "r6id.12xlarge": {
-    "up": "r6id.16xlarge",
-    "down": "r6id.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "384.0"
-  },
-  "r6id.16xlarge": {
-    "up": "r6id.24xlarge",
-    "down": "r6id.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "512.0"
-  },
-  "r6id.24xlarge": {
-    "up": "r6id.32xlarge",
-    "down": "r6id.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "768.0"
-  },
-  "r6id.32xlarge": {
-    "up": null,
-    "down": "r6id.24xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "128",
-    "nfu": "256",
-    "memory": "1024.0"
-  },
-  "r6id.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "128",
-    "nfu": "256",
-    "memory": "1024.0"
-  },
-  "x1.16xlarge": {
-    "up": "x1.32xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "976.0"
-  },
-  "x1.32xlarge": {
-    "up": null,
-    "down": "x1.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "128",
-    "nfu": "256",
-    "memory": "1952.0"
-  },
-  "x1e.xlarge": {
-    "up": "x1e.2xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "122.0"
-  },
-  "x1e.2xlarge": {
-    "up": "x1e.4xlarge",
-    "down": "x1e.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "244.0"
-  },
-  "x1e.4xlarge": {
-    "up": "x1e.8xlarge",
-    "down": "x1e.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "488.0"
-  },
-  "x1e.8xlarge": {
-    "up": "x1e.16xlarge",
-    "down": "x1e.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "976.0"
-  },
-  "x1e.16xlarge": {
-    "up": "x1e.32xlarge",
-    "down": "x1e.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "1952.0"
-  },
-  "x1e.32xlarge": {
-    "up": null,
-    "down": "x1e.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "128",
-    "nfu": "256",
-    "memory": "3904.0"
-  },
-  "x2gd.medium": {
-    "up": "x2gd.large",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "1",
-    "nfu": "16",
-    "memory": "16.0"
-  },
-  "x2gd.large": {
-    "up": "x2gd.xlarge",
-    "down": "x2gd.medium",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "32",
-    "memory": "32.0"
-  },
-  "x2gd.xlarge": {
-    "up": "x2gd.2xlarge",
-    "down": "x2gd.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "64",
-    "memory": "64.0"
-  },
-  "x2gd.2xlarge": {
-    "up": "x2gd.4xlarge",
-    "down": "x2gd.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "128",
-    "memory": "128.0"
-  },
-  "x2gd.4xlarge": {
-    "up": "x2gd.8xlarge",
-    "down": "x2gd.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "256",
-    "memory": "256.0"
-  },
-  "x2gd.8xlarge": {
-    "up": "x2gd.12xlarge",
-    "down": "x2gd.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "512",
-    "memory": "512.0"
-  },
-  "x2gd.12xlarge": {
-    "up": "x2gd.16xlarge",
-    "down": "x2gd.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "768",
-    "memory": "768.0"
-  },
-  "x2gd.16xlarge": {
-    "up": "x2gd.metal",
-    "down": "x2gd.12xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "1024",
-    "memory": "1024.0"
-  },
-  "x2gd.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "1024",
-    "memory": "1024.0"
-  },
-  "x2idn.16xlarge": {
-    "up": "x2idn.24xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "1024.0"
-  },
-  "x2idn.24xlarge": {
-    "up": "x2idn.32xlarge",
-    "down": "x2idn.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "1536.0"
-  },
-  "x2idn.32xlarge": {
-    "up": null,
-    "down": "x2idn.24xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "128",
-    "nfu": "256",
-    "memory": "2048.0"
-  },
-  "x2idn.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "128",
-    "nfu": "256",
-    "memory": "2048.0"
-  },
-  "x2iedn.xlarge": {
-    "up": "x2iedn.2xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "128.0"
-  },
-  "x2iedn.2xlarge": {
-    "up": "x2iedn.4xlarge",
-    "down": "x2iedn.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "256.0"
-  },
-  "x2iedn.4xlarge": {
-    "up": "x2iedn.8xlarge",
-    "down": "x2iedn.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "512.0"
-  },
-  "x2iedn.8xlarge": {
-    "up": "x2iedn.16xlarge",
-    "down": "x2iedn.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "1024.0"
-  },
-  "x2iedn.16xlarge": {
-    "up": "x2iedn.24xlarge",
-    "down": "x2iedn.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "64",
-    "nfu": "128",
-    "memory": "2048.0"
-  },
-  "x2iedn.24xlarge": {
-    "up": "x2iedn.32xlarge",
-    "down": "x2iedn.16xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "96",
-    "nfu": "192",
-    "memory": "3072.0"
-  },
-  "x2iedn.32xlarge": {
-    "up": null,
-    "down": "x2iedn.24xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "128",
-    "nfu": "256",
-    "memory": "4096.0"
-  },
-  "x2iedn.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "128",
-    "nfu": "256",
-    "memory": "4096.0"
-  },
-  "x2iezn.2xlarge": {
-    "up": "x2iezn.4xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "256.0"
-  },
-  "x2iezn.4xlarge": {
-    "up": "x2iezn.6xlarge",
-    "down": "x2iezn.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "16",
-    "nfu": "32",
-    "memory": "512.0"
-  },
-  "x2iezn.6xlarge": {
-    "up": "x2iezn.8xlarge",
-    "down": "x2iezn.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "24",
-    "nfu": "46",
-    "memory": "768.0"
-  },
-  "x2iezn.8xlarge": {
-    "up": "x2iezn.12xlarge",
-    "down": "x2iezn.4xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "32",
-    "nfu": "64",
-    "memory": "1024.0"
-  },
-  "x2iezn.12xlarge": {
-    "up": null,
-    "down": "x2iezn.8xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "1536.0"
-  },
-  "x2iezn.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "1536.0"
-  },
-  "z1d.large": {
-    "up": "z1d.xlarge",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "16.0"
-  },
-  "z1d.xlarge": {
-    "up": "z1d.2xlarge",
-    "down": "z1d.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "32.0"
-  },
-  "z1d.2xlarge": {
-    "up": "z1d.3xlarge",
-    "down": "z1d.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "64.0"
-  },
-  "z1d.3xlarge": {
-    "up": "z1d.6xlarge",
-    "down": "z1d.2xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "12",
-    "nfu": "24",
-    "memory": "96.0"
-  },
-  "z1d.6xlarge": {
-    "up": "z1d.12xlarge",
-    "down": "z1d.3xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "24",
-    "nfu": "48",
-    "memory": "192.0"
-  },
-  "z1d.12xlarge": {
-    "up": null,
-    "down": "z1d.6xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "nfu": "96",
-    "memory": "384.0"
-  },
-  "z1d.metal": {
-    "up": null,
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "48",
-    "memory": "384.0"
-  },
-  "u-6tb1.metal": {
-    "up": "u-9tb1.metal",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "448",
-    "memory": "6144.0"
-  },
-  "u-9tb1.metal": {
-    "up": "u-12tb1.metal",
-    "down": "u-6tb1.metal",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "448",
-    "memory": "9216.0"
-  },
-  "u-12tb1.metal": {
-    "up": "u-18tb1.metal",
-    "down": "u-9tb1.metal",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "448",
-    "memory": "12288.0"
-  },
-  "u-18tb1.metal": {
-    "up": "u-24tb1.metal",
-    "down": "u-12tb1.metal",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "448",
-    "memory": "18432.0"
-  },
-  "u-24tb1.metal": {
-    "up": null,
-    "down": "u-18tb1.metal",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "vcpu": "448",
-    "memory": "24576.0"
-  },
-  "t1.micro": {
-    "up": null,
-    "down": null,
-    "superseded": {
-      "regular": "t2.micro",
-      "next_gen": "t3.micro",
-      "burstable": "",
-      "amd": "t3a.micro"
-    },
-    "ec2_classic": true,
-    "enhanced_networking": false,
-    "vcpu": "1",
-    "nfu": "0.5",
-    "memory": "0.613"
-  },
-  "t2.nano": {
-    "up": "t2.micro",
-    "down": null,
-    "superseded": {
-      "regular": "t3.nano",
-      "next_gen": "",
-      "burstable": "",
-      "amd": "t3a.nano"
-    },
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 3,
-      "max_earnable_credits": 72
-    },
-    "vcpu": "1",
-    "nfu": "0.25",
-    "memory": "0.5"
-  },
-  "t2.micro": {
-    "up": "t2.small",
-    "down": "t2.nano",
-    "superseded": {
-      "regular": "t3.micro",
-      "next_gen": "",
-      "burstable": "",
-      "amd": "t3a.micro"
-    },
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 6,
-      "max_earnable_credits": 144
-    },
-    "vcpu": "1",
-    "nfu": "0.5",
-    "memory": "1.0"
-  },
-  "t2.small": {
-    "up": "t2.medium",
-    "down": "t2.micro",
-    "superseded": {
-      "regular": "t3.small",
-      "next_gen": "",
-      "burstable": "",
-      "amd": "t3a.small"
-    },
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 12,
-      "max_earnable_credits": 288
-    },
-    "vcpu": "1",
-    "nfu": "1",
-    "memory": "2.0"
-  },
-  "t2.medium": {
-    "up": "t2.large",
-    "down": "t2.small",
-    "superseded": {
-      "regular": "t3.medium",
-      "next_gen": "",
-      "burstable": "",
-      "amd": "t3a.medium"
-    },
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 24,
-      "max_earnable_credits": 576
-    },
-    "vcpu": "2",
-    "nfu": "2",
-    "memory": "4.0"
-  },
-  "t2.large": {
-    "up": "t2.xlarge",
-    "down": "t2.medium",
-    "superseded": {
-      "regular": "t3.large",
-      "next_gen": "",
-      "burstable": "",
-      "amd": "t3a.large"
-    },
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 36,
-      "max_earnable_credits": 864
-    },
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "8.0"
-  },
-  "t2.xlarge": {
-    "up": "t2.2xlarge",
-    "down": "t2.large",
-    "superseded": {
-      "regular": "t3.xlarge",
-      "next_gen": "",
-      "burstable": "",
-      "amd": "t3a.xlarge"
-    },
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 54,
-      "max_earnable_credits": 1296
-    },
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "16.0"
-  },
-  "t2.2xlarge": {
-    "up": null,
-    "down": "t2.xlarge",
-    "superseded": {
-      "regular": "t3.2xlarge",
-      "next_gen": "",
-      "burstable": "",
-      "amd": "t3a.2xlarge"
-    },
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 81.6,
-      "max_earnable_credits": 1958.4
-    },
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "32.0"
-  },
-  "t3.nano": {
-    "up": "t3.micro",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 6,
-      "max_earnable_credits": 144
-    },
-    "vcpu": "2",
-    "nfu": "0.25",
-    "memory": "0.5"
-  },
-  "t3.micro": {
-    "up": "t3.small",
-    "down": "t3.nano",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 12,
-      "max_earnable_credits": 288
-    },
-    "vcpu": "2",
-    "nfu": "0.5",
-    "memory": "1.0"
-  },
-  "t3.small": {
-    "up": "t3.medium",
-    "down": "t3.micro",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 24,
-      "max_earnable_credits": 576
-    },
-    "vcpu": "2",
-    "nfu": "1",
-    "memory": "2.0"
-  },
-  "t3.medium": {
-    "up": "t3.large",
-    "down": "t3.small",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 24,
-      "max_earnable_credits": 576
-    },
-    "vcpu": "2",
-    "nfu": "2",
-    "memory": "4.0"
-  },
-  "t3.large": {
-    "up": "t3.xlarge",
-    "down": "t3.medium",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 36,
-      "max_earnable_credits": 864
-    },
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "8.0"
-  },
-  "t3.xlarge": {
-    "up": "t3.2xlarge",
-    "down": "t3.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 96,
-      "max_earnable_credits": 2304
-    },
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "16.0"
-  },
-  "t3.2xlarge": {
-    "up": null,
-    "down": "t3.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 192,
-      "max_earnable_credits": 4608
-    },
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "32.0"
-  },
-  "t3a.nano": {
-    "up": "t3.micro",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 6,
-      "max_earnable_credits": 144
-    },
-    "vcpu": "2",
-    "nfu": "0.25",
-    "memory": "0.5"
-  },
-  "t3a.micro": {
-    "up": "t3.small",
-    "down": "t3.nano",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 12,
-      "max_earnable_credits": 288
-    },
-    "vcpu": "2",
-    "nfu": "0.5",
-    "memory": "1.0"
-  },
-  "t3a.small": {
-    "up": "t3.medium",
-    "down": "t3.micro",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 24,
-      "max_earnable_credits": 576
-    },
-    "vcpu": "2",
-    "nfu": "1",
-    "memory": "2.0"
-  },
-  "t3a.medium": {
-    "up": "t3.large",
-    "down": "t3.small",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 24,
-      "max_earnable_credits": 576
-    },
-    "vcpu": "2",
-    "nfu": "2",
-    "memory": "4.0"
-  },
-  "t3a.large": {
-    "up": "t3.xlarge",
-    "down": "t3.medium",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 36,
-      "max_earnable_credits": 864
-    },
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "8.0"
-  },
-  "t3a.xlarge": {
-    "up": "t3.2xlarge",
-    "down": "t3.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 96,
-      "max_earnable_credits": 2304
-    },
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "16.0"
-  },
-  "t3a.2xlarge": {
-    "up": null,
-    "down": "t3.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 192,
-      "max_earnable_credits": 4608
-    },
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "32.0"
-  },
-  "t4g.nano": {
-    "up": "t4g.micro",
-    "down": null,
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 6,
-      "max_earnable_credits": 144
-    },
-    "vcpu": "2",
-    "nfu": "0.25",
-    "memory": "0.5"
-  },
-  "t4g.micro": {
-    "up": "t4g.small",
-    "down": "t4g.nano",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 12,
-      "max_earnable_credits": 288
-    },
-    "vcpu": "2",
-    "nfu": "0.5",
-    "memory": "1.0"
-  },
-  "t4g.small": {
-    "up": "t4g.medium",
-    "down": "t4g.micro",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 24,
-      "max_earnable_credits": 576
-    },
-    "vcpu": "2",
-    "nfu": "1",
-    "memory": "2.0"
-  },
-  "t4g.medium": {
-    "up": "t4g.large",
-    "down": "t4g.small",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 24,
-      "max_earnable_credits": 576
-    },
-    "vcpu": "2",
-    "nfu": "2",
-    "memory": "4.0"
-  },
-  "t4g.large": {
-    "up": "t4g.xlarge",
-    "down": "t4g.medium",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 26,
-      "max_earnable_credits": 864
-    },
-    "vcpu": "2",
-    "nfu": "4",
-    "memory": "8.0"
-  },
-  "t4g.xlarge": {
-    "up": "t4g.2xlarge",
-    "down": "t4g.large",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 96,
-      "max_earnable_credits": 2304
-    },
-    "vcpu": "4",
-    "nfu": "8",
-    "memory": "16.0"
-  },
-  "t4g.2xlarge": {
-    "up": null,
-    "down": "t4g.xlarge",
-    "superseded": null,
-    "ec2_classic": false,
-    "enhanced_networking": true,
-    "burst_info": {
-      "credits_per_hour": 192,
-      "max_earnable_credits": 4608
-    },
-    "vcpu": "8",
-    "nfu": "16",
-    "memory": "32.0"
-  },
-  "db.t1.micro": {
-    "vcpu": "1",
-    "up": null,
-    "down": null,
-    "nfu": "0.5",
-    "memory": "0.613"
-  },
-  "db.t2.micro": {
-    "vcpu": "1",
-    "up": "db.t2.small",
-    "down": null,
-    "nfu": "0.5",
-    "memory": "1"
-  },
-  "db.t2.small": {
-    "vcpu": "1",
-    "up": "db.t2.medium",
-    "down": "db.t2.micro",
-    "nfu": "1",
-    "memory": "2"
-  },
-  "db.t2.medium": {
-    "vcpu": "2",
-    "up": "db.t2.large",
-    "down": "db.t2.small",
-    "nfu": "2",
-    "memory": "4"
-  },
-  "db.t2.large": {
-    "vcpu": "2",
-    "up": "db.t2.xlarge",
-    "down": "db.t2.medium",
-    "nfu": "4",
-    "memory": "8"
-  },
-  "db.t2.xlarge": {
-    "vcpu": "4",
-    "up": "db.t2.2xlarge",
-    "down": "db.t2.large",
-    "nfu": "8",
-    "memory": "16"
-  },
-  "db.t2.2xlarge": {
-    "vcpu": "8",
-    "up": null,
-    "down": "db.t2.xlarge",
-    "nfu": "16",
-    "memory": "32"
-  },
-  "db.t3.micro": {
-    "vcpu": "2",
-    "up": "db.t3.small",
-    "down": null,
-    "nfu": "0.5",
-    "memory": "1"
-  },
-  "db.t3.small": {
-    "vcpu": "2",
-    "up": "db.t3.medium",
-    "down": "db.t3.micro",
-    "nfu": "1",
-    "memory": "2"
-  },
-  "db.t3.medium": {
-    "vcpu": "2",
-    "up": "db.t3.large",
-    "down": "db.t3.small",
-    "nfu": "2",
-    "memory": "4"
-  },
-  "db.t3.large": {
-    "vcpu": "2",
-    "up": "db.t3.xlarge",
-    "down": "db.t3.medium",
-    "nfu": "4",
-    "memory": "8"
-  },
-  "db.t3.xlarge": {
-    "vcpu": "4",
-    "up": "db.t3.2xlarge",
-    "down": "db.t3.large",
-    "nfu": "8",
-    "memory": "16"
-  },
-  "db.t3.2xlarge": {
-    "vcpu": "8",
-    "up": null,
-    "down": "db.t3.xlarge",
-    "nfu": "16",
-    "memory": "32"
-  },
-  "db.t4g.micro": {
-    "vcpu": "2",
-    "up": "db.t4g.small",
-    "down": null,
-    "nfu": "0.5",
-    "memory": "1"
-  },
-  "db.t4g.small": {
-    "vcpu": "2",
-    "up": "db.t4g.medium",
-    "down": "db.t4g.micro",
-    "nfu": "1",
-    "memory": "2"
-  },
-  "db.t4g.medium": {
-    "vcpu": "2",
-    "up": "db.t4g.large",
-    "down": "db.t4g.small",
-    "nfu": "2",
-    "memory": "4"
-  },
-  "db.t4g.large": {
-    "vcpu": "2",
-    "up": "db.t4g.xlarge",
-    "down": "db.t4g.medium",
-    "nfu": "4",
-    "memory": "8"
-  },
-  "db.t4g.xlarge": {
-    "vcpu": "4",
-    "up": "db.t4g.2xlarge",
-    "down": "db.t4g.large",
-    "nfu": "8",
-    "memory": "16"
-  },
-  "db.t4g.2xlarge": {
-    "vcpu": "8",
-    "up": null,
-    "down": "db.t4g.xlarge",
-    "nfu": "16",
-    "memory": "32"
-  },
-  "db.m4.large": {
-    "vcpu": "2",
-    "up": "db.m4.xlarge",
-    "down": null,
-    "nfu": "4",
-    "memory": "8"
-  },
-  "db.m4.xlarge": {
-    "vcpu": "4",
-    "up": "db.m4.2xlarge",
-    "down": "db.m4.large",
-    "nfu": "8",
-    "memory": "16"
-  },
-  "db.m4.2xlarge": {
-    "vcpu": "8",
-    "up": "db.m4.4xlarge",
-    "down": "db.m4.xlarge",
-    "nfu": "16",
-    "memory": "32"
-  },
-  "db.m4.4xlarge": {
-    "vcpu": "16",
-    "up": "db.m4.10xlarge",
-    "down": "db.m4.2xlarge",
-    "nfu": "32",
-    "memory": "64"
-  },
-  "db.m4.10xlarge": {
-    "vcpu": "40",
-    "up": "db.m4.16xlarge",
-    "down": "db.m4.4xlarge",
-    "nfu": "80",
-    "memory": "160"
-  },
-  "db.m4.16xlarge": {
-    "vcpu": "64",
-    "up": null,
-    "down": "db.m4.10xlarge",
-    "nfu": "128",
-    "memory": "256"
-  },
-  "db.m5.large": {
-    "vcpu": "2",
-    "up": "db.m5.xlarge",
-    "down": null,
-    "nfu": "4",
-    "memory": "8"
-  },
-  "db.m5.xlarge": {
-    "vcpu": "4",
-    "up": "db.m5.2xlarge",
-    "down": "db.m5.large",
-    "nfu": "8",
-    "memory": "16"
-  },
-  "db.m5.2xlarge": {
-    "vcpu": "8",
-    "up": "db.m5.4xlarge",
-    "down": "db.m5.xlarge",
-    "nfu": "16",
-    "memory": "32"
-  },
-  "db.m5.4xlarge": {
-    "vcpu": "16",
-    "up": "db.m5.12xlarge",
-    "down": "db.m5.2xlarge",
-    "nfu": "32",
-    "memory": "64"
-  },
-  "db.m5.12xlarge": {
-    "vcpu": "48",
-    "up": "db.m5.16xlarge",
-    "down": "db.m5.4xlarge",
-    "nfu": "96",
-    "memory": "192"
-  },
-  "db.m5.16xlarge": {
-    "vcpu": "64",
-    "up": "db.m5.24xlarge",
-    "down": "db.m5.12xlarge",
-    "nfu": "128",
-    "memory": "256"
-  },
-  "db.m5.24xlarge": {
-    "vcpu": "96",
-    "up": null,
-    "down": "db.m5.16xlarge",
-    "nfu": "192",
-    "memory": "384"
-  },
-  "db.m6g.large": {
-    "vcpu": "2",
-    "up": "db.m6g.xlarge",
-    "down": null,
-    "nfu": "4",
-    "memory": "8"
-  },
-  "db.m6g.xlarge": {
-    "vcpu": "4",
-    "up": "db.m6g.2xlarge",
-    "down": "db.m6g.large",
-    "nfu": "8",
-    "memory": "16"
-  },
-  "db.m6g.2xlarge": {
-    "vcpu": "8",
-    "up": "db.m6g.4xlarge",
-    "down": "db.m6g.xlarge",
-    "nfu": "16",
-    "memory": "32"
-  },
-  "db.m6g.4xlarge": {
-    "vcpu": "16",
-    "up": "db.m6g.8xlarge",
-    "down": "db.m6g.2xlarge",
-    "nfu": "32",
-    "memory": "64"
-  },
-  "db.m6g.8xlarge": {
-    "vcpu": "32",
-    "up": "db.m6g.16xlarge",
-    "down": "db.m6g.4xlarge",
-    "nfu": "64",
-    "memory": "128"
-  },
-  "db.m6g.12xlarge": {
-    "vcpu": "48",
-    "up": "db.m6g.16xlarge",
-    "down": "db.m6g.8xlarge",
-    "nfu": "96",
-    "memory": "192"
-  },
-  "db.m6g.16xlarge": {
-    "vcpu": "64",
-    "up": null,
-    "down": "db.m6g.12xlarge",
-    "nfu": "128",
-    "memory": "256"
-  },
-  "db.m6i.large": {
-    "vcpu": "2",
-    "up": "db.m6i.xlarge",
-    "down": null,
-    "nfu": "4",
-    "memory": "8"
-  },
-  "db.m6i.xlarge": {
-    "vcpu": "4",
-    "up": "db.m6i.2xlarge",
-    "down": "db.m6i.large",
-    "nfu": "8",
-    "memory": "16"
-  },
-  "db.m6i.2xlarge": {
-    "vcpu": "8",
-    "up": "db.m6i.4xlarge",
-    "down": "db.m6i.xlarge",
-    "nfu": "16",
-    "memory": "32"
-  },
-  "db.m6i.4xlarge": {
-    "vcpu": "16",
-    "up": "db.m6i.8xlarge",
-    "down": "db.m6i.2xlarge",
-    "nfu": "32",
-    "memory": "64"
-  },
-  "db.m6i.8xlarge": {
-    "vcpu": "32",
-    "up": "db.m6i.12xlarge",
-    "down": "db.m6i.4xlarge",
-    "nfu": "64",
-    "memory": "128"
-  },
-  "db.m6i.12xlarge": {
-    "vcpu": "48",
-    "up": "db.m6i.16xlarge",
-    "down": "db.m6i.8xlarge",
-    "nfu": "96",
-    "memory": "192"
-  },
-  "db.m6i.16xlarge": {
-    "vcpu": "64",
-    "up": "db.m6i.24xlarge",
-    "down": "db.m6i.12xlarge",
-    "nfu": "128",
-    "memory": "256"
-  },
-  "db.m6i.24xlarge": {
-    "vcpu": "96",
-    "up": "db.m6i.32xlarge",
-    "down": "db.m6i.16xlarge",
-    "nfu": "192",
-    "memory": "384"
-  },
-  "db.m6i.32xlarge": {
-    "vcpu": "128",
-    "up": null,
-    "down": "db.m6i.24xlarge",
-    "nfu": "256",
-    "memory": "512"
-  },
-  "db.r6g.large": {
-    "vcpu": "2",
-    "up": "db.r6g.xlarge",
-    "down": null,
-    "nfu": "4",
-    "memory": "16"
-  },
-  "db.r6g.xlarge": {
-    "vcpu": "4",
-    "up": "db.r6g.2xlarge",
-    "down": "db.r6g.large",
-    "nfu": "8",
-    "memory": "32"
-  },
-  "db.r6g.2xlarge": {
-    "vcpu": "8",
-    "up": "db.r6g.4xlarge",
-    "down": "db.r6g.xlarge",
-    "nfu": "16",
-    "memory": "64"
-  },
-  "db.r6g.4xlarge": {
-    "vcpu": "16",
-    "up": "db.r6g.8xlarge",
-    "down": "db.r6g.2xlarge",
-    "nfu": "32",
-    "memory": "128"
-  },
-  "db.r6g.8xlarge": {
-    "vcpu": "32",
-    "up": "db.r6g.16xlarge",
-    "down": "db.r6g.4xlarge",
-    "nfu": "64",
-    "memory": "256"
-  },
-  "db.r6g.12xlarge": {
-    "vcpu": "48",
-    "up": "db.r6g.16xlarge",
-    "down": "db.r6g.8xlarge",
-    "nfu": "96",
-    "memory": "384"
-  },
-  "db.r6g.16xlarge": {
-    "vcpu": "64",
-    "up": null,
-    "down": "db.r6g.12xlarge",
-    "nfu": "128",
-    "memory": "512"
-  },
-  "db.r4.large": {
-    "vcpu": "2",
-    "up": "db.r4.xlarge",
-    "down": null,
-    "nfu": "4",
-    "memory": "15.25"
-  },
-  "db.r4.xlarge": {
-    "vcpu": "4",
-    "up": "db.r4.2xlarge",
-    "down": "db.r4.large",
-    "nfu": "8",
-    "memory": "30.5"
-  },
-  "db.r4.2xlarge": {
-    "vcpu": "8",
-    "up": "db.r4.4xlarge",
-    "down": "db.r4.xlarge",
-    "nfu": "16",
-    "memory": "61"
-  },
-  "db.r4.4xlarge": {
-    "vcpu": "16",
-    "up": "db.r4.8xlarge",
-    "down": "db.r4.2xlarge",
-    "nfu": "32",
-    "memory": "122"
-  },
-  "db.r4.8xlarge": {
-    "vcpu": "32",
-    "up": "db.r4.16xlarge",
-    "down": "db.r4.4xlarge",
-    "nfu": "64",
-    "memory": "244"
-  },
-  "db.r4.16xlarge": {
-    "vcpu": "64",
-    "up": null,
-    "down": "db.r4.8xlarge",
-    "nfu": "128",
-    "memory": "488"
-  },
-  "db.r5.large": {
-    "vcpu": "2",
-    "up": "db.r5.xlarge",
-    "down": null,
-    "nfu": "4",
-    "memory": "16"
-  },
-  "db.r5.xlarge": {
-    "vcpu": "4",
-    "up": "db.r5.2xlarge",
-    "down": "db.r5.large",
-    "nfu": "8",
-    "memory": "32"
-  },
-  "db.r5.2xlarge": {
-    "vcpu": "8",
-    "up": "db.r5.4xlarge",
-    "down": "db.r5.xlarge",
-    "nfu": "16",
-    "memory": "64"
-  },
-  "db.r5.4xlarge": {
-    "vcpu": "16",
-    "up": "db.r5.8xlarge",
-    "down": "db.r5.2xlarge",
-    "nfu": "32",
-    "memory": "128"
-  },
-  "db.r5.8xlarge": {
-    "vcpu": "32",
-    "up": "db.r5.12xlarge",
-    "down": "db.r5.4xlarge",
-    "nfu": "64",
-    "memory": "256"
-  },
-  "db.r5.12xlarge": {
-    "vcpu": "48",
-    "up": "db.r5.24xlarge",
-    "down": "db.r5.4xlarge",
-    "nfu": "96",
-    "memory": "384"
-  },
-  "db.r5.24xlarge": {
-    "vcpu": "64",
-    "up": null,
-    "down": "db.r5.12xlarge",
-    "nfu": "192",
-    "memory": "768"
-  },
-  "db.x1e.xlarge": {
-    "vcpu": "4",
-    "up": "db.x1e.2xlarge",
-    "down": null,
-    "nfu": "8",
-    "memory": "122"
-  },
-  "db.x1e.2xlarge": {
-    "vcpu": "8",
-    "up": "db.x1e.4xlarge",
-    "down": "db.x1e.xlarge",
-    "nfu": "16",
-    "memory": "244"
-  },
-  "db.x1e.4xlarge": {
-    "vcpu": "16",
-    "up": "db.x1e.8xlarge",
-    "down": "db.x1e.2xlarge",
-    "nfu": "32",
-    "memory": "488"
-  },
-  "db.x1e.8xlarge": {
-    "vcpu": "32",
-    "up": "db.x1e.16xlarge",
-    "down": "db.x1e.4xlarge",
-    "nfu": "64",
-    "memory": "976"
-  },
-  "db.x1e.16xlarge": {
-    "vcpu": "64",
-    "up": "db.x1e.32xlarge",
-    "down": "db.x1e.8xlarge",
-    "nfu": "128",
-    "memory": "1952"
-  },
-  "db.x1e.32xlarge": {
-    "vcpu": "128",
-    "up": null,
-    "down": "db.x1e.16xlarge",
-    "nfu": "256",
-    "memory": "3904"
-  },
-  "db.x1.16xlarge": {
-    "vcpu": "64",
-    "up": "db.x1.32xlarge",
-    "down": null,
-    "nfu": "128",
-    "memory": "976"
-  },
-  "db.x1.32xlarge": {
-    "vcpu": "128",
-    "up": null,
-    "down": "db.x1.16xlarge",
-    "nfu": "256",
-    "memory": "1952"
-  },
-  "db.m1.small": {
-    "vcpu": "1",
-    "up": "db.m1.medium",
-    "down": null,
-    "nfu": "1",
-    "memory": "1.7"
-  },
-  "db.m1.medium": {
-    "vcpu": "1",
-    "up": "db.m1.large",
-    "down": "db.m1.small",
-    "nfu": "2",
-    "memory": "3.75"
-  },
-  "db.m1.large": {
-    "vcpu": "2",
-    "up": "db.m1.xlarge",
-    "down": "db.m1.medium",
-    "nfu": "4",
-    "memory": "7.5"
-  },
-  "db.m1.xlarge": {
-    "vcpu": "4",
-    "up": null,
-    "down": "db.m1.large",
-    "nfu": "8",
-    "memory": "15"
-  },
-  "db.m3.medium": {
-    "vcpu": "1",
-    "up": "db.m3.large",
-    "down": null,
-    "nfu": "2",
-    "memory": "3.75"
-  },
-  "db.m3.large": {
-    "vcpu": "2",
-    "up": "db.m3.xlarge",
-    "down": "db.m3.medium",
-    "nfu": "4",
-    "memory": "7.5"
-  },
-  "db.m3.xlarge": {
-    "vcpu": "4",
-    "up": "db.m3.2xlarge",
-    "down": "db.m3.large",
-    "nfu": "8",
-    "memory": "15"
-  },
-  "db.m3.2xlarge": {
-    "vcpu": "8",
-    "up": null,
-    "down": "db.m3.xlarge",
-    "nfu": "16",
-    "memory": "30"
-  },
-  "db.m2.xlarge": {
-    "vcpu": "2",
-    "up": "db.m2.2xlarge",
-    "down": null,
-    "nfu": "8",
-    "memory": "17.1"
-  },
-  "db.m2.2xlarge": {
-    "vcpu": "4",
-    "up": "db.m2.4xlarge",
-    "down": "db.m2.xlarge",
-    "nfu": "16",
-    "memory": "34.2"
-  },
-  "db.m2.4xlarge": {
-    "vcpu": "8",
-    "up": null,
-    "down": "db.m2.2xlarge",
-    "nfu": "32",
-    "memory": "68.4"
-  },
-  "db.r3.large": {
-    "vcpu": "2",
-    "up": "db.r3.xlarge",
-    "down": null,
-    "nfu": "4",
-    "memory": "15.25"
-  },
-  "db.r3.xlarge": {
-    "vcpu": "4",
-    "up": "db.r3.2xlarge",
-    "down": "db.r3.large",
-    "nfu": "8",
-    "memory": "30.5"
-  },
-  "db.r3.2xlarge": {
-    "vcpu": "8",
-    "up": "db.r3.4xlarge",
-    "down": "db.r3.xlarge",
-    "nfu": "16",
-    "memory": "61"
-  },
-  "db.r3.4xlarge": {
-    "vcpu": "16",
-    "up": "db.r3.8xlarge",
-    "down": "db.r3.2xlarge",
-    "nfu": "32",
-    "memory": "122"
-  },
-  "db.r3.8xlarge": {
-    "vcpu": "32",
-    "up": null,
-    "down": "db.r3.4xlarge",
-    "nfu": "64",
-    "memory": "244"
-  }
+    "a1.medium": {
+        "up": "a1.large",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "1",
+        "nfu": "2",
+        "memory": "2"
+    },
+    "a1.large": {
+        "up": "a1.xlarge",
+        "down": "a1.medium",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "4"
+    },
+    "a1.xlarge": {
+        "up": "a1.2xlarge",
+        "down": "a1.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "8"
+    },
+    "a1.2xlarge": {
+        "up": "a1.4xlarge",
+        "down": "a1.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "16"
+    },
+    "a1.4xlarge": {
+        "up": null,
+        "down": "a1.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "32"
+    },
+    "a1.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "memory": "32"
+    },
+    "c1.medium": {
+        "up": "c1.xlarge",
+        "down": null,
+        "superseded": {
+            "regular": "c5.large",
+            "next_gen": "",
+            "burstable": "",
+            "amd": ""
+        },
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "2",
+        "nfu": "2",
+        "memory": "1.7"
+    },
+    "c1.xlarge": {
+        "up": null,
+        "down": "c1.medium",
+        "superseded": {
+            "regular": "c5.xlarge",
+            "next_gen": "",
+            "burstable": "",
+            "amd": ""
+        },
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "8",
+        "nfu": "8",
+        "memory": "7"
+    },
+    "c3.large": {
+        "up": "c3.xlarge",
+        "down": null,
+        "superseded": {
+            "regular": "c5.large",
+            "next_gen": "",
+            "burstable": "",
+            "amd": ""
+        },
+        "ec2_classic": true,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "3.75"
+    },
+    "c3.xlarge": {
+        "up": "c3.2xlarge",
+        "down": "c3.large",
+        "superseded": {
+            "regular": "c5.xlarge",
+            "next_gen": "",
+            "burstable": "",
+            "amd": ""
+        },
+        "ec2_classic": true,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "7.5"
+    },
+    "c3.2xlarge": {
+        "up": "c3.4xlarge",
+        "down": "c3.xlarge",
+        "superseded": {
+            "regular": "c5.2xlarge",
+            "next_gen": "",
+            "burstable": "",
+            "amd": ""
+        },
+        "ec2_classic": true,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "15"
+    },
+    "c3.4xlarge": {
+        "up": "c3.8xlarge",
+        "down": "c3.2xlarge",
+        "superseded": {
+            "regular": "c5.4xlarge",
+            "next_gen": "",
+            "burstable": "",
+            "amd": ""
+        },
+        "ec2_classic": true,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "30"
+    },
+    "c3.8xlarge": {
+        "up": null,
+        "down": "c3.4xlarge",
+        "superseded": {
+            "regular": "c5.9xlarge",
+            "next_gen": "",
+            "burstable": "",
+            "amd": ""
+        },
+        "ec2_classic": true,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "60"
+    },
+    "c4.large": {
+        "up": "c4.xlarge",
+        "down": null,
+        "superseded": {
+            "regular": "c5.large",
+            "next_gen": "",
+            "burstable": "",
+            "amd": ""
+        },
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "3.75"
+    },
+    "c4.xlarge": {
+        "up": "c4.2xlarge",
+        "down": "c4.large",
+        "superseded": {
+            "regular": "c5.xlarge",
+            "next_gen": "",
+            "burstable": "",
+            "amd": ""
+        },
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "7.5"
+    },
+    "c4.2xlarge": {
+        "up": "c4.4xlarge",
+        "down": "c4.xlarge",
+        "superseded": {
+            "regular": "c5.2xlarge",
+            "next_gen": "",
+            "burstable": "",
+            "amd": ""
+        },
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "15"
+    },
+    "c4.4xlarge": {
+        "up": "c4.8xlarge",
+        "down": "c4.2xlarge",
+        "superseded": {
+            "regular": "c5.4xlarge",
+            "next_gen": "",
+            "burstable": "",
+            "amd": ""
+        },
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "30"
+    },
+    "c4.8xlarge": {
+        "up": null,
+        "down": "c4.4xlarge",
+        "superseded": {
+            "regular": "c5.9xlarge",
+            "next_gen": "",
+            "burstable": "",
+            "amd": ""
+        },
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "36",
+        "nfu": "64",
+        "memory": "60"
+    },
+    "c5.large": {
+        "up": "c5.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "4"
+    },
+    "c5.xlarge": {
+        "up": "c5.2xlarge",
+        "down": "c5.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "8"
+    },
+    "c5.2xlarge": {
+        "up": "c5.4xlarge",
+        "down": "c5.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "16"
+    },
+    "c5.4xlarge": {
+        "up": "c5.9xlarge",
+        "down": "c5.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "32"
+    },
+    "c5.9xlarge": {
+        "up": "c5.12xlarge",
+        "down": "c5.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "36",
+        "nfu": "72",
+        "memory": "72"
+    },
+    "c5.12xlarge": {
+        "up": "c5.18xlarge",
+        "down": "c5.9xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "96"
+    },
+    "c5.18xlarge": {
+        "up": "c5.24xlarge",
+        "down": "c5.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "72",
+        "nfu": "144",
+        "memory": "144"
+    },
+    "c5.24xlarge": {
+        "up": null,
+        "down": "c18.18xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "192"
+    },
+    "c5.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "memory": "192"
+    },
+    "c5a.large": {
+        "up": "c5a.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "4"
+    },
+    "c5a.xlarge": {
+        "up": "c5a.2xlarge",
+        "down": "c5a.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "8"
+    },
+    "c5a.2xlarge": {
+        "up": "c5a.4xlarge",
+        "down": "c5a.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "16"
+    },
+    "c5a.4xlarge": {
+        "up": "c5a.8xlarge",
+        "down": "c5a.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "32"
+    },
+    "c5a.8xlarge": {
+        "up": "c5a.12xlarge",
+        "down": "c5a.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "64"
+    },
+    "c5a.12xlarge": {
+        "up": "c5a.16xlarge",
+        "down": "c5a.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "96"
+    },
+    "c5a.16xlarge": {
+        "up": "c5a.24xlarge",
+        "down": "c5a.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "128"
+    },
+    "c5a.24xlarge": {
+        "up": null,
+        "down": "c18.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "192"
+    },
+    "c5d.large": {
+        "up": "c5d.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "4"
+    },
+    "c5d.xlarge": {
+        "up": "c5d.2xlarge",
+        "down": "c5d.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "8"
+    },
+    "c5d.2xlarge": {
+        "up": "c5d.4xlarge",
+        "down": "c5d.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "16"
+    },
+    "c5d.4xlarge": {
+        "up": "c5d.9xlarge",
+        "down": "c5d.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "32"
+    },
+    "c5d.9xlarge": {
+        "up": "c5d.12xlarge",
+        "down": "c5d.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "36",
+        "nfu": "72",
+        "memory": "72"
+    },
+    "c5d.12xlarge": {
+        "up": "c5d.18xlarge",
+        "down": "c5d.9xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "96"
+    },
+    "c5d.18xlarge": {
+        "up": "c5d.24xlarge",
+        "down": "c5d.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "72",
+        "nfu": "144",
+        "memory": "144"
+    },
+    "c5d.24xlarge": {
+        "up": null,
+        "down": "c5d.18xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "192"
+    },
+    "c5d.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "memory": "192"
+    },
+    "c5ad.large": {
+        "up": "c5ad.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "4"
+    },
+    "c5ad.xlarge": {
+        "up": "c5ad.2xlarge",
+        "down": "c5ad.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "8"
+    },
+    "c5ad.2xlarge": {
+        "up": "c5ad.4xlarge",
+        "down": "c5ad.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "16"
+    },
+    "c5ad.4xlarge": {
+        "up": "c5ad.8xlarge",
+        "down": "c5ad.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "32"
+    },
+    "c5ad.8xlarge": {
+        "up": "c5ad.12xlarge",
+        "down": "c5ad.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "64"
+    },
+    "c5ad.12xlarge": {
+        "up": "c5ad.16xlarge",
+        "down": "c5ad.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "96"
+    },
+    "c5ad.16xlarge": {
+        "up": "c5ad.24xlarge",
+        "down": "c5ad.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "128"
+    },
+    "c5ad.24xlarge": {
+        "up": null,
+        "down": "c5ad.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "192"
+    },
+    "c5n.large": {
+        "up": "c5n.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "5.25"
+    },
+    "c5n.xlarge": {
+        "up": "c5n.2xlarge",
+        "down": "c5n.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "10.5"
+    },
+    "c5n.2xlarge": {
+        "up": "c5n.4xlarge",
+        "down": "c5n.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "21"
+    },
+    "c5n.4xlarge": {
+        "up": "c5n.9xlarge",
+        "down": "c5n.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "42"
+    },
+    "c5n.9xlarge": {
+        "up": "c5n.18xlarge",
+        "down": "c5n.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "36",
+        "nfu": "72",
+        "memory": "96"
+    },
+    "c5n.18xlarge": {
+        "up": null,
+        "down": "c5n.9xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "72",
+        "nfu": "144",
+        "memory": "192"
+    },
+    "c5n.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "72",
+        "memory": "192"
+    },
+    "c6a.large": {
+        "up": "c6a.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "4"
+    },
+    "c6a.xlarge": {
+        "up": "c6a.2xlarge",
+        "down": "c6a.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "8"
+    },
+    "c6a.2xlarge": {
+        "up": "c6a.4xlarge",
+        "down": "c6a.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "16"
+    },
+    "c6a.4xlarge": {
+        "up": "c6a.8xlarge",
+        "down": "c6a.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "32"
+    },
+    "c6a.8xlarge": {
+        "up": "c6a.12xlarge",
+        "down": "c6a.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "64"
+    },
+    "c6a.12xlarge": {
+        "up": "c6a.16xlarge",
+        "down": "c6a.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "96"
+    },
+    "c6a.16xlarge": {
+        "up": "c6a.24xlarge",
+        "down": "c6a.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "128"
+    },
+    "c6a.24xlarge": {
+        "up": "c6a.32xlarge",
+        "down": "c6a.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "192"
+    },
+    "c6a.32xlarge": {
+        "up": "c6a.48xlarge",
+        "down": "c6a.24xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "128",
+        "nfu": "256",
+        "memory": "256"
+    },
+    "c6a.48xlarge": {
+        "up": null,
+        "down": "c6a.32xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "192",
+        "nfu": "384",
+        "memory": "384"
+    },
+    "c6a.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "192",
+        "nfu": "384",
+        "memory": "384"
+    },
+    "c6g.medium": {
+        "up": "c6g.large",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "1",
+        "nfu": "2",
+        "memory": "2"
+    },
+    "c6g.large": {
+        "up": "c6g.xlarge",
+        "down": "c6g.medium",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "4"
+    },
+    "c6g.xlarge": {
+        "up": "c6g.2xlarge",
+        "down": "c6g.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "8"
+    },
+    "c6g.2xlarge": {
+        "up": "c6g.4xlarge",
+        "down": "c6g.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "16"
+    },
+    "c6g.4xlarge": {
+        "up": "c6g.8xlarge",
+        "down": "c6g.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "32"
+    },
+    "c6g.8xlarge": {
+        "up": "c6g.12xlarge",
+        "down": "c6g.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "64"
+    },
+    "c6g.12xlarge": {
+        "up": "c6g.16xlarge",
+        "down": "c6g.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "96"
+    },
+    "c6g.16xlarge": {
+        "up": null,
+        "down": "c6g.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "128"
+    },
+    "c6g.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "memory": "128"
+    },
+    "c6gd.medium": {
+        "up": "c6gd.large",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "1",
+        "nfu": "2",
+        "memory": "2"
+    },
+    "c6gd.large": {
+        "up": "c6gd.xlarge",
+        "down": "c6gd.medium",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "4"
+    },
+    "c6gd.xlarge": {
+        "up": "c6gd.2xlarge",
+        "down": "c6gd.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "8"
+    },
+    "c6gd.2xlarge": {
+        "up": "c6gd.4xlarge",
+        "down": "c6gd.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "16"
+    },
+    "c6gd.4xlarge": {
+        "up": "c6gd.8xlarge",
+        "down": "c6gd.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "32"
+    },
+    "c6gd.8xlarge": {
+        "up": "c6gd.12xlarge",
+        "down": "c6gd.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "64"
+    },
+    "c6gd.12xlarge": {
+        "up": "c6gd.16xlarge",
+        "down": "c6gd.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "96"
+    },
+    "c6gd.16xlarge": {
+        "up": null,
+        "down": "c6gd.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "128"
+    },
+    "c6gd.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "memory": "128"
+    },
+    "c6gn.medium": {
+        "up": "c6gn.large",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "1",
+        "nfu": "2",
+        "memory": "2"
+    },
+    "c6gn.large": {
+        "up": "c6gn.xlarge",
+        "down": "c6gn.medium",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "4"
+    },
+    "c6gn.xlarge": {
+        "up": "c6gn.2xlarge",
+        "down": "c6gn.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "8"
+    },
+    "c6gn.2xlarge": {
+        "up": "c6gn.4xlarge",
+        "down": "c6gn.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "16"
+    },
+    "c6gn.4xlarge": {
+        "up": "c6gn.8xlarge",
+        "down": "c6gn.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "32"
+    },
+    "c6gn.8xlarge": {
+        "up": "c6gn.12xlarge",
+        "down": "c6gn.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "64"
+    },
+    "c6gn.12xlarge": {
+        "up": "c6gn.16xlarge",
+        "down": "c6gn.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "96"
+    },
+    "c6gn.16xlarge": {
+        "up": null,
+        "down": "c6gn.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "128"
+    },
+    "c6i.large": {
+        "up": "c6i.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "4"
+    },
+    "c6i.xlarge": {
+        "up": "c6i.2xlarge",
+        "down": "c6i.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "8"
+    },
+    "c6i.2xlarge": {
+        "up": "c6i.4xlarge",
+        "down": "c6i.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "16"
+    },
+    "c6i.4xlarge": {
+        "up": "c6i.8xlarge",
+        "down": "c6i.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "32"
+    },
+    "c6i.8xlarge": {
+        "up": "c6i.12xlarge",
+        "down": "c6i.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "64"
+    },
+    "c6i.12xlarge": {
+        "up": "c6i.16xlarge",
+        "down": "c6i.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "96"
+    },
+    "c6i.16xlarge": {
+        "up": "c6i.24xlarge",
+        "down": "c6i.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "128"
+    },
+    "c6i.24xlarge": {
+        "up": "c6i.32xlarge",
+        "down": "c6i.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "192"
+    },
+    "c6i.32xlarge": {
+        "up": null,
+        "down": "c6i.24xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "128",
+        "nfu": "256",
+        "memory": "256"
+    },
+    "c6i.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "128",
+        "nfu": "256",
+        "memory": "256"
+    },
+    "c6id.large": {
+        "up": "c6id.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "4"
+    },
+    "c6id.xlarge": {
+        "up": "c6id.2xlarge",
+        "down": "c6id.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "8"
+    },
+    "c6id.2xlarge": {
+        "up": "c6id.4xlarge",
+        "down": "c6id.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "16"
+    },
+    "c6id.4xlarge": {
+        "up": "c6id.8xlarge",
+        "down": "c6id.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "32"
+    },
+    "c6id.8xlarge": {
+        "up": "c6id.12xlarge",
+        "down": "c6id.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "64"
+    },
+    "c6id.12xlarge": {
+        "up": "c6id.16xlarge",
+        "down": "c6id.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "96"
+    },
+    "c6id.16xlarge": {
+        "up": "c6id.24xlarge",
+        "down": "c6id.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "128"
+    },
+    "c6id.24xlarge": {
+        "up": "c6id.32xlarge",
+        "down": "c6id.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "192"
+    },
+    "c6id.32xlarge": {
+        "up": null,
+        "down": "c6id.24xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "128",
+        "nfu": "256",
+        "memory": "256"
+    },
+    "c6id.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "128",
+        "nfu": "256",
+        "memory": "256"
+    },
+    "c7g.medium": {
+        "up": "c7g.large",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "1",
+        "nfu": "2",
+        "memory": "2"
+    },
+    "c7g.large": {
+        "up": "c7g.xlarge",
+        "down": "c7g.medium",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "4"
+    },
+    "c7g.xlarge": {
+        "up": "c7g.2xlarge",
+        "down": "c7g.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "8"
+    },
+    "c7g.2xlarge": {
+        "up": "c7g.4xlarge",
+        "down": "c7g.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "16"
+    },
+    "c7g.4xlarge": {
+        "up": "c7g.8xlarge",
+        "down": "c7g.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "32"
+    },
+    "c7g.8xlarge": {
+        "up": "c7g.12xlarge",
+        "down": "c7g.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "64"
+    },
+    "c7g.12xlarge": {
+        "up": "c7g.16xlarge",
+        "down": "c7g.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "96"
+    },
+    "c7g.16xlarge": {
+        "up": null,
+        "down": "c7g.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "128"
+    },
+    "cc1.4xlarge": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "nfu": "32"
+    },
+    "cc2.8xlarge": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "60.5"
+    },
+    "cg1.4xlarge": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "nfu": "32"
+    },
+    "cr1.8xlarge": {
+        "up": null,
+        "down": null,
+        "superseded": {
+            "regular": "r3.8xlarge",
+            "next_gen": "r4.8xlarge",
+            "burstable": "",
+            "amd": ""
+        },
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "244"
+    },
+    "d2.xlarge": {
+        "up": "d2.2xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "30.5"
+    },
+    "d2.2xlarge": {
+        "up": "d2.4xlarge",
+        "down": "d2.xlarge",
+        "superseded": null,
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "61"
+    },
+    "d2.4xlarge": {
+        "up": "d2.8xlarge",
+        "down": "d2.2xlarge",
+        "superseded": null,
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "122"
+    },
+    "d2.8xlarge": {
+        "up": null,
+        "down": "d2.4xlarge",
+        "superseded": null,
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "36",
+        "nfu": "64",
+        "memory": "244"
+    },
+    "d3.xlarge": {
+        "up": "d3.2xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "32"
+    },
+    "d3.2xlarge": {
+        "up": "d3.4xlarge",
+        "down": "d3.xlarge",
+        "superseded": null,
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "64"
+    },
+    "d3.4xlarge": {
+        "up": "d3.8xlarge",
+        "down": "d3.2xlarge",
+        "superseded": null,
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "128"
+    },
+    "d3.8xlarge": {
+        "up": null,
+        "down": "d3.4xlarge",
+        "superseded": null,
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "256"
+    },
+    "d3en.xlarge": {
+        "up": "d3en.2xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "d3en.2xlarge": {
+        "up": "d3en.4xlarge",
+        "down": "d3en.xlarge",
+        "superseded": null,
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "d3en.4xlarge": {
+        "up": "d3en.6xlarge",
+        "down": "d3en.2xlarge",
+        "superseded": null,
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "64"
+    },
+    "d3en.6xlarge": {
+        "up": "d3en.8xlarge",
+        "down": "d3en.4xlarge",
+        "superseded": null,
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "24",
+        "nfu": "48",
+        "memory": "96"
+    },
+    "d3en.8xlarge": {
+        "up": "d3en.12xlarge",
+        "down": "d3en.6xlarge",
+        "superseded": null,
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "128"
+    },
+    "d3en.12xlarge": {
+        "up": null,
+        "down": "d3en.8xlarge",
+        "superseded": null,
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "192"
+    },
+    "p2.xlarge": {
+        "up": "p2.8xlarge",
+        "down": null,
+        "superseded": {
+            "regular": "p3.xlarge",
+            "next_gen": null,
+            "burstable": "",
+            "amd": ""
+        },
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "61"
+    },
+    "p2.8xlarge": {
+        "up": "p2.16xlarge",
+        "down": "p2.xlarge",
+        "superseded": {
+            "regular": "p3.8xlarge",
+            "next_gen": null,
+            "burstable": "",
+            "amd": ""
+        },
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "488"
+    },
+    "p2.16xlarge": {
+        "up": null,
+        "down": "p2.8xlarge",
+        "superseded": {
+            "regular": "p3.16xlarge",
+            "next_gen": null,
+            "burstable": "",
+            "amd": ""
+        },
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "732"
+    },
+    "p3.2xlarge": {
+        "up": "p3.8xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "61"
+    },
+    "p3.8xlarge": {
+        "up": "p3.16xlarge",
+        "down": "p3.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "244"
+    },
+    "p3.16xlarge": {
+        "up": "p3dn.24xlarge",
+        "down": "p3.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "488"
+    },
+    "p3dn.24xlarge": {
+        "up": null,
+        "down": "p3.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "768"
+    },
+    "inf1.xlarge": {
+        "up": "inf1.2xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "8"
+    },
+    "inf1.2xlarge": {
+        "up": "inf1.6xlarge",
+        "down": "inf1.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "16"
+    },
+    "inf1.6xlarge": {
+        "up": "inf1.24xlarge",
+        "down": "inf1.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "24",
+        "nfu": "48",
+        "memory": "48"
+    },
+    "inf1.24xlarge": {
+        "up": null,
+        "down": "inf1.6xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "192"
+    },
+    "g2.2xlarge": {
+        "up": "g2.8xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "15"
+    },
+    "g2.8xlarge": {
+        "up": null,
+        "down": "g2.2xlarge",
+        "superseded": null,
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "60"
+    },
+    "g3s.xlarge": {
+        "up": "g3.4xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "30.5"
+    },
+    "g3.4xlarge": {
+        "up": "g3.8xlarge",
+        "down": "g3s.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "122"
+    },
+    "g3.8xlarge": {
+        "up": "g3.16xlarge",
+        "down": "g3.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "244"
+    },
+    "g3.16xlarge": {
+        "up": null,
+        "down": "g3.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "488"
+    },
+    "g4.large": {
+        "up": "g4.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "nfu": "4"
+    },
+    "g4.2xlarge": {
+        "up": "g4.4xlarge",
+        "down": "g4.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "nfu": "16"
+    },
+    "g4.4xlarge": {
+        "up": "g4.8xlarge",
+        "down": "g4.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "nfu": "32"
+    },
+    "g4.8xlarge": {
+        "up": "g4.16xlarge",
+        "down": "g4.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "nfu": "64"
+    },
+    "g4.16xlarge": {
+        "up": null,
+        "down": "g4.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "nfu": "128"
+    },
+    "g4dn.12xlarge": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "192"
+    },
+    "g4dn.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "memory": "384"
+    },
+    "g4ad.4xlarge": {
+        "up": "g4ad.8xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "64"
+    },
+    "g4ad.8xlarge": {
+        "up": "g4ad.16xlarge",
+        "down": "g4ad.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "128"
+    },
+    "g4ad.16xlarge": {
+        "up": null,
+        "down": "g4ad.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "256"
+    },
+    "g4dn.xlarge": {
+        "up": "g4dn.2xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "g4dn.2xlarge": {
+        "up": "g4dn.4xlarge",
+        "down": "g4dn.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "g4dn.4xlarge": {
+        "up": "g4dn.8xlarge",
+        "down": "g4dn.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "64"
+    },
+    "g4dn.8xlarge": {
+        "up": "g4dn.16xlarge",
+        "down": "g4dn.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "128"
+    },
+    "g4dn.16xlarge": {
+        "up": null,
+        "down": "g4dn.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "256"
+    },
+    "g5g.xlarge": {
+        "up": "g5g.2xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": false,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "8"
+    },
+    "g5g.2xlarge": {
+        "up": "g5g.4xlarge",
+        "down": "g5g.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": false,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "16"
+    },
+    "g5g.4xlarge": {
+        "up": "g5g.8xlarge",
+        "down": "g5g.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": false,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "32"
+    },
+    "g5g.8xlarge": {
+        "up": "g5g.16xlarge",
+        "down": "g5g.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": false,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "64"
+    },
+    "g5g.16xlarge": {
+        "up": "g5g.metal",
+        "down": "g5g.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": false,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "128"
+    },
+    "g5g.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": false,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "128"
+    },
+    "f1.2xlarge": {
+        "up": "f1.4xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "122"
+    },
+    "f1.4xlarge": {
+        "up": "f1.16xlarge",
+        "down": "f1.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "244"
+    },
+    "f1.16xlarge": {
+        "up": null,
+        "down": "f1.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "976"
+    },
+    "h1.2xlarge": {
+        "up": "h1.4xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "h1.4xlarge": {
+        "up": "h1.8xlarge",
+        "down": "h1.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "64"
+    },
+    "h1.8xlarge": {
+        "up": "h1.16xlarge",
+        "down": "h1.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "128"
+    },
+    "h1.16xlarge": {
+        "up": null,
+        "down": "h1.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "256"
+    },
+    "hi1.4xlarge": {
+        "up": "hs1.8xlarge",
+        "down": null,
+        "superseded": {
+            "regular": "i3.4xlarge",
+            "next_gen": "",
+            "burstable": "",
+            "amd": ""
+        },
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "nfu": "32"
+    },
+    "hs1.8xlarge": {
+        "up": null,
+        "down": "hi1.4xlarge",
+        "superseded": {
+            "regular": "d2.8xlarge",
+            "next_gen": "",
+            "burstable": "",
+            "amd": ""
+        },
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "16",
+        "nfu": "64",
+        "memory": "117"
+    },
+    "i2.xlarge": {
+        "up": "i2.2xlarge",
+        "down": null,
+        "superseded": {
+            "regular": "i3.xlarge",
+            "next_gen": "",
+            "burstable": "",
+            "amd": ""
+        },
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "30.5"
+    },
+    "i2.2xlarge": {
+        "up": "i2.4xlarge",
+        "down": "i2.xlarge",
+        "superseded": {
+            "regular": "i3.2xlarge",
+            "next_gen": "",
+            "burstable": "",
+            "amd": ""
+        },
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "61"
+    },
+    "i2.4xlarge": {
+        "up": "i2.8xlarge",
+        "down": "i2.2xlarge",
+        "superseded": {
+            "regular": "i3.4xlarge",
+            "next_gen": "",
+            "burstable": "",
+            "amd": ""
+        },
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "122"
+    },
+    "i2.8xlarge": {
+        "up": null,
+        "down": "i2.4xlarge",
+        "superseded": {
+            "regular": "i3.8xlarge",
+            "next_gen": "",
+            "burstable": "",
+            "amd": ""
+        },
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "244"
+    },
+    "i3.large": {
+        "up": "i3.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "15.25"
+    },
+    "i3.xlarge": {
+        "up": "i3.2xlarge",
+        "down": "i3.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "30.5"
+    },
+    "i3.2xlarge": {
+        "up": "i3.4xlarge",
+        "down": "i3.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "61"
+    },
+    "i3.4xlarge": {
+        "up": "i3.8xlarge",
+        "down": "i3.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "122"
+    },
+    "i3.8xlarge": {
+        "up": "i3.16xlarge",
+        "down": "i3.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "244"
+    },
+    "i3.16xlarge": {
+        "up": null,
+        "down": "i3.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "488"
+    },
+    "i3.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "memory": "512"
+    },
+    "i3en.large": {
+        "up": "i3en.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "16"
+    },
+    "i3en.xlarge": {
+        "up": "i3en.2xlarge",
+        "down": "i3en.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "32"
+    },
+    "i3en.2xlarge": {
+        "up": "i3en.3xlarge",
+        "down": "i3en.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "64"
+    },
+    "i3en.3xlarge": {
+        "up": "i3en.6xlarge",
+        "down": "i3en.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "12",
+        "nfu": "24",
+        "memory": "96"
+    },
+    "i3en.6xlarge": {
+        "up": "i3en.12xlarge",
+        "down": "i3en.3xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "24",
+        "nfu": "48",
+        "memory": "192"
+    },
+    "i3en.12xlarge": {
+        "up": "i3en.24xlarge",
+        "down": "i3en.6xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "384"
+    },
+    "i3en.24xlarge": {
+        "up": null,
+        "down": "i3en.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "768"
+    },
+    "i3en.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "memory": "768"
+    },
+    "im4gn.large": {
+        "up": "im4gn.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "8",
+        "memory": "8"
+    },
+    "im4gn.xlarge": {
+        "up": "im4gn.2xlarge",
+        "down": "im4gn.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "16",
+        "memory": "16"
+    },
+    "im4gn.2xlarge": {
+        "up": "im4gn.4xlarge",
+        "down": "im4gn.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "32",
+        "memory": "32"
+    },
+    "im4gn.4xlarge": {
+        "up": "im4gn.8xlarge",
+        "down": "im4gn.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "64",
+        "memory": "64"
+    },
+    "im4gn.8xlarge": {
+        "up": "im4gn.16xlarge",
+        "down": "im4gn.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "128",
+        "memory": "128"
+    },
+    "im4gn.16xlarge": {
+        "up": null,
+        "down": "im4gn.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "256",
+        "memory": "256"
+    },
+    "is4gen.medium": {
+        "up": "is4gen.large",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "1",
+        "nfu": "6",
+        "memory": "6"
+    },
+    "is4gen.large": {
+        "up": "is4gen.xlarge",
+        "down": "is4gen.medium",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "12",
+        "memory": "12"
+    },
+    "is4gen.xlarge": {
+        "up": "is4gen.2xlarge",
+        "down": "is4gen.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "24",
+        "memory": "24"
+    },
+    "is4gen.2xlarge": {
+        "up": "is4gen.4xlarge",
+        "down": "is4gen.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "48",
+        "memory": "48"
+    },
+    "is4gen.4xlarge": {
+        "up": "is4gen.8xlarge",
+        "down": "is4gen.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "96",
+        "memory": "96"
+    },
+    "is4gen.8xlarge": {
+        "up": null,
+        "down": "is4gen.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "192",
+        "memory": "192"
+    },
+    "m1.small": {
+        "up": "m1.medium",
+        "down": null,
+        "superseded": {
+            "regular": "t3.large",
+            "next_gen": "",
+            "burstable": "t3.large",
+            "amd": "m5a.large"
+        },
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "1",
+        "nfu": "1",
+        "memory": "1.7"
+    },
+    "m1.medium": {
+        "up": "m1.large",
+        "down": "m1.small",
+        "superseded": {
+            "regular": "m5.large",
+            "next_gen": "",
+            "burstable": "t3.large",
+            "amd": "m5a.large"
+        },
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "1",
+        "nfu": "2",
+        "memory": "3.75"
+    },
+    "m1.large": {
+        "up": "m1.xlarge",
+        "down": "m1.medium",
+        "superseded": {
+            "regular": "m5.large",
+            "next_gen": "",
+            "burstable": "t3.xlarge",
+            "amd": "m5a.large"
+        },
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "7.5"
+    },
+    "m1.xlarge": {
+        "up": null,
+        "down": "m1.large",
+        "superseded": {
+            "regular": "m5.xlarge",
+            "next_gen": "",
+            "burstable": "t3.2xlarge",
+            "amd": "m5a.xlarge"
+        },
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "15"
+    },
+    "m2.xlarge": {
+        "up": "m2.2xlarge",
+        "down": null,
+        "superseded": {
+            "regular": "r3.large",
+            "next_gen": "r5.large",
+            "burstable": "",
+            "amd": "r5a.large"
+        },
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "2",
+        "nfu": "8",
+        "memory": "17.1"
+    },
+    "m2.2xlarge": {
+        "up": "m2.4xlarge",
+        "down": "m2.xlarge",
+        "superseded": {
+            "regular": "r3.xlarge",
+            "next_gen": "r5.xlarge",
+            "burstable": "",
+            "amd": "r5a.xlarge"
+        },
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "4",
+        "nfu": "16",
+        "memory": "34.2"
+    },
+    "m2.4xlarge": {
+        "up": null,
+        "down": "m2.2xlarge",
+        "superseded": {
+            "regular": "r3.2xlarge",
+            "next_gen": "r5.2xlarge",
+            "burstable": "",
+            "amd": "r5a.2xlarge"
+        },
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "8",
+        "nfu": "32",
+        "memory": "68.4"
+    },
+    "m3.medium": {
+        "up": "m3.large",
+        "down": null,
+        "superseded": {
+            "regular": "m5.large",
+            "next_gen": "",
+            "burstable": "t3.large",
+            "amd": "m5a.large"
+        },
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "1",
+        "nfu": "2",
+        "memory": "3.75"
+    },
+    "m3.large": {
+        "up": "m3.xlarge",
+        "down": "m3.medium",
+        "superseded": {
+            "regular": "m5.large",
+            "next_gen": "",
+            "burstable": "t3.xlarge",
+            "amd": "m5a.large"
+        },
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "7.5"
+    },
+    "m3.xlarge": {
+        "up": "m3.2xlarge",
+        "down": "m3.large",
+        "superseded": {
+            "regular": "m5.xlarge",
+            "next_gen": "",
+            "burstable": "t3.2xlarge",
+            "amd": "m5a.xlarge"
+        },
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "15"
+    },
+    "m3.2xlarge": {
+        "up": null,
+        "down": "m3.xlarge",
+        "superseded": {
+            "regular": "m5.2xlarge",
+            "next_gen": "",
+            "burstable": "",
+            "amd": "m5a.2xlarge"
+        },
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "30"
+    },
+    "m4.large": {
+        "up": "m4.xlarge",
+        "down": null,
+        "superseded": {
+            "regular": "m5.large",
+            "next_gen": "",
+            "burstable": "t3.xlarge",
+            "amd": "m5a.large"
+        },
+        "ec2_classic": false,
+        "enhanced_networking": false,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "8"
+    },
+    "m4.xlarge": {
+        "up": "m4.2xlarge",
+        "down": "m4.large",
+        "superseded": {
+            "regular": "m5.xlarge",
+            "next_gen": "",
+            "burstable": "t3.2xlarge",
+            "amd": "m5a.xlarge"
+        },
+        "ec2_classic": false,
+        "enhanced_networking": false,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "m4.2xlarge": {
+        "up": "m4.4xlarge",
+        "down": "m4.xlarge",
+        "superseded": {
+            "regular": "m5.2xlarge",
+            "next_gen": "",
+            "burstable": "",
+            "amd": "m5a.2xlarge"
+        },
+        "ec2_classic": false,
+        "enhanced_networking": false,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "m4.4xlarge": {
+        "up": "m4.10xlarge",
+        "down": "m4.2xlarge",
+        "superseded": {
+            "regular": "m5.4xlarge",
+            "next_gen": "",
+            "burstable": "",
+            "amd": "m5a.4xlarge"
+        },
+        "ec2_classic": false,
+        "enhanced_networking": false,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "64"
+    },
+    "m4.10xlarge": {
+        "up": "m4.16xlarge",
+        "down": "m4.4xlarge",
+        "superseded": {
+            "regular": "m5.12xlarge",
+            "next_gen": "",
+            "burstable": "",
+            "amd": "m5a.12xlarge"
+        },
+        "ec2_classic": false,
+        "enhanced_networking": false,
+        "vcpu": "40",
+        "nfu": "80",
+        "memory": "160"
+    },
+    "m4.16xlarge": {
+        "up": null,
+        "down": "m4.10xlarge",
+        "superseded": {
+            "regular": "m5.16xlarge",
+            "next_gen": "",
+            "burstable": "",
+            "amd": "m5a.16xlarge"
+        },
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "256"
+    },
+    "m5.large": {
+        "up": "m5.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "8"
+    },
+    "m5.xlarge": {
+        "up": "m5.2xlarge",
+        "down": "m5.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "m5.2xlarge": {
+        "up": "m5.4xlarge",
+        "down": "m5.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "m5.4xlarge": {
+        "up": "m5.8xlarge",
+        "down": "m5.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "64"
+    },
+    "m5.8xlarge": {
+        "up": "m5.12xlarge",
+        "down": "m5.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "128"
+    },
+    "m5.12xlarge": {
+        "up": "m5.16xlarge",
+        "down": "m5.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "192"
+    },
+    "m5.16xlarge": {
+        "up": "m5.24xlarge",
+        "down": "m5.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "256"
+    },
+    "m5.24xlarge": {
+        "up": null,
+        "down": "m5.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "384"
+    },
+    "m5.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "memory": "384"
+    },
+    "m5n.large": {
+        "up": "m5n.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "8"
+    },
+    "m5n.xlarge": {
+        "up": "m5n.2xlarge",
+        "down": "m5n.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "m5n.2xlarge": {
+        "up": "m5n.4xlarge",
+        "down": "m5n.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "m5n.4xlarge": {
+        "up": "m5n.8xlarge",
+        "down": "m5n.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "64"
+    },
+    "m5n.8xlarge": {
+        "up": "m5n.12xlarge",
+        "down": "m5n.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "128"
+    },
+    "m5n.12xlarge": {
+        "up": "m5n.16xlarge",
+        "down": "m5n.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "192"
+    },
+    "m5n.16xlarge": {
+        "up": "m5n.24xlarge",
+        "down": "m5n.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "256"
+    },
+    "m5n.24xlarge": {
+        "up": null,
+        "down": "m5n.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "384"
+    },
+    "m5n.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "memory": "384"
+    },
+    "m5dn.large": {
+        "up": "m5dn.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "8"
+    },
+    "m5dn.xlarge": {
+        "up": "m5dn.2xlarge",
+        "down": "m5dn.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "m5dn.2xlarge": {
+        "up": "m5dn.4xlarge",
+        "down": "m5dn.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "m5dn.4xlarge": {
+        "up": "m5dn.8xlarge",
+        "down": "m5dn.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "64"
+    },
+    "m5dn.8xlarge": {
+        "up": "m5dn.12xlarge",
+        "down": "m5dn.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "128"
+    },
+    "m5dn.12xlarge": {
+        "up": "m5dn.16xlarge",
+        "down": "m5dn.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "192"
+    },
+    "m5dn.16xlarge": {
+        "up": "m5dn.24xlarge",
+        "down": "m5dn.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "256"
+    },
+    "m5dn.24xlarge": {
+        "up": null,
+        "down": "m5dn.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "384"
+    },
+    "m5dn.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "memory": "384"
+    },
+    "m5zn.large": {
+        "up": "m5zn.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "8"
+    },
+    "m5zn.xlarge": {
+        "up": "m5zn.2xlarge",
+        "down": "m5zn.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "m5zn.2xlarge": {
+        "up": "m5zn.3xlarge",
+        "down": "m5zn.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "m5zn.3xlarge": {
+        "up": "m5zn.6xlarge",
+        "down": "m5zn.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "12",
+        "nfu": "24",
+        "memory": "48"
+    },
+    "m5zn.6xlarge": {
+        "up": "m5zn.12xlarge",
+        "down": "m5zn.3xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "24",
+        "nfu": "48",
+        "memory": "96"
+    },
+    "m5zn.12xlarge": {
+        "up": null,
+        "down": "m5zn.6xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "192"
+    },
+    "m5zn.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "memory": "192"
+    },
+    "mac1.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "12",
+        "memory": "32"
+    },
+    "p4d.24xlarge": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "1152"
+    },
+    "m6a.large": {
+        "up": "m6a.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "8"
+    },
+    "m6a.xlarge": {
+        "up": "m6a.2xlarge",
+        "down": "m6a.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "m6a.2xlarge": {
+        "up": "m6a.4xlarge",
+        "down": "m6a.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "m6a.4xlarge": {
+        "up": "m6a.8xlarge",
+        "down": "m6a.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "64"
+    },
+    "m6a.8xlarge": {
+        "up": "m6a.12xlarge",
+        "down": "m6a.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "128"
+    },
+    "m6a.12xlarge": {
+        "up": "m6a.16xlarge",
+        "down": "m6a.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "192"
+    },
+    "m6a.16xlarge": {
+        "up": "m6a.24xlarge",
+        "down": "m6a.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "256"
+    },
+    "m6a.24xlarge": {
+        "up": "m6a.32xlarge",
+        "down": "m6a.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "384"
+    },
+    "m6a.32xlarge": {
+        "up": "m6a.48xlarge",
+        "down": "m6a.24xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "128",
+        "nfu": "256",
+        "memory": "512"
+    },
+    "m6a.48xlarge": {
+        "up": null,
+        "down": "m6a.32xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "192",
+        "nfu": "384",
+        "memory": "768"
+    },
+    "m6a.metal": {
+        "up": null,
+        "down": "m6a.32xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "192",
+        "nfu": "384",
+        "memory": "768"
+    },
+    "m6g.medium": {
+        "up": "m6g.large",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "1",
+        "nfu": "2",
+        "memory": "4"
+    },
+    "m6g.large": {
+        "up": "m6g.xlarge",
+        "down": "m6g.medium",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "8"
+    },
+    "m6g.xlarge": {
+        "up": "m6g.2xlarge",
+        "down": "m6g.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "m6g.2xlarge": {
+        "up": "m6g.4xlarge",
+        "down": "m6g.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "m6g.4xlarge": {
+        "up": "m6g.8xlarge",
+        "down": "m6g.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "64"
+    },
+    "m6g.8xlarge": {
+        "up": "m6g.12xlarge",
+        "down": "m6g.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "128"
+    },
+    "m6g.12xlarge": {
+        "up": "m6g.16xlarge",
+        "down": "m6g.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "192"
+    },
+    "m6g.16xlarge": {
+        "up": "m6g.24xlarge",
+        "down": "m6g.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "256"
+    },
+    "m6g.24xlarge": {
+        "up": null,
+        "down": "m6g.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "nfu": "192"
+    },
+    "m6g.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "memory": "256"
+    },
+    "m6gd.medium": {
+        "up": "m6gd.large",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "1",
+        "nfu": "2",
+        "memory": "4"
+    },
+    "m6gd.large": {
+        "up": "m6gd.xlarge",
+        "down": "m6gd.medium",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "8"
+    },
+    "m6gd.xlarge": {
+        "up": "m6gd.2xlarge",
+        "down": "m6gd.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "m6gd.2xlarge": {
+        "up": "m6gd.4xlarge",
+        "down": "m6gd.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "m6gd.4xlarge": {
+        "up": "m6gd.8xlarge",
+        "down": "m6gd.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "64"
+    },
+    "m6gd.8xlarge": {
+        "up": "m6gd.12xlarge",
+        "down": "m6gd.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "128"
+    },
+    "m6gd.12xlarge": {
+        "up": "m6gd.16xlarge",
+        "down": "m6gd.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "192"
+    },
+    "m6gd.16xlarge": {
+        "up": "m6gd.24xlarge",
+        "down": "m6gd.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "256"
+    },
+    "m6gd.24xlarge": {
+        "up": null,
+        "down": "m6gd.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "nfu": "192"
+    },
+    "m6gd.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "memory": "256"
+    },
+    "m6i.large": {
+        "up": "m6i.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "8"
+    },
+    "m6i.xlarge": {
+        "up": "m6i.2xlarge",
+        "down": "m6i.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "m6i.2xlarge": {
+        "up": "m6i.4xlarge",
+        "down": "m6i.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "m6i.4xlarge": {
+        "up": "m6i.8xlarge",
+        "down": "m6i.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "64"
+    },
+    "m6i.8xlarge": {
+        "up": "m6i.12xlarge",
+        "down": "m6i.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "128"
+    },
+    "m6i.12xlarge": {
+        "up": "m6i.16xlarge",
+        "down": "m6i.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "192"
+    },
+    "m6i.16xlarge": {
+        "up": "m6i.24xlarge",
+        "down": "m6i.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "256"
+    },
+    "m6i.24xlarge": {
+        "up": "m6i.32xlarge",
+        "down": "m6i.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "384"
+    },
+    "m6i.32xlarge": {
+        "up": null,
+        "down": "m6i.24xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "128",
+        "nfu": "256",
+        "memory": "512"
+    },
+    "m6i.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "128",
+        "nfu": "256",
+        "memory": "512"
+    },
+    "m6id.large": {
+        "up": "m6id.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "8"
+    },
+    "m6id.xlarge": {
+        "up": "m6id.2xlarge",
+        "down": "m6id.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "m6id.2xlarge": {
+        "up": "m6id.4xlarge",
+        "down": "m6id.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "m6id.4xlarge": {
+        "up": "m6id.8xlarge",
+        "down": "m6id.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "64"
+    },
+    "m6id.8xlarge": {
+        "up": "m6id.12xlarge",
+        "down": "m6id.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "128"
+    },
+    "m6id.12xlarge": {
+        "up": "m6id.16xlarge",
+        "down": "m6id.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "192"
+    },
+    "m6id.16xlarge": {
+        "up": "m6id.24xlarge",
+        "down": "m6id.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "256"
+    },
+    "m6id.24xlarge": {
+        "up": "m6id.32xlarge",
+        "down": "m6id.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "384"
+    },
+    "m6id.32xlarge": {
+        "up": null,
+        "down": "m6id.24xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "128",
+        "nfu": "256",
+        "memory": "512"
+    },
+    "m6id.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "128",
+        "nfu": "256",
+        "memory": "512"
+    },
+    "m5a.large": {
+        "up": "m5a.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "8"
+    },
+    "m5a.xlarge": {
+        "up": "m5a.2xlarge",
+        "down": "m5a.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "m5a.2xlarge": {
+        "up": "m5a.4xlarge",
+        "down": "m5a.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "m5a.4xlarge": {
+        "up": "m5a.8xlarge",
+        "down": "m5a.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "64"
+    },
+    "m5a.8xlarge": {
+        "up": "m5a.12xlarge",
+        "down": "m5a.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "128"
+    },
+    "m5a.12xlarge": {
+        "up": "m5a.16xlarge",
+        "down": "m5a.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "192"
+    },
+    "m5a.16xlarge": {
+        "up": "m5a.24xlarge",
+        "down": "m5a.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "256"
+    },
+    "m5a.24xlarge": {
+        "up": null,
+        "down": "m5a.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "384"
+    },
+    "m5ad.large": {
+        "up": "m5ad.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "8"
+    },
+    "m5ad.xlarge": {
+        "up": "m5ad.2xlarge",
+        "down": "m5ad.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "m5ad.2xlarge": {
+        "up": "m5ad.4xlarge",
+        "down": "m5ad.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "m5ad.4xlarge": {
+        "up": "m5ad.8xlarge",
+        "down": "m5ad.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "64"
+    },
+    "m5ad.8xlarge": {
+        "up": "m5ad.12xlarge",
+        "down": "m5ad.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "128"
+    },
+    "m5ad.12xlarge": {
+        "up": "m5ad.16xlarge",
+        "down": "m5ad.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "192"
+    },
+    "m5ad.16xlarge": {
+        "up": "m5ad.24xlarge",
+        "down": "m5ad.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "256"
+    },
+    "m5ad.24xlarge": {
+        "up": null,
+        "down": "m5ad.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "384"
+    },
+    "m5d.large": {
+        "up": "m5d.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "8"
+    },
+    "m5d.xlarge": {
+        "up": "m5d.2xlarge",
+        "down": "m5d.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "m5d.2xlarge": {
+        "up": "m5d.4xlarge",
+        "down": "m5d.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "m5d.4xlarge": {
+        "up": "m5d.8xlarge",
+        "down": "m5d.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "64"
+    },
+    "m5d.8xlarge": {
+        "up": "m5d.12xlarge",
+        "down": "m5d.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "128"
+    },
+    "m5d.12xlarge": {
+        "up": "m5d.16xlarge",
+        "down": "m5d.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "192"
+    },
+    "m5d.16xlarge": {
+        "up": "m5d.24xlarge",
+        "down": "m5d.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "256"
+    },
+    "m5d.24xlarge": {
+        "up": null,
+        "down": "m5d.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "384"
+    },
+    "m5d.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "memory": "384"
+    },
+    "r3.large": {
+        "up": "r3.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "15.25"
+    },
+    "r3.xlarge": {
+        "up": "r3.2xlarge",
+        "down": "r3.large",
+        "superseded": null,
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "30.5"
+    },
+    "r3.2xlarge": {
+        "up": "r3.4xlarge",
+        "down": "r3.xlarge",
+        "superseded": null,
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "61"
+    },
+    "r3.4xlarge": {
+        "up": "r3.8xlarge",
+        "down": "r3.2xlarge",
+        "superseded": null,
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "122"
+    },
+    "r3.8xlarge": {
+        "up": null,
+        "down": "r3.4xlarge",
+        "superseded": null,
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "244"
+    },
+    "r4.large": {
+        "up": "r4.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "15.25"
+    },
+    "r4.xlarge": {
+        "up": "r4.2xlarge",
+        "down": "r4.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "30.5"
+    },
+    "r4.2xlarge": {
+        "up": "r4.4xlarge",
+        "down": "r4.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "61"
+    },
+    "r4.4xlarge": {
+        "up": "r4.8xlarge",
+        "down": "r4.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "122"
+    },
+    "r4.8xlarge": {
+        "up": "r4.16xlarge",
+        "down": "r4.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "244"
+    },
+    "r4.16xlarge": {
+        "up": null,
+        "down": "r4.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "488"
+    },
+    "r5.large": {
+        "up": "r5.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "16"
+    },
+    "r5.xlarge": {
+        "up": "r5.2xlarge",
+        "down": "r5.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "32"
+    },
+    "r5.2xlarge": {
+        "up": "r5.4xlarge",
+        "down": "r5.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "64"
+    },
+    "r5.4xlarge": {
+        "up": "r5.8xlarge",
+        "down": "r5.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "128"
+    },
+    "r5.8xlarge": {
+        "up": "r5.12xlarge",
+        "down": "r5.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "256"
+    },
+    "r5.12xlarge": {
+        "up": "r5.16xlarge",
+        "down": "r5.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "384"
+    },
+    "r5.16xlarge": {
+        "up": "r5.24xlarge",
+        "down": "r5.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "512"
+    },
+    "r5.24xlarge": {
+        "up": null,
+        "down": "r5.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "768"
+    },
+    "r5.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "memory": "768"
+    },
+    "r5a.large": {
+        "up": "r5a.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "16"
+    },
+    "r5a.xlarge": {
+        "up": "r5a.2xlarge",
+        "down": "r5a.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "32"
+    },
+    "r5a.2xlarge": {
+        "up": "r5a.4xlarge",
+        "down": "r5a.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "64"
+    },
+    "r5a.4xlarge": {
+        "up": "r5a.8xlarge",
+        "down": "r5a.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "128"
+    },
+    "r5a.8xlarge": {
+        "up": "r5a.12xlarge",
+        "down": "r5a.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "256"
+    },
+    "r5a.12xlarge": {
+        "up": "r5a.16xlarge",
+        "down": "r5a.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "384"
+    },
+    "r5a.16xlarge": {
+        "up": "r5a.24xlarge",
+        "down": "r5a.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "512"
+    },
+    "r5a.24xlarge": {
+        "up": null,
+        "down": "r5a.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "768"
+    },
+    "r5b.large": {
+        "up": "r5b.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "16"
+    },
+    "r5b.xlarge": {
+        "up": "r5b.2xlarge",
+        "down": "r5b.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "32"
+    },
+    "r5b.2xlarge": {
+        "up": "r5b.4xlarge",
+        "down": "r5b.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "64"
+    },
+    "r5b.4xlarge": {
+        "up": "r5b.8xlarge",
+        "down": "r5b.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "128"
+    },
+    "r5b.8xlarge": {
+        "up": "r5b.12xlarge",
+        "down": "r5b.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "256"
+    },
+    "r5b.12xlarge": {
+        "up": "r5b.16xlarge",
+        "down": "r5b.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "384"
+    },
+    "r5b.16xlarge": {
+        "up": "r5b.24xlarge",
+        "down": "r5b.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "512"
+    },
+    "r5b.24xlarge": {
+        "up": null,
+        "down": "r5b.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "768"
+    },
+    "r5b.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "memory": "768"
+    },
+    "r5ad.large": {
+        "up": "r5ad.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "16"
+    },
+    "r5ad.xlarge": {
+        "up": "r5ad.2xlarge",
+        "down": "r5ad.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "32"
+    },
+    "r5ad.2xlarge": {
+        "up": "r5ad.4xlarge",
+        "down": "r5ad.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "64"
+    },
+    "r5ad.4xlarge": {
+        "up": "r5ad.8xlarge",
+        "down": "r5ad.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "128"
+    },
+    "r5ad.8xlarge": {
+        "up": "r5ad.12xlarge",
+        "down": "r5ad.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "256"
+    },
+    "r5ad.12xlarge": {
+        "up": "r5ad.16xlarge",
+        "down": "r5ad.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "384"
+    },
+    "r5ad.16xlarge": {
+        "up": "r5ad.24xlarge",
+        "down": "r5ad.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "512"
+    },
+    "r5ad.24xlarge": {
+        "up": null,
+        "down": "r5ad.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "768"
+    },
+    "r5n.large": {
+        "up": "r5n.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "16"
+    },
+    "r5n.xlarge": {
+        "up": "r5n.2xlarge",
+        "down": "r5n.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "32"
+    },
+    "r5n.2xlarge": {
+        "up": "r5n.4xlarge",
+        "down": "r5n.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "64"
+    },
+    "r5n.4xlarge": {
+        "up": "r5n.8xlarge",
+        "down": "r5n.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "128"
+    },
+    "r5n.8xlarge": {
+        "up": "r5n.12xlarge",
+        "down": "r5n.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "256"
+    },
+    "r5n.12xlarge": {
+        "up": "r5n.16xlarge",
+        "down": "r5n.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "384"
+    },
+    "r5n.16xlarge": {
+        "up": "r5n.24xlarge",
+        "down": "r5n.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "512"
+    },
+    "r5n.24xlarge": {
+        "up": null,
+        "down": "r5n.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "768"
+    },
+    "r5n.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "memory": "768"
+    },
+    "r5dn.large": {
+        "up": "r5dn.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "16"
+    },
+    "r5dn.xlarge": {
+        "up": "r5dn.2xlarge",
+        "down": "r5dn.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "32"
+    },
+    "r5dn.2xlarge": {
+        "up": "r5dn.4xlarge",
+        "down": "r5dn.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "64"
+    },
+    "r5dn.4xlarge": {
+        "up": "r5dn.8xlarge",
+        "down": "r5dn.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "128"
+    },
+    "r5dn.8xlarge": {
+        "up": "r5dn.12xlarge",
+        "down": "r5dn.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "256"
+    },
+    "r5dn.12xlarge": {
+        "up": "r5dn.16xlarge",
+        "down": "r5dn.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "384"
+    },
+    "r5dn.16xlarge": {
+        "up": "r5dn.24xlarge",
+        "down": "r5dn.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "512"
+    },
+    "r5dn.24xlarge": {
+        "up": null,
+        "down": "r5dn.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "768"
+    },
+    "r5dn.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "memory": "768"
+    },
+    "r5d.large": {
+        "up": "r5d.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "16"
+    },
+    "r5d.xlarge": {
+        "up": "r5d.2xlarge",
+        "down": "r5d.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "32"
+    },
+    "r5d.2xlarge": {
+        "up": "r5d.4xlarge",
+        "down": "r5d.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "64"
+    },
+    "r5d.4xlarge": {
+        "up": "r5d.8xlarge",
+        "down": "r5d.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "128"
+    },
+    "r5d.8xlarge": {
+        "up": "r5d.12xlarge",
+        "down": "r5d.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "256"
+    },
+    "r5d.12xlarge": {
+        "up": "r5d.16xlarge",
+        "down": "r5d.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "384"
+    },
+    "r5d.16xlarge": {
+        "up": "r5d.24xlarge",
+        "down": "r5d.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "512"
+    },
+    "r5d.24xlarge": {
+        "up": null,
+        "down": "r5d.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "768"
+    },
+    "r5d.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "memory": "768"
+    },
+    "r6a.large": {
+        "up": "r6a.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "16"
+    },
+    "r6a.xlarge": {
+        "up": "r6a.2xlarge",
+        "down": "r6a.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "32"
+    },
+    "r6a.2xlarge": {
+        "up": "r6a.4xlarge",
+        "down": "r6a.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "64"
+    },
+    "r6a.4xlarge": {
+        "up": "r6a.8xlarge",
+        "down": "r6a.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "128"
+    },
+    "r6a.8xlarge": {
+        "up": "r6a.12xlarge",
+        "down": "r6a.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "256"
+    },
+    "r6a.12xlarge": {
+        "up": "r6a.16xlarge",
+        "down": "r6a.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "384"
+    },
+    "r6a.16xlarge": {
+        "up": "r6a.24xlarge",
+        "down": "r6a.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "512"
+    },
+    "r6a.24xlarge": {
+        "up": "r6a.32xlarge",
+        "down": "r6a.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "768"
+    },
+    "r6a.32xlarge": {
+        "up": "r6a.48xlarge",
+        "down": "r6a.24xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "128",
+        "nfu": "256",
+        "memory": "1024"
+    },
+    "r6a.48xlarge": {
+        "up": null,
+        "down": "r6a.32xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "192",
+        "nfu": "384",
+        "memory": "1536"
+    },
+    "r6a.metal": {
+        "up": null,
+        "down": "r6a.32xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "192",
+        "nfu": "384",
+        "memory": "1536"
+    },
+    "r6g.medium": {
+        "up": "r6g.large",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "1",
+        "nfu": "2",
+        "memory": "8"
+    },
+    "r6g.large": {
+        "up": "r6g.xlarge",
+        "down": "r6g.medium",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "16"
+    },
+    "r6g.xlarge": {
+        "up": "r6g.2xlarge",
+        "down": "r6g.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "32"
+    },
+    "r6g.2xlarge": {
+        "up": "r6g.4xlarge",
+        "down": "r6g.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "64"
+    },
+    "r6g.4xlarge": {
+        "up": "r6g.8xlarge",
+        "down": "r6g.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "128"
+    },
+    "r6g.8xlarge": {
+        "up": "r6g.12xlarge",
+        "down": "r6g.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "256"
+    },
+    "r6g.12xlarge": {
+        "up": "r6g.16xlarge",
+        "down": "r6g.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "384"
+    },
+    "r6g.16xlarge": {
+        "up": null,
+        "down": "r6g.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "512"
+    },
+    "r6g.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "memory": "512"
+    },
+    "r6gd.medium": {
+        "up": "r6gd.large",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "1",
+        "nfu": "2",
+        "memory": "8"
+    },
+    "r6gd.large": {
+        "up": "r6gd.xlarge",
+        "down": "r6gd.medium",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "16"
+    },
+    "r6gd.xlarge": {
+        "up": "r6gd.2xlarge",
+        "down": "r6gd.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "32"
+    },
+    "r6gd.2xlarge": {
+        "up": "r6gd.4xlarge",
+        "down": "r6gd.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "64"
+    },
+    "r6gd.4xlarge": {
+        "up": "r6gd.8xlarge",
+        "down": "r6gd.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "128"
+    },
+    "r6gd.8xlarge": {
+        "up": "r6gd.12xlarge",
+        "down": "r6gd.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "256"
+    },
+    "r6gd.12xlarge": {
+        "up": "r6gd.16xlarge",
+        "down": "r6gd.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "384"
+    },
+    "r6gd.16xlarge": {
+        "up": null,
+        "down": "r6gd.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "512"
+    },
+    "r6gd.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "memory": "512"
+    },
+    "r6i.large": {
+        "up": "r6i.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "16"
+    },
+    "r6i.xlarge": {
+        "up": "r6i.2xlarge",
+        "down": "r6i.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "32"
+    },
+    "r6i.2xlarge": {
+        "up": "r6i.4xlarge",
+        "down": "r6i.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "64"
+    },
+    "r6i.4xlarge": {
+        "up": "r6i.8xlarge",
+        "down": "r6i.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "128"
+    },
+    "r6i.8xlarge": {
+        "up": "r6i.12xlarge",
+        "down": "r6i.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "256"
+    },
+    "r6i.12xlarge": {
+        "up": "r6i.16xlarge",
+        "down": "r6i.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "384"
+    },
+    "r6i.16xlarge": {
+        "up": "r6i.24xlarge",
+        "down": "r6i.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "512"
+    },
+    "r6i.24xlarge": {
+        "up": "r6i.32xlarge",
+        "down": "r6i.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "768"
+    },
+    "r6i.32xlarge": {
+        "up": null,
+        "down": "r6i.24xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "128",
+        "nfu": "256",
+        "memory": "1024"
+    },
+    "r6i.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "128",
+        "nfu": "256",
+        "memory": "1024"
+    },
+    "r6id.large": {
+        "up": "r6id.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "16"
+    },
+    "r6id.xlarge": {
+        "up": "r6id.2xlarge",
+        "down": "r6id.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "32"
+    },
+    "r6id.2xlarge": {
+        "up": "r6id.4xlarge",
+        "down": "r6id.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "64"
+    },
+    "r6id.4xlarge": {
+        "up": "r6id.8xlarge",
+        "down": "r6id.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "128"
+    },
+    "r6id.8xlarge": {
+        "up": "r6id.12xlarge",
+        "down": "r6id.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "256"
+    },
+    "r6id.12xlarge": {
+        "up": "r6id.16xlarge",
+        "down": "r6id.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "384"
+    },
+    "r6id.16xlarge": {
+        "up": "r6id.24xlarge",
+        "down": "r6id.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "512"
+    },
+    "r6id.24xlarge": {
+        "up": "r6id.32xlarge",
+        "down": "r6id.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "768"
+    },
+    "r6id.32xlarge": {
+        "up": null,
+        "down": "r6id.24xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "128",
+        "nfu": "256",
+        "memory": "1024"
+    },
+    "r6id.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "128",
+        "nfu": "256",
+        "memory": "1024"
+    },
+    "x1.16xlarge": {
+        "up": "x1.32xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "976"
+    },
+    "x1.32xlarge": {
+        "up": null,
+        "down": "x1.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "128",
+        "nfu": "256",
+        "memory": "1952"
+    },
+    "x1e.xlarge": {
+        "up": "x1e.2xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "122"
+    },
+    "x1e.2xlarge": {
+        "up": "x1e.4xlarge",
+        "down": "x1e.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "244"
+    },
+    "x1e.4xlarge": {
+        "up": "x1e.8xlarge",
+        "down": "x1e.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "488"
+    },
+    "x1e.8xlarge": {
+        "up": "x1e.16xlarge",
+        "down": "x1e.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "976"
+    },
+    "x1e.16xlarge": {
+        "up": "x1e.32xlarge",
+        "down": "x1e.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "1952"
+    },
+    "x1e.32xlarge": {
+        "up": null,
+        "down": "x1e.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "128",
+        "nfu": "256",
+        "memory": "3904"
+    },
+    "x2gd.medium": {
+        "up": "x2gd.large",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "1",
+        "nfu": "16",
+        "memory": "16"
+    },
+    "x2gd.large": {
+        "up": "x2gd.xlarge",
+        "down": "x2gd.medium",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "32",
+        "memory": "32"
+    },
+    "x2gd.xlarge": {
+        "up": "x2gd.2xlarge",
+        "down": "x2gd.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "64",
+        "memory": "64"
+    },
+    "x2gd.2xlarge": {
+        "up": "x2gd.4xlarge",
+        "down": "x2gd.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "128",
+        "memory": "128"
+    },
+    "x2gd.4xlarge": {
+        "up": "x2gd.8xlarge",
+        "down": "x2gd.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "256",
+        "memory": "256"
+    },
+    "x2gd.8xlarge": {
+        "up": "x2gd.12xlarge",
+        "down": "x2gd.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "512",
+        "memory": "512"
+    },
+    "x2gd.12xlarge": {
+        "up": "x2gd.16xlarge",
+        "down": "x2gd.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "768",
+        "memory": "768"
+    },
+    "x2gd.16xlarge": {
+        "up": "x2gd.metal",
+        "down": "x2gd.12xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "1024",
+        "memory": "1024"
+    },
+    "x2gd.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "1024",
+        "memory": "1024"
+    },
+    "x2idn.16xlarge": {
+        "up": "x2idn.24xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "1024"
+    },
+    "x2idn.24xlarge": {
+        "up": "x2idn.32xlarge",
+        "down": "x2idn.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "1536"
+    },
+    "x2idn.32xlarge": {
+        "up": null,
+        "down": "x2idn.24xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "128",
+        "nfu": "256",
+        "memory": "2048"
+    },
+    "x2idn.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "128",
+        "nfu": "256",
+        "memory": "2048"
+    },
+    "x2iedn.xlarge": {
+        "up": "x2iedn.2xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "128"
+    },
+    "x2iedn.2xlarge": {
+        "up": "x2iedn.4xlarge",
+        "down": "x2iedn.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "256"
+    },
+    "x2iedn.4xlarge": {
+        "up": "x2iedn.8xlarge",
+        "down": "x2iedn.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "512"
+    },
+    "x2iedn.8xlarge": {
+        "up": "x2iedn.16xlarge",
+        "down": "x2iedn.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "1024"
+    },
+    "x2iedn.16xlarge": {
+        "up": "x2iedn.24xlarge",
+        "down": "x2iedn.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "64",
+        "nfu": "128",
+        "memory": "2048"
+    },
+    "x2iedn.24xlarge": {
+        "up": "x2iedn.32xlarge",
+        "down": "x2iedn.16xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "96",
+        "nfu": "192",
+        "memory": "3072"
+    },
+    "x2iedn.32xlarge": {
+        "up": null,
+        "down": "x2iedn.24xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "128",
+        "nfu": "256",
+        "memory": "4096"
+    },
+    "x2iedn.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "128",
+        "nfu": "256",
+        "memory": "4096"
+    },
+    "x2iezn.2xlarge": {
+        "up": "x2iezn.4xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "256"
+    },
+    "x2iezn.4xlarge": {
+        "up": "x2iezn.6xlarge",
+        "down": "x2iezn.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "16",
+        "nfu": "32",
+        "memory": "512"
+    },
+    "x2iezn.6xlarge": {
+        "up": "x2iezn.8xlarge",
+        "down": "x2iezn.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "24",
+        "nfu": "46",
+        "memory": "768"
+    },
+    "x2iezn.8xlarge": {
+        "up": "x2iezn.12xlarge",
+        "down": "x2iezn.4xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "32",
+        "nfu": "64",
+        "memory": "1024"
+    },
+    "x2iezn.12xlarge": {
+        "up": null,
+        "down": "x2iezn.8xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "1536"
+    },
+    "x2iezn.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "1536"
+    },
+    "z1d.large": {
+        "up": "z1d.xlarge",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "16"
+    },
+    "z1d.xlarge": {
+        "up": "z1d.2xlarge",
+        "down": "z1d.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "32"
+    },
+    "z1d.2xlarge": {
+        "up": "z1d.3xlarge",
+        "down": "z1d.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "64"
+    },
+    "z1d.3xlarge": {
+        "up": "z1d.6xlarge",
+        "down": "z1d.2xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "12",
+        "nfu": "24",
+        "memory": "96"
+    },
+    "z1d.6xlarge": {
+        "up": "z1d.12xlarge",
+        "down": "z1d.3xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "24",
+        "nfu": "48",
+        "memory": "192"
+    },
+    "z1d.12xlarge": {
+        "up": null,
+        "down": "z1d.6xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "nfu": "96",
+        "memory": "384"
+    },
+    "z1d.metal": {
+        "up": null,
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "48",
+        "memory": "384"
+    },
+    "u-6tb1.metal": {
+        "up": "u-9tb1.metal",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "448",
+        "memory": "6144"
+    },
+    "u-9tb1.metal": {
+        "up": "u-12tb1.metal",
+        "down": "u-6tb1.metal",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "448",
+        "memory": "9216"
+    },
+    "u-12tb1.metal": {
+        "up": "u-18tb1.metal",
+        "down": "u-9tb1.metal",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "448",
+        "memory": "12288"
+    },
+    "u-18tb1.metal": {
+        "up": "u-24tb1.metal",
+        "down": "u-12tb1.metal",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "448",
+        "memory": "18432"
+    },
+    "u-24tb1.metal": {
+        "up": null,
+        "down": "u-18tb1.metal",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "vcpu": "448",
+        "memory": "24576"
+    },
+    "t1.micro": {
+        "up": null,
+        "down": null,
+        "superseded": {
+            "regular": "t2.micro",
+            "next_gen": "t3.micro",
+            "burstable": "",
+            "amd": "t3a.micro"
+        },
+        "ec2_classic": true,
+        "enhanced_networking": false,
+        "vcpu": "1",
+        "nfu": "0.5",
+        "memory": "0.613"
+    },
+    "t2.nano": {
+        "up": "t2.micro",
+        "down": null,
+        "superseded": {
+            "regular": "t3.nano",
+            "next_gen": "",
+            "burstable": "",
+            "amd": "t3a.nano"
+        },
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 3,
+            "max_earnable_credits": 72
+        },
+        "vcpu": "1",
+        "nfu": "0.25",
+        "memory": "0.5"
+    },
+    "t2.micro": {
+        "up": "t2.small",
+        "down": "t2.nano",
+        "superseded": {
+            "regular": "t3.micro",
+            "next_gen": "",
+            "burstable": "",
+            "amd": "t3a.micro"
+        },
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 6,
+            "max_earnable_credits": 144
+        },
+        "vcpu": "1",
+        "nfu": "0.5",
+        "memory": "1"
+    },
+    "t2.small": {
+        "up": "t2.medium",
+        "down": "t2.micro",
+        "superseded": {
+            "regular": "t3.small",
+            "next_gen": "",
+            "burstable": "",
+            "amd": "t3a.small"
+        },
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 12,
+            "max_earnable_credits": 288
+        },
+        "vcpu": "1",
+        "nfu": "1",
+        "memory": "2"
+    },
+    "t2.medium": {
+        "up": "t2.large",
+        "down": "t2.small",
+        "superseded": {
+            "regular": "t3.medium",
+            "next_gen": "",
+            "burstable": "",
+            "amd": "t3a.medium"
+        },
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 24,
+            "max_earnable_credits": 576
+        },
+        "vcpu": "2",
+        "nfu": "2",
+        "memory": "4"
+    },
+    "t2.large": {
+        "up": "t2.xlarge",
+        "down": "t2.medium",
+        "superseded": {
+            "regular": "t3.large",
+            "next_gen": "",
+            "burstable": "",
+            "amd": "t3a.large"
+        },
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 36,
+            "max_earnable_credits": 864
+        },
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "8"
+    },
+    "t2.xlarge": {
+        "up": "t2.2xlarge",
+        "down": "t2.large",
+        "superseded": {
+            "regular": "t3.xlarge",
+            "next_gen": "",
+            "burstable": "",
+            "amd": "t3a.xlarge"
+        },
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 54,
+            "max_earnable_credits": 1296
+        },
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "t2.2xlarge": {
+        "up": null,
+        "down": "t2.xlarge",
+        "superseded": {
+            "regular": "t3.2xlarge",
+            "next_gen": "",
+            "burstable": "",
+            "amd": "t3a.2xlarge"
+        },
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 81.6,
+            "max_earnable_credits": 1958.4
+        },
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "t3.nano": {
+        "up": "t3.micro",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 6,
+            "max_earnable_credits": 144
+        },
+        "vcpu": "2",
+        "nfu": "0.25",
+        "memory": "0.5"
+    },
+    "t3.micro": {
+        "up": "t3.small",
+        "down": "t3.nano",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 12,
+            "max_earnable_credits": 288
+        },
+        "vcpu": "2",
+        "nfu": "0.5",
+        "memory": "1"
+    },
+    "t3.small": {
+        "up": "t3.medium",
+        "down": "t3.micro",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 24,
+            "max_earnable_credits": 576
+        },
+        "vcpu": "2",
+        "nfu": "1",
+        "memory": "2"
+    },
+    "t3.medium": {
+        "up": "t3.large",
+        "down": "t3.small",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 24,
+            "max_earnable_credits": 576
+        },
+        "vcpu": "2",
+        "nfu": "2",
+        "memory": "4"
+    },
+    "t3.large": {
+        "up": "t3.xlarge",
+        "down": "t3.medium",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 36,
+            "max_earnable_credits": 864
+        },
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "8"
+    },
+    "t3.xlarge": {
+        "up": "t3.2xlarge",
+        "down": "t3.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 96,
+            "max_earnable_credits": 2304
+        },
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "t3.2xlarge": {
+        "up": null,
+        "down": "t3.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 192,
+            "max_earnable_credits": 4608
+        },
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "t3a.nano": {
+        "up": "t3.micro",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 6,
+            "max_earnable_credits": 144
+        },
+        "vcpu": "2",
+        "nfu": "0.25",
+        "memory": "0.5"
+    },
+    "t3a.micro": {
+        "up": "t3.small",
+        "down": "t3.nano",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 12,
+            "max_earnable_credits": 288
+        },
+        "vcpu": "2",
+        "nfu": "0.5",
+        "memory": "1"
+    },
+    "t3a.small": {
+        "up": "t3.medium",
+        "down": "t3.micro",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 24,
+            "max_earnable_credits": 576
+        },
+        "vcpu": "2",
+        "nfu": "1",
+        "memory": "2"
+    },
+    "t3a.medium": {
+        "up": "t3.large",
+        "down": "t3.small",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 24,
+            "max_earnable_credits": 576
+        },
+        "vcpu": "2",
+        "nfu": "2",
+        "memory": "4"
+    },
+    "t3a.large": {
+        "up": "t3.xlarge",
+        "down": "t3.medium",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 36,
+            "max_earnable_credits": 864
+        },
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "8"
+    },
+    "t3a.xlarge": {
+        "up": "t3.2xlarge",
+        "down": "t3.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 96,
+            "max_earnable_credits": 2304
+        },
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "t3a.2xlarge": {
+        "up": null,
+        "down": "t3.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 192,
+            "max_earnable_credits": 4608
+        },
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "t4g.nano": {
+        "up": "t4g.micro",
+        "down": null,
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 6,
+            "max_earnable_credits": 144
+        },
+        "vcpu": "2",
+        "nfu": "0.25",
+        "memory": "0.5"
+    },
+    "t4g.micro": {
+        "up": "t4g.small",
+        "down": "t4g.nano",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 12,
+            "max_earnable_credits": 288
+        },
+        "vcpu": "2",
+        "nfu": "0.5",
+        "memory": "1"
+    },
+    "t4g.small": {
+        "up": "t4g.medium",
+        "down": "t4g.micro",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 24,
+            "max_earnable_credits": 576
+        },
+        "vcpu": "2",
+        "nfu": "1",
+        "memory": "2"
+    },
+    "t4g.medium": {
+        "up": "t4g.large",
+        "down": "t4g.small",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 24,
+            "max_earnable_credits": 576
+        },
+        "vcpu": "2",
+        "nfu": "2",
+        "memory": "4"
+    },
+    "t4g.large": {
+        "up": "t4g.xlarge",
+        "down": "t4g.medium",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 26,
+            "max_earnable_credits": 864
+        },
+        "vcpu": "2",
+        "nfu": "4",
+        "memory": "8"
+    },
+    "t4g.xlarge": {
+        "up": "t4g.2xlarge",
+        "down": "t4g.large",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 96,
+            "max_earnable_credits": 2304
+        },
+        "vcpu": "4",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "t4g.2xlarge": {
+        "up": null,
+        "down": "t4g.xlarge",
+        "superseded": null,
+        "ec2_classic": false,
+        "enhanced_networking": true,
+        "burst_info": {
+            "credits_per_hour": 192,
+            "max_earnable_credits": 4608
+        },
+        "vcpu": "8",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "db.t1.micro": {
+        "vcpu": "1",
+        "up": null,
+        "down": null,
+        "nfu": "0.5",
+        "memory": "0.613"
+    },
+    "db.t2.micro": {
+        "vcpu": "1",
+        "up": "db.t2.small",
+        "down": null,
+        "nfu": "0.5",
+        "memory": "1"
+    },
+    "db.t2.small": {
+        "vcpu": "1",
+        "up": "db.t2.medium",
+        "down": "db.t2.micro",
+        "nfu": "1",
+        "memory": "2"
+    },
+    "db.t2.medium": {
+        "vcpu": "2",
+        "up": "db.t2.large",
+        "down": "db.t2.small",
+        "nfu": "2",
+        "memory": "4"
+    },
+    "db.t2.large": {
+        "vcpu": "2",
+        "up": "db.t2.xlarge",
+        "down": "db.t2.medium",
+        "nfu": "4",
+        "memory": "8"
+    },
+    "db.t2.xlarge": {
+        "vcpu": "4",
+        "up": "db.t2.2xlarge",
+        "down": "db.t2.large",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "db.t2.2xlarge": {
+        "vcpu": "8",
+        "up": null,
+        "down": "db.t2.xlarge",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "db.t3.micro": {
+        "vcpu": "2",
+        "up": "db.t3.small",
+        "down": null,
+        "nfu": "0.5",
+        "memory": "1"
+    },
+    "db.t3.small": {
+        "vcpu": "2",
+        "up": "db.t3.medium",
+        "down": "db.t3.micro",
+        "nfu": "1",
+        "memory": "2"
+    },
+    "db.t3.medium": {
+        "vcpu": "2",
+        "up": "db.t3.large",
+        "down": "db.t3.small",
+        "nfu": "2",
+        "memory": "4"
+    },
+    "db.t3.large": {
+        "vcpu": "2",
+        "up": "db.t3.xlarge",
+        "down": "db.t3.medium",
+        "nfu": "4",
+        "memory": "8"
+    },
+    "db.t3.xlarge": {
+        "vcpu": "4",
+        "up": "db.t3.2xlarge",
+        "down": "db.t3.large",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "db.t3.2xlarge": {
+        "vcpu": "8",
+        "up": null,
+        "down": "db.t3.xlarge",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "db.t4g.micro": {
+        "vcpu": "2",
+        "up": "db.t4g.small",
+        "down": null,
+        "nfu": "0.5",
+        "memory": "1"
+    },
+    "db.t4g.small": {
+        "vcpu": "2",
+        "up": "db.t4g.medium",
+        "down": "db.t4g.micro",
+        "nfu": "1",
+        "memory": "2"
+    },
+    "db.t4g.medium": {
+        "vcpu": "2",
+        "up": "db.t4g.large",
+        "down": "db.t4g.small",
+        "nfu": "2",
+        "memory": "4"
+    },
+    "db.t4g.large": {
+        "vcpu": "2",
+        "up": "db.t4g.xlarge",
+        "down": "db.t4g.medium",
+        "nfu": "4",
+        "memory": "8"
+    },
+    "db.t4g.xlarge": {
+        "vcpu": "4",
+        "up": "db.t4g.2xlarge",
+        "down": "db.t4g.large",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "db.t4g.2xlarge": {
+        "vcpu": "8",
+        "up": null,
+        "down": "db.t4g.xlarge",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "db.m4.large": {
+        "vcpu": "2",
+        "up": "db.m4.xlarge",
+        "down": null,
+        "nfu": "4",
+        "memory": "8"
+    },
+    "db.m4.xlarge": {
+        "vcpu": "4",
+        "up": "db.m4.2xlarge",
+        "down": "db.m4.large",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "db.m4.2xlarge": {
+        "vcpu": "8",
+        "up": "db.m4.4xlarge",
+        "down": "db.m4.xlarge",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "db.m4.4xlarge": {
+        "vcpu": "16",
+        "up": "db.m4.10xlarge",
+        "down": "db.m4.2xlarge",
+        "nfu": "32",
+        "memory": "64"
+    },
+    "db.m4.10xlarge": {
+        "vcpu": "40",
+        "up": "db.m4.16xlarge",
+        "down": "db.m4.4xlarge",
+        "nfu": "80",
+        "memory": "160"
+    },
+    "db.m4.16xlarge": {
+        "vcpu": "64",
+        "up": null,
+        "down": "db.m4.10xlarge",
+        "nfu": "128",
+        "memory": "256"
+    },
+    "db.m5.large": {
+        "vcpu": "2",
+        "up": "db.m5.xlarge",
+        "down": null,
+        "nfu": "4",
+        "memory": "8"
+    },
+    "db.m5.xlarge": {
+        "vcpu": "4",
+        "up": "db.m5.2xlarge",
+        "down": "db.m5.large",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "db.m5.2xlarge": {
+        "vcpu": "8",
+        "up": "db.m5.4xlarge",
+        "down": "db.m5.xlarge",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "db.m5.4xlarge": {
+        "vcpu": "16",
+        "up": "db.m5.12xlarge",
+        "down": "db.m5.2xlarge",
+        "nfu": "32",
+        "memory": "64"
+    },
+    "db.m5.12xlarge": {
+        "vcpu": "48",
+        "up": "db.m5.16xlarge",
+        "down": "db.m5.4xlarge",
+        "nfu": "96",
+        "memory": "192"
+    },
+    "db.m5.16xlarge": {
+        "vcpu": "64",
+        "up": "db.m5.24xlarge",
+        "down": "db.m5.12xlarge",
+        "nfu": "128",
+        "memory": "256"
+    },
+    "db.m5.24xlarge": {
+        "vcpu": "96",
+        "up": null,
+        "down": "db.m5.16xlarge",
+        "nfu": "192",
+        "memory": "384"
+    },
+    "db.m6g.large": {
+        "vcpu": "2",
+        "up": "db.m6g.xlarge",
+        "down": null,
+        "nfu": "4",
+        "memory": "8"
+    },
+    "db.m6g.xlarge": {
+        "vcpu": "4",
+        "up": "db.m6g.2xlarge",
+        "down": "db.m6g.large",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "db.m6g.2xlarge": {
+        "vcpu": "8",
+        "up": "db.m6g.4xlarge",
+        "down": "db.m6g.xlarge",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "db.m6g.4xlarge": {
+        "vcpu": "16",
+        "up": "db.m6g.8xlarge",
+        "down": "db.m6g.2xlarge",
+        "nfu": "32",
+        "memory": "64"
+    },
+    "db.m6g.8xlarge": {
+        "vcpu": "32",
+        "up": "db.m6g.16xlarge",
+        "down": "db.m6g.4xlarge",
+        "nfu": "64",
+        "memory": "128"
+    },
+    "db.m6g.12xlarge": {
+        "vcpu": "48",
+        "up": "db.m6g.16xlarge",
+        "down": "db.m6g.8xlarge",
+        "nfu": "96",
+        "memory": "192"
+    },
+    "db.m6g.16xlarge": {
+        "vcpu": "64",
+        "up": null,
+        "down": "db.m6g.12xlarge",
+        "nfu": "128",
+        "memory": "256"
+    },
+    "db.m6i.large": {
+        "vcpu": "2",
+        "up": "db.m6i.xlarge",
+        "down": null,
+        "nfu": "4",
+        "memory": "8"
+    },
+    "db.m6i.xlarge": {
+        "vcpu": "4",
+        "up": "db.m6i.2xlarge",
+        "down": "db.m6i.large",
+        "nfu": "8",
+        "memory": "16"
+    },
+    "db.m6i.2xlarge": {
+        "vcpu": "8",
+        "up": "db.m6i.4xlarge",
+        "down": "db.m6i.xlarge",
+        "nfu": "16",
+        "memory": "32"
+    },
+    "db.m6i.4xlarge": {
+        "vcpu": "16",
+        "up": "db.m6i.8xlarge",
+        "down": "db.m6i.2xlarge",
+        "nfu": "32",
+        "memory": "64"
+    },
+    "db.m6i.8xlarge": {
+        "vcpu": "32",
+        "up": "db.m6i.12xlarge",
+        "down": "db.m6i.4xlarge",
+        "nfu": "64",
+        "memory": "128"
+    },
+    "db.m6i.12xlarge": {
+        "vcpu": "48",
+        "up": "db.m6i.16xlarge",
+        "down": "db.m6i.8xlarge",
+        "nfu": "96",
+        "memory": "192"
+    },
+    "db.m6i.16xlarge": {
+        "vcpu": "64",
+        "up": "db.m6i.24xlarge",
+        "down": "db.m6i.12xlarge",
+        "nfu": "128",
+        "memory": "256"
+    },
+    "db.m6i.24xlarge": {
+        "vcpu": "96",
+        "up": "db.m6i.32xlarge",
+        "down": "db.m6i.16xlarge",
+        "nfu": "192",
+        "memory": "384"
+    },
+    "db.m6i.32xlarge": {
+        "vcpu": "128",
+        "up": null,
+        "down": "db.m6i.24xlarge",
+        "nfu": "256",
+        "memory": "512"
+    },
+    "db.r6g.large": {
+        "vcpu": "2",
+        "up": "db.r6g.xlarge",
+        "down": null,
+        "nfu": "4",
+        "memory": "16"
+    },
+    "db.r6g.xlarge": {
+        "vcpu": "4",
+        "up": "db.r6g.2xlarge",
+        "down": "db.r6g.large",
+        "nfu": "8",
+        "memory": "32"
+    },
+    "db.r6g.2xlarge": {
+        "vcpu": "8",
+        "up": "db.r6g.4xlarge",
+        "down": "db.r6g.xlarge",
+        "nfu": "16",
+        "memory": "64"
+    },
+    "db.r6g.4xlarge": {
+        "vcpu": "16",
+        "up": "db.r6g.8xlarge",
+        "down": "db.r6g.2xlarge",
+        "nfu": "32",
+        "memory": "128"
+    },
+    "db.r6g.8xlarge": {
+        "vcpu": "32",
+        "up": "db.r6g.16xlarge",
+        "down": "db.r6g.4xlarge",
+        "nfu": "64",
+        "memory": "256"
+    },
+    "db.r6g.12xlarge": {
+        "vcpu": "48",
+        "up": "db.r6g.16xlarge",
+        "down": "db.r6g.8xlarge",
+        "nfu": "96",
+        "memory": "384"
+    },
+    "db.r6g.16xlarge": {
+        "vcpu": "64",
+        "up": null,
+        "down": "db.r6g.12xlarge",
+        "nfu": "128",
+        "memory": "512"
+    },
+    "db.r4.large": {
+        "vcpu": "2",
+        "up": "db.r4.xlarge",
+        "down": null,
+        "nfu": "4",
+        "memory": "15.25"
+    },
+    "db.r4.xlarge": {
+        "vcpu": "4",
+        "up": "db.r4.2xlarge",
+        "down": "db.r4.large",
+        "nfu": "8",
+        "memory": "30.5"
+    },
+    "db.r4.2xlarge": {
+        "vcpu": "8",
+        "up": "db.r4.4xlarge",
+        "down": "db.r4.xlarge",
+        "nfu": "16",
+        "memory": "61"
+    },
+    "db.r4.4xlarge": {
+        "vcpu": "16",
+        "up": "db.r4.8xlarge",
+        "down": "db.r4.2xlarge",
+        "nfu": "32",
+        "memory": "122"
+    },
+    "db.r4.8xlarge": {
+        "vcpu": "32",
+        "up": "db.r4.16xlarge",
+        "down": "db.r4.4xlarge",
+        "nfu": "64",
+        "memory": "244"
+    },
+    "db.r4.16xlarge": {
+        "vcpu": "64",
+        "up": null,
+        "down": "db.r4.8xlarge",
+        "nfu": "128",
+        "memory": "488"
+    },
+    "db.r5.large": {
+        "vcpu": "2",
+        "up": "db.r5.xlarge",
+        "down": null,
+        "nfu": "4",
+        "memory": "16"
+    },
+    "db.r5.xlarge": {
+        "vcpu": "4",
+        "up": "db.r5.2xlarge",
+        "down": "db.r5.large",
+        "nfu": "8",
+        "memory": "32"
+    },
+    "db.r5.2xlarge": {
+        "vcpu": "8",
+        "up": "db.r5.4xlarge",
+        "down": "db.r5.xlarge",
+        "nfu": "16",
+        "memory": "64"
+    },
+    "db.r5.4xlarge": {
+        "vcpu": "16",
+        "up": "db.r5.8xlarge",
+        "down": "db.r5.2xlarge",
+        "nfu": "32",
+        "memory": "128"
+    },
+    "db.r5.8xlarge": {
+        "vcpu": "32",
+        "up": "db.r5.12xlarge",
+        "down": "db.r5.4xlarge",
+        "nfu": "64",
+        "memory": "256"
+    },
+    "db.r5.12xlarge": {
+        "vcpu": "48",
+        "up": "db.r5.24xlarge",
+        "down": "db.r5.4xlarge",
+        "nfu": "96",
+        "memory": "384"
+    },
+    "db.r5.24xlarge": {
+        "vcpu": "64",
+        "up": null,
+        "down": "db.r5.12xlarge",
+        "nfu": "192",
+        "memory": "768"
+    },
+    "db.x1e.xlarge": {
+        "vcpu": "4",
+        "up": "db.x1e.2xlarge",
+        "down": null,
+        "nfu": "8",
+        "memory": "122"
+    },
+    "db.x1e.2xlarge": {
+        "vcpu": "8",
+        "up": "db.x1e.4xlarge",
+        "down": "db.x1e.xlarge",
+        "nfu": "16",
+        "memory": "244"
+    },
+    "db.x1e.4xlarge": {
+        "vcpu": "16",
+        "up": "db.x1e.8xlarge",
+        "down": "db.x1e.2xlarge",
+        "nfu": "32",
+        "memory": "488"
+    },
+    "db.x1e.8xlarge": {
+        "vcpu": "32",
+        "up": "db.x1e.16xlarge",
+        "down": "db.x1e.4xlarge",
+        "nfu": "64",
+        "memory": "976"
+    },
+    "db.x1e.16xlarge": {
+        "vcpu": "64",
+        "up": "db.x1e.32xlarge",
+        "down": "db.x1e.8xlarge",
+        "nfu": "128",
+        "memory": "1952"
+    },
+    "db.x1e.32xlarge": {
+        "vcpu": "128",
+        "up": null,
+        "down": "db.x1e.16xlarge",
+        "nfu": "256",
+        "memory": "3904"
+    },
+    "db.x1.16xlarge": {
+        "vcpu": "64",
+        "up": "db.x1.32xlarge",
+        "down": null,
+        "nfu": "128",
+        "memory": "976"
+    },
+    "db.x1.32xlarge": {
+        "vcpu": "128",
+        "up": null,
+        "down": "db.x1.16xlarge",
+        "nfu": "256",
+        "memory": "1952"
+    },
+    "db.m1.small": {
+        "vcpu": "1",
+        "up": "db.m1.medium",
+        "down": null,
+        "nfu": "1",
+        "memory": "1.7"
+    },
+    "db.m1.medium": {
+        "vcpu": "1",
+        "up": "db.m1.large",
+        "down": "db.m1.small",
+        "nfu": "2",
+        "memory": "3.75"
+    },
+    "db.m1.large": {
+        "vcpu": "2",
+        "up": "db.m1.xlarge",
+        "down": "db.m1.medium",
+        "nfu": "4",
+        "memory": "7.5"
+    },
+    "db.m1.xlarge": {
+        "vcpu": "4",
+        "up": null,
+        "down": "db.m1.large",
+        "nfu": "8",
+        "memory": "15"
+    },
+    "db.m3.medium": {
+        "vcpu": "1",
+        "up": "db.m3.large",
+        "down": null,
+        "nfu": "2",
+        "memory": "3.75"
+    },
+    "db.m3.large": {
+        "vcpu": "2",
+        "up": "db.m3.xlarge",
+        "down": "db.m3.medium",
+        "nfu": "4",
+        "memory": "7.5"
+    },
+    "db.m3.xlarge": {
+        "vcpu": "4",
+        "up": "db.m3.2xlarge",
+        "down": "db.m3.large",
+        "nfu": "8",
+        "memory": "15"
+    },
+    "db.m3.2xlarge": {
+        "vcpu": "8",
+        "up": null,
+        "down": "db.m3.xlarge",
+        "nfu": "16",
+        "memory": "30"
+    },
+    "db.m2.xlarge": {
+        "vcpu": "2",
+        "up": "db.m2.2xlarge",
+        "down": null,
+        "nfu": "8",
+        "memory": "17.1"
+    },
+    "db.m2.2xlarge": {
+        "vcpu": "4",
+        "up": "db.m2.4xlarge",
+        "down": "db.m2.xlarge",
+        "nfu": "16",
+        "memory": "34.2"
+    },
+    "db.m2.4xlarge": {
+        "vcpu": "8",
+        "up": null,
+        "down": "db.m2.2xlarge",
+        "nfu": "32",
+        "memory": "68.4"
+    },
+    "db.r3.large": {
+        "vcpu": "2",
+        "up": "db.r3.xlarge",
+        "down": null,
+        "nfu": "4",
+        "memory": "15.25"
+    },
+    "db.r3.xlarge": {
+        "vcpu": "4",
+        "up": "db.r3.2xlarge",
+        "down": "db.r3.large",
+        "nfu": "8",
+        "memory": "30.5"
+    },
+    "db.r3.2xlarge": {
+        "vcpu": "8",
+        "up": "db.r3.4xlarge",
+        "down": "db.r3.xlarge",
+        "nfu": "16",
+        "memory": "61"
+    },
+    "db.r3.4xlarge": {
+        "vcpu": "16",
+        "up": "db.r3.8xlarge",
+        "down": "db.r3.2xlarge",
+        "nfu": "32",
+        "memory": "122"
+    },
+    "db.r3.8xlarge": {
+        "vcpu": "32",
+        "up": null,
+        "down": "db.r3.4xlarge",
+        "nfu": "64",
+        "memory": "244"
+    }
 }

--- a/data/aws/instance_types.json
+++ b/data/aws/instance_types.json
@@ -6,7 +6,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "1",
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "2.0"
   },
   "a1.large": {
     "up": "a1.xlarge",
@@ -15,7 +16,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "4.0"
   },
   "a1.xlarge": {
     "up": "a1.2xlarge",
@@ -24,7 +26,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "8.0"
   },
   "a1.2xlarge": {
     "up": "a1.4xlarge",
@@ -33,7 +36,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "16.0"
   },
   "a1.4xlarge": {
     "up": null,
@@ -42,7 +46,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "32.0"
   },
   "a1.metal": {
     "up": null,
@@ -50,7 +55,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "16"
+    "vcpu": "16",
+    "memory": "32.0"
   },
   "c1.medium": {
     "up": "c1.xlarge",
@@ -64,7 +70,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "2",
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "1.7"
   },
   "c1.xlarge": {
     "up": null,
@@ -78,7 +85,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "8",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "7.0"
   },
   "c3.large": {
     "up": "c3.xlarge",
@@ -92,7 +100,8 @@
     "ec2_classic": true,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "3.75"
   },
   "c3.xlarge": {
     "up": "c3.2xlarge",
@@ -106,7 +115,8 @@
     "ec2_classic": true,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "7.5"
   },
   "c3.2xlarge": {
     "up": "c3.4xlarge",
@@ -120,7 +130,8 @@
     "ec2_classic": true,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "15.0"
   },
   "c3.4xlarge": {
     "up": "c3.8xlarge",
@@ -134,7 +145,8 @@
     "ec2_classic": true,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "30.0"
   },
   "c3.8xlarge": {
     "up": null,
@@ -148,7 +160,8 @@
     "ec2_classic": true,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "60.0"
   },
   "c4.large": {
     "up": "c4.xlarge",
@@ -162,7 +175,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "3.75"
   },
   "c4.xlarge": {
     "up": "c4.2xlarge",
@@ -176,7 +190,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "7.5"
   },
   "c4.2xlarge": {
     "up": "c4.4xlarge",
@@ -190,7 +205,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "15.0"
   },
   "c4.4xlarge": {
     "up": "c4.8xlarge",
@@ -204,7 +220,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "30.0"
   },
   "c4.8xlarge": {
     "up": null,
@@ -218,7 +235,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "36",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "60.0"
   },
   "c5.large": {
     "up": "c5.xlarge",
@@ -227,7 +245,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "4.0"
   },
   "c5.xlarge": {
     "up": "c5.2xlarge",
@@ -236,7 +255,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "8.0"
   },
   "c5.2xlarge": {
     "up": "c5.4xlarge",
@@ -245,7 +265,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "16.0"
   },
   "c5.4xlarge": {
     "up": "c5.9xlarge",
@@ -254,7 +275,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "32.0"
   },
   "c5.9xlarge": {
     "up": "c5.12xlarge",
@@ -263,7 +285,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "36",
-    "nfu": "72"
+    "nfu": "72",
+    "memory": "72.0"
   },
   "c5.12xlarge": {
     "up": "c5.18xlarge",
@@ -272,7 +295,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "96.0"
   },
   "c5.18xlarge": {
     "up": "c5.24xlarge",
@@ -281,7 +305,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "72",
-    "nfu": "144"
+    "nfu": "144",
+    "memory": "144.0"
   },
   "c5.24xlarge": {
     "up": null,
@@ -290,7 +315,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "192.0"
   },
   "c5.metal": {
     "up": null,
@@ -298,7 +324,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "96"
+    "vcpu": "96",
+    "memory": "192.0"
   },
   "c5a.large": {
     "up": "c5a.xlarge",
@@ -307,7 +334,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "4.0"
   },
   "c5a.xlarge": {
     "up": "c5a.2xlarge",
@@ -316,7 +344,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "8.0"
   },
   "c5a.2xlarge": {
     "up": "c5a.4xlarge",
@@ -325,7 +354,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "16.0"
   },
   "c5a.4xlarge": {
     "up": "c5a.8xlarge",
@@ -334,7 +364,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "32.0"
   },
   "c5a.8xlarge": {
     "up": "c5a.12xlarge",
@@ -343,7 +374,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "64.0"
   },
   "c5a.12xlarge": {
     "up": "c5a.16xlarge",
@@ -352,7 +384,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "96.0"
   },
   "c5a.16xlarge": {
     "up": "c5a.24xlarge",
@@ -361,7 +394,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "128.0"
   },
   "c5a.24xlarge": {
     "up": null,
@@ -370,7 +404,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "192.0"
   },
   "c5d.large": {
     "up": "c5d.xlarge",
@@ -379,7 +414,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "4.0"
   },
   "c5d.xlarge": {
     "up": "c5d.2xlarge",
@@ -388,7 +424,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "8.0"
   },
   "c5d.2xlarge": {
     "up": "c5d.4xlarge",
@@ -397,7 +434,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "16.0"
   },
   "c5d.4xlarge": {
     "up": "c5d.9xlarge",
@@ -406,7 +444,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "32.0"
   },
   "c5d.9xlarge": {
     "up": "c5d.12xlarge",
@@ -415,7 +454,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "36",
-    "nfu": "72"
+    "nfu": "72",
+    "memory": "72.0"
   },
   "c5d.12xlarge": {
     "up": "c5d.18xlarge",
@@ -424,7 +464,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "96.0"
   },
   "c5d.18xlarge": {
     "up": "c5d.24xlarge",
@@ -433,7 +474,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "72",
-    "nfu": "144"
+    "nfu": "144",
+    "memory": "144.0"
   },
   "c5d.24xlarge": {
     "up": null,
@@ -442,7 +484,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "192.0"
   },
   "c5d.metal": {
     "up": null,
@@ -450,7 +493,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "96"
+    "vcpu": "96",
+    "memory": "192.0"
   },
   "c5ad.large": {
     "up": "c5ad.xlarge",
@@ -459,7 +503,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "4.0"
   },
   "c5ad.xlarge": {
     "up": "c5ad.2xlarge",
@@ -468,7 +513,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "8.0"
   },
   "c5ad.2xlarge": {
     "up": "c5ad.4xlarge",
@@ -477,7 +523,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "16.0"
   },
   "c5ad.4xlarge": {
     "up": "c5ad.8xlarge",
@@ -486,7 +533,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "32.0"
   },
   "c5ad.8xlarge": {
     "up": "c5ad.12xlarge",
@@ -495,7 +543,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "64.0"
   },
   "c5ad.12xlarge": {
     "up": "c5ad.16xlarge",
@@ -504,7 +553,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "96.0"
   },
   "c5ad.16xlarge": {
     "up": "c5ad.24xlarge",
@@ -513,7 +563,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "128.0"
   },
   "c5ad.24xlarge": {
     "up": null,
@@ -522,7 +573,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "192.0"
   },
   "c5n.large": {
     "up": "c5n.xlarge",
@@ -531,7 +583,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "5.25"
   },
   "c5n.xlarge": {
     "up": "c5n.2xlarge",
@@ -540,7 +593,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "10.5"
   },
   "c5n.2xlarge": {
     "up": "c5n.4xlarge",
@@ -549,7 +603,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "21.0"
   },
   "c5n.4xlarge": {
     "up": "c5n.9xlarge",
@@ -558,7 +613,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "42.0"
   },
   "c5n.9xlarge": {
     "up": "c5n.18xlarge",
@@ -567,7 +623,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "36",
-    "nfu": "72"
+    "nfu": "72",
+    "memory": "96.0"
   },
   "c5n.18xlarge": {
     "up": null,
@@ -576,7 +633,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "72",
-    "nfu": "144"
+    "nfu": "144",
+    "memory": "192.0"
   },
   "c5n.metal": {
     "up": null,
@@ -584,7 +642,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "72"
+    "vcpu": "72",
+    "memory": "192.0"
   },
   "c6a.large": {
     "up": "c6a.xlarge",
@@ -593,7 +652,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "4.0"
   },
   "c6a.xlarge": {
     "up": "c6a.2xlarge",
@@ -602,7 +662,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "8.0"
   },
   "c6a.2xlarge": {
     "up": "c6a.4xlarge",
@@ -611,7 +672,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "16.0"
   },
   "c6a.4xlarge": {
     "up": "c6a.8xlarge",
@@ -620,7 +682,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "32.0"
   },
   "c6a.8xlarge": {
     "up": "c6a.12xlarge",
@@ -629,7 +692,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "64.0"
   },
   "c6a.12xlarge": {
     "up": "c6a.16xlarge",
@@ -638,7 +702,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "96.0"
   },
   "c6a.16xlarge": {
     "up": "c6a.24xlarge",
@@ -647,7 +712,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "128.0"
   },
   "c6a.24xlarge": {
     "up": "c6a.32xlarge",
@@ -656,7 +722,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "192.0"
   },
   "c6a.32xlarge": {
     "up": "c6a.48xlarge",
@@ -665,7 +732,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "128",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "256.0"
   },
   "c6a.48xlarge": {
     "up": null,
@@ -674,7 +742,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "192",
-    "nfu": "384"
+    "nfu": "384",
+    "memory": "384.0"
   },
   "c6a.metal": {
     "up": null,
@@ -683,7 +752,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "192",
-    "nfu": "384"
+    "nfu": "384",
+    "memory": "384.0"
   },
   "c6g.medium": {
     "up": "c6g.large",
@@ -692,7 +762,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "1",
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "2.0"
   },
   "c6g.large": {
     "up": "c6g.xlarge",
@@ -701,7 +772,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "4.0"
   },
   "c6g.xlarge": {
     "up": "c6g.2xlarge",
@@ -710,7 +782,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "8.0"
   },
   "c6g.2xlarge": {
     "up": "c6g.4xlarge",
@@ -719,7 +792,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "16.0"
   },
   "c6g.4xlarge": {
     "up": "c6g.8xlarge",
@@ -728,7 +802,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "32.0"
   },
   "c6g.8xlarge": {
     "up": "c6g.12xlarge",
@@ -737,7 +812,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "64.0"
   },
   "c6g.12xlarge": {
     "up": "c6g.16xlarge",
@@ -746,7 +822,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "96.0"
   },
   "c6g.16xlarge": {
     "up": null,
@@ -755,7 +832,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "128.0"
   },
   "c6g.metal": {
     "up": null,
@@ -763,7 +841,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "64"
+    "vcpu": "64",
+    "memory": "128.0"
   },
   "c6gd.medium": {
     "up": "c6gd.large",
@@ -772,7 +851,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "1",
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "2.0"
   },
   "c6gd.large": {
     "up": "c6gd.xlarge",
@@ -781,7 +861,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "4.0"
   },
   "c6gd.xlarge": {
     "up": "c6gd.2xlarge",
@@ -790,7 +871,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "8.0"
   },
   "c6gd.2xlarge": {
     "up": "c6gd.4xlarge",
@@ -799,7 +881,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "16.0"
   },
   "c6gd.4xlarge": {
     "up": "c6gd.8xlarge",
@@ -808,7 +891,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "32.0"
   },
   "c6gd.8xlarge": {
     "up": "c6gd.12xlarge",
@@ -817,7 +901,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "64.0"
   },
   "c6gd.12xlarge": {
     "up": "c6gd.16xlarge",
@@ -826,7 +911,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "96.0"
   },
   "c6gd.16xlarge": {
     "up": null,
@@ -835,7 +921,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "128.0"
   },
   "c6gd.metal": {
     "up": null,
@@ -843,7 +930,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "64"
+    "vcpu": "64",
+    "memory": "128.0"
   },
   "c6gn.medium": {
     "up": "c6gn.large",
@@ -852,7 +940,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "1",
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "2.0"
   },
   "c6gn.large": {
     "up": "c6gn.xlarge",
@@ -861,7 +950,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "4.0"
   },
   "c6gn.xlarge": {
     "up": "c6gn.2xlarge",
@@ -870,7 +960,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "8.0"
   },
   "c6gn.2xlarge": {
     "up": "c6gn.4xlarge",
@@ -879,7 +970,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "16.0"
   },
   "c6gn.4xlarge": {
     "up": "c6gn.8xlarge",
@@ -888,7 +980,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "32.0"
   },
   "c6gn.8xlarge": {
     "up": "c6gn.12xlarge",
@@ -897,7 +990,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "64.0"
   },
   "c6gn.12xlarge": {
     "up": "c6gn.16xlarge",
@@ -906,7 +1000,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "96.0"
   },
   "c6gn.16xlarge": {
     "up": null,
@@ -915,7 +1010,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "128.0"
   },
   "c6i.large": {
     "up": "c6i.xlarge",
@@ -924,7 +1020,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "4.0"
   },
   "c6i.xlarge": {
     "up": "c6i.2xlarge",
@@ -933,7 +1030,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "8.0"
   },
   "c6i.2xlarge": {
     "up": "c6i.4xlarge",
@@ -942,7 +1040,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "16.0"
   },
   "c6i.4xlarge": {
     "up": "c6i.8xlarge",
@@ -951,7 +1050,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "32.0"
   },
   "c6i.8xlarge": {
     "up": "c6i.12xlarge",
@@ -960,7 +1060,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "64.0"
   },
   "c6i.12xlarge": {
     "up": "c6i.16xlarge",
@@ -969,7 +1070,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "96.0"
   },
   "c6i.16xlarge": {
     "up": "c6i.24xlarge",
@@ -978,7 +1080,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "128.0"
   },
   "c6i.24xlarge": {
     "up": "c6i.32xlarge",
@@ -987,7 +1090,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "192.0"
   },
   "c6i.32xlarge": {
     "up": null,
@@ -996,7 +1100,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "128",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "256.0"
   },
   "c6i.metal": {
     "up": null,
@@ -1005,7 +1110,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "128",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "256.0"
   },
   "c6id.large": {
     "up": "c6id.xlarge",
@@ -1014,7 +1120,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "4.0"
   },
   "c6id.xlarge": {
     "up": "c6id.2xlarge",
@@ -1023,7 +1130,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "8.0"
   },
   "c6id.2xlarge": {
     "up": "c6id.4xlarge",
@@ -1032,7 +1140,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "16.0"
   },
   "c6id.4xlarge": {
     "up": "c6id.8xlarge",
@@ -1041,7 +1150,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "32.0"
   },
   "c6id.8xlarge": {
     "up": "c6id.12xlarge",
@@ -1050,7 +1160,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "64.0"
   },
   "c6id.12xlarge": {
     "up": "c6id.16xlarge",
@@ -1059,7 +1170,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "96.0"
   },
   "c6id.16xlarge": {
     "up": "c6id.24xlarge",
@@ -1068,7 +1180,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "128.0"
   },
   "c6id.24xlarge": {
     "up": "c6id.32xlarge",
@@ -1077,7 +1190,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "192.0"
   },
   "c6id.32xlarge": {
     "up": null,
@@ -1086,7 +1200,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "128",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "256.0"
   },
   "c6id.metal": {
     "up": null,
@@ -1095,7 +1210,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "128",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "256.0"
   },
   "c7g.medium": {
     "up": "c7g.large",
@@ -1104,7 +1220,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "1",
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "2.0"
   },
   "c7g.large": {
     "up": "c7g.xlarge",
@@ -1113,7 +1230,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "4.0"
   },
   "c7g.xlarge": {
     "up": "c7g.2xlarge",
@@ -1122,7 +1240,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "8.0"
   },
   "c7g.2xlarge": {
     "up": "c7g.4xlarge",
@@ -1131,7 +1250,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "16.0"
   },
   "c7g.4xlarge": {
     "up": "c7g.8xlarge",
@@ -1140,7 +1260,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "32.0"
   },
   "c7g.8xlarge": {
     "up": "c7g.12xlarge",
@@ -1149,7 +1270,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "64.0"
   },
   "c7g.12xlarge": {
     "up": "c7g.16xlarge",
@@ -1158,7 +1280,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "96.0"
   },
   "c7g.16xlarge": {
     "up": null,
@@ -1167,7 +1290,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "128.0"
   },
   "cc1.4xlarge": {
     "up": null,
@@ -1184,7 +1308,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "60.5"
   },
   "cg1.4xlarge": {
     "up": null,
@@ -1206,7 +1331,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "244.0"
   },
   "d2.xlarge": {
     "up": "d2.2xlarge",
@@ -1215,7 +1341,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "30.5"
   },
   "d2.2xlarge": {
     "up": "d2.4xlarge",
@@ -1224,7 +1351,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "61.0"
   },
   "d2.4xlarge": {
     "up": "d2.8xlarge",
@@ -1233,7 +1361,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "122.0"
   },
   "d2.8xlarge": {
     "up": null,
@@ -1242,7 +1371,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "36",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "244.0"
   },
   "d3.xlarge": {
     "up": "d3.2xlarge",
@@ -1251,7 +1381,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "32.0"
   },
   "d3.2xlarge": {
     "up": "d3.4xlarge",
@@ -1260,7 +1391,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "64.0"
   },
   "d3.4xlarge": {
     "up": "d3.8xlarge",
@@ -1269,7 +1401,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "128.0"
   },
   "d3.8xlarge": {
     "up": null,
@@ -1278,7 +1411,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "256.0"
   },
   "d3en.xlarge": {
     "up": "d3en.2xlarge",
@@ -1287,7 +1421,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16.0"
   },
   "d3en.2xlarge": {
     "up": "d3en.4xlarge",
@@ -1296,7 +1431,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32.0"
   },
   "d3en.4xlarge": {
     "up": "d3en.6xlarge",
@@ -1305,7 +1441,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "64.0"
   },
   "d3en.6xlarge": {
     "up": "d3en.8xlarge",
@@ -1314,7 +1451,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "24",
-    "nfu": "48"
+    "nfu": "48",
+    "memory": "96.0"
   },
   "d3en.8xlarge": {
     "up": "d3en.12xlarge",
@@ -1323,7 +1461,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "128.0"
   },
   "d3en.12xlarge": {
     "up": null,
@@ -1332,7 +1471,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "192.0"
   },
   "p2.xlarge": {
     "up": "p2.8xlarge",
@@ -1346,7 +1486,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "61.0"
   },
   "p2.8xlarge": {
     "up": "p2.16xlarge",
@@ -1360,7 +1501,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "488.0"
   },
   "p2.16xlarge": {
     "up": null,
@@ -1374,7 +1516,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "732.0"
   },
   "p3.2xlarge": {
     "up": "p3.8xlarge",
@@ -1383,7 +1526,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "61.0"
   },
   "p3.8xlarge": {
     "up": "p3.16xlarge",
@@ -1392,7 +1536,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "244.0"
   },
   "p3.16xlarge": {
     "up": "p3dn.24xlarge",
@@ -1401,7 +1546,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "488.0"
   },
   "p3dn.24xlarge": {
     "up": null,
@@ -1410,7 +1556,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "768.0"
   },
   "inf1.xlarge": {
     "up": "inf1.2xlarge",
@@ -1419,7 +1566,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "8.0"
   },
   "inf1.2xlarge": {
     "up": "inf1.6xlarge",
@@ -1428,7 +1576,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "16.0"
   },
   "inf1.6xlarge": {
     "up": "inf1.24xlarge",
@@ -1437,7 +1586,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "24",
-    "nfu": "48"
+    "nfu": "48",
+    "memory": "48.0"
   },
   "inf1.24xlarge": {
     "up": null,
@@ -1446,7 +1596,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "192.0"
   },
   "g2.2xlarge": {
     "up": "g2.8xlarge",
@@ -1455,7 +1606,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "15.0"
   },
   "g2.8xlarge": {
     "up": null,
@@ -1464,7 +1616,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "60.0"
   },
   "g3s.xlarge": {
     "up": "g3.4xlarge",
@@ -1473,7 +1626,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "30.5"
   },
   "g3.4xlarge": {
     "up": "g3.8xlarge",
@@ -1482,7 +1636,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "122.0"
   },
   "g3.8xlarge": {
     "up": "g3.16xlarge",
@@ -1491,7 +1646,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "244.0"
   },
   "g3.16xlarge": {
     "up": null,
@@ -1500,7 +1656,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "488.0"
   },
   "g4.large": {
     "up": "g4.xlarge",
@@ -1549,7 +1706,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "192.0"
   },
   "g4dn.metal": {
     "up": null,
@@ -1557,7 +1715,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "96"
+    "vcpu": "96",
+    "memory": "384.0"
   },
   "g4ad.4xlarge": {
     "up": "g4ad.8xlarge",
@@ -1566,7 +1725,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "64.0"
   },
   "g4ad.8xlarge": {
     "up": "g4ad.16xlarge",
@@ -1575,7 +1735,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "128.0"
   },
   "g4ad.16xlarge": {
     "up": null,
@@ -1584,7 +1745,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "256.0"
   },
   "g4dn.xlarge": {
     "up": "g4dn.2xlarge",
@@ -1593,7 +1755,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16.0"
   },
   "g4dn.2xlarge": {
     "up": "g4dn.4xlarge",
@@ -1602,7 +1765,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32.0"
   },
   "g4dn.4xlarge": {
     "up": "g4dn.8xlarge",
@@ -1611,7 +1775,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "64.0"
   },
   "g4dn.8xlarge": {
     "up": "g4dn.16xlarge",
@@ -1620,7 +1785,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "128.0"
   },
   "g4dn.16xlarge": {
     "up": null,
@@ -1629,7 +1795,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "256.0"
   },
   "g5g.xlarge": {
     "up": "g5g.2xlarge",
@@ -1638,7 +1805,8 @@
     "ec2_classic": false,
     "enhanced_networking": false,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "8.0"
   },
   "g5g.2xlarge": {
     "up": "g5g.4xlarge",
@@ -1647,7 +1815,8 @@
     "ec2_classic": false,
     "enhanced_networking": false,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "16.0"
   },
   "g5g.4xlarge": {
     "up": "g5g.8xlarge",
@@ -1656,7 +1825,8 @@
     "ec2_classic": false,
     "enhanced_networking": false,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "32.0"
   },
   "g5g.8xlarge": {
     "up": "g5g.16xlarge",
@@ -1665,7 +1835,8 @@
     "ec2_classic": false,
     "enhanced_networking": false,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "64.0"
   },
   "g5g.16xlarge": {
     "up": "g5g.metal",
@@ -1674,7 +1845,8 @@
     "ec2_classic": false,
     "enhanced_networking": false,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "128.0"
   },
   "g5g.metal": {
     "up": null,
@@ -1683,7 +1855,8 @@
     "ec2_classic": false,
     "enhanced_networking": false,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "128.0"
   },
   "f1.2xlarge": {
     "up": "f1.4xlarge",
@@ -1692,7 +1865,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "122.0"
   },
   "f1.4xlarge": {
     "up": "f1.16xlarge",
@@ -1701,7 +1875,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "244.0"
   },
   "f1.16xlarge": {
     "up": null,
@@ -1710,7 +1885,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "976.0"
   },
   "h1.2xlarge": {
     "up": "h1.4xlarge",
@@ -1719,7 +1895,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32.0"
   },
   "h1.4xlarge": {
     "up": "h1.8xlarge",
@@ -1728,7 +1905,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "64.0"
   },
   "h1.8xlarge": {
     "up": "h1.16xlarge",
@@ -1737,7 +1915,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "128.0"
   },
   "h1.16xlarge": {
     "up": null,
@@ -1746,7 +1925,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "256.0"
   },
   "hi1.4xlarge": {
     "up": "hs1.8xlarge",
@@ -1773,7 +1953,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "16",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "117.0"
   },
   "i2.xlarge": {
     "up": "i2.2xlarge",
@@ -1787,7 +1968,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "30.5"
   },
   "i2.2xlarge": {
     "up": "i2.4xlarge",
@@ -1801,7 +1983,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "61.0"
   },
   "i2.4xlarge": {
     "up": "i2.8xlarge",
@@ -1815,7 +1998,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "122.0"
   },
   "i2.8xlarge": {
     "up": null,
@@ -1829,7 +2013,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "244.0"
   },
   "i3.large": {
     "up": "i3.xlarge",
@@ -1838,7 +2023,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "15.25"
   },
   "i3.xlarge": {
     "up": "i3.2xlarge",
@@ -1847,7 +2033,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "30.5"
   },
   "i3.2xlarge": {
     "up": "i3.4xlarge",
@@ -1856,7 +2043,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "61.0"
   },
   "i3.4xlarge": {
     "up": "i3.8xlarge",
@@ -1865,7 +2053,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "122.0"
   },
   "i3.8xlarge": {
     "up": "i3.16xlarge",
@@ -1874,7 +2063,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "244.0"
   },
   "i3.16xlarge": {
     "up": null,
@@ -1883,7 +2073,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "488.0"
   },
   "i3.metal": {
     "up": null,
@@ -1891,7 +2082,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "64"
+    "vcpu": "64",
+    "memory": "512.0"
   },
   "i3en.large": {
     "up": "i3en.xlarge",
@@ -1900,7 +2092,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "16.0"
   },
   "i3en.xlarge": {
     "up": "i3en.2xlarge",
@@ -1909,7 +2102,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "32.0"
   },
   "i3en.2xlarge": {
     "up": "i3en.3xlarge",
@@ -1918,7 +2112,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "64.0"
   },
   "i3en.3xlarge": {
     "up": "i3en.6xlarge",
@@ -1927,7 +2122,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "12",
-    "nfu": "24"
+    "nfu": "24",
+    "memory": "96.0"
   },
   "i3en.6xlarge": {
     "up": "i3en.12xlarge",
@@ -1936,7 +2132,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "24",
-    "nfu": "48"
+    "nfu": "48",
+    "memory": "192.0"
   },
   "i3en.12xlarge": {
     "up": "i3en.24xlarge",
@@ -1945,7 +2142,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "384.0"
   },
   "i3en.24xlarge": {
     "up": null,
@@ -1954,7 +2152,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "768.0"
   },
   "i3en.metal": {
     "up": null,
@@ -1962,7 +2161,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "96"
+    "vcpu": "96",
+    "memory": "768.0"
   },
   "im4gn.large": {
     "up": "im4gn.xlarge",
@@ -1971,7 +2171,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "8.0"
   },
   "im4gn.xlarge": {
     "up": "im4gn.2xlarge",
@@ -1980,7 +2181,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "16.0"
   },
   "im4gn.2xlarge": {
     "up": "im4gn.4xlarge",
@@ -1989,7 +2191,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "32.0"
   },
   "im4gn.4xlarge": {
     "up": "im4gn.8xlarge",
@@ -1998,7 +2201,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "64.0"
   },
   "im4gn.8xlarge": {
     "up": "im4gn.16xlarge",
@@ -2007,7 +2211,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "128.0"
   },
   "im4gn.16xlarge": {
     "up": null,
@@ -2016,7 +2221,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "256.0"
   },
   "is4gen.medium": {
     "up": "is4gen.large",
@@ -2025,7 +2231,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "1",
-    "nfu": "6"
+    "nfu": "6",
+    "memory": "6.0"
   },
   "is4gen.large": {
     "up": "is4gen.xlarge",
@@ -2034,7 +2241,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "12"
+    "nfu": "12",
+    "memory": "12.0"
   },
   "is4gen.xlarge": {
     "up": "is4gen.2xlarge",
@@ -2043,7 +2251,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "24"
+    "nfu": "24",
+    "memory": "24.0"
   },
   "is4gen.2xlarge": {
     "up": "is4gen.4xlarge",
@@ -2052,7 +2261,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "48"
+    "nfu": "48",
+    "memory": "48.0"
   },
   "is4gen.4xlarge": {
     "up": "is4gen.8xlarge",
@@ -2061,7 +2271,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "96.0"
   },
   "is4gen.8xlarge": {
     "up": null,
@@ -2070,7 +2281,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "192.0"
   },
   "m1.small": {
     "up": "m1.medium",
@@ -2084,7 +2296,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "1",
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "1.7"
   },
   "m1.medium": {
     "up": "m1.large",
@@ -2098,7 +2311,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "1",
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "3.75"
   },
   "m1.large": {
     "up": "m1.xlarge",
@@ -2112,7 +2326,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "7.5"
   },
   "m1.xlarge": {
     "up": null,
@@ -2126,7 +2341,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "15.0"
   },
   "m2.xlarge": {
     "up": "m2.2xlarge",
@@ -2140,7 +2356,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "2",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "17.1"
   },
   "m2.2xlarge": {
     "up": "m2.4xlarge",
@@ -2154,7 +2371,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "4",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "34.2"
   },
   "m2.4xlarge": {
     "up": null,
@@ -2168,7 +2386,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "8",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "68.4"
   },
   "m3.medium": {
     "up": "m3.large",
@@ -2182,7 +2401,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "1",
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "3.75"
   },
   "m3.large": {
     "up": "m3.xlarge",
@@ -2196,7 +2416,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "7.5"
   },
   "m3.xlarge": {
     "up": "m3.2xlarge",
@@ -2210,7 +2431,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "15.0"
   },
   "m3.2xlarge": {
     "up": null,
@@ -2224,7 +2446,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "30.0"
   },
   "m4.large": {
     "up": "m4.xlarge",
@@ -2238,7 +2461,8 @@
     "ec2_classic": false,
     "enhanced_networking": false,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8.0"
   },
   "m4.xlarge": {
     "up": "m4.2xlarge",
@@ -2252,7 +2476,8 @@
     "ec2_classic": false,
     "enhanced_networking": false,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16.0"
   },
   "m4.2xlarge": {
     "up": "m4.4xlarge",
@@ -2266,7 +2491,8 @@
     "ec2_classic": false,
     "enhanced_networking": false,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32.0"
   },
   "m4.4xlarge": {
     "up": "m4.10xlarge",
@@ -2280,7 +2506,8 @@
     "ec2_classic": false,
     "enhanced_networking": false,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "64.0"
   },
   "m4.10xlarge": {
     "up": "m4.16xlarge",
@@ -2294,7 +2521,8 @@
     "ec2_classic": false,
     "enhanced_networking": false,
     "vcpu": "40",
-    "nfu": "80"
+    "nfu": "80",
+    "memory": "160.0"
   },
   "m4.16xlarge": {
     "up": null,
@@ -2308,7 +2536,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "256.0"
   },
   "m5.large": {
     "up": "m5.xlarge",
@@ -2317,7 +2546,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8.0"
   },
   "m5.xlarge": {
     "up": "m5.2xlarge",
@@ -2326,7 +2556,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16.0"
   },
   "m5.2xlarge": {
     "up": "m5.4xlarge",
@@ -2335,7 +2566,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32.0"
   },
   "m5.4xlarge": {
     "up": "m5.8xlarge",
@@ -2344,7 +2576,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "64.0"
   },
   "m5.8xlarge": {
     "up": "m5.12xlarge",
@@ -2353,7 +2586,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "128.0"
   },
   "m5.12xlarge": {
     "up": "m5.16xlarge",
@@ -2362,7 +2596,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "192.0"
   },
   "m5.16xlarge": {
     "up": "m5.24xlarge",
@@ -2371,7 +2606,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "256.0"
   },
   "m5.24xlarge": {
     "up": null,
@@ -2380,7 +2616,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "384.0"
   },
   "m5.metal": {
     "up": null,
@@ -2388,7 +2625,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "96"
+    "vcpu": "96",
+    "memory": "384.0"
   },
   "m5n.large": {
     "up": "m5n.xlarge",
@@ -2397,7 +2635,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8.0"
   },
   "m5n.xlarge": {
     "up": "m5n.2xlarge",
@@ -2406,7 +2645,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16.0"
   },
   "m5n.2xlarge": {
     "up": "m5n.4xlarge",
@@ -2415,7 +2655,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32.0"
   },
   "m5n.4xlarge": {
     "up": "m5n.8xlarge",
@@ -2424,7 +2665,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "64.0"
   },
   "m5n.8xlarge": {
     "up": "m5n.12xlarge",
@@ -2433,7 +2675,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "128.0"
   },
   "m5n.12xlarge": {
     "up": "m5n.16xlarge",
@@ -2442,7 +2685,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "192.0"
   },
   "m5n.16xlarge": {
     "up": "m5n.24xlarge",
@@ -2451,7 +2695,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "256.0"
   },
   "m5n.24xlarge": {
     "up": null,
@@ -2460,7 +2705,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "384.0"
   },
   "m5n.metal": {
     "up": null,
@@ -2468,7 +2714,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "96"
+    "vcpu": "96",
+    "memory": "384.0"
   },
   "m5dn.large": {
     "up": "m5dn.xlarge",
@@ -2477,7 +2724,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8.0"
   },
   "m5dn.xlarge": {
     "up": "m5dn.2xlarge",
@@ -2486,7 +2734,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16.0"
   },
   "m5dn.2xlarge": {
     "up": "m5dn.4xlarge",
@@ -2495,7 +2744,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32.0"
   },
   "m5dn.4xlarge": {
     "up": "m5dn.8xlarge",
@@ -2504,7 +2754,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "64.0"
   },
   "m5dn.8xlarge": {
     "up": "m5dn.12xlarge",
@@ -2513,7 +2764,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "128.0"
   },
   "m5dn.12xlarge": {
     "up": "m5dn.16xlarge",
@@ -2522,7 +2774,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "192.0"
   },
   "m5dn.16xlarge": {
     "up": "m5dn.24xlarge",
@@ -2531,7 +2784,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "256.0"
   },
   "m5dn.24xlarge": {
     "up": null,
@@ -2540,7 +2794,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "384.0"
   },
   "m5dn.metal": {
     "up": null,
@@ -2548,7 +2803,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "96"
+    "vcpu": "96",
+    "memory": "384.0"
   },
   "m5zn.large": {
     "up": "m5zn.xlarge",
@@ -2557,7 +2813,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8.0"
   },
   "m5zn.xlarge": {
     "up": "m5zn.2xlarge",
@@ -2566,7 +2823,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16.0"
   },
   "m5zn.2xlarge": {
     "up": "m5zn.3xlarge",
@@ -2575,7 +2833,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32.0"
   },
   "m5zn.3xlarge": {
     "up": "m5zn.6xlarge",
@@ -2584,7 +2843,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "12",
-    "nfu": "24"
+    "nfu": "24",
+    "memory": "48.0"
   },
   "m5zn.6xlarge": {
     "up": "m5zn.12xlarge",
@@ -2593,7 +2853,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "24",
-    "nfu": "48"
+    "nfu": "48",
+    "memory": "96.0"
   },
   "m5zn.12xlarge": {
     "up": null,
@@ -2602,7 +2863,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "192.0"
   },
   "m5zn.metal": {
     "up": null,
@@ -2610,7 +2872,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "48"
+    "vcpu": "48",
+    "memory": "192.0"
   },
   "mac1.metal": {
     "up": null,
@@ -2618,7 +2881,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "12"
+    "vcpu": "12",
+    "memory": "32.0"
   },
   "p4d.24xlarge": {
     "up": null,
@@ -2627,7 +2891,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "1152.0"
   },
   "m6a.large": {
     "up": "m6a.xlarge",
@@ -2636,7 +2901,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8.0"
   },
   "m6a.xlarge": {
     "up": "m6a.2xlarge",
@@ -2645,7 +2911,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16.0"
   },
   "m6a.2xlarge": {
     "up": "m6a.4xlarge",
@@ -2654,7 +2921,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32.0"
   },
   "m6a.4xlarge": {
     "up": "m6a.8xlarge",
@@ -2663,7 +2931,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "64.0"
   },
   "m6a.8xlarge": {
     "up": "m6a.12xlarge",
@@ -2672,7 +2941,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "128.0"
   },
   "m6a.12xlarge": {
     "up": "m6a.16xlarge",
@@ -2681,7 +2951,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "192.0"
   },
   "m6a.16xlarge": {
     "up": "m6a.24xlarge",
@@ -2690,7 +2961,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "256.0"
   },
   "m6a.24xlarge": {
     "up": "m6a.32xlarge",
@@ -2699,7 +2971,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "384.0"
   },
   "m6a.32xlarge": {
     "up": "m6a.48xlarge",
@@ -2708,7 +2981,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "128",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "512.0"
   },
   "m6a.48xlarge": {
     "up": null,
@@ -2717,7 +2991,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "192",
-    "nfu": "384"
+    "nfu": "384",
+    "memory": "768.0"
   },
   "m6a.metal": {
     "up": null,
@@ -2726,7 +3001,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "192",
-    "nfu": "384"
+    "nfu": "384",
+    "memory": "768.0"
   },
   "m6g.medium": {
     "up": "m6g.large",
@@ -2735,7 +3011,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "1",
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "4.0"
   },
   "m6g.large": {
     "up": "m6g.xlarge",
@@ -2744,7 +3021,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8.0"
   },
   "m6g.xlarge": {
     "up": "m6g.2xlarge",
@@ -2753,7 +3031,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16.0"
   },
   "m6g.2xlarge": {
     "up": "m6g.4xlarge",
@@ -2762,7 +3041,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32.0"
   },
   "m6g.4xlarge": {
     "up": "m6g.8xlarge",
@@ -2771,7 +3051,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "64.0"
   },
   "m6g.8xlarge": {
     "up": "m6g.12xlarge",
@@ -2780,7 +3061,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "128.0"
   },
   "m6g.12xlarge": {
     "up": "m6g.16xlarge",
@@ -2789,7 +3071,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "192.0"
   },
   "m6g.16xlarge": {
     "up": "m6g.24xlarge",
@@ -2798,7 +3081,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "256.0"
   },
   "m6g.24xlarge": {
     "up": null,
@@ -2814,7 +3098,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "64"
+    "vcpu": "64",
+    "memory": "256.0"
   },
   "m6gd.medium": {
     "up": "m6gd.large",
@@ -2823,7 +3108,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "1",
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "4.0"
   },
   "m6gd.large": {
     "up": "m6gd.xlarge",
@@ -2832,7 +3118,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8.0"
   },
   "m6gd.xlarge": {
     "up": "m6gd.2xlarge",
@@ -2841,7 +3128,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16.0"
   },
   "m6gd.2xlarge": {
     "up": "m6gd.4xlarge",
@@ -2850,7 +3138,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32.0"
   },
   "m6gd.4xlarge": {
     "up": "m6gd.8xlarge",
@@ -2859,7 +3148,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "64.0"
   },
   "m6gd.8xlarge": {
     "up": "m6gd.12xlarge",
@@ -2868,7 +3158,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "128.0"
   },
   "m6gd.12xlarge": {
     "up": "m6gd.16xlarge",
@@ -2877,7 +3168,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "192.0"
   },
   "m6gd.16xlarge": {
     "up": "m6gd.24xlarge",
@@ -2886,7 +3178,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "256.0"
   },
   "m6gd.24xlarge": {
     "up": null,
@@ -2902,7 +3195,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "64"
+    "vcpu": "64",
+    "memory": "256.0"
   },
   "m6i.large": {
     "up": "m6i.xlarge",
@@ -2911,7 +3205,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8.0"
   },
   "m6i.xlarge": {
     "up": "m6i.2xlarge",
@@ -2920,7 +3215,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16.0"
   },
   "m6i.2xlarge": {
     "up": "m6i.4xlarge",
@@ -2929,7 +3225,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32.0"
   },
   "m6i.4xlarge": {
     "up": "m6i.8xlarge",
@@ -2938,7 +3235,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "64.0"
   },
   "m6i.8xlarge": {
     "up": "m6i.12xlarge",
@@ -2947,7 +3245,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "128.0"
   },
   "m6i.12xlarge": {
     "up": "m6i.16xlarge",
@@ -2956,7 +3255,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "192.0"
   },
   "m6i.16xlarge": {
     "up": "m6i.24xlarge",
@@ -2965,7 +3265,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "256.0"
   },
   "m6i.24xlarge": {
     "up": "m6i.32xlarge",
@@ -2974,7 +3275,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "384.0"
   },
   "m6i.32xlarge": {
     "up": null,
@@ -2983,7 +3285,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "128",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "512.0"
   },
   "m6i.metal": {
     "up": null,
@@ -2992,7 +3295,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "128",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "512.0"
   },
   "m6id.large": {
     "up": "m6id.xlarge",
@@ -3001,7 +3305,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8.0"
   },
   "m6id.xlarge": {
     "up": "m6id.2xlarge",
@@ -3010,7 +3315,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16.0"
   },
   "m6id.2xlarge": {
     "up": "m6id.4xlarge",
@@ -3019,7 +3325,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32.0"
   },
   "m6id.4xlarge": {
     "up": "m6id.8xlarge",
@@ -3028,7 +3335,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "64.0"
   },
   "m6id.8xlarge": {
     "up": "m6id.12xlarge",
@@ -3037,7 +3345,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "128.0"
   },
   "m6id.12xlarge": {
     "up": "m6id.16xlarge",
@@ -3046,7 +3355,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "192.0"
   },
   "m6id.16xlarge": {
     "up": "m6id.24xlarge",
@@ -3055,7 +3365,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "256.0"
   },
   "m6id.24xlarge": {
     "up": "m6id.32xlarge",
@@ -3064,7 +3375,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "384.0"
   },
   "m6id.32xlarge": {
     "up": null,
@@ -3073,7 +3385,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "128",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "512.0"
   },
   "m6id.metal": {
     "up": null,
@@ -3082,7 +3395,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "128",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "512.0"
   },
   "m5a.large": {
     "up": "m5a.xlarge",
@@ -3091,7 +3405,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8.0"
   },
   "m5a.xlarge": {
     "up": "m5a.2xlarge",
@@ -3100,7 +3415,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16.0"
   },
   "m5a.2xlarge": {
     "up": "m5a.4xlarge",
@@ -3109,7 +3425,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32.0"
   },
   "m5a.4xlarge": {
     "up": "m5a.8xlarge",
@@ -3118,7 +3435,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "64.0"
   },
   "m5a.8xlarge": {
     "up": "m5a.12xlarge",
@@ -3127,7 +3445,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "128.0"
   },
   "m5a.12xlarge": {
     "up": "m5a.16xlarge",
@@ -3136,7 +3455,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "192.0"
   },
   "m5a.16xlarge": {
     "up": "m5a.24xlarge",
@@ -3145,7 +3465,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "256.0"
   },
   "m5a.24xlarge": {
     "up": null,
@@ -3154,7 +3475,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "384.0"
   },
   "m5ad.large": {
     "up": "m5ad.xlarge",
@@ -3163,7 +3485,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8.0"
   },
   "m5ad.xlarge": {
     "up": "m5ad.2xlarge",
@@ -3172,7 +3495,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16.0"
   },
   "m5ad.2xlarge": {
     "up": "m5ad.4xlarge",
@@ -3181,7 +3505,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32.0"
   },
   "m5ad.4xlarge": {
     "up": "m5ad.8xlarge",
@@ -3190,7 +3515,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "64.0"
   },
   "m5ad.8xlarge": {
     "up": "m5ad.12xlarge",
@@ -3199,7 +3525,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "128.0"
   },
   "m5ad.12xlarge": {
     "up": "m5ad.16xlarge",
@@ -3208,7 +3535,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "192.0"
   },
   "m5ad.16xlarge": {
     "up": "m5ad.24xlarge",
@@ -3217,7 +3545,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "256.0"
   },
   "m5ad.24xlarge": {
     "up": null,
@@ -3226,7 +3555,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "384.0"
   },
   "m5d.large": {
     "up": "m5d.xlarge",
@@ -3235,7 +3565,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8.0"
   },
   "m5d.xlarge": {
     "up": "m5d.2xlarge",
@@ -3244,7 +3575,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16.0"
   },
   "m5d.2xlarge": {
     "up": "m5d.4xlarge",
@@ -3253,7 +3585,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32.0"
   },
   "m5d.4xlarge": {
     "up": "m5d.8xlarge",
@@ -3262,7 +3595,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "64.0"
   },
   "m5d.8xlarge": {
     "up": "m5d.12xlarge",
@@ -3271,7 +3605,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "128.0"
   },
   "m5d.12xlarge": {
     "up": "m5d.16xlarge",
@@ -3280,7 +3615,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "192.0"
   },
   "m5d.16xlarge": {
     "up": "m5d.24xlarge",
@@ -3289,7 +3625,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "256.0"
   },
   "m5d.24xlarge": {
     "up": null,
@@ -3298,7 +3635,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "384.0"
   },
   "m5d.metal": {
     "up": null,
@@ -3306,7 +3644,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "96"
+    "vcpu": "96",
+    "memory": "384.0"
   },
   "r3.large": {
     "up": "r3.xlarge",
@@ -3315,7 +3654,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "15.25"
   },
   "r3.xlarge": {
     "up": "r3.2xlarge",
@@ -3324,7 +3664,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "30.5"
   },
   "r3.2xlarge": {
     "up": "r3.4xlarge",
@@ -3333,7 +3674,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "61.0"
   },
   "r3.4xlarge": {
     "up": "r3.8xlarge",
@@ -3342,7 +3684,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "122.0"
   },
   "r3.8xlarge": {
     "up": null,
@@ -3351,7 +3694,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "244.0"
   },
   "r4.large": {
     "up": "r4.xlarge",
@@ -3360,7 +3704,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "15.25"
   },
   "r4.xlarge": {
     "up": "r4.2xlarge",
@@ -3369,7 +3714,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "30.5"
   },
   "r4.2xlarge": {
     "up": "r4.4xlarge",
@@ -3378,7 +3724,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "61.0"
   },
   "r4.4xlarge": {
     "up": "r4.8xlarge",
@@ -3387,7 +3734,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "122.0"
   },
   "r4.8xlarge": {
     "up": "r4.16xlarge",
@@ -3396,7 +3744,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "244.0"
   },
   "r4.16xlarge": {
     "up": null,
@@ -3405,7 +3754,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "488.0"
   },
   "r5.large": {
     "up": "r5.xlarge",
@@ -3414,7 +3764,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "16.0"
   },
   "r5.xlarge": {
     "up": "r5.2xlarge",
@@ -3423,7 +3774,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "32.0"
   },
   "r5.2xlarge": {
     "up": "r5.4xlarge",
@@ -3432,7 +3784,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "64.0"
   },
   "r5.4xlarge": {
     "up": "r5.8xlarge",
@@ -3441,7 +3794,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "128.0"
   },
   "r5.8xlarge": {
     "up": "r5.12xlarge",
@@ -3450,7 +3804,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "256.0"
   },
   "r5.12xlarge": {
     "up": "r5.16xlarge",
@@ -3459,7 +3814,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "384.0"
   },
   "r5.16xlarge": {
     "up": "r5.24xlarge",
@@ -3468,7 +3824,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "512.0"
   },
   "r5.24xlarge": {
     "up": null,
@@ -3477,7 +3834,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "768.0"
   },
   "r5.metal": {
     "up": null,
@@ -3485,7 +3843,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "96"
+    "vcpu": "96",
+    "memory": "768.0"
   },
   "r5a.large": {
     "up": "r5a.xlarge",
@@ -3494,7 +3853,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "16.0"
   },
   "r5a.xlarge": {
     "up": "r5a.2xlarge",
@@ -3503,7 +3863,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "32.0"
   },
   "r5a.2xlarge": {
     "up": "r5a.4xlarge",
@@ -3512,7 +3873,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "64.0"
   },
   "r5a.4xlarge": {
     "up": "r5a.8xlarge",
@@ -3521,7 +3883,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "128.0"
   },
   "r5a.8xlarge": {
     "up": "r5a.12xlarge",
@@ -3530,7 +3893,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "256.0"
   },
   "r5a.12xlarge": {
     "up": "r5a.16xlarge",
@@ -3539,7 +3903,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "384.0"
   },
   "r5a.16xlarge": {
     "up": "r5a.24xlarge",
@@ -3548,7 +3913,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "512.0"
   },
   "r5a.24xlarge": {
     "up": null,
@@ -3557,7 +3923,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "768.0"
   },
   "r5b.large": {
     "up": "r5b.xlarge",
@@ -3566,7 +3933,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "16.0"
   },
   "r5b.xlarge": {
     "up": "r5b.2xlarge",
@@ -3575,7 +3943,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "32.0"
   },
   "r5b.2xlarge": {
     "up": "r5b.4xlarge",
@@ -3584,7 +3953,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "64.0"
   },
   "r5b.4xlarge": {
     "up": "r5b.8xlarge",
@@ -3593,7 +3963,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "128.0"
   },
   "r5b.8xlarge": {
     "up": "r5b.12xlarge",
@@ -3602,7 +3973,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "256.0"
   },
   "r5b.12xlarge": {
     "up": "r5b.16xlarge",
@@ -3611,7 +3983,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "384.0"
   },
   "r5b.16xlarge": {
     "up": "r5b.24xlarge",
@@ -3620,7 +3993,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "512.0"
   },
   "r5b.24xlarge": {
     "up": null,
@@ -3629,7 +4003,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "768.0"
   },
   "r5b.metal": {
     "up": null,
@@ -3637,7 +4012,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "96"
+    "vcpu": "96",
+    "memory": "768.0"
   },
   "r5ad.large": {
     "up": "r5ad.xlarge",
@@ -3646,7 +4022,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "16.0"
   },
   "r5ad.xlarge": {
     "up": "r5ad.2xlarge",
@@ -3655,7 +4032,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "32.0"
   },
   "r5ad.2xlarge": {
     "up": "r5ad.4xlarge",
@@ -3664,7 +4042,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "64.0"
   },
   "r5ad.4xlarge": {
     "up": "r5ad.8xlarge",
@@ -3673,7 +4052,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "128.0"
   },
   "r5ad.8xlarge": {
     "up": "r5ad.12xlarge",
@@ -3682,7 +4062,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "256.0"
   },
   "r5ad.12xlarge": {
     "up": "r5ad.16xlarge",
@@ -3691,7 +4072,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "384.0"
   },
   "r5ad.16xlarge": {
     "up": "r5ad.24xlarge",
@@ -3700,7 +4082,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "512.0"
   },
   "r5ad.24xlarge": {
     "up": null,
@@ -3709,7 +4092,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "768.0"
   },
   "r5n.large": {
     "up": "r5n.xlarge",
@@ -3718,7 +4102,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "16.0"
   },
   "r5n.xlarge": {
     "up": "r5n.2xlarge",
@@ -3727,7 +4112,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "32.0"
   },
   "r5n.2xlarge": {
     "up": "r5n.4xlarge",
@@ -3736,7 +4122,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "64.0"
   },
   "r5n.4xlarge": {
     "up": "r5n.8xlarge",
@@ -3745,7 +4132,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "128.0"
   },
   "r5n.8xlarge": {
     "up": "r5n.12xlarge",
@@ -3754,7 +4142,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "256.0"
   },
   "r5n.12xlarge": {
     "up": "r5n.16xlarge",
@@ -3763,7 +4152,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "384.0"
   },
   "r5n.16xlarge": {
     "up": "r5n.24xlarge",
@@ -3772,7 +4162,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "512.0"
   },
   "r5n.24xlarge": {
     "up": null,
@@ -3781,7 +4172,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "768.0"
   },
   "r5n.metal": {
     "up": null,
@@ -3789,7 +4181,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "96"
+    "vcpu": "96",
+    "memory": "768.0"
   },
   "r5dn.large": {
     "up": "r5dn.xlarge",
@@ -3798,7 +4191,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "16.0"
   },
   "r5dn.xlarge": {
     "up": "r5dn.2xlarge",
@@ -3807,7 +4201,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "32.0"
   },
   "r5dn.2xlarge": {
     "up": "r5dn.4xlarge",
@@ -3816,7 +4211,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "64.0"
   },
   "r5dn.4xlarge": {
     "up": "r5dn.8xlarge",
@@ -3825,7 +4221,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "128.0"
   },
   "r5dn.8xlarge": {
     "up": "r5dn.12xlarge",
@@ -3834,7 +4231,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "256.0"
   },
   "r5dn.12xlarge": {
     "up": "r5dn.16xlarge",
@@ -3843,7 +4241,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "384.0"
   },
   "r5dn.16xlarge": {
     "up": "r5dn.24xlarge",
@@ -3852,7 +4251,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "512.0"
   },
   "r5dn.24xlarge": {
     "up": null,
@@ -3861,7 +4261,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "768.0"
   },
   "r5dn.metal": {
     "up": null,
@@ -3869,7 +4270,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "96"
+    "vcpu": "96",
+    "memory": "768.0"
   },
   "r5d.large": {
     "up": "r5d.xlarge",
@@ -3878,7 +4280,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "16.0"
   },
   "r5d.xlarge": {
     "up": "r5d.2xlarge",
@@ -3887,7 +4290,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "32.0"
   },
   "r5d.2xlarge": {
     "up": "r5d.4xlarge",
@@ -3896,7 +4300,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "64.0"
   },
   "r5d.4xlarge": {
     "up": "r5d.8xlarge",
@@ -3905,7 +4310,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "128.0"
   },
   "r5d.8xlarge": {
     "up": "r5d.12xlarge",
@@ -3914,7 +4320,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "256.0"
   },
   "r5d.12xlarge": {
     "up": "r5d.16xlarge",
@@ -3923,7 +4330,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "384.0"
   },
   "r5d.16xlarge": {
     "up": "r5d.24xlarge",
@@ -3932,7 +4340,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "512.0"
   },
   "r5d.24xlarge": {
     "up": null,
@@ -3941,7 +4350,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "768.0"
   },
   "r5d.metal": {
     "up": null,
@@ -3949,7 +4359,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "96"
+    "vcpu": "96",
+    "memory": "768.0"
   },
   "r6a.large": {
     "up": "r6a.xlarge",
@@ -3958,7 +4369,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "16.0"
   },
   "r6a.xlarge": {
     "up": "r6a.2xlarge",
@@ -3967,7 +4379,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "32.0"
   },
   "r6a.2xlarge": {
     "up": "r6a.4xlarge",
@@ -3976,7 +4389,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "64.0"
   },
   "r6a.4xlarge": {
     "up": "r6a.8xlarge",
@@ -3985,7 +4399,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "128.0"
   },
   "r6a.8xlarge": {
     "up": "r6a.12xlarge",
@@ -3994,7 +4409,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "256.0"
   },
   "r6a.12xlarge": {
     "up": "r6a.16xlarge",
@@ -4003,7 +4419,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "384.0"
   },
   "r6a.16xlarge": {
     "up": "r6a.24xlarge",
@@ -4012,7 +4429,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "512.0"
   },
   "r6a.24xlarge": {
     "up": "r6a.32xlarge",
@@ -4021,7 +4439,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "768.0"
   },
   "r6a.32xlarge": {
     "up": "r6a.48xlarge",
@@ -4030,7 +4449,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "128",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "1024.0"
   },
   "r6a.48xlarge": {
     "up": null,
@@ -4039,7 +4459,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "192",
-    "nfu": "384"
+    "nfu": "384",
+    "memory": "1536.0"
   },
   "r6a.metal": {
     "up": null,
@@ -4048,7 +4469,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "192",
-    "nfu": "384"
+    "nfu": "384",
+    "memory": "1536.0"
   },
   "r6g.medium": {
     "up": "r6g.large",
@@ -4057,7 +4479,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "1",
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "8.0"
   },
   "r6g.large": {
     "up": "r6g.xlarge",
@@ -4066,7 +4489,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "16.0"
   },
   "r6g.xlarge": {
     "up": "r6g.2xlarge",
@@ -4075,7 +4499,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "32.0"
   },
   "r6g.2xlarge": {
     "up": "r6g.4xlarge",
@@ -4084,7 +4509,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "64.0"
   },
   "r6g.4xlarge": {
     "up": "r6g.8xlarge",
@@ -4093,7 +4519,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "128.0"
   },
   "r6g.8xlarge": {
     "up": "r6g.12xlarge",
@@ -4102,7 +4529,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "256.0"
   },
   "r6g.12xlarge": {
     "up": "r6g.16xlarge",
@@ -4111,7 +4539,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "384.0"
   },
   "r6g.16xlarge": {
     "up": null,
@@ -4120,7 +4549,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "512.0"
   },
   "r6g.metal": {
     "up": null,
@@ -4128,7 +4558,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "64"
+    "vcpu": "64",
+    "memory": "512.0"
   },
   "r6gd.medium": {
     "up": "r6gd.large",
@@ -4137,7 +4568,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "1",
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "8.0"
   },
   "r6gd.large": {
     "up": "r6gd.xlarge",
@@ -4146,7 +4578,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "16.0"
   },
   "r6gd.xlarge": {
     "up": "r6gd.2xlarge",
@@ -4155,7 +4588,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "32.0"
   },
   "r6gd.2xlarge": {
     "up": "r6gd.4xlarge",
@@ -4164,7 +4598,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "64.0"
   },
   "r6gd.4xlarge": {
     "up": "r6gd.8xlarge",
@@ -4173,7 +4608,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "128.0"
   },
   "r6gd.8xlarge": {
     "up": "r6gd.12xlarge",
@@ -4182,7 +4618,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "256.0"
   },
   "r6gd.12xlarge": {
     "up": "r6gd.16xlarge",
@@ -4191,7 +4628,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "384.0"
   },
   "r6gd.16xlarge": {
     "up": null,
@@ -4200,7 +4638,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "512.0"
   },
   "r6gd.metal": {
     "up": null,
@@ -4208,7 +4647,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "64"
+    "vcpu": "64",
+    "memory": "512.0"
   },
   "r6i.large": {
     "up": "r6i.xlarge",
@@ -4217,7 +4657,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "16.0"
   },
   "r6i.xlarge": {
     "up": "r6i.2xlarge",
@@ -4226,7 +4667,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "32.0"
   },
   "r6i.2xlarge": {
     "up": "r6i.4xlarge",
@@ -4235,7 +4677,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "64.0"
   },
   "r6i.4xlarge": {
     "up": "r6i.8xlarge",
@@ -4244,7 +4687,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "128.0"
   },
   "r6i.8xlarge": {
     "up": "r6i.12xlarge",
@@ -4253,7 +4697,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "256.0"
   },
   "r6i.12xlarge": {
     "up": "r6i.16xlarge",
@@ -4262,7 +4707,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "384.0"
   },
   "r6i.16xlarge": {
     "up": "r6i.24xlarge",
@@ -4271,7 +4717,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "512.0"
   },
   "r6i.24xlarge": {
     "up": "r6i.32xlarge",
@@ -4280,7 +4727,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "768.0"
   },
   "r6i.32xlarge": {
     "up": null,
@@ -4289,7 +4737,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "128",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "1024.0"
   },
   "r6i.metal": {
     "up": null,
@@ -4298,7 +4747,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "128",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "1024.0"
   },
   "r6id.large": {
     "up": "r6id.xlarge",
@@ -4307,7 +4757,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "16.0"
   },
   "r6id.xlarge": {
     "up": "r6id.2xlarge",
@@ -4316,7 +4767,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "32.0"
   },
   "r6id.2xlarge": {
     "up": "r6id.4xlarge",
@@ -4325,7 +4777,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "64.0"
   },
   "r6id.4xlarge": {
     "up": "r6id.8xlarge",
@@ -4334,7 +4787,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "128.0"
   },
   "r6id.8xlarge": {
     "up": "r6id.12xlarge",
@@ -4343,7 +4797,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "256.0"
   },
   "r6id.12xlarge": {
     "up": "r6id.16xlarge",
@@ -4352,7 +4807,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "384.0"
   },
   "r6id.16xlarge": {
     "up": "r6id.24xlarge",
@@ -4361,7 +4817,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "512.0"
   },
   "r6id.24xlarge": {
     "up": "r6id.32xlarge",
@@ -4370,7 +4827,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "768.0"
   },
   "r6id.32xlarge": {
     "up": null,
@@ -4379,7 +4837,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "128",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "1024.0"
   },
   "r6id.metal": {
     "up": null,
@@ -4388,7 +4847,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "128",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "1024.0"
   },
   "x1.16xlarge": {
     "up": "x1.32xlarge",
@@ -4397,7 +4857,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "976.0"
   },
   "x1.32xlarge": {
     "up": null,
@@ -4406,7 +4867,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "128",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "1952.0"
   },
   "x1e.xlarge": {
     "up": "x1e.2xlarge",
@@ -4415,7 +4877,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "122.0"
   },
   "x1e.2xlarge": {
     "up": "x1e.4xlarge",
@@ -4424,7 +4887,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "244.0"
   },
   "x1e.4xlarge": {
     "up": "x1e.8xlarge",
@@ -4433,7 +4897,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "488.0"
   },
   "x1e.8xlarge": {
     "up": "x1e.16xlarge",
@@ -4442,7 +4907,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "976.0"
   },
   "x1e.16xlarge": {
     "up": "x1e.32xlarge",
@@ -4451,7 +4917,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "1952.0"
   },
   "x1e.32xlarge": {
     "up": null,
@@ -4460,7 +4927,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "128",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "3904.0"
   },
   "x2gd.medium": {
     "up": "x2gd.large",
@@ -4469,7 +4937,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "1",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "16.0"
   },
   "x2gd.large": {
     "up": "x2gd.xlarge",
@@ -4478,7 +4947,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "32.0"
   },
   "x2gd.xlarge": {
     "up": "x2gd.2xlarge",
@@ -4487,7 +4957,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "64.0"
   },
   "x2gd.2xlarge": {
     "up": "x2gd.4xlarge",
@@ -4496,7 +4967,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "128.0"
   },
   "x2gd.4xlarge": {
     "up": "x2gd.8xlarge",
@@ -4505,7 +4977,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "256.0"
   },
   "x2gd.8xlarge": {
     "up": "x2gd.12xlarge",
@@ -4514,7 +4987,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "512"
+    "nfu": "512",
+    "memory": "512.0"
   },
   "x2gd.12xlarge": {
     "up": "x2gd.16xlarge",
@@ -4523,7 +4997,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "768"
+    "nfu": "768",
+    "memory": "768.0"
   },
   "x2gd.16xlarge": {
     "up": "x2gd.metal",
@@ -4532,7 +5007,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "1024"
+    "nfu": "1024",
+    "memory": "1024.0"
   },
   "x2gd.metal": {
     "up": null,
@@ -4541,7 +5017,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "1024"
+    "nfu": "1024",
+    "memory": "1024.0"
   },
   "x2idn.16xlarge": {
     "up": "x2idn.24xlarge",
@@ -4550,7 +5027,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "1024.0"
   },
   "x2idn.24xlarge": {
     "up": "x2idn.32xlarge",
@@ -4559,7 +5037,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "1536.0"
   },
   "x2idn.32xlarge": {
     "up": null,
@@ -4568,7 +5047,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "128",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "2048.0"
   },
   "x2idn.metal": {
     "up": null,
@@ -4577,7 +5057,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "128",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "2048.0"
   },
   "x2iedn.xlarge": {
     "up": "x2iedn.2xlarge",
@@ -4586,7 +5067,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "128.0"
   },
   "x2iedn.2xlarge": {
     "up": "x2iedn.4xlarge",
@@ -4595,7 +5077,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "256.0"
   },
   "x2iedn.4xlarge": {
     "up": "x2iedn.8xlarge",
@@ -4604,7 +5087,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "512.0"
   },
   "x2iedn.8xlarge": {
     "up": "x2iedn.16xlarge",
@@ -4613,7 +5097,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "1024.0"
   },
   "x2iedn.16xlarge": {
     "up": "x2iedn.24xlarge",
@@ -4622,7 +5107,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "2048.0"
   },
   "x2iedn.24xlarge": {
     "up": "x2iedn.32xlarge",
@@ -4631,7 +5117,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "96",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "3072.0"
   },
   "x2iedn.32xlarge": {
     "up": null,
@@ -4640,7 +5127,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "128",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "4096.0"
   },
   "x2iedn.metal": {
     "up": null,
@@ -4649,7 +5137,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "128",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "4096.0"
   },
   "x2iezn.2xlarge": {
     "up": "x2iezn.4xlarge",
@@ -4658,7 +5147,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "256.0"
   },
   "x2iezn.4xlarge": {
     "up": "x2iezn.6xlarge",
@@ -4667,7 +5157,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "512.0"
   },
   "x2iezn.6xlarge": {
     "up": "x2iezn.8xlarge",
@@ -4676,7 +5167,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "24",
-    "nfu": "46"
+    "nfu": "46",
+    "memory": "768.0"
   },
   "x2iezn.8xlarge": {
     "up": "x2iezn.12xlarge",
@@ -4685,7 +5177,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "1024.0"
   },
   "x2iezn.12xlarge": {
     "up": null,
@@ -4694,7 +5187,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "1536.0"
   },
   "x2iezn.metal": {
     "up": null,
@@ -4703,7 +5197,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "1536.0"
   },
   "z1d.large": {
     "up": "z1d.xlarge",
@@ -4712,7 +5207,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "16.0"
   },
   "z1d.xlarge": {
     "up": "z1d.2xlarge",
@@ -4721,7 +5217,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "32.0"
   },
   "z1d.2xlarge": {
     "up": "z1d.3xlarge",
@@ -4730,7 +5227,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "64.0"
   },
   "z1d.3xlarge": {
     "up": "z1d.6xlarge",
@@ -4739,7 +5237,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "12",
-    "nfu": "24"
+    "nfu": "24",
+    "memory": "96.0"
   },
   "z1d.6xlarge": {
     "up": "z1d.12xlarge",
@@ -4748,7 +5247,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "24",
-    "nfu": "48"
+    "nfu": "48",
+    "memory": "192.0"
   },
   "z1d.12xlarge": {
     "up": null,
@@ -4757,7 +5257,8 @@
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "48",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "384.0"
   },
   "z1d.metal": {
     "up": null,
@@ -4765,7 +5266,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "48"
+    "vcpu": "48",
+    "memory": "384.0"
   },
   "u-6tb1.metal": {
     "up": "u-9tb1.metal",
@@ -4773,7 +5275,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "448"
+    "vcpu": "448",
+    "memory": "6144.0"
   },
   "u-9tb1.metal": {
     "up": "u-12tb1.metal",
@@ -4781,7 +5284,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "448"
+    "vcpu": "448",
+    "memory": "9216.0"
   },
   "u-12tb1.metal": {
     "up": "u-18tb1.metal",
@@ -4789,7 +5293,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "448"
+    "vcpu": "448",
+    "memory": "12288.0"
   },
   "u-18tb1.metal": {
     "up": "u-24tb1.metal",
@@ -4797,7 +5302,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "448"
+    "vcpu": "448",
+    "memory": "18432.0"
   },
   "u-24tb1.metal": {
     "up": null,
@@ -4805,7 +5311,8 @@
     "superseded": null,
     "ec2_classic": false,
     "enhanced_networking": true,
-    "vcpu": "448"
+    "vcpu": "448",
+    "memory": "24576.0"
   },
   "t1.micro": {
     "up": null,
@@ -4819,7 +5326,8 @@
     "ec2_classic": true,
     "enhanced_networking": false,
     "vcpu": "1",
-    "nfu": "0.5"
+    "nfu": "0.5",
+    "memory": "0.613"
   },
   "t2.nano": {
     "up": "t2.micro",
@@ -4837,7 +5345,8 @@
       "max_earnable_credits": 72
     },
     "vcpu": "1",
-    "nfu": "0.25"
+    "nfu": "0.25",
+    "memory": "0.5"
   },
   "t2.micro": {
     "up": "t2.small",
@@ -4855,7 +5364,8 @@
       "max_earnable_credits": 144
     },
     "vcpu": "1",
-    "nfu": "0.5"
+    "nfu": "0.5",
+    "memory": "1.0"
   },
   "t2.small": {
     "up": "t2.medium",
@@ -4873,7 +5383,8 @@
       "max_earnable_credits": 288
     },
     "vcpu": "1",
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "2.0"
   },
   "t2.medium": {
     "up": "t2.large",
@@ -4891,7 +5402,8 @@
       "max_earnable_credits": 576
     },
     "vcpu": "2",
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "4.0"
   },
   "t2.large": {
     "up": "t2.xlarge",
@@ -4909,7 +5421,8 @@
       "max_earnable_credits": 864
     },
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8.0"
   },
   "t2.xlarge": {
     "up": "t2.2xlarge",
@@ -4927,7 +5440,8 @@
       "max_earnable_credits": 1296
     },
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16.0"
   },
   "t2.2xlarge": {
     "up": null,
@@ -4945,7 +5459,8 @@
       "max_earnable_credits": 1958.4
     },
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32.0"
   },
   "t3.nano": {
     "up": "t3.micro",
@@ -4958,7 +5473,8 @@
       "max_earnable_credits": 144
     },
     "vcpu": "2",
-    "nfu": "0.25"
+    "nfu": "0.25",
+    "memory": "0.5"
   },
   "t3.micro": {
     "up": "t3.small",
@@ -4971,7 +5487,8 @@
       "max_earnable_credits": 288
     },
     "vcpu": "2",
-    "nfu": "0.5"
+    "nfu": "0.5",
+    "memory": "1.0"
   },
   "t3.small": {
     "up": "t3.medium",
@@ -4984,7 +5501,8 @@
       "max_earnable_credits": 576
     },
     "vcpu": "2",
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "2.0"
   },
   "t3.medium": {
     "up": "t3.large",
@@ -4997,7 +5515,8 @@
       "max_earnable_credits": 576
     },
     "vcpu": "2",
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "4.0"
   },
   "t3.large": {
     "up": "t3.xlarge",
@@ -5010,7 +5529,8 @@
       "max_earnable_credits": 864
     },
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8.0"
   },
   "t3.xlarge": {
     "up": "t3.2xlarge",
@@ -5023,7 +5543,8 @@
       "max_earnable_credits": 2304
     },
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16.0"
   },
   "t3.2xlarge": {
     "up": null,
@@ -5036,7 +5557,8 @@
       "max_earnable_credits": 4608
     },
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32.0"
   },
   "t3a.nano": {
     "up": "t3.micro",
@@ -5049,7 +5571,8 @@
       "max_earnable_credits": 144
     },
     "vcpu": "2",
-    "nfu": "0.25"
+    "nfu": "0.25",
+    "memory": "0.5"
   },
   "t3a.micro": {
     "up": "t3.small",
@@ -5062,7 +5585,8 @@
       "max_earnable_credits": 288
     },
     "vcpu": "2",
-    "nfu": "0.5"
+    "nfu": "0.5",
+    "memory": "1.0"
   },
   "t3a.small": {
     "up": "t3.medium",
@@ -5075,7 +5599,8 @@
       "max_earnable_credits": 576
     },
     "vcpu": "2",
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "2.0"
   },
   "t3a.medium": {
     "up": "t3.large",
@@ -5088,7 +5613,8 @@
       "max_earnable_credits": 576
     },
     "vcpu": "2",
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "4.0"
   },
   "t3a.large": {
     "up": "t3.xlarge",
@@ -5101,7 +5627,8 @@
       "max_earnable_credits": 864
     },
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8.0"
   },
   "t3a.xlarge": {
     "up": "t3.2xlarge",
@@ -5114,7 +5641,8 @@
       "max_earnable_credits": 2304
     },
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16.0"
   },
   "t3a.2xlarge": {
     "up": null,
@@ -5127,7 +5655,8 @@
       "max_earnable_credits": 4608
     },
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32.0"
   },
   "t4g.nano": {
     "up": "t4g.micro",
@@ -5140,7 +5669,8 @@
       "max_earnable_credits": 144
     },
     "vcpu": "2",
-    "nfu": "0.25"
+    "nfu": "0.25",
+    "memory": "0.5"
   },
   "t4g.micro": {
     "up": "t4g.small",
@@ -5153,7 +5683,8 @@
       "max_earnable_credits": 288
     },
     "vcpu": "2",
-    "nfu": "0.5"
+    "nfu": "0.5",
+    "memory": "1.0"
   },
   "t4g.small": {
     "up": "t4g.medium",
@@ -5166,7 +5697,8 @@
       "max_earnable_credits": 576
     },
     "vcpu": "2",
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "2.0"
   },
   "t4g.medium": {
     "up": "t4g.large",
@@ -5179,7 +5711,8 @@
       "max_earnable_credits": 576
     },
     "vcpu": "2",
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "4.0"
   },
   "t4g.large": {
     "up": "t4g.xlarge",
@@ -5192,7 +5725,8 @@
       "max_earnable_credits": 864
     },
     "vcpu": "2",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8.0"
   },
   "t4g.xlarge": {
     "up": "t4g.2xlarge",
@@ -5205,7 +5739,8 @@
       "max_earnable_credits": 2304
     },
     "vcpu": "4",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16.0"
   },
   "t4g.2xlarge": {
     "up": null,
@@ -5218,558 +5753,651 @@
       "max_earnable_credits": 4608
     },
     "vcpu": "8",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32.0"
   },
   "db.t1.micro": {
     "vcpu": "1",
     "up": null,
     "down": null,
-    "nfu": "0.5"
+    "nfu": "0.5",
+    "memory": "0.613"
   },
   "db.t2.micro": {
     "vcpu": "1",
     "up": "db.t2.small",
     "down": null,
-    "nfu": "0.5"
+    "nfu": "0.5",
+    "memory": "1"
   },
   "db.t2.small": {
     "vcpu": "1",
     "up": "db.t2.medium",
     "down": "db.t2.micro",
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "2"
   },
   "db.t2.medium": {
     "vcpu": "2",
     "up": "db.t2.large",
     "down": "db.t2.small",
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "4"
   },
   "db.t2.large": {
     "vcpu": "2",
     "up": "db.t2.xlarge",
     "down": "db.t2.medium",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8"
   },
   "db.t2.xlarge": {
     "vcpu": "4",
     "up": "db.t2.2xlarge",
     "down": "db.t2.large",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16"
   },
   "db.t2.2xlarge": {
     "vcpu": "8",
     "up": null,
     "down": "db.t2.xlarge",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32"
   },
   "db.t3.micro": {
     "vcpu": "2",
     "up": "db.t3.small",
     "down": null,
-    "nfu": "0.5"
+    "nfu": "0.5",
+    "memory": "1"
   },
   "db.t3.small": {
     "vcpu": "2",
     "up": "db.t3.medium",
     "down": "db.t3.micro",
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "2"
   },
   "db.t3.medium": {
     "vcpu": "2",
     "up": "db.t3.large",
     "down": "db.t3.small",
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "4"
   },
   "db.t3.large": {
     "vcpu": "2",
     "up": "db.t3.xlarge",
     "down": "db.t3.medium",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8"
   },
   "db.t3.xlarge": {
     "vcpu": "4",
     "up": "db.t3.2xlarge",
     "down": "db.t3.large",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16"
   },
   "db.t3.2xlarge": {
     "vcpu": "8",
     "up": null,
     "down": "db.t3.xlarge",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32"
   },
   "db.t4g.micro": {
     "vcpu": "2",
     "up": "db.t4g.small",
     "down": null,
-    "nfu": "0.5"
+    "nfu": "0.5",
+    "memory": "1"
   },
   "db.t4g.small": {
     "vcpu": "2",
     "up": "db.t4g.medium",
     "down": "db.t4g.micro",
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "2"
   },
   "db.t4g.medium": {
     "vcpu": "2",
     "up": "db.t4g.large",
     "down": "db.t4g.small",
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "4"
   },
   "db.t4g.large": {
     "vcpu": "2",
     "up": "db.t4g.xlarge",
     "down": "db.t4g.medium",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8"
   },
   "db.t4g.xlarge": {
     "vcpu": "4",
     "up": "db.t4g.2xlarge",
     "down": "db.t4g.large",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16"
   },
   "db.t4g.2xlarge": {
     "vcpu": "8",
     "up": null,
     "down": "db.t4g.xlarge",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32"
   },
   "db.m4.large": {
     "vcpu": "2",
     "up": "db.m4.xlarge",
     "down": null,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8"
   },
   "db.m4.xlarge": {
     "vcpu": "4",
     "up": "db.m4.2xlarge",
     "down": "db.m4.large",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16"
   },
   "db.m4.2xlarge": {
     "vcpu": "8",
     "up": "db.m4.4xlarge",
     "down": "db.m4.xlarge",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32"
   },
   "db.m4.4xlarge": {
     "vcpu": "16",
     "up": "db.m4.10xlarge",
     "down": "db.m4.2xlarge",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "64"
   },
   "db.m4.10xlarge": {
     "vcpu": "40",
     "up": "db.m4.16xlarge",
     "down": "db.m4.4xlarge",
-    "nfu": "80"
+    "nfu": "80",
+    "memory": "160"
   },
   "db.m4.16xlarge": {
     "vcpu": "64",
     "up": null,
     "down": "db.m4.10xlarge",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "256"
   },
   "db.m5.large": {
     "vcpu": "2",
     "up": "db.m5.xlarge",
     "down": null,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8"
   },
   "db.m5.xlarge": {
     "vcpu": "4",
     "up": "db.m5.2xlarge",
     "down": "db.m5.large",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16"
   },
   "db.m5.2xlarge": {
     "vcpu": "8",
     "up": "db.m5.4xlarge",
     "down": "db.m5.xlarge",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32"
   },
   "db.m5.4xlarge": {
     "vcpu": "16",
     "up": "db.m5.12xlarge",
     "down": "db.m5.2xlarge",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "64"
   },
   "db.m5.12xlarge": {
     "vcpu": "48",
     "up": "db.m5.16xlarge",
     "down": "db.m5.4xlarge",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "192"
   },
   "db.m5.16xlarge": {
     "vcpu": "64",
     "up": "db.m5.24xlarge",
     "down": "db.m5.12xlarge",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "256"
   },
   "db.m5.24xlarge": {
     "vcpu": "96",
     "up": null,
     "down": "db.m5.16xlarge",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "384"
   },
   "db.m6g.large": {
     "vcpu": "2",
     "up": "db.m6g.xlarge",
     "down": null,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8"
   },
   "db.m6g.xlarge": {
     "vcpu": "4",
     "up": "db.m6g.2xlarge",
     "down": "db.m6g.large",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16"
   },
   "db.m6g.2xlarge": {
     "vcpu": "8",
     "up": "db.m6g.4xlarge",
     "down": "db.m6g.xlarge",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32"
   },
   "db.m6g.4xlarge": {
     "vcpu": "16",
     "up": "db.m6g.8xlarge",
     "down": "db.m6g.2xlarge",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "64"
   },
   "db.m6g.8xlarge": {
     "vcpu": "32",
     "up": "db.m6g.16xlarge",
     "down": "db.m6g.4xlarge",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "128"
   },
   "db.m6g.12xlarge": {
     "vcpu": "48",
     "up": "db.m6g.16xlarge",
     "down": "db.m6g.8xlarge",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "192"
   },
   "db.m6g.16xlarge": {
     "vcpu": "64",
     "up": null,
     "down": "db.m6g.12xlarge",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "256"
   },
   "db.m6i.large": {
     "vcpu": "2",
     "up": "db.m6i.xlarge",
     "down": null,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8"
   },
   "db.m6i.xlarge": {
     "vcpu": "4",
     "up": "db.m6i.2xlarge",
     "down": "db.m6i.large",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16"
   },
   "db.m6i.2xlarge": {
     "vcpu": "8",
     "up": "db.m6i.4xlarge",
     "down": "db.m6i.xlarge",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32"
   },
   "db.m6i.4xlarge": {
     "vcpu": "16",
     "up": "db.m6i.8xlarge",
     "down": "db.m6i.2xlarge",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "64"
   },
   "db.m6i.8xlarge": {
     "vcpu": "32",
     "up": "db.m6i.12xlarge",
     "down": "db.m6i.4xlarge",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "128"
   },
   "db.m6i.12xlarge": {
     "vcpu": "48",
     "up": "db.m6i.16xlarge",
     "down": "db.m6i.8xlarge",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "192"
   },
   "db.m6i.16xlarge": {
     "vcpu": "64",
     "up": "db.m6i.24xlarge",
     "down": "db.m6i.12xlarge",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "256"
   },
   "db.m6i.24xlarge": {
     "vcpu": "96",
     "up": "db.m6i.32xlarge",
     "down": "db.m6i.16xlarge",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "384"
   },
   "db.m6i.32xlarge": {
     "vcpu": "128",
     "up": null,
     "down": "db.m6i.24xlarge",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "512"
   },
   "db.r6g.large": {
     "vcpu": "2",
     "up": "db.r6g.xlarge",
     "down": null,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "16"
   },
   "db.r6g.xlarge": {
     "vcpu": "4",
     "up": "db.r6g.2xlarge",
     "down": "db.r6g.large",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "32"
   },
   "db.r6g.2xlarge": {
     "vcpu": "8",
     "up": "db.r6g.4xlarge",
     "down": "db.r6g.xlarge",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "64"
   },
   "db.r6g.4xlarge": {
     "vcpu": "16",
     "up": "db.r6g.8xlarge",
     "down": "db.r6g.2xlarge",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "128"
   },
   "db.r6g.8xlarge": {
     "vcpu": "32",
     "up": "db.r6g.16xlarge",
     "down": "db.r6g.4xlarge",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "256"
   },
   "db.r6g.12xlarge": {
     "vcpu": "48",
     "up": "db.r6g.16xlarge",
     "down": "db.r6g.8xlarge",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "384"
   },
   "db.r6g.16xlarge": {
     "vcpu": "64",
     "up": null,
     "down": "db.r6g.12xlarge",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "512"
   },
   "db.r4.large": {
     "vcpu": "2",
     "up": "db.r4.xlarge",
     "down": null,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "15.25"
   },
   "db.r4.xlarge": {
     "vcpu": "4",
     "up": "db.r4.2xlarge",
     "down": "db.r4.large",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "30.5"
   },
   "db.r4.2xlarge": {
     "vcpu": "8",
     "up": "db.r4.4xlarge",
     "down": "db.r4.xlarge",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "61"
   },
   "db.r4.4xlarge": {
     "vcpu": "16",
     "up": "db.r4.8xlarge",
     "down": "db.r4.2xlarge",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "122"
   },
   "db.r4.8xlarge": {
     "vcpu": "32",
     "up": "db.r4.16xlarge",
     "down": "db.r4.4xlarge",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "244"
   },
   "db.r4.16xlarge": {
     "vcpu": "64",
     "up": null,
     "down": "db.r4.8xlarge",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "488"
   },
   "db.r5.large": {
     "vcpu": "2",
     "up": "db.r5.xlarge",
     "down": null,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "16"
   },
   "db.r5.xlarge": {
     "vcpu": "4",
     "up": "db.r5.2xlarge",
     "down": "db.r5.large",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "32"
   },
   "db.r5.2xlarge": {
     "vcpu": "8",
     "up": "db.r5.4xlarge",
     "down": "db.r5.xlarge",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "64"
   },
   "db.r5.4xlarge": {
     "vcpu": "16",
     "up": "db.r5.8xlarge",
     "down": "db.r5.2xlarge",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "128"
   },
   "db.r5.8xlarge": {
     "vcpu": "32",
     "up": "db.r5.12xlarge",
     "down": "db.r5.4xlarge",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "256"
   },
   "db.r5.12xlarge": {
     "vcpu": "48",
     "up": "db.r5.24xlarge",
     "down": "db.r5.4xlarge",
-    "nfu": "96"
+    "nfu": "96",
+    "memory": "384"
   },
   "db.r5.24xlarge": {
     "vcpu": "64",
     "up": null,
     "down": "db.r5.12xlarge",
-    "nfu": "192"
+    "nfu": "192",
+    "memory": "768"
   },
   "db.x1e.xlarge": {
     "vcpu": "4",
     "up": "db.x1e.2xlarge",
     "down": null,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "122"
   },
   "db.x1e.2xlarge": {
     "vcpu": "8",
     "up": "db.x1e.4xlarge",
     "down": "db.x1e.xlarge",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "244"
   },
   "db.x1e.4xlarge": {
     "vcpu": "16",
     "up": "db.x1e.8xlarge",
     "down": "db.x1e.2xlarge",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "488"
   },
   "db.x1e.8xlarge": {
     "vcpu": "32",
     "up": "db.x1e.16xlarge",
     "down": "db.x1e.4xlarge",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "976"
   },
   "db.x1e.16xlarge": {
     "vcpu": "64",
     "up": "db.x1e.32xlarge",
     "down": "db.x1e.8xlarge",
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "1952"
   },
   "db.x1e.32xlarge": {
     "vcpu": "128",
     "up": null,
     "down": "db.x1e.16xlarge",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "3904"
   },
   "db.x1.16xlarge": {
     "vcpu": "64",
     "up": "db.x1.32xlarge",
     "down": null,
-    "nfu": "128"
+    "nfu": "128",
+    "memory": "976"
   },
   "db.x1.32xlarge": {
     "vcpu": "128",
     "up": null,
     "down": "db.x1.16xlarge",
-    "nfu": "256"
+    "nfu": "256",
+    "memory": "1952"
   },
   "db.m1.small": {
     "vcpu": "1",
     "up": "db.m1.medium",
     "down": null,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "1.7"
   },
   "db.m1.medium": {
     "vcpu": "1",
     "up": "db.m1.large",
     "down": "db.m1.small",
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "3.75"
   },
   "db.m1.large": {
     "vcpu": "2",
     "up": "db.m1.xlarge",
     "down": "db.m1.medium",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "7.5"
   },
   "db.m1.xlarge": {
     "vcpu": "4",
     "up": null,
     "down": "db.m1.large",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "15"
   },
   "db.m3.medium": {
     "vcpu": "1",
     "up": "db.m3.large",
     "down": null,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "3.75"
   },
   "db.m3.large": {
     "vcpu": "2",
     "up": "db.m3.xlarge",
     "down": "db.m3.medium",
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "7.5"
   },
   "db.m3.xlarge": {
     "vcpu": "4",
     "up": "db.m3.2xlarge",
     "down": "db.m3.large",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "15"
   },
   "db.m3.2xlarge": {
     "vcpu": "8",
     "up": null,
     "down": "db.m3.xlarge",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "30"
   },
   "db.m2.xlarge": {
     "vcpu": "2",
     "up": "db.m2.2xlarge",
     "down": null,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "17.1"
   },
   "db.m2.2xlarge": {
     "vcpu": "4",
     "up": "db.m2.4xlarge",
     "down": "db.m2.xlarge",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "34.2"
   },
   "db.m2.4xlarge": {
     "vcpu": "8",
     "up": null,
     "down": "db.m2.2xlarge",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "68.4"
   },
   "db.r3.large": {
     "vcpu": "2",
     "up": "db.r3.xlarge",
     "down": null,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "15.25"
   },
   "db.r3.xlarge": {
     "vcpu": "4",
     "up": "db.r3.2xlarge",
     "down": "db.r3.large",
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "30.5"
   },
   "db.r3.2xlarge": {
     "vcpu": "8",
     "up": "db.r3.4xlarge",
     "down": "db.r3.xlarge",
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "61"
   },
   "db.r3.4xlarge": {
     "vcpu": "16",
     "up": "db.r3.8xlarge",
     "down": "db.r3.2xlarge",
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "122"
   },
   "db.r3.8xlarge": {
     "vcpu": "32",
     "up": null,
     "down": "db.r3.4xlarge",
-    "nfu": "64"
+    "nfu": "64",
+    "memory": "244"
   }
 }

--- a/data/aws/instance_types.json
+++ b/data/aws/instance_types.json
@@ -1,6403 +1,6403 @@
 {
-	"a1.medium": {
-		"up": "a1.large",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "1",
-		"nfu": "2",
-		"memory": "2"
-	},
-	"a1.large": {
-		"up": "a1.xlarge",
-		"down": "a1.medium",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "4"
-	},
-	"a1.xlarge": {
-		"up": "a1.2xlarge",
-		"down": "a1.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "8"
-	},
-	"a1.2xlarge": {
-		"up": "a1.4xlarge",
-		"down": "a1.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "16"
-	},
-	"a1.4xlarge": {
-		"up": null,
-		"down": "a1.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "32"
-	},
-	"a1.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"memory": "32"
-	},
-	"c1.medium": {
-		"up": "c1.xlarge",
-		"down": null,
-		"superseded": {
-			"regular": "c5.large",
-			"next_gen": "",
-			"burstable": "",
-			"amd": ""
-		},
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "2",
-		"nfu": "2",
-		"memory": "1.7"
-	},
-	"c1.xlarge": {
-		"up": null,
-		"down": "c1.medium",
-		"superseded": {
-			"regular": "c5.xlarge",
-			"next_gen": "",
-			"burstable": "",
-			"amd": ""
-		},
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "8",
-		"nfu": "8",
-		"memory": "7"
-	},
-	"c3.large": {
-		"up": "c3.xlarge",
-		"down": null,
-		"superseded": {
-			"regular": "c5.large",
-			"next_gen": "",
-			"burstable": "",
-			"amd": ""
-		},
-		"ec2_classic": true,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "3.75"
-	},
-	"c3.xlarge": {
-		"up": "c3.2xlarge",
-		"down": "c3.large",
-		"superseded": {
-			"regular": "c5.xlarge",
-			"next_gen": "",
-			"burstable": "",
-			"amd": ""
-		},
-		"ec2_classic": true,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "7.5"
-	},
-	"c3.2xlarge": {
-		"up": "c3.4xlarge",
-		"down": "c3.xlarge",
-		"superseded": {
-			"regular": "c5.2xlarge",
-			"next_gen": "",
-			"burstable": "",
-			"amd": ""
-		},
-		"ec2_classic": true,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "15"
-	},
-	"c3.4xlarge": {
-		"up": "c3.8xlarge",
-		"down": "c3.2xlarge",
-		"superseded": {
-			"regular": "c5.4xlarge",
-			"next_gen": "",
-			"burstable": "",
-			"amd": ""
-		},
-		"ec2_classic": true,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "30"
-	},
-	"c3.8xlarge": {
-		"up": null,
-		"down": "c3.4xlarge",
-		"superseded": {
-			"regular": "c5.9xlarge",
-			"next_gen": "",
-			"burstable": "",
-			"amd": ""
-		},
-		"ec2_classic": true,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "60"
-	},
-	"c4.large": {
-		"up": "c4.xlarge",
-		"down": null,
-		"superseded": {
-			"regular": "c5.large",
-			"next_gen": "",
-			"burstable": "",
-			"amd": ""
-		},
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "3.75"
-	},
-	"c4.xlarge": {
-		"up": "c4.2xlarge",
-		"down": "c4.large",
-		"superseded": {
-			"regular": "c5.xlarge",
-			"next_gen": "",
-			"burstable": "",
-			"amd": ""
-		},
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "7.5"
-	},
-	"c4.2xlarge": {
-		"up": "c4.4xlarge",
-		"down": "c4.xlarge",
-		"superseded": {
-			"regular": "c5.2xlarge",
-			"next_gen": "",
-			"burstable": "",
-			"amd": ""
-		},
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "15"
-	},
-	"c4.4xlarge": {
-		"up": "c4.8xlarge",
-		"down": "c4.2xlarge",
-		"superseded": {
-			"regular": "c5.4xlarge",
-			"next_gen": "",
-			"burstable": "",
-			"amd": ""
-		},
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "30"
-	},
-	"c4.8xlarge": {
-		"up": null,
-		"down": "c4.4xlarge",
-		"superseded": {
-			"regular": "c5.9xlarge",
-			"next_gen": "",
-			"burstable": "",
-			"amd": ""
-		},
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "36",
-		"nfu": "64",
-		"memory": "60"
-	},
-	"c5.large": {
-		"up": "c5.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "4"
-	},
-	"c5.xlarge": {
-		"up": "c5.2xlarge",
-		"down": "c5.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "8"
-	},
-	"c5.2xlarge": {
-		"up": "c5.4xlarge",
-		"down": "c5.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "16"
-	},
-	"c5.4xlarge": {
-		"up": "c5.9xlarge",
-		"down": "c5.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "32"
-	},
-	"c5.9xlarge": {
-		"up": "c5.12xlarge",
-		"down": "c5.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "36",
-		"nfu": "72",
-		"memory": "72"
-	},
-	"c5.12xlarge": {
-		"up": "c5.18xlarge",
-		"down": "c5.9xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "96"
-	},
-	"c5.18xlarge": {
-		"up": "c5.24xlarge",
-		"down": "c5.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "72",
-		"nfu": "144",
-		"memory": "144"
-	},
-	"c5.24xlarge": {
-		"up": null,
-		"down": "c18.18xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "192"
-	},
-	"c5.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"memory": "192"
-	},
-	"c5a.large": {
-		"up": "c5a.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "4"
-	},
-	"c5a.xlarge": {
-		"up": "c5a.2xlarge",
-		"down": "c5a.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "8"
-	},
-	"c5a.2xlarge": {
-		"up": "c5a.4xlarge",
-		"down": "c5a.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "16"
-	},
-	"c5a.4xlarge": {
-		"up": "c5a.8xlarge",
-		"down": "c5a.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "32"
-	},
-	"c5a.8xlarge": {
-		"up": "c5a.12xlarge",
-		"down": "c5a.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "64"
-	},
-	"c5a.12xlarge": {
-		"up": "c5a.16xlarge",
-		"down": "c5a.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "96"
-	},
-	"c5a.16xlarge": {
-		"up": "c5a.24xlarge",
-		"down": "c5a.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "128"
-	},
-	"c5a.24xlarge": {
-		"up": null,
-		"down": "c18.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "192"
-	},
-	"c5d.large": {
-		"up": "c5d.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "4"
-	},
-	"c5d.xlarge": {
-		"up": "c5d.2xlarge",
-		"down": "c5d.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "8"
-	},
-	"c5d.2xlarge": {
-		"up": "c5d.4xlarge",
-		"down": "c5d.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "16"
-	},
-	"c5d.4xlarge": {
-		"up": "c5d.9xlarge",
-		"down": "c5d.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "32"
-	},
-	"c5d.9xlarge": {
-		"up": "c5d.12xlarge",
-		"down": "c5d.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "36",
-		"nfu": "72",
-		"memory": "72"
-	},
-	"c5d.12xlarge": {
-		"up": "c5d.18xlarge",
-		"down": "c5d.9xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "96"
-	},
-	"c5d.18xlarge": {
-		"up": "c5d.24xlarge",
-		"down": "c5d.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "72",
-		"nfu": "144",
-		"memory": "144"
-	},
-	"c5d.24xlarge": {
-		"up": null,
-		"down": "c5d.18xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "192"
-	},
-	"c5d.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"memory": "192"
-	},
-	"c5ad.large": {
-		"up": "c5ad.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "4"
-	},
-	"c5ad.xlarge": {
-		"up": "c5ad.2xlarge",
-		"down": "c5ad.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "8"
-	},
-	"c5ad.2xlarge": {
-		"up": "c5ad.4xlarge",
-		"down": "c5ad.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "16"
-	},
-	"c5ad.4xlarge": {
-		"up": "c5ad.8xlarge",
-		"down": "c5ad.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "32"
-	},
-	"c5ad.8xlarge": {
-		"up": "c5ad.12xlarge",
-		"down": "c5ad.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "64"
-	},
-	"c5ad.12xlarge": {
-		"up": "c5ad.16xlarge",
-		"down": "c5ad.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "96"
-	},
-	"c5ad.16xlarge": {
-		"up": "c5ad.24xlarge",
-		"down": "c5ad.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "128"
-	},
-	"c5ad.24xlarge": {
-		"up": null,
-		"down": "c5ad.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "192"
-	},
-	"c5n.large": {
-		"up": "c5n.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "5.25"
-	},
-	"c5n.xlarge": {
-		"up": "c5n.2xlarge",
-		"down": "c5n.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "10.5"
-	},
-	"c5n.2xlarge": {
-		"up": "c5n.4xlarge",
-		"down": "c5n.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "21"
-	},
-	"c5n.4xlarge": {
-		"up": "c5n.9xlarge",
-		"down": "c5n.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "42"
-	},
-	"c5n.9xlarge": {
-		"up": "c5n.18xlarge",
-		"down": "c5n.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "36",
-		"nfu": "72",
-		"memory": "96"
-	},
-	"c5n.18xlarge": {
-		"up": null,
-		"down": "c5n.9xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "72",
-		"nfu": "144",
-		"memory": "192"
-	},
-	"c5n.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "72",
-		"memory": "192"
-	},
-	"c6a.large": {
-		"up": "c6a.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "4"
-	},
-	"c6a.xlarge": {
-		"up": "c6a.2xlarge",
-		"down": "c6a.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "8"
-	},
-	"c6a.2xlarge": {
-		"up": "c6a.4xlarge",
-		"down": "c6a.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "16"
-	},
-	"c6a.4xlarge": {
-		"up": "c6a.8xlarge",
-		"down": "c6a.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "32"
-	},
-	"c6a.8xlarge": {
-		"up": "c6a.12xlarge",
-		"down": "c6a.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "64"
-	},
-	"c6a.12xlarge": {
-		"up": "c6a.16xlarge",
-		"down": "c6a.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "96"
-	},
-	"c6a.16xlarge": {
-		"up": "c6a.24xlarge",
-		"down": "c6a.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "128"
-	},
-	"c6a.24xlarge": {
-		"up": "c6a.32xlarge",
-		"down": "c6a.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "192"
-	},
-	"c6a.32xlarge": {
-		"up": "c6a.48xlarge",
-		"down": "c6a.24xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "128",
-		"nfu": "256",
-		"memory": "256"
-	},
-	"c6a.48xlarge": {
-		"up": null,
-		"down": "c6a.32xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "192",
-		"nfu": "384",
-		"memory": "384"
-	},
-	"c6a.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "192",
-		"nfu": "384",
-		"memory": "384"
-	},
-	"c6g.medium": {
-		"up": "c6g.large",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "1",
-		"nfu": "2",
-		"memory": "2"
-	},
-	"c6g.large": {
-		"up": "c6g.xlarge",
-		"down": "c6g.medium",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "4"
-	},
-	"c6g.xlarge": {
-		"up": "c6g.2xlarge",
-		"down": "c6g.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "8"
-	},
-	"c6g.2xlarge": {
-		"up": "c6g.4xlarge",
-		"down": "c6g.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "16"
-	},
-	"c6g.4xlarge": {
-		"up": "c6g.8xlarge",
-		"down": "c6g.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "32"
-	},
-	"c6g.8xlarge": {
-		"up": "c6g.12xlarge",
-		"down": "c6g.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "64"
-	},
-	"c6g.12xlarge": {
-		"up": "c6g.16xlarge",
-		"down": "c6g.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "96"
-	},
-	"c6g.16xlarge": {
-		"up": null,
-		"down": "c6g.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "128"
-	},
-	"c6g.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"memory": "128"
-	},
-	"c6gd.medium": {
-		"up": "c6gd.large",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "1",
-		"nfu": "2",
-		"memory": "2"
-	},
-	"c6gd.large": {
-		"up": "c6gd.xlarge",
-		"down": "c6gd.medium",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "4"
-	},
-	"c6gd.xlarge": {
-		"up": "c6gd.2xlarge",
-		"down": "c6gd.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "8"
-	},
-	"c6gd.2xlarge": {
-		"up": "c6gd.4xlarge",
-		"down": "c6gd.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "16"
-	},
-	"c6gd.4xlarge": {
-		"up": "c6gd.8xlarge",
-		"down": "c6gd.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "32"
-	},
-	"c6gd.8xlarge": {
-		"up": "c6gd.12xlarge",
-		"down": "c6gd.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "64"
-	},
-	"c6gd.12xlarge": {
-		"up": "c6gd.16xlarge",
-		"down": "c6gd.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "96"
-	},
-	"c6gd.16xlarge": {
-		"up": null,
-		"down": "c6gd.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "128"
-	},
-	"c6gd.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"memory": "128"
-	},
-	"c6gn.medium": {
-		"up": "c6gn.large",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "1",
-		"nfu": "2",
-		"memory": "2"
-	},
-	"c6gn.large": {
-		"up": "c6gn.xlarge",
-		"down": "c6gn.medium",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "4"
-	},
-	"c6gn.xlarge": {
-		"up": "c6gn.2xlarge",
-		"down": "c6gn.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "8"
-	},
-	"c6gn.2xlarge": {
-		"up": "c6gn.4xlarge",
-		"down": "c6gn.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "16"
-	},
-	"c6gn.4xlarge": {
-		"up": "c6gn.8xlarge",
-		"down": "c6gn.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "32"
-	},
-	"c6gn.8xlarge": {
-		"up": "c6gn.12xlarge",
-		"down": "c6gn.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "64"
-	},
-	"c6gn.12xlarge": {
-		"up": "c6gn.16xlarge",
-		"down": "c6gn.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "96"
-	},
-	"c6gn.16xlarge": {
-		"up": null,
-		"down": "c6gn.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "128"
-	},
-	"c6i.large": {
-		"up": "c6i.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "4"
-	},
-	"c6i.xlarge": {
-		"up": "c6i.2xlarge",
-		"down": "c6i.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "8"
-	},
-	"c6i.2xlarge": {
-		"up": "c6i.4xlarge",
-		"down": "c6i.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "16"
-	},
-	"c6i.4xlarge": {
-		"up": "c6i.8xlarge",
-		"down": "c6i.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "32"
-	},
-	"c6i.8xlarge": {
-		"up": "c6i.12xlarge",
-		"down": "c6i.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "64"
-	},
-	"c6i.12xlarge": {
-		"up": "c6i.16xlarge",
-		"down": "c6i.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "96"
-	},
-	"c6i.16xlarge": {
-		"up": "c6i.24xlarge",
-		"down": "c6i.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "128"
-	},
-	"c6i.24xlarge": {
-		"up": "c6i.32xlarge",
-		"down": "c6i.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "192"
-	},
-	"c6i.32xlarge": {
-		"up": null,
-		"down": "c6i.24xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "128",
-		"nfu": "256",
-		"memory": "256"
-	},
-	"c6i.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "128",
-		"nfu": "256",
-		"memory": "256"
-	},
-	"c6id.large": {
-		"up": "c6id.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "4"
-	},
-	"c6id.xlarge": {
-		"up": "c6id.2xlarge",
-		"down": "c6id.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "8"
-	},
-	"c6id.2xlarge": {
-		"up": "c6id.4xlarge",
-		"down": "c6id.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "16"
-	},
-	"c6id.4xlarge": {
-		"up": "c6id.8xlarge",
-		"down": "c6id.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "32"
-	},
-	"c6id.8xlarge": {
-		"up": "c6id.12xlarge",
-		"down": "c6id.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "64"
-	},
-	"c6id.12xlarge": {
-		"up": "c6id.16xlarge",
-		"down": "c6id.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "96"
-	},
-	"c6id.16xlarge": {
-		"up": "c6id.24xlarge",
-		"down": "c6id.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "128"
-	},
-	"c6id.24xlarge": {
-		"up": "c6id.32xlarge",
-		"down": "c6id.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "192"
-	},
-	"c6id.32xlarge": {
-		"up": null,
-		"down": "c6id.24xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "128",
-		"nfu": "256",
-		"memory": "256"
-	},
-	"c6id.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "128",
-		"nfu": "256",
-		"memory": "256"
-	},
-	"c7g.medium": {
-		"up": "c7g.large",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "1",
-		"nfu": "2",
-		"memory": "2"
-	},
-	"c7g.large": {
-		"up": "c7g.xlarge",
-		"down": "c7g.medium",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "4"
-	},
-	"c7g.xlarge": {
-		"up": "c7g.2xlarge",
-		"down": "c7g.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "8"
-	},
-	"c7g.2xlarge": {
-		"up": "c7g.4xlarge",
-		"down": "c7g.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "16"
-	},
-	"c7g.4xlarge": {
-		"up": "c7g.8xlarge",
-		"down": "c7g.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "32"
-	},
-	"c7g.8xlarge": {
-		"up": "c7g.12xlarge",
-		"down": "c7g.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "64"
-	},
-	"c7g.12xlarge": {
-		"up": "c7g.16xlarge",
-		"down": "c7g.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "96"
-	},
-	"c7g.16xlarge": {
-		"up": null,
-		"down": "c7g.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "128"
-	},
-	"cc1.4xlarge": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"nfu": "32"
-	},
-	"cc2.8xlarge": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "60.5"
-	},
-	"cg1.4xlarge": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"nfu": "32"
-	},
-	"cr1.8xlarge": {
-		"up": null,
-		"down": null,
-		"superseded": {
-			"regular": "r3.8xlarge",
-			"next_gen": "r4.8xlarge",
-			"burstable": "",
-			"amd": ""
-		},
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "244"
-	},
-	"d2.xlarge": {
-		"up": "d2.2xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "30.5"
-	},
-	"d2.2xlarge": {
-		"up": "d2.4xlarge",
-		"down": "d2.xlarge",
-		"superseded": null,
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "61"
-	},
-	"d2.4xlarge": {
-		"up": "d2.8xlarge",
-		"down": "d2.2xlarge",
-		"superseded": null,
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "122"
-	},
-	"d2.8xlarge": {
-		"up": null,
-		"down": "d2.4xlarge",
-		"superseded": null,
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "36",
-		"nfu": "64",
-		"memory": "244"
-	},
-	"d3.xlarge": {
-		"up": "d3.2xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "32"
-	},
-	"d3.2xlarge": {
-		"up": "d3.4xlarge",
-		"down": "d3.xlarge",
-		"superseded": null,
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "64"
-	},
-	"d3.4xlarge": {
-		"up": "d3.8xlarge",
-		"down": "d3.2xlarge",
-		"superseded": null,
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "128"
-	},
-	"d3.8xlarge": {
-		"up": null,
-		"down": "d3.4xlarge",
-		"superseded": null,
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "256"
-	},
-	"d3en.xlarge": {
-		"up": "d3en.2xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"d3en.2xlarge": {
-		"up": "d3en.4xlarge",
-		"down": "d3en.xlarge",
-		"superseded": null,
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"d3en.4xlarge": {
-		"up": "d3en.6xlarge",
-		"down": "d3en.2xlarge",
-		"superseded": null,
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "64"
-	},
-	"d3en.6xlarge": {
-		"up": "d3en.8xlarge",
-		"down": "d3en.4xlarge",
-		"superseded": null,
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "24",
-		"nfu": "48",
-		"memory": "96"
-	},
-	"d3en.8xlarge": {
-		"up": "d3en.12xlarge",
-		"down": "d3en.6xlarge",
-		"superseded": null,
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "128"
-	},
-	"d3en.12xlarge": {
-		"up": null,
-		"down": "d3en.8xlarge",
-		"superseded": null,
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "192"
-	},
-	"p2.xlarge": {
-		"up": "p2.8xlarge",
-		"down": null,
-		"superseded": {
-			"regular": "p3.xlarge",
-			"next_gen": null,
-			"burstable": "",
-			"amd": ""
-		},
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "61"
-	},
-	"p2.8xlarge": {
-		"up": "p2.16xlarge",
-		"down": "p2.xlarge",
-		"superseded": {
-			"regular": "p3.8xlarge",
-			"next_gen": null,
-			"burstable": "",
-			"amd": ""
-		},
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "488"
-	},
-	"p2.16xlarge": {
-		"up": null,
-		"down": "p2.8xlarge",
-		"superseded": {
-			"regular": "p3.16xlarge",
-			"next_gen": null,
-			"burstable": "",
-			"amd": ""
-		},
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "732"
-	},
-	"p3.2xlarge": {
-		"up": "p3.8xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "61"
-	},
-	"p3.8xlarge": {
-		"up": "p3.16xlarge",
-		"down": "p3.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "244"
-	},
-	"p3.16xlarge": {
-		"up": "p3dn.24xlarge",
-		"down": "p3.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "488"
-	},
-	"p3dn.24xlarge": {
-		"up": null,
-		"down": "p3.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "768"
-	},
-	"inf1.xlarge": {
-		"up": "inf1.2xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "8"
-	},
-	"inf1.2xlarge": {
-		"up": "inf1.6xlarge",
-		"down": "inf1.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "16"
-	},
-	"inf1.6xlarge": {
-		"up": "inf1.24xlarge",
-		"down": "inf1.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "24",
-		"nfu": "48",
-		"memory": "48"
-	},
-	"inf1.24xlarge": {
-		"up": null,
-		"down": "inf1.6xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "192"
-	},
-	"g2.2xlarge": {
-		"up": "g2.8xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "15"
-	},
-	"g2.8xlarge": {
-		"up": null,
-		"down": "g2.2xlarge",
-		"superseded": null,
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "60"
-	},
-	"g3s.xlarge": {
-		"up": "g3.4xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "30.5"
-	},
-	"g3.4xlarge": {
-		"up": "g3.8xlarge",
-		"down": "g3s.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "122"
-	},
-	"g3.8xlarge": {
-		"up": "g3.16xlarge",
-		"down": "g3.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "244"
-	},
-	"g3.16xlarge": {
-		"up": null,
-		"down": "g3.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "488"
-	},
-	"g4.large": {
-		"up": "g4.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"nfu": "4"
-	},
-	"g4.2xlarge": {
-		"up": "g4.4xlarge",
-		"down": "g4.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"nfu": "16"
-	},
-	"g4.4xlarge": {
-		"up": "g4.8xlarge",
-		"down": "g4.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"nfu": "32"
-	},
-	"g4.8xlarge": {
-		"up": "g4.16xlarge",
-		"down": "g4.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"nfu": "64"
-	},
-	"g4.16xlarge": {
-		"up": null,
-		"down": "g4.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"nfu": "128"
-	},
-	"g4dn.12xlarge": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "192"
-	},
-	"g4dn.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"memory": "384"
-	},
-	"g4ad.4xlarge": {
-		"up": "g4ad.8xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "64"
-	},
-	"g4ad.8xlarge": {
-		"up": "g4ad.16xlarge",
-		"down": "g4ad.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "128"
-	},
-	"g4ad.16xlarge": {
-		"up": null,
-		"down": "g4ad.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "256"
-	},
-	"g4dn.xlarge": {
-		"up": "g4dn.2xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"g4dn.2xlarge": {
-		"up": "g4dn.4xlarge",
-		"down": "g4dn.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"g4dn.4xlarge": {
-		"up": "g4dn.8xlarge",
-		"down": "g4dn.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "64"
-	},
-	"g4dn.8xlarge": {
-		"up": "g4dn.16xlarge",
-		"down": "g4dn.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "128"
-	},
-	"g4dn.16xlarge": {
-		"up": null,
-		"down": "g4dn.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "256"
-	},
-	"g5g.xlarge": {
-		"up": "g5g.2xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": false,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "8"
-	},
-	"g5g.2xlarge": {
-		"up": "g5g.4xlarge",
-		"down": "g5g.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": false,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "16"
-	},
-	"g5g.4xlarge": {
-		"up": "g5g.8xlarge",
-		"down": "g5g.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": false,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "32"
-	},
-	"g5g.8xlarge": {
-		"up": "g5g.16xlarge",
-		"down": "g5g.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": false,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "64"
-	},
-	"g5g.16xlarge": {
-		"up": "g5g.metal",
-		"down": "g5g.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": false,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "128"
-	},
-	"g5g.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": false,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "128"
-	},
-	"f1.2xlarge": {
-		"up": "f1.4xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "122"
-	},
-	"f1.4xlarge": {
-		"up": "f1.16xlarge",
-		"down": "f1.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "244"
-	},
-	"f1.16xlarge": {
-		"up": null,
-		"down": "f1.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "976"
-	},
-	"h1.2xlarge": {
-		"up": "h1.4xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"h1.4xlarge": {
-		"up": "h1.8xlarge",
-		"down": "h1.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "64"
-	},
-	"h1.8xlarge": {
-		"up": "h1.16xlarge",
-		"down": "h1.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "128"
-	},
-	"h1.16xlarge": {
-		"up": null,
-		"down": "h1.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "256"
-	},
-	"hi1.4xlarge": {
-		"up": "hs1.8xlarge",
-		"down": null,
-		"superseded": {
-			"regular": "i3.4xlarge",
-			"next_gen": "",
-			"burstable": "",
-			"amd": ""
-		},
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"nfu": "32"
-	},
-	"hs1.8xlarge": {
-		"up": null,
-		"down": "hi1.4xlarge",
-		"superseded": {
-			"regular": "d2.8xlarge",
-			"next_gen": "",
-			"burstable": "",
-			"amd": ""
-		},
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "16",
-		"nfu": "64",
-		"memory": "117"
-	},
-	"i2.xlarge": {
-		"up": "i2.2xlarge",
-		"down": null,
-		"superseded": {
-			"regular": "i3.xlarge",
-			"next_gen": "",
-			"burstable": "",
-			"amd": ""
-		},
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "30.5"
-	},
-	"i2.2xlarge": {
-		"up": "i2.4xlarge",
-		"down": "i2.xlarge",
-		"superseded": {
-			"regular": "i3.2xlarge",
-			"next_gen": "",
-			"burstable": "",
-			"amd": ""
-		},
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "61"
-	},
-	"i2.4xlarge": {
-		"up": "i2.8xlarge",
-		"down": "i2.2xlarge",
-		"superseded": {
-			"regular": "i3.4xlarge",
-			"next_gen": "",
-			"burstable": "",
-			"amd": ""
-		},
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "122"
-	},
-	"i2.8xlarge": {
-		"up": null,
-		"down": "i2.4xlarge",
-		"superseded": {
-			"regular": "i3.8xlarge",
-			"next_gen": "",
-			"burstable": "",
-			"amd": ""
-		},
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "244"
-	},
-	"i3.large": {
-		"up": "i3.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "15.25"
-	},
-	"i3.xlarge": {
-		"up": "i3.2xlarge",
-		"down": "i3.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "30.5"
-	},
-	"i3.2xlarge": {
-		"up": "i3.4xlarge",
-		"down": "i3.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "61"
-	},
-	"i3.4xlarge": {
-		"up": "i3.8xlarge",
-		"down": "i3.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "122"
-	},
-	"i3.8xlarge": {
-		"up": "i3.16xlarge",
-		"down": "i3.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "244"
-	},
-	"i3.16xlarge": {
-		"up": null,
-		"down": "i3.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "488"
-	},
-	"i3.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"memory": "512"
-	},
-	"i3en.large": {
-		"up": "i3en.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "16"
-	},
-	"i3en.xlarge": {
-		"up": "i3en.2xlarge",
-		"down": "i3en.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "32"
-	},
-	"i3en.2xlarge": {
-		"up": "i3en.3xlarge",
-		"down": "i3en.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "64"
-	},
-	"i3en.3xlarge": {
-		"up": "i3en.6xlarge",
-		"down": "i3en.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "12",
-		"nfu": "24",
-		"memory": "96"
-	},
-	"i3en.6xlarge": {
-		"up": "i3en.12xlarge",
-		"down": "i3en.3xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "24",
-		"nfu": "48",
-		"memory": "192"
-	},
-	"i3en.12xlarge": {
-		"up": "i3en.24xlarge",
-		"down": "i3en.6xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "384"
-	},
-	"i3en.24xlarge": {
-		"up": null,
-		"down": "i3en.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "768"
-	},
-	"i3en.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"memory": "768"
-	},
-	"im4gn.large": {
-		"up": "im4gn.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "8",
-		"memory": "8"
-	},
-	"im4gn.xlarge": {
-		"up": "im4gn.2xlarge",
-		"down": "im4gn.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "16",
-		"memory": "16"
-	},
-	"im4gn.2xlarge": {
-		"up": "im4gn.4xlarge",
-		"down": "im4gn.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "32",
-		"memory": "32"
-	},
-	"im4gn.4xlarge": {
-		"up": "im4gn.8xlarge",
-		"down": "im4gn.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "64",
-		"memory": "64"
-	},
-	"im4gn.8xlarge": {
-		"up": "im4gn.16xlarge",
-		"down": "im4gn.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "128",
-		"memory": "128"
-	},
-	"im4gn.16xlarge": {
-		"up": null,
-		"down": "im4gn.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "256",
-		"memory": "256"
-	},
-	"is4gen.medium": {
-		"up": "is4gen.large",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "1",
-		"nfu": "6",
-		"memory": "6"
-	},
-	"is4gen.large": {
-		"up": "is4gen.xlarge",
-		"down": "is4gen.medium",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "12",
-		"memory": "12"
-	},
-	"is4gen.xlarge": {
-		"up": "is4gen.2xlarge",
-		"down": "is4gen.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "24",
-		"memory": "24"
-	},
-	"is4gen.2xlarge": {
-		"up": "is4gen.4xlarge",
-		"down": "is4gen.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "48",
-		"memory": "48"
-	},
-	"is4gen.4xlarge": {
-		"up": "is4gen.8xlarge",
-		"down": "is4gen.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "96",
-		"memory": "96"
-	},
-	"is4gen.8xlarge": {
-		"up": null,
-		"down": "is4gen.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "192",
-		"memory": "192"
-	},
-	"m1.small": {
-		"up": "m1.medium",
-		"down": null,
-		"superseded": {
-			"regular": "t3.large",
-			"next_gen": "",
-			"burstable": "t3.large",
-			"amd": "m5a.large"
-		},
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "1",
-		"nfu": "1",
-		"memory": "1.7"
-	},
-	"m1.medium": {
-		"up": "m1.large",
-		"down": "m1.small",
-		"superseded": {
-			"regular": "m5.large",
-			"next_gen": "",
-			"burstable": "t3.large",
-			"amd": "m5a.large"
-		},
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "1",
-		"nfu": "2",
-		"memory": "3.75"
-	},
-	"m1.large": {
-		"up": "m1.xlarge",
-		"down": "m1.medium",
-		"superseded": {
-			"regular": "m5.large",
-			"next_gen": "",
-			"burstable": "t3.xlarge",
-			"amd": "m5a.large"
-		},
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "7.5"
-	},
-	"m1.xlarge": {
-		"up": null,
-		"down": "m1.large",
-		"superseded": {
-			"regular": "m5.xlarge",
-			"next_gen": "",
-			"burstable": "t3.2xlarge",
-			"amd": "m5a.xlarge"
-		},
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "15"
-	},
-	"m2.xlarge": {
-		"up": "m2.2xlarge",
-		"down": null,
-		"superseded": {
-			"regular": "r3.large",
-			"next_gen": "r5.large",
-			"burstable": "",
-			"amd": "r5a.large"
-		},
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "2",
-		"nfu": "8",
-		"memory": "17.1"
-	},
-	"m2.2xlarge": {
-		"up": "m2.4xlarge",
-		"down": "m2.xlarge",
-		"superseded": {
-			"regular": "r3.xlarge",
-			"next_gen": "r5.xlarge",
-			"burstable": "",
-			"amd": "r5a.xlarge"
-		},
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "4",
-		"nfu": "16",
-		"memory": "34.2"
-	},
-	"m2.4xlarge": {
-		"up": null,
-		"down": "m2.2xlarge",
-		"superseded": {
-			"regular": "r3.2xlarge",
-			"next_gen": "r5.2xlarge",
-			"burstable": "",
-			"amd": "r5a.2xlarge"
-		},
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "8",
-		"nfu": "32",
-		"memory": "68.4"
-	},
-	"m3.medium": {
-		"up": "m3.large",
-		"down": null,
-		"superseded": {
-			"regular": "m5.large",
-			"next_gen": "",
-			"burstable": "t3.large",
-			"amd": "m5a.large"
-		},
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "1",
-		"nfu": "2",
-		"memory": "3.75"
-	},
-	"m3.large": {
-		"up": "m3.xlarge",
-		"down": "m3.medium",
-		"superseded": {
-			"regular": "m5.large",
-			"next_gen": "",
-			"burstable": "t3.xlarge",
-			"amd": "m5a.large"
-		},
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "7.5"
-	},
-	"m3.xlarge": {
-		"up": "m3.2xlarge",
-		"down": "m3.large",
-		"superseded": {
-			"regular": "m5.xlarge",
-			"next_gen": "",
-			"burstable": "t3.2xlarge",
-			"amd": "m5a.xlarge"
-		},
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "15"
-	},
-	"m3.2xlarge": {
-		"up": null,
-		"down": "m3.xlarge",
-		"superseded": {
-			"regular": "m5.2xlarge",
-			"next_gen": "",
-			"burstable": "",
-			"amd": "m5a.2xlarge"
-		},
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "30"
-	},
-	"m4.large": {
-		"up": "m4.xlarge",
-		"down": null,
-		"superseded": {
-			"regular": "m5.large",
-			"next_gen": "",
-			"burstable": "t3.xlarge",
-			"amd": "m5a.large"
-		},
-		"ec2_classic": false,
-		"enhanced_networking": false,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "8"
-	},
-	"m4.xlarge": {
-		"up": "m4.2xlarge",
-		"down": "m4.large",
-		"superseded": {
-			"regular": "m5.xlarge",
-			"next_gen": "",
-			"burstable": "t3.2xlarge",
-			"amd": "m5a.xlarge"
-		},
-		"ec2_classic": false,
-		"enhanced_networking": false,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"m4.2xlarge": {
-		"up": "m4.4xlarge",
-		"down": "m4.xlarge",
-		"superseded": {
-			"regular": "m5.2xlarge",
-			"next_gen": "",
-			"burstable": "",
-			"amd": "m5a.2xlarge"
-		},
-		"ec2_classic": false,
-		"enhanced_networking": false,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"m4.4xlarge": {
-		"up": "m4.10xlarge",
-		"down": "m4.2xlarge",
-		"superseded": {
-			"regular": "m5.4xlarge",
-			"next_gen": "",
-			"burstable": "",
-			"amd": "m5a.4xlarge"
-		},
-		"ec2_classic": false,
-		"enhanced_networking": false,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "64"
-	},
-	"m4.10xlarge": {
-		"up": "m4.16xlarge",
-		"down": "m4.4xlarge",
-		"superseded": {
-			"regular": "m5.12xlarge",
-			"next_gen": "",
-			"burstable": "",
-			"amd": "m5a.12xlarge"
-		},
-		"ec2_classic": false,
-		"enhanced_networking": false,
-		"vcpu": "40",
-		"nfu": "80",
-		"memory": "160"
-	},
-	"m4.16xlarge": {
-		"up": null,
-		"down": "m4.10xlarge",
-		"superseded": {
-			"regular": "m5.16xlarge",
-			"next_gen": "",
-			"burstable": "",
-			"amd": "m5a.16xlarge"
-		},
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "256"
-	},
-	"m5.large": {
-		"up": "m5.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "8"
-	},
-	"m5.xlarge": {
-		"up": "m5.2xlarge",
-		"down": "m5.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"m5.2xlarge": {
-		"up": "m5.4xlarge",
-		"down": "m5.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"m5.4xlarge": {
-		"up": "m5.8xlarge",
-		"down": "m5.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "64"
-	},
-	"m5.8xlarge": {
-		"up": "m5.12xlarge",
-		"down": "m5.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "128"
-	},
-	"m5.12xlarge": {
-		"up": "m5.16xlarge",
-		"down": "m5.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "192"
-	},
-	"m5.16xlarge": {
-		"up": "m5.24xlarge",
-		"down": "m5.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "256"
-	},
-	"m5.24xlarge": {
-		"up": null,
-		"down": "m5.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "384"
-	},
-	"m5.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"memory": "384"
-	},
-	"m5n.large": {
-		"up": "m5n.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "8"
-	},
-	"m5n.xlarge": {
-		"up": "m5n.2xlarge",
-		"down": "m5n.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"m5n.2xlarge": {
-		"up": "m5n.4xlarge",
-		"down": "m5n.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"m5n.4xlarge": {
-		"up": "m5n.8xlarge",
-		"down": "m5n.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "64"
-	},
-	"m5n.8xlarge": {
-		"up": "m5n.12xlarge",
-		"down": "m5n.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "128"
-	},
-	"m5n.12xlarge": {
-		"up": "m5n.16xlarge",
-		"down": "m5n.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "192"
-	},
-	"m5n.16xlarge": {
-		"up": "m5n.24xlarge",
-		"down": "m5n.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "256"
-	},
-	"m5n.24xlarge": {
-		"up": null,
-		"down": "m5n.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "384"
-	},
-	"m5n.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"memory": "384"
-	},
-	"m5dn.large": {
-		"up": "m5dn.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "8"
-	},
-	"m5dn.xlarge": {
-		"up": "m5dn.2xlarge",
-		"down": "m5dn.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"m5dn.2xlarge": {
-		"up": "m5dn.4xlarge",
-		"down": "m5dn.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"m5dn.4xlarge": {
-		"up": "m5dn.8xlarge",
-		"down": "m5dn.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "64"
-	},
-	"m5dn.8xlarge": {
-		"up": "m5dn.12xlarge",
-		"down": "m5dn.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "128"
-	},
-	"m5dn.12xlarge": {
-		"up": "m5dn.16xlarge",
-		"down": "m5dn.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "192"
-	},
-	"m5dn.16xlarge": {
-		"up": "m5dn.24xlarge",
-		"down": "m5dn.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "256"
-	},
-	"m5dn.24xlarge": {
-		"up": null,
-		"down": "m5dn.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "384"
-	},
-	"m5dn.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"memory": "384"
-	},
-	"m5zn.large": {
-		"up": "m5zn.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "8"
-	},
-	"m5zn.xlarge": {
-		"up": "m5zn.2xlarge",
-		"down": "m5zn.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"m5zn.2xlarge": {
-		"up": "m5zn.3xlarge",
-		"down": "m5zn.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"m5zn.3xlarge": {
-		"up": "m5zn.6xlarge",
-		"down": "m5zn.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "12",
-		"nfu": "24",
-		"memory": "48"
-	},
-	"m5zn.6xlarge": {
-		"up": "m5zn.12xlarge",
-		"down": "m5zn.3xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "24",
-		"nfu": "48",
-		"memory": "96"
-	},
-	"m5zn.12xlarge": {
-		"up": null,
-		"down": "m5zn.6xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "192"
-	},
-	"m5zn.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"memory": "192"
-	},
-	"mac1.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "12",
-		"memory": "32"
-	},
-	"p4d.24xlarge": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "1152"
-	},
-	"m6a.large": {
-		"up": "m6a.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "8"
-	},
-	"m6a.xlarge": {
-		"up": "m6a.2xlarge",
-		"down": "m6a.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"m6a.2xlarge": {
-		"up": "m6a.4xlarge",
-		"down": "m6a.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"m6a.4xlarge": {
-		"up": "m6a.8xlarge",
-		"down": "m6a.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "64"
-	},
-	"m6a.8xlarge": {
-		"up": "m6a.12xlarge",
-		"down": "m6a.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "128"
-	},
-	"m6a.12xlarge": {
-		"up": "m6a.16xlarge",
-		"down": "m6a.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "192"
-	},
-	"m6a.16xlarge": {
-		"up": "m6a.24xlarge",
-		"down": "m6a.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "256"
-	},
-	"m6a.24xlarge": {
-		"up": "m6a.32xlarge",
-		"down": "m6a.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "384"
-	},
-	"m6a.32xlarge": {
-		"up": "m6a.48xlarge",
-		"down": "m6a.24xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "128",
-		"nfu": "256",
-		"memory": "512"
-	},
-	"m6a.48xlarge": {
-		"up": null,
-		"down": "m6a.32xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "192",
-		"nfu": "384",
-		"memory": "768"
-	},
-	"m6a.metal": {
-		"up": null,
-		"down": "m6a.32xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "192",
-		"nfu": "384",
-		"memory": "768"
-	},
-	"m6g.medium": {
-		"up": "m6g.large",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "1",
-		"nfu": "2",
-		"memory": "4"
-	},
-	"m6g.large": {
-		"up": "m6g.xlarge",
-		"down": "m6g.medium",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "8"
-	},
-	"m6g.xlarge": {
-		"up": "m6g.2xlarge",
-		"down": "m6g.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"m6g.2xlarge": {
-		"up": "m6g.4xlarge",
-		"down": "m6g.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"m6g.4xlarge": {
-		"up": "m6g.8xlarge",
-		"down": "m6g.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "64"
-	},
-	"m6g.8xlarge": {
-		"up": "m6g.12xlarge",
-		"down": "m6g.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "128"
-	},
-	"m6g.12xlarge": {
-		"up": "m6g.16xlarge",
-		"down": "m6g.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "192"
-	},
-	"m6g.16xlarge": {
-		"up": "m6g.24xlarge",
-		"down": "m6g.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "256"
-	},
-	"m6g.24xlarge": {
-		"up": null,
-		"down": "m6g.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"nfu": "192"
-	},
-	"m6g.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"memory": "256"
-	},
-	"m6gd.medium": {
-		"up": "m6gd.large",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "1",
-		"nfu": "2",
-		"memory": "4"
-	},
-	"m6gd.large": {
-		"up": "m6gd.xlarge",
-		"down": "m6gd.medium",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "8"
-	},
-	"m6gd.xlarge": {
-		"up": "m6gd.2xlarge",
-		"down": "m6gd.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"m6gd.2xlarge": {
-		"up": "m6gd.4xlarge",
-		"down": "m6gd.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"m6gd.4xlarge": {
-		"up": "m6gd.8xlarge",
-		"down": "m6gd.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "64"
-	},
-	"m6gd.8xlarge": {
-		"up": "m6gd.12xlarge",
-		"down": "m6gd.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "128"
-	},
-	"m6gd.12xlarge": {
-		"up": "m6gd.16xlarge",
-		"down": "m6gd.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "192"
-	},
-	"m6gd.16xlarge": {
-		"up": "m6gd.24xlarge",
-		"down": "m6gd.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "256"
-	},
-	"m6gd.24xlarge": {
-		"up": null,
-		"down": "m6gd.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"nfu": "192"
-	},
-	"m6gd.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"memory": "256"
-	},
-	"m6i.large": {
-		"up": "m6i.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "8"
-	},
-	"m6i.xlarge": {
-		"up": "m6i.2xlarge",
-		"down": "m6i.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"m6i.2xlarge": {
-		"up": "m6i.4xlarge",
-		"down": "m6i.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"m6i.4xlarge": {
-		"up": "m6i.8xlarge",
-		"down": "m6i.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "64"
-	},
-	"m6i.8xlarge": {
-		"up": "m6i.12xlarge",
-		"down": "m6i.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "128"
-	},
-	"m6i.12xlarge": {
-		"up": "m6i.16xlarge",
-		"down": "m6i.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "192"
-	},
-	"m6i.16xlarge": {
-		"up": "m6i.24xlarge",
-		"down": "m6i.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "256"
-	},
-	"m6i.24xlarge": {
-		"up": "m6i.32xlarge",
-		"down": "m6i.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "384"
-	},
-	"m6i.32xlarge": {
-		"up": null,
-		"down": "m6i.24xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "128",
-		"nfu": "256",
-		"memory": "512"
-	},
-	"m6i.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "128",
-		"nfu": "256",
-		"memory": "512"
-	},
-	"m6id.large": {
-		"up": "m6id.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "8"
-	},
-	"m6id.xlarge": {
-		"up": "m6id.2xlarge",
-		"down": "m6id.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"m6id.2xlarge": {
-		"up": "m6id.4xlarge",
-		"down": "m6id.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"m6id.4xlarge": {
-		"up": "m6id.8xlarge",
-		"down": "m6id.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "64"
-	},
-	"m6id.8xlarge": {
-		"up": "m6id.12xlarge",
-		"down": "m6id.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "128"
-	},
-	"m6id.12xlarge": {
-		"up": "m6id.16xlarge",
-		"down": "m6id.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "192"
-	},
-	"m6id.16xlarge": {
-		"up": "m6id.24xlarge",
-		"down": "m6id.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "256"
-	},
-	"m6id.24xlarge": {
-		"up": "m6id.32xlarge",
-		"down": "m6id.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "384"
-	},
-	"m6id.32xlarge": {
-		"up": null,
-		"down": "m6id.24xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "128",
-		"nfu": "256",
-		"memory": "512"
-	},
-	"m6id.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "128",
-		"nfu": "256",
-		"memory": "512"
-	},
-	"m5a.large": {
-		"up": "m5a.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "8"
-	},
-	"m5a.xlarge": {
-		"up": "m5a.2xlarge",
-		"down": "m5a.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"m5a.2xlarge": {
-		"up": "m5a.4xlarge",
-		"down": "m5a.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"m5a.4xlarge": {
-		"up": "m5a.8xlarge",
-		"down": "m5a.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "64"
-	},
-	"m5a.8xlarge": {
-		"up": "m5a.12xlarge",
-		"down": "m5a.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "128"
-	},
-	"m5a.12xlarge": {
-		"up": "m5a.16xlarge",
-		"down": "m5a.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "192"
-	},
-	"m5a.16xlarge": {
-		"up": "m5a.24xlarge",
-		"down": "m5a.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "256"
-	},
-	"m5a.24xlarge": {
-		"up": null,
-		"down": "m5a.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "384"
-	},
-	"m5ad.large": {
-		"up": "m5ad.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "8"
-	},
-	"m5ad.xlarge": {
-		"up": "m5ad.2xlarge",
-		"down": "m5ad.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"m5ad.2xlarge": {
-		"up": "m5ad.4xlarge",
-		"down": "m5ad.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"m5ad.4xlarge": {
-		"up": "m5ad.8xlarge",
-		"down": "m5ad.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "64"
-	},
-	"m5ad.8xlarge": {
-		"up": "m5ad.12xlarge",
-		"down": "m5ad.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "128"
-	},
-	"m5ad.12xlarge": {
-		"up": "m5ad.16xlarge",
-		"down": "m5ad.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "192"
-	},
-	"m5ad.16xlarge": {
-		"up": "m5ad.24xlarge",
-		"down": "m5ad.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "256"
-	},
-	"m5ad.24xlarge": {
-		"up": null,
-		"down": "m5ad.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "384"
-	},
-	"m5d.large": {
-		"up": "m5d.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "8"
-	},
-	"m5d.xlarge": {
-		"up": "m5d.2xlarge",
-		"down": "m5d.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"m5d.2xlarge": {
-		"up": "m5d.4xlarge",
-		"down": "m5d.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"m5d.4xlarge": {
-		"up": "m5d.8xlarge",
-		"down": "m5d.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "64"
-	},
-	"m5d.8xlarge": {
-		"up": "m5d.12xlarge",
-		"down": "m5d.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "128"
-	},
-	"m5d.12xlarge": {
-		"up": "m5d.16xlarge",
-		"down": "m5d.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "192"
-	},
-	"m5d.16xlarge": {
-		"up": "m5d.24xlarge",
-		"down": "m5d.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "256"
-	},
-	"m5d.24xlarge": {
-		"up": null,
-		"down": "m5d.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "384"
-	},
-	"m5d.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"memory": "384"
-	},
-	"r3.large": {
-		"up": "r3.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "15.25"
-	},
-	"r3.xlarge": {
-		"up": "r3.2xlarge",
-		"down": "r3.large",
-		"superseded": null,
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "30.5"
-	},
-	"r3.2xlarge": {
-		"up": "r3.4xlarge",
-		"down": "r3.xlarge",
-		"superseded": null,
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "61"
-	},
-	"r3.4xlarge": {
-		"up": "r3.8xlarge",
-		"down": "r3.2xlarge",
-		"superseded": null,
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "122"
-	},
-	"r3.8xlarge": {
-		"up": null,
-		"down": "r3.4xlarge",
-		"superseded": null,
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "244"
-	},
-	"r4.large": {
-		"up": "r4.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "15.25"
-	},
-	"r4.xlarge": {
-		"up": "r4.2xlarge",
-		"down": "r4.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "30.5"
-	},
-	"r4.2xlarge": {
-		"up": "r4.4xlarge",
-		"down": "r4.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "61"
-	},
-	"r4.4xlarge": {
-		"up": "r4.8xlarge",
-		"down": "r4.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "122"
-	},
-	"r4.8xlarge": {
-		"up": "r4.16xlarge",
-		"down": "r4.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "244"
-	},
-	"r4.16xlarge": {
-		"up": null,
-		"down": "r4.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "488"
-	},
-	"r5.large": {
-		"up": "r5.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "16"
-	},
-	"r5.xlarge": {
-		"up": "r5.2xlarge",
-		"down": "r5.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "32"
-	},
-	"r5.2xlarge": {
-		"up": "r5.4xlarge",
-		"down": "r5.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "64"
-	},
-	"r5.4xlarge": {
-		"up": "r5.8xlarge",
-		"down": "r5.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "128"
-	},
-	"r5.8xlarge": {
-		"up": "r5.12xlarge",
-		"down": "r5.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "256"
-	},
-	"r5.12xlarge": {
-		"up": "r5.16xlarge",
-		"down": "r5.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "384"
-	},
-	"r5.16xlarge": {
-		"up": "r5.24xlarge",
-		"down": "r5.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "512"
-	},
-	"r5.24xlarge": {
-		"up": null,
-		"down": "r5.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "768"
-	},
-	"r5.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"memory": "768"
-	},
-	"r5a.large": {
-		"up": "r5a.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "16"
-	},
-	"r5a.xlarge": {
-		"up": "r5a.2xlarge",
-		"down": "r5a.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "32"
-	},
-	"r5a.2xlarge": {
-		"up": "r5a.4xlarge",
-		"down": "r5a.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "64"
-	},
-	"r5a.4xlarge": {
-		"up": "r5a.8xlarge",
-		"down": "r5a.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "128"
-	},
-	"r5a.8xlarge": {
-		"up": "r5a.12xlarge",
-		"down": "r5a.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "256"
-	},
-	"r5a.12xlarge": {
-		"up": "r5a.16xlarge",
-		"down": "r5a.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "384"
-	},
-	"r5a.16xlarge": {
-		"up": "r5a.24xlarge",
-		"down": "r5a.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "512"
-	},
-	"r5a.24xlarge": {
-		"up": null,
-		"down": "r5a.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "768"
-	},
-	"r5b.large": {
-		"up": "r5b.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "16"
-	},
-	"r5b.xlarge": {
-		"up": "r5b.2xlarge",
-		"down": "r5b.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "32"
-	},
-	"r5b.2xlarge": {
-		"up": "r5b.4xlarge",
-		"down": "r5b.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "64"
-	},
-	"r5b.4xlarge": {
-		"up": "r5b.8xlarge",
-		"down": "r5b.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "128"
-	},
-	"r5b.8xlarge": {
-		"up": "r5b.12xlarge",
-		"down": "r5b.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "256"
-	},
-	"r5b.12xlarge": {
-		"up": "r5b.16xlarge",
-		"down": "r5b.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "384"
-	},
-	"r5b.16xlarge": {
-		"up": "r5b.24xlarge",
-		"down": "r5b.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "512"
-	},
-	"r5b.24xlarge": {
-		"up": null,
-		"down": "r5b.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "768"
-	},
-	"r5b.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"memory": "768"
-	},
-	"r5ad.large": {
-		"up": "r5ad.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "16"
-	},
-	"r5ad.xlarge": {
-		"up": "r5ad.2xlarge",
-		"down": "r5ad.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "32"
-	},
-	"r5ad.2xlarge": {
-		"up": "r5ad.4xlarge",
-		"down": "r5ad.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "64"
-	},
-	"r5ad.4xlarge": {
-		"up": "r5ad.8xlarge",
-		"down": "r5ad.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "128"
-	},
-	"r5ad.8xlarge": {
-		"up": "r5ad.12xlarge",
-		"down": "r5ad.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "256"
-	},
-	"r5ad.12xlarge": {
-		"up": "r5ad.16xlarge",
-		"down": "r5ad.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "384"
-	},
-	"r5ad.16xlarge": {
-		"up": "r5ad.24xlarge",
-		"down": "r5ad.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "512"
-	},
-	"r5ad.24xlarge": {
-		"up": null,
-		"down": "r5ad.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "768"
-	},
-	"r5n.large": {
-		"up": "r5n.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "16"
-	},
-	"r5n.xlarge": {
-		"up": "r5n.2xlarge",
-		"down": "r5n.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "32"
-	},
-	"r5n.2xlarge": {
-		"up": "r5n.4xlarge",
-		"down": "r5n.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "64"
-	},
-	"r5n.4xlarge": {
-		"up": "r5n.8xlarge",
-		"down": "r5n.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "128"
-	},
-	"r5n.8xlarge": {
-		"up": "r5n.12xlarge",
-		"down": "r5n.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "256"
-	},
-	"r5n.12xlarge": {
-		"up": "r5n.16xlarge",
-		"down": "r5n.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "384"
-	},
-	"r5n.16xlarge": {
-		"up": "r5n.24xlarge",
-		"down": "r5n.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "512"
-	},
-	"r5n.24xlarge": {
-		"up": null,
-		"down": "r5n.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "768"
-	},
-	"r5n.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"memory": "768"
-	},
-	"r5dn.large": {
-		"up": "r5dn.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "16"
-	},
-	"r5dn.xlarge": {
-		"up": "r5dn.2xlarge",
-		"down": "r5dn.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "32"
-	},
-	"r5dn.2xlarge": {
-		"up": "r5dn.4xlarge",
-		"down": "r5dn.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "64"
-	},
-	"r5dn.4xlarge": {
-		"up": "r5dn.8xlarge",
-		"down": "r5dn.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "128"
-	},
-	"r5dn.8xlarge": {
-		"up": "r5dn.12xlarge",
-		"down": "r5dn.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "256"
-	},
-	"r5dn.12xlarge": {
-		"up": "r5dn.16xlarge",
-		"down": "r5dn.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "384"
-	},
-	"r5dn.16xlarge": {
-		"up": "r5dn.24xlarge",
-		"down": "r5dn.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "512"
-	},
-	"r5dn.24xlarge": {
-		"up": null,
-		"down": "r5dn.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "768"
-	},
-	"r5dn.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"memory": "768"
-	},
-	"r5d.large": {
-		"up": "r5d.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "16"
-	},
-	"r5d.xlarge": {
-		"up": "r5d.2xlarge",
-		"down": "r5d.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "32"
-	},
-	"r5d.2xlarge": {
-		"up": "r5d.4xlarge",
-		"down": "r5d.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "64"
-	},
-	"r5d.4xlarge": {
-		"up": "r5d.8xlarge",
-		"down": "r5d.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "128"
-	},
-	"r5d.8xlarge": {
-		"up": "r5d.12xlarge",
-		"down": "r5d.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "256"
-	},
-	"r5d.12xlarge": {
-		"up": "r5d.16xlarge",
-		"down": "r5d.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "384"
-	},
-	"r5d.16xlarge": {
-		"up": "r5d.24xlarge",
-		"down": "r5d.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "512"
-	},
-	"r5d.24xlarge": {
-		"up": null,
-		"down": "r5d.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "768"
-	},
-	"r5d.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"memory": "768"
-	},
-	"r6a.large": {
-		"up": "r6a.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "16"
-	},
-	"r6a.xlarge": {
-		"up": "r6a.2xlarge",
-		"down": "r6a.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "32"
-	},
-	"r6a.2xlarge": {
-		"up": "r6a.4xlarge",
-		"down": "r6a.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "64"
-	},
-	"r6a.4xlarge": {
-		"up": "r6a.8xlarge",
-		"down": "r6a.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "128"
-	},
-	"r6a.8xlarge": {
-		"up": "r6a.12xlarge",
-		"down": "r6a.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "256"
-	},
-	"r6a.12xlarge": {
-		"up": "r6a.16xlarge",
-		"down": "r6a.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "384"
-	},
-	"r6a.16xlarge": {
-		"up": "r6a.24xlarge",
-		"down": "r6a.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "512"
-	},
-	"r6a.24xlarge": {
-		"up": "r6a.32xlarge",
-		"down": "r6a.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "768"
-	},
-	"r6a.32xlarge": {
-		"up": "r6a.48xlarge",
-		"down": "r6a.24xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "128",
-		"nfu": "256",
-		"memory": "1024"
-	},
-	"r6a.48xlarge": {
-		"up": null,
-		"down": "r6a.32xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "192",
-		"nfu": "384",
-		"memory": "1536"
-	},
-	"r6a.metal": {
-		"up": null,
-		"down": "r6a.32xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "192",
-		"nfu": "384",
-		"memory": "1536"
-	},
-	"r6g.medium": {
-		"up": "r6g.large",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "1",
-		"nfu": "2",
-		"memory": "8"
-	},
-	"r6g.large": {
-		"up": "r6g.xlarge",
-		"down": "r6g.medium",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "16"
-	},
-	"r6g.xlarge": {
-		"up": "r6g.2xlarge",
-		"down": "r6g.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "32"
-	},
-	"r6g.2xlarge": {
-		"up": "r6g.4xlarge",
-		"down": "r6g.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "64"
-	},
-	"r6g.4xlarge": {
-		"up": "r6g.8xlarge",
-		"down": "r6g.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "128"
-	},
-	"r6g.8xlarge": {
-		"up": "r6g.12xlarge",
-		"down": "r6g.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "256"
-	},
-	"r6g.12xlarge": {
-		"up": "r6g.16xlarge",
-		"down": "r6g.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "384"
-	},
-	"r6g.16xlarge": {
-		"up": null,
-		"down": "r6g.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "512"
-	},
-	"r6g.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"memory": "512"
-	},
-	"r6gd.medium": {
-		"up": "r6gd.large",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "1",
-		"nfu": "2",
-		"memory": "8"
-	},
-	"r6gd.large": {
-		"up": "r6gd.xlarge",
-		"down": "r6gd.medium",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "16"
-	},
-	"r6gd.xlarge": {
-		"up": "r6gd.2xlarge",
-		"down": "r6gd.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "32"
-	},
-	"r6gd.2xlarge": {
-		"up": "r6gd.4xlarge",
-		"down": "r6gd.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "64"
-	},
-	"r6gd.4xlarge": {
-		"up": "r6gd.8xlarge",
-		"down": "r6gd.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "128"
-	},
-	"r6gd.8xlarge": {
-		"up": "r6gd.12xlarge",
-		"down": "r6gd.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "256"
-	},
-	"r6gd.12xlarge": {
-		"up": "r6gd.16xlarge",
-		"down": "r6gd.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "384"
-	},
-	"r6gd.16xlarge": {
-		"up": null,
-		"down": "r6gd.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "512"
-	},
-	"r6gd.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"memory": "512"
-	},
-	"r6i.large": {
-		"up": "r6i.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "16"
-	},
-	"r6i.xlarge": {
-		"up": "r6i.2xlarge",
-		"down": "r6i.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "32"
-	},
-	"r6i.2xlarge": {
-		"up": "r6i.4xlarge",
-		"down": "r6i.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "64"
-	},
-	"r6i.4xlarge": {
-		"up": "r6i.8xlarge",
-		"down": "r6i.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "128"
-	},
-	"r6i.8xlarge": {
-		"up": "r6i.12xlarge",
-		"down": "r6i.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "256"
-	},
-	"r6i.12xlarge": {
-		"up": "r6i.16xlarge",
-		"down": "r6i.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "384"
-	},
-	"r6i.16xlarge": {
-		"up": "r6i.24xlarge",
-		"down": "r6i.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "512"
-	},
-	"r6i.24xlarge": {
-		"up": "r6i.32xlarge",
-		"down": "r6i.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "768"
-	},
-	"r6i.32xlarge": {
-		"up": null,
-		"down": "r6i.24xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "128",
-		"nfu": "256",
-		"memory": "1024"
-	},
-	"r6i.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "128",
-		"nfu": "256",
-		"memory": "1024"
-	},
-	"r6id.large": {
-		"up": "r6id.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "16"
-	},
-	"r6id.xlarge": {
-		"up": "r6id.2xlarge",
-		"down": "r6id.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "32"
-	},
-	"r6id.2xlarge": {
-		"up": "r6id.4xlarge",
-		"down": "r6id.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "64"
-	},
-	"r6id.4xlarge": {
-		"up": "r6id.8xlarge",
-		"down": "r6id.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "128"
-	},
-	"r6id.8xlarge": {
-		"up": "r6id.12xlarge",
-		"down": "r6id.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "256"
-	},
-	"r6id.12xlarge": {
-		"up": "r6id.16xlarge",
-		"down": "r6id.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "384"
-	},
-	"r6id.16xlarge": {
-		"up": "r6id.24xlarge",
-		"down": "r6id.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "512"
-	},
-	"r6id.24xlarge": {
-		"up": "r6id.32xlarge",
-		"down": "r6id.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "768"
-	},
-	"r6id.32xlarge": {
-		"up": null,
-		"down": "r6id.24xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "128",
-		"nfu": "256",
-		"memory": "1024"
-	},
-	"r6id.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "128",
-		"nfu": "256",
-		"memory": "1024"
-	},
-	"x1.16xlarge": {
-		"up": "x1.32xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "976"
-	},
-	"x1.32xlarge": {
-		"up": null,
-		"down": "x1.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "128",
-		"nfu": "256",
-		"memory": "1952"
-	},
-	"x1e.xlarge": {
-		"up": "x1e.2xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "122"
-	},
-	"x1e.2xlarge": {
-		"up": "x1e.4xlarge",
-		"down": "x1e.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "244"
-	},
-	"x1e.4xlarge": {
-		"up": "x1e.8xlarge",
-		"down": "x1e.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "488"
-	},
-	"x1e.8xlarge": {
-		"up": "x1e.16xlarge",
-		"down": "x1e.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "976"
-	},
-	"x1e.16xlarge": {
-		"up": "x1e.32xlarge",
-		"down": "x1e.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "1952"
-	},
-	"x1e.32xlarge": {
-		"up": null,
-		"down": "x1e.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "128",
-		"nfu": "256",
-		"memory": "3904"
-	},
-	"x2gd.medium": {
-		"up": "x2gd.large",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "1",
-		"nfu": "16",
-		"memory": "16"
-	},
-	"x2gd.large": {
-		"up": "x2gd.xlarge",
-		"down": "x2gd.medium",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "32",
-		"memory": "32"
-	},
-	"x2gd.xlarge": {
-		"up": "x2gd.2xlarge",
-		"down": "x2gd.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "64",
-		"memory": "64"
-	},
-	"x2gd.2xlarge": {
-		"up": "x2gd.4xlarge",
-		"down": "x2gd.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "128",
-		"memory": "128"
-	},
-	"x2gd.4xlarge": {
-		"up": "x2gd.8xlarge",
-		"down": "x2gd.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "256",
-		"memory": "256"
-	},
-	"x2gd.8xlarge": {
-		"up": "x2gd.12xlarge",
-		"down": "x2gd.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "512",
-		"memory": "512"
-	},
-	"x2gd.12xlarge": {
-		"up": "x2gd.16xlarge",
-		"down": "x2gd.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "768",
-		"memory": "768"
-	},
-	"x2gd.16xlarge": {
-		"up": "x2gd.metal",
-		"down": "x2gd.12xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "1024",
-		"memory": "1024"
-	},
-	"x2gd.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "1024",
-		"memory": "1024"
-	},
-	"x2idn.16xlarge": {
-		"up": "x2idn.24xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "1024"
-	},
-	"x2idn.24xlarge": {
-		"up": "x2idn.32xlarge",
-		"down": "x2idn.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "1536"
-	},
-	"x2idn.32xlarge": {
-		"up": null,
-		"down": "x2idn.24xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "128",
-		"nfu": "256",
-		"memory": "2048"
-	},
-	"x2idn.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "128",
-		"nfu": "256",
-		"memory": "2048"
-	},
-	"x2iedn.xlarge": {
-		"up": "x2iedn.2xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "128"
-	},
-	"x2iedn.2xlarge": {
-		"up": "x2iedn.4xlarge",
-		"down": "x2iedn.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "256"
-	},
-	"x2iedn.4xlarge": {
-		"up": "x2iedn.8xlarge",
-		"down": "x2iedn.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "512"
-	},
-	"x2iedn.8xlarge": {
-		"up": "x2iedn.16xlarge",
-		"down": "x2iedn.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "1024"
-	},
-	"x2iedn.16xlarge": {
-		"up": "x2iedn.24xlarge",
-		"down": "x2iedn.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "64",
-		"nfu": "128",
-		"memory": "2048"
-	},
-	"x2iedn.24xlarge": {
-		"up": "x2iedn.32xlarge",
-		"down": "x2iedn.16xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "96",
-		"nfu": "192",
-		"memory": "3072"
-	},
-	"x2iedn.32xlarge": {
-		"up": null,
-		"down": "x2iedn.24xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "128",
-		"nfu": "256",
-		"memory": "4096"
-	},
-	"x2iedn.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "128",
-		"nfu": "256",
-		"memory": "4096"
-	},
-	"x2iezn.2xlarge": {
-		"up": "x2iezn.4xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "256"
-	},
-	"x2iezn.4xlarge": {
-		"up": "x2iezn.6xlarge",
-		"down": "x2iezn.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "16",
-		"nfu": "32",
-		"memory": "512"
-	},
-	"x2iezn.6xlarge": {
-		"up": "x2iezn.8xlarge",
-		"down": "x2iezn.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "24",
-		"nfu": "46",
-		"memory": "768"
-	},
-	"x2iezn.8xlarge": {
-		"up": "x2iezn.12xlarge",
-		"down": "x2iezn.4xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "32",
-		"nfu": "64",
-		"memory": "1024"
-	},
-	"x2iezn.12xlarge": {
-		"up": null,
-		"down": "x2iezn.8xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "1536"
-	},
-	"x2iezn.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "1536"
-	},
-	"z1d.large": {
-		"up": "z1d.xlarge",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "16"
-	},
-	"z1d.xlarge": {
-		"up": "z1d.2xlarge",
-		"down": "z1d.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "32"
-	},
-	"z1d.2xlarge": {
-		"up": "z1d.3xlarge",
-		"down": "z1d.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "64"
-	},
-	"z1d.3xlarge": {
-		"up": "z1d.6xlarge",
-		"down": "z1d.2xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "12",
-		"nfu": "24",
-		"memory": "96"
-	},
-	"z1d.6xlarge": {
-		"up": "z1d.12xlarge",
-		"down": "z1d.3xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "24",
-		"nfu": "48",
-		"memory": "192"
-	},
-	"z1d.12xlarge": {
-		"up": null,
-		"down": "z1d.6xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"nfu": "96",
-		"memory": "384"
-	},
-	"z1d.metal": {
-		"up": null,
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "48",
-		"memory": "384"
-	},
-	"u-6tb1.metal": {
-		"up": "u-9tb1.metal",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "448",
-		"memory": "6144"
-	},
-	"u-9tb1.metal": {
-		"up": "u-12tb1.metal",
-		"down": "u-6tb1.metal",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "448",
-		"memory": "9216"
-	},
-	"u-12tb1.metal": {
-		"up": "u-18tb1.metal",
-		"down": "u-9tb1.metal",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "448",
-		"memory": "12288"
-	},
-	"u-18tb1.metal": {
-		"up": "u-24tb1.metal",
-		"down": "u-12tb1.metal",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "448",
-		"memory": "18432"
-	},
-	"u-24tb1.metal": {
-		"up": null,
-		"down": "u-18tb1.metal",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"vcpu": "448",
-		"memory": "24576"
-	},
-	"t1.micro": {
-		"up": null,
-		"down": null,
-		"superseded": {
-			"regular": "t2.micro",
-			"next_gen": "t3.micro",
-			"burstable": "",
-			"amd": "t3a.micro"
-		},
-		"ec2_classic": true,
-		"enhanced_networking": false,
-		"vcpu": "1",
-		"nfu": "0.5",
-		"memory": "0.613"
-	},
-	"t2.nano": {
-		"up": "t2.micro",
-		"down": null,
-		"superseded": {
-			"regular": "t3.nano",
-			"next_gen": "",
-			"burstable": "",
-			"amd": "t3a.nano"
-		},
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 3,
-			"max_earnable_credits": 72
-		},
-		"vcpu": "1",
-		"nfu": "0.25",
-		"memory": "0.5"
-	},
-	"t2.micro": {
-		"up": "t2.small",
-		"down": "t2.nano",
-		"superseded": {
-			"regular": "t3.micro",
-			"next_gen": "",
-			"burstable": "",
-			"amd": "t3a.micro"
-		},
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 6,
-			"max_earnable_credits": 144
-		},
-		"vcpu": "1",
-		"nfu": "0.5",
-		"memory": "1"
-	},
-	"t2.small": {
-		"up": "t2.medium",
-		"down": "t2.micro",
-		"superseded": {
-			"regular": "t3.small",
-			"next_gen": "",
-			"burstable": "",
-			"amd": "t3a.small"
-		},
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 12,
-			"max_earnable_credits": 288
-		},
-		"vcpu": "1",
-		"nfu": "1",
-		"memory": "2"
-	},
-	"t2.medium": {
-		"up": "t2.large",
-		"down": "t2.small",
-		"superseded": {
-			"regular": "t3.medium",
-			"next_gen": "",
-			"burstable": "",
-			"amd": "t3a.medium"
-		},
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 24,
-			"max_earnable_credits": 576
-		},
-		"vcpu": "2",
-		"nfu": "2",
-		"memory": "4"
-	},
-	"t2.large": {
-		"up": "t2.xlarge",
-		"down": "t2.medium",
-		"superseded": {
-			"regular": "t3.large",
-			"next_gen": "",
-			"burstable": "",
-			"amd": "t3a.large"
-		},
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 36,
-			"max_earnable_credits": 864
-		},
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "8"
-	},
-	"t2.xlarge": {
-		"up": "t2.2xlarge",
-		"down": "t2.large",
-		"superseded": {
-			"regular": "t3.xlarge",
-			"next_gen": "",
-			"burstable": "",
-			"amd": "t3a.xlarge"
-		},
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 54,
-			"max_earnable_credits": 1296
-		},
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"t2.2xlarge": {
-		"up": null,
-		"down": "t2.xlarge",
-		"superseded": {
-			"regular": "t3.2xlarge",
-			"next_gen": "",
-			"burstable": "",
-			"amd": "t3a.2xlarge"
-		},
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 81.6,
-			"max_earnable_credits": 1958.4
-		},
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"t3.nano": {
-		"up": "t3.micro",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 6,
-			"max_earnable_credits": 144
-		},
-		"vcpu": "2",
-		"nfu": "0.25",
-		"memory": "0.5"
-	},
-	"t3.micro": {
-		"up": "t3.small",
-		"down": "t3.nano",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 12,
-			"max_earnable_credits": 288
-		},
-		"vcpu": "2",
-		"nfu": "0.5",
-		"memory": "1"
-	},
-	"t3.small": {
-		"up": "t3.medium",
-		"down": "t3.micro",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 24,
-			"max_earnable_credits": 576
-		},
-		"vcpu": "2",
-		"nfu": "1",
-		"memory": "2"
-	},
-	"t3.medium": {
-		"up": "t3.large",
-		"down": "t3.small",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 24,
-			"max_earnable_credits": 576
-		},
-		"vcpu": "2",
-		"nfu": "2",
-		"memory": "4"
-	},
-	"t3.large": {
-		"up": "t3.xlarge",
-		"down": "t3.medium",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 36,
-			"max_earnable_credits": 864
-		},
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "8"
-	},
-	"t3.xlarge": {
-		"up": "t3.2xlarge",
-		"down": "t3.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 96,
-			"max_earnable_credits": 2304
-		},
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"t3.2xlarge": {
-		"up": null,
-		"down": "t3.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 192,
-			"max_earnable_credits": 4608
-		},
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"t3a.nano": {
-		"up": "t3.micro",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 6,
-			"max_earnable_credits": 144
-		},
-		"vcpu": "2",
-		"nfu": "0.25",
-		"memory": "0.5"
-	},
-	"t3a.micro": {
-		"up": "t3.small",
-		"down": "t3.nano",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 12,
-			"max_earnable_credits": 288
-		},
-		"vcpu": "2",
-		"nfu": "0.5",
-		"memory": "1"
-	},
-	"t3a.small": {
-		"up": "t3.medium",
-		"down": "t3.micro",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 24,
-			"max_earnable_credits": 576
-		},
-		"vcpu": "2",
-		"nfu": "1",
-		"memory": "2"
-	},
-	"t3a.medium": {
-		"up": "t3.large",
-		"down": "t3.small",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 24,
-			"max_earnable_credits": 576
-		},
-		"vcpu": "2",
-		"nfu": "2",
-		"memory": "4"
-	},
-	"t3a.large": {
-		"up": "t3.xlarge",
-		"down": "t3.medium",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 36,
-			"max_earnable_credits": 864
-		},
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "8"
-	},
-	"t3a.xlarge": {
-		"up": "t3.2xlarge",
-		"down": "t3.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 96,
-			"max_earnable_credits": 2304
-		},
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"t3a.2xlarge": {
-		"up": null,
-		"down": "t3.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 192,
-			"max_earnable_credits": 4608
-		},
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"t4g.nano": {
-		"up": "t4g.micro",
-		"down": null,
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 6,
-			"max_earnable_credits": 144
-		},
-		"vcpu": "2",
-		"nfu": "0.25",
-		"memory": "0.5"
-	},
-	"t4g.micro": {
-		"up": "t4g.small",
-		"down": "t4g.nano",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 12,
-			"max_earnable_credits": 288
-		},
-		"vcpu": "2",
-		"nfu": "0.5",
-		"memory": "1"
-	},
-	"t4g.small": {
-		"up": "t4g.medium",
-		"down": "t4g.micro",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 24,
-			"max_earnable_credits": 576
-		},
-		"vcpu": "2",
-		"nfu": "1",
-		"memory": "2"
-	},
-	"t4g.medium": {
-		"up": "t4g.large",
-		"down": "t4g.small",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 24,
-			"max_earnable_credits": 576
-		},
-		"vcpu": "2",
-		"nfu": "2",
-		"memory": "4"
-	},
-	"t4g.large": {
-		"up": "t4g.xlarge",
-		"down": "t4g.medium",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 26,
-			"max_earnable_credits": 864
-		},
-		"vcpu": "2",
-		"nfu": "4",
-		"memory": "8"
-	},
-	"t4g.xlarge": {
-		"up": "t4g.2xlarge",
-		"down": "t4g.large",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 96,
-			"max_earnable_credits": 2304
-		},
-		"vcpu": "4",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"t4g.2xlarge": {
-		"up": null,
-		"down": "t4g.xlarge",
-		"superseded": null,
-		"ec2_classic": false,
-		"enhanced_networking": true,
-		"burst_info": {
-			"credits_per_hour": 192,
-			"max_earnable_credits": 4608
-		},
-		"vcpu": "8",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"db.t1.micro": {
-		"vcpu": "1",
-		"up": null,
-		"down": null,
-		"nfu": "0.5",
-		"memory": "0.613"
-	},
-	"db.t2.micro": {
-		"vcpu": "1",
-		"up": "db.t2.small",
-		"down": null,
-		"nfu": "0.5",
-		"memory": "1"
-	},
-	"db.t2.small": {
-		"vcpu": "1",
-		"up": "db.t2.medium",
-		"down": "db.t2.micro",
-		"nfu": "1",
-		"memory": "2"
-	},
-	"db.t2.medium": {
-		"vcpu": "2",
-		"up": "db.t2.large",
-		"down": "db.t2.small",
-		"nfu": "2",
-		"memory": "4"
-	},
-	"db.t2.large": {
-		"vcpu": "2",
-		"up": "db.t2.xlarge",
-		"down": "db.t2.medium",
-		"nfu": "4",
-		"memory": "8"
-	},
-	"db.t2.xlarge": {
-		"vcpu": "4",
-		"up": "db.t2.2xlarge",
-		"down": "db.t2.large",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"db.t2.2xlarge": {
-		"vcpu": "8",
-		"up": null,
-		"down": "db.t2.xlarge",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"db.t3.micro": {
-		"vcpu": "2",
-		"up": "db.t3.small",
-		"down": null,
-		"nfu": "0.5",
-		"memory": "1"
-	},
-	"db.t3.small": {
-		"vcpu": "2",
-		"up": "db.t3.medium",
-		"down": "db.t3.micro",
-		"nfu": "1",
-		"memory": "2"
-	},
-	"db.t3.medium": {
-		"vcpu": "2",
-		"up": "db.t3.large",
-		"down": "db.t3.small",
-		"nfu": "2",
-		"memory": "4"
-	},
-	"db.t3.large": {
-		"vcpu": "2",
-		"up": "db.t3.xlarge",
-		"down": "db.t3.medium",
-		"nfu": "4",
-		"memory": "8"
-	},
-	"db.t3.xlarge": {
-		"vcpu": "4",
-		"up": "db.t3.2xlarge",
-		"down": "db.t3.large",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"db.t3.2xlarge": {
-		"vcpu": "8",
-		"up": null,
-		"down": "db.t3.xlarge",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"db.t4g.micro": {
-		"vcpu": "2",
-		"up": "db.t4g.small",
-		"down": null,
-		"nfu": "0.5",
-		"memory": "1"
-	},
-	"db.t4g.small": {
-		"vcpu": "2",
-		"up": "db.t4g.medium",
-		"down": "db.t4g.micro",
-		"nfu": "1",
-		"memory": "2"
-	},
-	"db.t4g.medium": {
-		"vcpu": "2",
-		"up": "db.t4g.large",
-		"down": "db.t4g.small",
-		"nfu": "2",
-		"memory": "4"
-	},
-	"db.t4g.large": {
-		"vcpu": "2",
-		"up": "db.t4g.xlarge",
-		"down": "db.t4g.medium",
-		"nfu": "4",
-		"memory": "8"
-	},
-	"db.t4g.xlarge": {
-		"vcpu": "4",
-		"up": "db.t4g.2xlarge",
-		"down": "db.t4g.large",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"db.t4g.2xlarge": {
-		"vcpu": "8",
-		"up": null,
-		"down": "db.t4g.xlarge",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"db.m4.large": {
-		"vcpu": "2",
-		"up": "db.m4.xlarge",
-		"down": null,
-		"nfu": "4",
-		"memory": "8"
-	},
-	"db.m4.xlarge": {
-		"vcpu": "4",
-		"up": "db.m4.2xlarge",
-		"down": "db.m4.large",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"db.m4.2xlarge": {
-		"vcpu": "8",
-		"up": "db.m4.4xlarge",
-		"down": "db.m4.xlarge",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"db.m4.4xlarge": {
-		"vcpu": "16",
-		"up": "db.m4.10xlarge",
-		"down": "db.m4.2xlarge",
-		"nfu": "32",
-		"memory": "64"
-	},
-	"db.m4.10xlarge": {
-		"vcpu": "40",
-		"up": "db.m4.16xlarge",
-		"down": "db.m4.4xlarge",
-		"nfu": "80",
-		"memory": "160"
-	},
-	"db.m4.16xlarge": {
-		"vcpu": "64",
-		"up": null,
-		"down": "db.m4.10xlarge",
-		"nfu": "128",
-		"memory": "256"
-	},
-	"db.m5.large": {
-		"vcpu": "2",
-		"up": "db.m5.xlarge",
-		"down": null,
-		"nfu": "4",
-		"memory": "8"
-	},
-	"db.m5.xlarge": {
-		"vcpu": "4",
-		"up": "db.m5.2xlarge",
-		"down": "db.m5.large",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"db.m5.2xlarge": {
-		"vcpu": "8",
-		"up": "db.m5.4xlarge",
-		"down": "db.m5.xlarge",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"db.m5.4xlarge": {
-		"vcpu": "16",
-		"up": "db.m5.12xlarge",
-		"down": "db.m5.2xlarge",
-		"nfu": "32",
-		"memory": "64"
-	},
-	"db.m5.12xlarge": {
-		"vcpu": "48",
-		"up": "db.m5.16xlarge",
-		"down": "db.m5.4xlarge",
-		"nfu": "96",
-		"memory": "192"
-	},
-	"db.m5.16xlarge": {
-		"vcpu": "64",
-		"up": "db.m5.24xlarge",
-		"down": "db.m5.12xlarge",
-		"nfu": "128",
-		"memory": "256"
-	},
-	"db.m5.24xlarge": {
-		"vcpu": "96",
-		"up": null,
-		"down": "db.m5.16xlarge",
-		"nfu": "192",
-		"memory": "384"
-	},
-	"db.m6g.large": {
-		"vcpu": "2",
-		"up": "db.m6g.xlarge",
-		"down": null,
-		"nfu": "4",
-		"memory": "8"
-	},
-	"db.m6g.xlarge": {
-		"vcpu": "4",
-		"up": "db.m6g.2xlarge",
-		"down": "db.m6g.large",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"db.m6g.2xlarge": {
-		"vcpu": "8",
-		"up": "db.m6g.4xlarge",
-		"down": "db.m6g.xlarge",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"db.m6g.4xlarge": {
-		"vcpu": "16",
-		"up": "db.m6g.8xlarge",
-		"down": "db.m6g.2xlarge",
-		"nfu": "32",
-		"memory": "64"
-	},
-	"db.m6g.8xlarge": {
-		"vcpu": "32",
-		"up": "db.m6g.16xlarge",
-		"down": "db.m6g.4xlarge",
-		"nfu": "64",
-		"memory": "128"
-	},
-	"db.m6g.12xlarge": {
-		"vcpu": "48",
-		"up": "db.m6g.16xlarge",
-		"down": "db.m6g.8xlarge",
-		"nfu": "96",
-		"memory": "192"
-	},
-	"db.m6g.16xlarge": {
-		"vcpu": "64",
-		"up": null,
-		"down": "db.m6g.12xlarge",
-		"nfu": "128",
-		"memory": "256"
-	},
-	"db.m6i.large": {
-		"vcpu": "2",
-		"up": "db.m6i.xlarge",
-		"down": null,
-		"nfu": "4",
-		"memory": "8"
-	},
-	"db.m6i.xlarge": {
-		"vcpu": "4",
-		"up": "db.m6i.2xlarge",
-		"down": "db.m6i.large",
-		"nfu": "8",
-		"memory": "16"
-	},
-	"db.m6i.2xlarge": {
-		"vcpu": "8",
-		"up": "db.m6i.4xlarge",
-		"down": "db.m6i.xlarge",
-		"nfu": "16",
-		"memory": "32"
-	},
-	"db.m6i.4xlarge": {
-		"vcpu": "16",
-		"up": "db.m6i.8xlarge",
-		"down": "db.m6i.2xlarge",
-		"nfu": "32",
-		"memory": "64"
-	},
-	"db.m6i.8xlarge": {
-		"vcpu": "32",
-		"up": "db.m6i.12xlarge",
-		"down": "db.m6i.4xlarge",
-		"nfu": "64",
-		"memory": "128"
-	},
-	"db.m6i.12xlarge": {
-		"vcpu": "48",
-		"up": "db.m6i.16xlarge",
-		"down": "db.m6i.8xlarge",
-		"nfu": "96",
-		"memory": "192"
-	},
-	"db.m6i.16xlarge": {
-		"vcpu": "64",
-		"up": "db.m6i.24xlarge",
-		"down": "db.m6i.12xlarge",
-		"nfu": "128",
-		"memory": "256"
-	},
-	"db.m6i.24xlarge": {
-		"vcpu": "96",
-		"up": "db.m6i.32xlarge",
-		"down": "db.m6i.16xlarge",
-		"nfu": "192",
-		"memory": "384"
-	},
-	"db.m6i.32xlarge": {
-		"vcpu": "128",
-		"up": null,
-		"down": "db.m6i.24xlarge",
-		"nfu": "256",
-		"memory": "512"
-	},
-	"db.r6g.large": {
-		"vcpu": "2",
-		"up": "db.r6g.xlarge",
-		"down": null,
-		"nfu": "4",
-		"memory": "16"
-	},
-	"db.r6g.xlarge": {
-		"vcpu": "4",
-		"up": "db.r6g.2xlarge",
-		"down": "db.r6g.large",
-		"nfu": "8",
-		"memory": "32"
-	},
-	"db.r6g.2xlarge": {
-		"vcpu": "8",
-		"up": "db.r6g.4xlarge",
-		"down": "db.r6g.xlarge",
-		"nfu": "16",
-		"memory": "64"
-	},
-	"db.r6g.4xlarge": {
-		"vcpu": "16",
-		"up": "db.r6g.8xlarge",
-		"down": "db.r6g.2xlarge",
-		"nfu": "32",
-		"memory": "128"
-	},
-	"db.r6g.8xlarge": {
-		"vcpu": "32",
-		"up": "db.r6g.16xlarge",
-		"down": "db.r6g.4xlarge",
-		"nfu": "64",
-		"memory": "256"
-	},
-	"db.r6g.12xlarge": {
-		"vcpu": "48",
-		"up": "db.r6g.16xlarge",
-		"down": "db.r6g.8xlarge",
-		"nfu": "96",
-		"memory": "384"
-	},
-	"db.r6g.16xlarge": {
-		"vcpu": "64",
-		"up": null,
-		"down": "db.r6g.12xlarge",
-		"nfu": "128",
-		"memory": "512"
-	},
-	"db.r4.large": {
-		"vcpu": "2",
-		"up": "db.r4.xlarge",
-		"down": null,
-		"nfu": "4",
-		"memory": "15.25"
-	},
-	"db.r4.xlarge": {
-		"vcpu": "4",
-		"up": "db.r4.2xlarge",
-		"down": "db.r4.large",
-		"nfu": "8",
-		"memory": "30.5"
-	},
-	"db.r4.2xlarge": {
-		"vcpu": "8",
-		"up": "db.r4.4xlarge",
-		"down": "db.r4.xlarge",
-		"nfu": "16",
-		"memory": "61"
-	},
-	"db.r4.4xlarge": {
-		"vcpu": "16",
-		"up": "db.r4.8xlarge",
-		"down": "db.r4.2xlarge",
-		"nfu": "32",
-		"memory": "122"
-	},
-	"db.r4.8xlarge": {
-		"vcpu": "32",
-		"up": "db.r4.16xlarge",
-		"down": "db.r4.4xlarge",
-		"nfu": "64",
-		"memory": "244"
-	},
-	"db.r4.16xlarge": {
-		"vcpu": "64",
-		"up": null,
-		"down": "db.r4.8xlarge",
-		"nfu": "128",
-		"memory": "488"
-	},
-	"db.r5.large": {
-		"vcpu": "2",
-		"up": "db.r5.xlarge",
-		"down": null,
-		"nfu": "4",
-		"memory": "16"
-	},
-	"db.r5.xlarge": {
-		"vcpu": "4",
-		"up": "db.r5.2xlarge",
-		"down": "db.r5.large",
-		"nfu": "8",
-		"memory": "32"
-	},
-	"db.r5.2xlarge": {
-		"vcpu": "8",
-		"up": "db.r5.4xlarge",
-		"down": "db.r5.xlarge",
-		"nfu": "16",
-		"memory": "64"
-	},
-	"db.r5.4xlarge": {
-		"vcpu": "16",
-		"up": "db.r5.8xlarge",
-		"down": "db.r5.2xlarge",
-		"nfu": "32",
-		"memory": "128"
-	},
-	"db.r5.8xlarge": {
-		"vcpu": "32",
-		"up": "db.r5.12xlarge",
-		"down": "db.r5.4xlarge",
-		"nfu": "64",
-		"memory": "256"
-	},
-	"db.r5.12xlarge": {
-		"vcpu": "48",
-		"up": "db.r5.24xlarge",
-		"down": "db.r5.4xlarge",
-		"nfu": "96",
-		"memory": "384"
-	},
-	"db.r5.24xlarge": {
-		"vcpu": "64",
-		"up": null,
-		"down": "db.r5.12xlarge",
-		"nfu": "192",
-		"memory": "768"
-	},
-	"db.x1e.xlarge": {
-		"vcpu": "4",
-		"up": "db.x1e.2xlarge",
-		"down": null,
-		"nfu": "8",
-		"memory": "122"
-	},
-	"db.x1e.2xlarge": {
-		"vcpu": "8",
-		"up": "db.x1e.4xlarge",
-		"down": "db.x1e.xlarge",
-		"nfu": "16",
-		"memory": "244"
-	},
-	"db.x1e.4xlarge": {
-		"vcpu": "16",
-		"up": "db.x1e.8xlarge",
-		"down": "db.x1e.2xlarge",
-		"nfu": "32",
-		"memory": "488"
-	},
-	"db.x1e.8xlarge": {
-		"vcpu": "32",
-		"up": "db.x1e.16xlarge",
-		"down": "db.x1e.4xlarge",
-		"nfu": "64",
-		"memory": "976"
-	},
-	"db.x1e.16xlarge": {
-		"vcpu": "64",
-		"up": "db.x1e.32xlarge",
-		"down": "db.x1e.8xlarge",
-		"nfu": "128",
-		"memory": "1952"
-	},
-	"db.x1e.32xlarge": {
-		"vcpu": "128",
-		"up": null,
-		"down": "db.x1e.16xlarge",
-		"nfu": "256",
-		"memory": "3904"
-	},
-	"db.x1.16xlarge": {
-		"vcpu": "64",
-		"up": "db.x1.32xlarge",
-		"down": null,
-		"nfu": "128",
-		"memory": "976"
-	},
-	"db.x1.32xlarge": {
-		"vcpu": "128",
-		"up": null,
-		"down": "db.x1.16xlarge",
-		"nfu": "256",
-		"memory": "1952"
-	},
-	"db.m1.small": {
-		"vcpu": "1",
-		"up": "db.m1.medium",
-		"down": null,
-		"nfu": "1",
-		"memory": "1.7"
-	},
-	"db.m1.medium": {
-		"vcpu": "1",
-		"up": "db.m1.large",
-		"down": "db.m1.small",
-		"nfu": "2",
-		"memory": "3.75"
-	},
-	"db.m1.large": {
-		"vcpu": "2",
-		"up": "db.m1.xlarge",
-		"down": "db.m1.medium",
-		"nfu": "4",
-		"memory": "7.5"
-	},
-	"db.m1.xlarge": {
-		"vcpu": "4",
-		"up": null,
-		"down": "db.m1.large",
-		"nfu": "8",
-		"memory": "15"
-	},
-	"db.m3.medium": {
-		"vcpu": "1",
-		"up": "db.m3.large",
-		"down": null,
-		"nfu": "2",
-		"memory": "3.75"
-	},
-	"db.m3.large": {
-		"vcpu": "2",
-		"up": "db.m3.xlarge",
-		"down": "db.m3.medium",
-		"nfu": "4",
-		"memory": "7.5"
-	},
-	"db.m3.xlarge": {
-		"vcpu": "4",
-		"up": "db.m3.2xlarge",
-		"down": "db.m3.large",
-		"nfu": "8",
-		"memory": "15"
-	},
-	"db.m3.2xlarge": {
-		"vcpu": "8",
-		"up": null,
-		"down": "db.m3.xlarge",
-		"nfu": "16",
-		"memory": "30"
-	},
-	"db.m2.xlarge": {
-		"vcpu": "2",
-		"up": "db.m2.2xlarge",
-		"down": null,
-		"nfu": "8",
-		"memory": "17.1"
-	},
-	"db.m2.2xlarge": {
-		"vcpu": "4",
-		"up": "db.m2.4xlarge",
-		"down": "db.m2.xlarge",
-		"nfu": "16",
-		"memory": "34.2"
-	},
-	"db.m2.4xlarge": {
-		"vcpu": "8",
-		"up": null,
-		"down": "db.m2.2xlarge",
-		"nfu": "32",
-		"memory": "68.4"
-	},
-	"db.r3.large": {
-		"vcpu": "2",
-		"up": "db.r3.xlarge",
-		"down": null,
-		"nfu": "4",
-		"memory": "15.25"
-	},
-	"db.r3.xlarge": {
-		"vcpu": "4",
-		"up": "db.r3.2xlarge",
-		"down": "db.r3.large",
-		"nfu": "8",
-		"memory": "30.5"
-	},
-	"db.r3.2xlarge": {
-		"vcpu": "8",
-		"up": "db.r3.4xlarge",
-		"down": "db.r3.xlarge",
-		"nfu": "16",
-		"memory": "61"
-	},
-	"db.r3.4xlarge": {
-		"vcpu": "16",
-		"up": "db.r3.8xlarge",
-		"down": "db.r3.2xlarge",
-		"nfu": "32",
-		"memory": "122"
-	},
-	"db.r3.8xlarge": {
-		"vcpu": "32",
-		"up": null,
-		"down": "db.r3.4xlarge",
-		"nfu": "64",
-		"memory": "244"
-	}
+  "a1.medium": {
+    "up": "a1.large",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "1",
+    "nfu": "2",
+    "memory": "2"
+  },
+  "a1.large": {
+    "up": "a1.xlarge",
+    "down": "a1.medium",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "4"
+  },
+  "a1.xlarge": {
+    "up": "a1.2xlarge",
+    "down": "a1.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "8"
+  },
+  "a1.2xlarge": {
+    "up": "a1.4xlarge",
+    "down": "a1.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "16"
+  },
+  "a1.4xlarge": {
+    "up": null,
+    "down": "a1.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "32"
+  },
+  "a1.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "memory": "32"
+  },
+  "c1.medium": {
+    "up": "c1.xlarge",
+    "down": null,
+    "superseded": {
+      "regular": "c5.large",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "2",
+    "nfu": "2",
+    "memory": "1.7"
+  },
+  "c1.xlarge": {
+    "up": null,
+    "down": "c1.medium",
+    "superseded": {
+      "regular": "c5.xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "8",
+    "nfu": "8",
+    "memory": "7"
+  },
+  "c3.large": {
+    "up": "c3.xlarge",
+    "down": null,
+    "superseded": {
+      "regular": "c5.large",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
+    "ec2_classic": true,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "3.75"
+  },
+  "c3.xlarge": {
+    "up": "c3.2xlarge",
+    "down": "c3.large",
+    "superseded": {
+      "regular": "c5.xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
+    "ec2_classic": true,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "7.5"
+  },
+  "c3.2xlarge": {
+    "up": "c3.4xlarge",
+    "down": "c3.xlarge",
+    "superseded": {
+      "regular": "c5.2xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
+    "ec2_classic": true,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "15"
+  },
+  "c3.4xlarge": {
+    "up": "c3.8xlarge",
+    "down": "c3.2xlarge",
+    "superseded": {
+      "regular": "c5.4xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
+    "ec2_classic": true,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "30"
+  },
+  "c3.8xlarge": {
+    "up": null,
+    "down": "c3.4xlarge",
+    "superseded": {
+      "regular": "c5.9xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
+    "ec2_classic": true,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "60"
+  },
+  "c4.large": {
+    "up": "c4.xlarge",
+    "down": null,
+    "superseded": {
+      "regular": "c5.large",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "3.75"
+  },
+  "c4.xlarge": {
+    "up": "c4.2xlarge",
+    "down": "c4.large",
+    "superseded": {
+      "regular": "c5.xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "7.5"
+  },
+  "c4.2xlarge": {
+    "up": "c4.4xlarge",
+    "down": "c4.xlarge",
+    "superseded": {
+      "regular": "c5.2xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "15"
+  },
+  "c4.4xlarge": {
+    "up": "c4.8xlarge",
+    "down": "c4.2xlarge",
+    "superseded": {
+      "regular": "c5.4xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "30"
+  },
+  "c4.8xlarge": {
+    "up": null,
+    "down": "c4.4xlarge",
+    "superseded": {
+      "regular": "c5.9xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "36",
+    "nfu": "64",
+    "memory": "60"
+  },
+  "c5.large": {
+    "up": "c5.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "4"
+  },
+  "c5.xlarge": {
+    "up": "c5.2xlarge",
+    "down": "c5.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "8"
+  },
+  "c5.2xlarge": {
+    "up": "c5.4xlarge",
+    "down": "c5.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "16"
+  },
+  "c5.4xlarge": {
+    "up": "c5.9xlarge",
+    "down": "c5.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "32"
+  },
+  "c5.9xlarge": {
+    "up": "c5.12xlarge",
+    "down": "c5.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "36",
+    "nfu": "72",
+    "memory": "72"
+  },
+  "c5.12xlarge": {
+    "up": "c5.18xlarge",
+    "down": "c5.9xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "96"
+  },
+  "c5.18xlarge": {
+    "up": "c5.24xlarge",
+    "down": "c5.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "72",
+    "nfu": "144",
+    "memory": "144"
+  },
+  "c5.24xlarge": {
+    "up": null,
+    "down": "c18.18xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "192"
+  },
+  "c5.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "memory": "192"
+  },
+  "c5a.large": {
+    "up": "c5a.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "4"
+  },
+  "c5a.xlarge": {
+    "up": "c5a.2xlarge",
+    "down": "c5a.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "8"
+  },
+  "c5a.2xlarge": {
+    "up": "c5a.4xlarge",
+    "down": "c5a.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "16"
+  },
+  "c5a.4xlarge": {
+    "up": "c5a.8xlarge",
+    "down": "c5a.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "32"
+  },
+  "c5a.8xlarge": {
+    "up": "c5a.12xlarge",
+    "down": "c5a.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "64"
+  },
+  "c5a.12xlarge": {
+    "up": "c5a.16xlarge",
+    "down": "c5a.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "96"
+  },
+  "c5a.16xlarge": {
+    "up": "c5a.24xlarge",
+    "down": "c5a.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "128"
+  },
+  "c5a.24xlarge": {
+    "up": null,
+    "down": "c18.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "192"
+  },
+  "c5d.large": {
+    "up": "c5d.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "4"
+  },
+  "c5d.xlarge": {
+    "up": "c5d.2xlarge",
+    "down": "c5d.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "8"
+  },
+  "c5d.2xlarge": {
+    "up": "c5d.4xlarge",
+    "down": "c5d.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "16"
+  },
+  "c5d.4xlarge": {
+    "up": "c5d.9xlarge",
+    "down": "c5d.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "32"
+  },
+  "c5d.9xlarge": {
+    "up": "c5d.12xlarge",
+    "down": "c5d.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "36",
+    "nfu": "72",
+    "memory": "72"
+  },
+  "c5d.12xlarge": {
+    "up": "c5d.18xlarge",
+    "down": "c5d.9xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "96"
+  },
+  "c5d.18xlarge": {
+    "up": "c5d.24xlarge",
+    "down": "c5d.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "72",
+    "nfu": "144",
+    "memory": "144"
+  },
+  "c5d.24xlarge": {
+    "up": null,
+    "down": "c5d.18xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "192"
+  },
+  "c5d.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "memory": "192"
+  },
+  "c5ad.large": {
+    "up": "c5ad.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "4"
+  },
+  "c5ad.xlarge": {
+    "up": "c5ad.2xlarge",
+    "down": "c5ad.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "8"
+  },
+  "c5ad.2xlarge": {
+    "up": "c5ad.4xlarge",
+    "down": "c5ad.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "16"
+  },
+  "c5ad.4xlarge": {
+    "up": "c5ad.8xlarge",
+    "down": "c5ad.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "32"
+  },
+  "c5ad.8xlarge": {
+    "up": "c5ad.12xlarge",
+    "down": "c5ad.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "64"
+  },
+  "c5ad.12xlarge": {
+    "up": "c5ad.16xlarge",
+    "down": "c5ad.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "96"
+  },
+  "c5ad.16xlarge": {
+    "up": "c5ad.24xlarge",
+    "down": "c5ad.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "128"
+  },
+  "c5ad.24xlarge": {
+    "up": null,
+    "down": "c5ad.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "192"
+  },
+  "c5n.large": {
+    "up": "c5n.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "5.25"
+  },
+  "c5n.xlarge": {
+    "up": "c5n.2xlarge",
+    "down": "c5n.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "10.5"
+  },
+  "c5n.2xlarge": {
+    "up": "c5n.4xlarge",
+    "down": "c5n.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "21"
+  },
+  "c5n.4xlarge": {
+    "up": "c5n.9xlarge",
+    "down": "c5n.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "42"
+  },
+  "c5n.9xlarge": {
+    "up": "c5n.18xlarge",
+    "down": "c5n.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "36",
+    "nfu": "72",
+    "memory": "96"
+  },
+  "c5n.18xlarge": {
+    "up": null,
+    "down": "c5n.9xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "72",
+    "nfu": "144",
+    "memory": "192"
+  },
+  "c5n.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "72",
+    "memory": "192"
+  },
+  "c6a.large": {
+    "up": "c6a.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "4"
+  },
+  "c6a.xlarge": {
+    "up": "c6a.2xlarge",
+    "down": "c6a.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "8"
+  },
+  "c6a.2xlarge": {
+    "up": "c6a.4xlarge",
+    "down": "c6a.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "16"
+  },
+  "c6a.4xlarge": {
+    "up": "c6a.8xlarge",
+    "down": "c6a.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "32"
+  },
+  "c6a.8xlarge": {
+    "up": "c6a.12xlarge",
+    "down": "c6a.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "64"
+  },
+  "c6a.12xlarge": {
+    "up": "c6a.16xlarge",
+    "down": "c6a.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "96"
+  },
+  "c6a.16xlarge": {
+    "up": "c6a.24xlarge",
+    "down": "c6a.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "128"
+  },
+  "c6a.24xlarge": {
+    "up": "c6a.32xlarge",
+    "down": "c6a.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "192"
+  },
+  "c6a.32xlarge": {
+    "up": "c6a.48xlarge",
+    "down": "c6a.24xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256",
+    "memory": "256"
+  },
+  "c6a.48xlarge": {
+    "up": null,
+    "down": "c6a.32xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "192",
+    "nfu": "384",
+    "memory": "384"
+  },
+  "c6a.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "192",
+    "nfu": "384",
+    "memory": "384"
+  },
+  "c6g.medium": {
+    "up": "c6g.large",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "1",
+    "nfu": "2",
+    "memory": "2"
+  },
+  "c6g.large": {
+    "up": "c6g.xlarge",
+    "down": "c6g.medium",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "4"
+  },
+  "c6g.xlarge": {
+    "up": "c6g.2xlarge",
+    "down": "c6g.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "8"
+  },
+  "c6g.2xlarge": {
+    "up": "c6g.4xlarge",
+    "down": "c6g.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "16"
+  },
+  "c6g.4xlarge": {
+    "up": "c6g.8xlarge",
+    "down": "c6g.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "32"
+  },
+  "c6g.8xlarge": {
+    "up": "c6g.12xlarge",
+    "down": "c6g.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "64"
+  },
+  "c6g.12xlarge": {
+    "up": "c6g.16xlarge",
+    "down": "c6g.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "96"
+  },
+  "c6g.16xlarge": {
+    "up": null,
+    "down": "c6g.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "128"
+  },
+  "c6g.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "memory": "128"
+  },
+  "c6gd.medium": {
+    "up": "c6gd.large",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "1",
+    "nfu": "2",
+    "memory": "2"
+  },
+  "c6gd.large": {
+    "up": "c6gd.xlarge",
+    "down": "c6gd.medium",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "4"
+  },
+  "c6gd.xlarge": {
+    "up": "c6gd.2xlarge",
+    "down": "c6gd.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "8"
+  },
+  "c6gd.2xlarge": {
+    "up": "c6gd.4xlarge",
+    "down": "c6gd.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "16"
+  },
+  "c6gd.4xlarge": {
+    "up": "c6gd.8xlarge",
+    "down": "c6gd.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "32"
+  },
+  "c6gd.8xlarge": {
+    "up": "c6gd.12xlarge",
+    "down": "c6gd.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "64"
+  },
+  "c6gd.12xlarge": {
+    "up": "c6gd.16xlarge",
+    "down": "c6gd.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "96"
+  },
+  "c6gd.16xlarge": {
+    "up": null,
+    "down": "c6gd.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "128"
+  },
+  "c6gd.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "memory": "128"
+  },
+  "c6gn.medium": {
+    "up": "c6gn.large",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "1",
+    "nfu": "2",
+    "memory": "2"
+  },
+  "c6gn.large": {
+    "up": "c6gn.xlarge",
+    "down": "c6gn.medium",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "4"
+  },
+  "c6gn.xlarge": {
+    "up": "c6gn.2xlarge",
+    "down": "c6gn.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "8"
+  },
+  "c6gn.2xlarge": {
+    "up": "c6gn.4xlarge",
+    "down": "c6gn.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "16"
+  },
+  "c6gn.4xlarge": {
+    "up": "c6gn.8xlarge",
+    "down": "c6gn.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "32"
+  },
+  "c6gn.8xlarge": {
+    "up": "c6gn.12xlarge",
+    "down": "c6gn.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "64"
+  },
+  "c6gn.12xlarge": {
+    "up": "c6gn.16xlarge",
+    "down": "c6gn.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "96"
+  },
+  "c6gn.16xlarge": {
+    "up": null,
+    "down": "c6gn.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "128"
+  },
+  "c6i.large": {
+    "up": "c6i.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "4"
+  },
+  "c6i.xlarge": {
+    "up": "c6i.2xlarge",
+    "down": "c6i.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "8"
+  },
+  "c6i.2xlarge": {
+    "up": "c6i.4xlarge",
+    "down": "c6i.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "16"
+  },
+  "c6i.4xlarge": {
+    "up": "c6i.8xlarge",
+    "down": "c6i.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "32"
+  },
+  "c6i.8xlarge": {
+    "up": "c6i.12xlarge",
+    "down": "c6i.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "64"
+  },
+  "c6i.12xlarge": {
+    "up": "c6i.16xlarge",
+    "down": "c6i.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "96"
+  },
+  "c6i.16xlarge": {
+    "up": "c6i.24xlarge",
+    "down": "c6i.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "128"
+  },
+  "c6i.24xlarge": {
+    "up": "c6i.32xlarge",
+    "down": "c6i.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "192"
+  },
+  "c6i.32xlarge": {
+    "up": null,
+    "down": "c6i.24xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256",
+    "memory": "256"
+  },
+  "c6i.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256",
+    "memory": "256"
+  },
+  "c6id.large": {
+    "up": "c6id.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "4"
+  },
+  "c6id.xlarge": {
+    "up": "c6id.2xlarge",
+    "down": "c6id.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "8"
+  },
+  "c6id.2xlarge": {
+    "up": "c6id.4xlarge",
+    "down": "c6id.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "16"
+  },
+  "c6id.4xlarge": {
+    "up": "c6id.8xlarge",
+    "down": "c6id.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "32"
+  },
+  "c6id.8xlarge": {
+    "up": "c6id.12xlarge",
+    "down": "c6id.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "64"
+  },
+  "c6id.12xlarge": {
+    "up": "c6id.16xlarge",
+    "down": "c6id.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "96"
+  },
+  "c6id.16xlarge": {
+    "up": "c6id.24xlarge",
+    "down": "c6id.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "128"
+  },
+  "c6id.24xlarge": {
+    "up": "c6id.32xlarge",
+    "down": "c6id.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "192"
+  },
+  "c6id.32xlarge": {
+    "up": null,
+    "down": "c6id.24xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256",
+    "memory": "256"
+  },
+  "c6id.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256",
+    "memory": "256"
+  },
+  "c7g.medium": {
+    "up": "c7g.large",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "1",
+    "nfu": "2",
+    "memory": "2"
+  },
+  "c7g.large": {
+    "up": "c7g.xlarge",
+    "down": "c7g.medium",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "4"
+  },
+  "c7g.xlarge": {
+    "up": "c7g.2xlarge",
+    "down": "c7g.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "8"
+  },
+  "c7g.2xlarge": {
+    "up": "c7g.4xlarge",
+    "down": "c7g.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "16"
+  },
+  "c7g.4xlarge": {
+    "up": "c7g.8xlarge",
+    "down": "c7g.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "32"
+  },
+  "c7g.8xlarge": {
+    "up": "c7g.12xlarge",
+    "down": "c7g.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "64"
+  },
+  "c7g.12xlarge": {
+    "up": "c7g.16xlarge",
+    "down": "c7g.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "96"
+  },
+  "c7g.16xlarge": {
+    "up": null,
+    "down": "c7g.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "128"
+  },
+  "cc1.4xlarge": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "nfu": "32"
+  },
+  "cc2.8xlarge": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "60.5"
+  },
+  "cg1.4xlarge": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "nfu": "32"
+  },
+  "cr1.8xlarge": {
+    "up": null,
+    "down": null,
+    "superseded": {
+      "regular": "r3.8xlarge",
+      "next_gen": "r4.8xlarge",
+      "burstable": "",
+      "amd": ""
+    },
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "244"
+  },
+  "d2.xlarge": {
+    "up": "d2.2xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "30.5"
+  },
+  "d2.2xlarge": {
+    "up": "d2.4xlarge",
+    "down": "d2.xlarge",
+    "superseded": null,
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "61"
+  },
+  "d2.4xlarge": {
+    "up": "d2.8xlarge",
+    "down": "d2.2xlarge",
+    "superseded": null,
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "122"
+  },
+  "d2.8xlarge": {
+    "up": null,
+    "down": "d2.4xlarge",
+    "superseded": null,
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "36",
+    "nfu": "64",
+    "memory": "244"
+  },
+  "d3.xlarge": {
+    "up": "d3.2xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "32"
+  },
+  "d3.2xlarge": {
+    "up": "d3.4xlarge",
+    "down": "d3.xlarge",
+    "superseded": null,
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "64"
+  },
+  "d3.4xlarge": {
+    "up": "d3.8xlarge",
+    "down": "d3.2xlarge",
+    "superseded": null,
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "128"
+  },
+  "d3.8xlarge": {
+    "up": null,
+    "down": "d3.4xlarge",
+    "superseded": null,
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "256"
+  },
+  "d3en.xlarge": {
+    "up": "d3en.2xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "d3en.2xlarge": {
+    "up": "d3en.4xlarge",
+    "down": "d3en.xlarge",
+    "superseded": null,
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "d3en.4xlarge": {
+    "up": "d3en.6xlarge",
+    "down": "d3en.2xlarge",
+    "superseded": null,
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "64"
+  },
+  "d3en.6xlarge": {
+    "up": "d3en.8xlarge",
+    "down": "d3en.4xlarge",
+    "superseded": null,
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "24",
+    "nfu": "48",
+    "memory": "96"
+  },
+  "d3en.8xlarge": {
+    "up": "d3en.12xlarge",
+    "down": "d3en.6xlarge",
+    "superseded": null,
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "128"
+  },
+  "d3en.12xlarge": {
+    "up": null,
+    "down": "d3en.8xlarge",
+    "superseded": null,
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "192"
+  },
+  "p2.xlarge": {
+    "up": "p2.8xlarge",
+    "down": null,
+    "superseded": {
+      "regular": "p3.xlarge",
+      "next_gen": null,
+      "burstable": "",
+      "amd": ""
+    },
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "61"
+  },
+  "p2.8xlarge": {
+    "up": "p2.16xlarge",
+    "down": "p2.xlarge",
+    "superseded": {
+      "regular": "p3.8xlarge",
+      "next_gen": null,
+      "burstable": "",
+      "amd": ""
+    },
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "488"
+  },
+  "p2.16xlarge": {
+    "up": null,
+    "down": "p2.8xlarge",
+    "superseded": {
+      "regular": "p3.16xlarge",
+      "next_gen": null,
+      "burstable": "",
+      "amd": ""
+    },
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "732"
+  },
+  "p3.2xlarge": {
+    "up": "p3.8xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "61"
+  },
+  "p3.8xlarge": {
+    "up": "p3.16xlarge",
+    "down": "p3.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "244"
+  },
+  "p3.16xlarge": {
+    "up": "p3dn.24xlarge",
+    "down": "p3.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "488"
+  },
+  "p3dn.24xlarge": {
+    "up": null,
+    "down": "p3.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "768"
+  },
+  "inf1.xlarge": {
+    "up": "inf1.2xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "8"
+  },
+  "inf1.2xlarge": {
+    "up": "inf1.6xlarge",
+    "down": "inf1.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "16"
+  },
+  "inf1.6xlarge": {
+    "up": "inf1.24xlarge",
+    "down": "inf1.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "24",
+    "nfu": "48",
+    "memory": "48"
+  },
+  "inf1.24xlarge": {
+    "up": null,
+    "down": "inf1.6xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "192"
+  },
+  "g2.2xlarge": {
+    "up": "g2.8xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "15"
+  },
+  "g2.8xlarge": {
+    "up": null,
+    "down": "g2.2xlarge",
+    "superseded": null,
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "60"
+  },
+  "g3s.xlarge": {
+    "up": "g3.4xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "30.5"
+  },
+  "g3.4xlarge": {
+    "up": "g3.8xlarge",
+    "down": "g3s.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "122"
+  },
+  "g3.8xlarge": {
+    "up": "g3.16xlarge",
+    "down": "g3.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "244"
+  },
+  "g3.16xlarge": {
+    "up": null,
+    "down": "g3.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "488"
+  },
+  "g4.large": {
+    "up": "g4.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "nfu": "4"
+  },
+  "g4.2xlarge": {
+    "up": "g4.4xlarge",
+    "down": "g4.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "nfu": "16"
+  },
+  "g4.4xlarge": {
+    "up": "g4.8xlarge",
+    "down": "g4.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "nfu": "32"
+  },
+  "g4.8xlarge": {
+    "up": "g4.16xlarge",
+    "down": "g4.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "nfu": "64"
+  },
+  "g4.16xlarge": {
+    "up": null,
+    "down": "g4.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "nfu": "128"
+  },
+  "g4dn.12xlarge": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "192"
+  },
+  "g4dn.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "memory": "384"
+  },
+  "g4ad.4xlarge": {
+    "up": "g4ad.8xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "64"
+  },
+  "g4ad.8xlarge": {
+    "up": "g4ad.16xlarge",
+    "down": "g4ad.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "128"
+  },
+  "g4ad.16xlarge": {
+    "up": null,
+    "down": "g4ad.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "256"
+  },
+  "g4dn.xlarge": {
+    "up": "g4dn.2xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "g4dn.2xlarge": {
+    "up": "g4dn.4xlarge",
+    "down": "g4dn.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "g4dn.4xlarge": {
+    "up": "g4dn.8xlarge",
+    "down": "g4dn.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "64"
+  },
+  "g4dn.8xlarge": {
+    "up": "g4dn.16xlarge",
+    "down": "g4dn.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "128"
+  },
+  "g4dn.16xlarge": {
+    "up": null,
+    "down": "g4dn.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "256"
+  },
+  "g5g.xlarge": {
+    "up": "g5g.2xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": false,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "8"
+  },
+  "g5g.2xlarge": {
+    "up": "g5g.4xlarge",
+    "down": "g5g.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": false,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "16"
+  },
+  "g5g.4xlarge": {
+    "up": "g5g.8xlarge",
+    "down": "g5g.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": false,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "32"
+  },
+  "g5g.8xlarge": {
+    "up": "g5g.16xlarge",
+    "down": "g5g.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": false,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "64"
+  },
+  "g5g.16xlarge": {
+    "up": "g5g.metal",
+    "down": "g5g.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": false,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "128"
+  },
+  "g5g.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": false,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "128"
+  },
+  "f1.2xlarge": {
+    "up": "f1.4xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "122"
+  },
+  "f1.4xlarge": {
+    "up": "f1.16xlarge",
+    "down": "f1.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "244"
+  },
+  "f1.16xlarge": {
+    "up": null,
+    "down": "f1.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "976"
+  },
+  "h1.2xlarge": {
+    "up": "h1.4xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "h1.4xlarge": {
+    "up": "h1.8xlarge",
+    "down": "h1.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "64"
+  },
+  "h1.8xlarge": {
+    "up": "h1.16xlarge",
+    "down": "h1.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "128"
+  },
+  "h1.16xlarge": {
+    "up": null,
+    "down": "h1.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "256"
+  },
+  "hi1.4xlarge": {
+    "up": "hs1.8xlarge",
+    "down": null,
+    "superseded": {
+      "regular": "i3.4xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "nfu": "32"
+  },
+  "hs1.8xlarge": {
+    "up": null,
+    "down": "hi1.4xlarge",
+    "superseded": {
+      "regular": "d2.8xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "16",
+    "nfu": "64",
+    "memory": "117"
+  },
+  "i2.xlarge": {
+    "up": "i2.2xlarge",
+    "down": null,
+    "superseded": {
+      "regular": "i3.xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "30.5"
+  },
+  "i2.2xlarge": {
+    "up": "i2.4xlarge",
+    "down": "i2.xlarge",
+    "superseded": {
+      "regular": "i3.2xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "61"
+  },
+  "i2.4xlarge": {
+    "up": "i2.8xlarge",
+    "down": "i2.2xlarge",
+    "superseded": {
+      "regular": "i3.4xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "122"
+  },
+  "i2.8xlarge": {
+    "up": null,
+    "down": "i2.4xlarge",
+    "superseded": {
+      "regular": "i3.8xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "244"
+  },
+  "i3.large": {
+    "up": "i3.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "15.25"
+  },
+  "i3.xlarge": {
+    "up": "i3.2xlarge",
+    "down": "i3.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "30.5"
+  },
+  "i3.2xlarge": {
+    "up": "i3.4xlarge",
+    "down": "i3.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "61"
+  },
+  "i3.4xlarge": {
+    "up": "i3.8xlarge",
+    "down": "i3.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "122"
+  },
+  "i3.8xlarge": {
+    "up": "i3.16xlarge",
+    "down": "i3.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "244"
+  },
+  "i3.16xlarge": {
+    "up": null,
+    "down": "i3.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "488"
+  },
+  "i3.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "memory": "512"
+  },
+  "i3en.large": {
+    "up": "i3en.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "16"
+  },
+  "i3en.xlarge": {
+    "up": "i3en.2xlarge",
+    "down": "i3en.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "32"
+  },
+  "i3en.2xlarge": {
+    "up": "i3en.3xlarge",
+    "down": "i3en.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "64"
+  },
+  "i3en.3xlarge": {
+    "up": "i3en.6xlarge",
+    "down": "i3en.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "12",
+    "nfu": "24",
+    "memory": "96"
+  },
+  "i3en.6xlarge": {
+    "up": "i3en.12xlarge",
+    "down": "i3en.3xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "24",
+    "nfu": "48",
+    "memory": "192"
+  },
+  "i3en.12xlarge": {
+    "up": "i3en.24xlarge",
+    "down": "i3en.6xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "384"
+  },
+  "i3en.24xlarge": {
+    "up": null,
+    "down": "i3en.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "768"
+  },
+  "i3en.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "memory": "768"
+  },
+  "im4gn.large": {
+    "up": "im4gn.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "8",
+    "memory": "8"
+  },
+  "im4gn.xlarge": {
+    "up": "im4gn.2xlarge",
+    "down": "im4gn.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "16",
+    "memory": "16"
+  },
+  "im4gn.2xlarge": {
+    "up": "im4gn.4xlarge",
+    "down": "im4gn.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "32",
+    "memory": "32"
+  },
+  "im4gn.4xlarge": {
+    "up": "im4gn.8xlarge",
+    "down": "im4gn.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "64",
+    "memory": "64"
+  },
+  "im4gn.8xlarge": {
+    "up": "im4gn.16xlarge",
+    "down": "im4gn.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "128",
+    "memory": "128"
+  },
+  "im4gn.16xlarge": {
+    "up": null,
+    "down": "im4gn.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "256",
+    "memory": "256"
+  },
+  "is4gen.medium": {
+    "up": "is4gen.large",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "1",
+    "nfu": "6",
+    "memory": "6"
+  },
+  "is4gen.large": {
+    "up": "is4gen.xlarge",
+    "down": "is4gen.medium",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "12",
+    "memory": "12"
+  },
+  "is4gen.xlarge": {
+    "up": "is4gen.2xlarge",
+    "down": "is4gen.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "24",
+    "memory": "24"
+  },
+  "is4gen.2xlarge": {
+    "up": "is4gen.4xlarge",
+    "down": "is4gen.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "48",
+    "memory": "48"
+  },
+  "is4gen.4xlarge": {
+    "up": "is4gen.8xlarge",
+    "down": "is4gen.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "96",
+    "memory": "96"
+  },
+  "is4gen.8xlarge": {
+    "up": null,
+    "down": "is4gen.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "192",
+    "memory": "192"
+  },
+  "m1.small": {
+    "up": "m1.medium",
+    "down": null,
+    "superseded": {
+      "regular": "t3.large",
+      "next_gen": "",
+      "burstable": "t3.large",
+      "amd": "m5a.large"
+    },
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "1",
+    "nfu": "1",
+    "memory": "1.7"
+  },
+  "m1.medium": {
+    "up": "m1.large",
+    "down": "m1.small",
+    "superseded": {
+      "regular": "m5.large",
+      "next_gen": "",
+      "burstable": "t3.large",
+      "amd": "m5a.large"
+    },
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "1",
+    "nfu": "2",
+    "memory": "3.75"
+  },
+  "m1.large": {
+    "up": "m1.xlarge",
+    "down": "m1.medium",
+    "superseded": {
+      "regular": "m5.large",
+      "next_gen": "",
+      "burstable": "t3.xlarge",
+      "amd": "m5a.large"
+    },
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "7.5"
+  },
+  "m1.xlarge": {
+    "up": null,
+    "down": "m1.large",
+    "superseded": {
+      "regular": "m5.xlarge",
+      "next_gen": "",
+      "burstable": "t3.2xlarge",
+      "amd": "m5a.xlarge"
+    },
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "15"
+  },
+  "m2.xlarge": {
+    "up": "m2.2xlarge",
+    "down": null,
+    "superseded": {
+      "regular": "r3.large",
+      "next_gen": "r5.large",
+      "burstable": "",
+      "amd": "r5a.large"
+    },
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "2",
+    "nfu": "8",
+    "memory": "17.1"
+  },
+  "m2.2xlarge": {
+    "up": "m2.4xlarge",
+    "down": "m2.xlarge",
+    "superseded": {
+      "regular": "r3.xlarge",
+      "next_gen": "r5.xlarge",
+      "burstable": "",
+      "amd": "r5a.xlarge"
+    },
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "4",
+    "nfu": "16",
+    "memory": "34.2"
+  },
+  "m2.4xlarge": {
+    "up": null,
+    "down": "m2.2xlarge",
+    "superseded": {
+      "regular": "r3.2xlarge",
+      "next_gen": "r5.2xlarge",
+      "burstable": "",
+      "amd": "r5a.2xlarge"
+    },
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "8",
+    "nfu": "32",
+    "memory": "68.4"
+  },
+  "m3.medium": {
+    "up": "m3.large",
+    "down": null,
+    "superseded": {
+      "regular": "m5.large",
+      "next_gen": "",
+      "burstable": "t3.large",
+      "amd": "m5a.large"
+    },
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "1",
+    "nfu": "2",
+    "memory": "3.75"
+  },
+  "m3.large": {
+    "up": "m3.xlarge",
+    "down": "m3.medium",
+    "superseded": {
+      "regular": "m5.large",
+      "next_gen": "",
+      "burstable": "t3.xlarge",
+      "amd": "m5a.large"
+    },
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "7.5"
+  },
+  "m3.xlarge": {
+    "up": "m3.2xlarge",
+    "down": "m3.large",
+    "superseded": {
+      "regular": "m5.xlarge",
+      "next_gen": "",
+      "burstable": "t3.2xlarge",
+      "amd": "m5a.xlarge"
+    },
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "15"
+  },
+  "m3.2xlarge": {
+    "up": null,
+    "down": "m3.xlarge",
+    "superseded": {
+      "regular": "m5.2xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": "m5a.2xlarge"
+    },
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "30"
+  },
+  "m4.large": {
+    "up": "m4.xlarge",
+    "down": null,
+    "superseded": {
+      "regular": "m5.large",
+      "next_gen": "",
+      "burstable": "t3.xlarge",
+      "amd": "m5a.large"
+    },
+    "ec2_classic": false,
+    "enhanced_networking": false,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "8"
+  },
+  "m4.xlarge": {
+    "up": "m4.2xlarge",
+    "down": "m4.large",
+    "superseded": {
+      "regular": "m5.xlarge",
+      "next_gen": "",
+      "burstable": "t3.2xlarge",
+      "amd": "m5a.xlarge"
+    },
+    "ec2_classic": false,
+    "enhanced_networking": false,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "m4.2xlarge": {
+    "up": "m4.4xlarge",
+    "down": "m4.xlarge",
+    "superseded": {
+      "regular": "m5.2xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": "m5a.2xlarge"
+    },
+    "ec2_classic": false,
+    "enhanced_networking": false,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "m4.4xlarge": {
+    "up": "m4.10xlarge",
+    "down": "m4.2xlarge",
+    "superseded": {
+      "regular": "m5.4xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": "m5a.4xlarge"
+    },
+    "ec2_classic": false,
+    "enhanced_networking": false,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "64"
+  },
+  "m4.10xlarge": {
+    "up": "m4.16xlarge",
+    "down": "m4.4xlarge",
+    "superseded": {
+      "regular": "m5.12xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": "m5a.12xlarge"
+    },
+    "ec2_classic": false,
+    "enhanced_networking": false,
+    "vcpu": "40",
+    "nfu": "80",
+    "memory": "160"
+  },
+  "m4.16xlarge": {
+    "up": null,
+    "down": "m4.10xlarge",
+    "superseded": {
+      "regular": "m5.16xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": "m5a.16xlarge"
+    },
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "256"
+  },
+  "m5.large": {
+    "up": "m5.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "8"
+  },
+  "m5.xlarge": {
+    "up": "m5.2xlarge",
+    "down": "m5.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "m5.2xlarge": {
+    "up": "m5.4xlarge",
+    "down": "m5.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "m5.4xlarge": {
+    "up": "m5.8xlarge",
+    "down": "m5.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "64"
+  },
+  "m5.8xlarge": {
+    "up": "m5.12xlarge",
+    "down": "m5.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "128"
+  },
+  "m5.12xlarge": {
+    "up": "m5.16xlarge",
+    "down": "m5.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "192"
+  },
+  "m5.16xlarge": {
+    "up": "m5.24xlarge",
+    "down": "m5.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "256"
+  },
+  "m5.24xlarge": {
+    "up": null,
+    "down": "m5.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "384"
+  },
+  "m5.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "memory": "384"
+  },
+  "m5n.large": {
+    "up": "m5n.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "8"
+  },
+  "m5n.xlarge": {
+    "up": "m5n.2xlarge",
+    "down": "m5n.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "m5n.2xlarge": {
+    "up": "m5n.4xlarge",
+    "down": "m5n.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "m5n.4xlarge": {
+    "up": "m5n.8xlarge",
+    "down": "m5n.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "64"
+  },
+  "m5n.8xlarge": {
+    "up": "m5n.12xlarge",
+    "down": "m5n.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "128"
+  },
+  "m5n.12xlarge": {
+    "up": "m5n.16xlarge",
+    "down": "m5n.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "192"
+  },
+  "m5n.16xlarge": {
+    "up": "m5n.24xlarge",
+    "down": "m5n.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "256"
+  },
+  "m5n.24xlarge": {
+    "up": null,
+    "down": "m5n.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "384"
+  },
+  "m5n.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "memory": "384"
+  },
+  "m5dn.large": {
+    "up": "m5dn.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "8"
+  },
+  "m5dn.xlarge": {
+    "up": "m5dn.2xlarge",
+    "down": "m5dn.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "m5dn.2xlarge": {
+    "up": "m5dn.4xlarge",
+    "down": "m5dn.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "m5dn.4xlarge": {
+    "up": "m5dn.8xlarge",
+    "down": "m5dn.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "64"
+  },
+  "m5dn.8xlarge": {
+    "up": "m5dn.12xlarge",
+    "down": "m5dn.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "128"
+  },
+  "m5dn.12xlarge": {
+    "up": "m5dn.16xlarge",
+    "down": "m5dn.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "192"
+  },
+  "m5dn.16xlarge": {
+    "up": "m5dn.24xlarge",
+    "down": "m5dn.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "256"
+  },
+  "m5dn.24xlarge": {
+    "up": null,
+    "down": "m5dn.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "384"
+  },
+  "m5dn.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "memory": "384"
+  },
+  "m5zn.large": {
+    "up": "m5zn.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "8"
+  },
+  "m5zn.xlarge": {
+    "up": "m5zn.2xlarge",
+    "down": "m5zn.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "m5zn.2xlarge": {
+    "up": "m5zn.3xlarge",
+    "down": "m5zn.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "m5zn.3xlarge": {
+    "up": "m5zn.6xlarge",
+    "down": "m5zn.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "12",
+    "nfu": "24",
+    "memory": "48"
+  },
+  "m5zn.6xlarge": {
+    "up": "m5zn.12xlarge",
+    "down": "m5zn.3xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "24",
+    "nfu": "48",
+    "memory": "96"
+  },
+  "m5zn.12xlarge": {
+    "up": null,
+    "down": "m5zn.6xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "192"
+  },
+  "m5zn.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "memory": "192"
+  },
+  "mac1.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "12",
+    "memory": "32"
+  },
+  "p4d.24xlarge": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "1152"
+  },
+  "m6a.large": {
+    "up": "m6a.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "8"
+  },
+  "m6a.xlarge": {
+    "up": "m6a.2xlarge",
+    "down": "m6a.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "m6a.2xlarge": {
+    "up": "m6a.4xlarge",
+    "down": "m6a.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "m6a.4xlarge": {
+    "up": "m6a.8xlarge",
+    "down": "m6a.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "64"
+  },
+  "m6a.8xlarge": {
+    "up": "m6a.12xlarge",
+    "down": "m6a.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "128"
+  },
+  "m6a.12xlarge": {
+    "up": "m6a.16xlarge",
+    "down": "m6a.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "192"
+  },
+  "m6a.16xlarge": {
+    "up": "m6a.24xlarge",
+    "down": "m6a.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "256"
+  },
+  "m6a.24xlarge": {
+    "up": "m6a.32xlarge",
+    "down": "m6a.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "384"
+  },
+  "m6a.32xlarge": {
+    "up": "m6a.48xlarge",
+    "down": "m6a.24xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256",
+    "memory": "512"
+  },
+  "m6a.48xlarge": {
+    "up": null,
+    "down": "m6a.32xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "192",
+    "nfu": "384",
+    "memory": "768"
+  },
+  "m6a.metal": {
+    "up": null,
+    "down": "m6a.32xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "192",
+    "nfu": "384",
+    "memory": "768"
+  },
+  "m6g.medium": {
+    "up": "m6g.large",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "1",
+    "nfu": "2",
+    "memory": "4"
+  },
+  "m6g.large": {
+    "up": "m6g.xlarge",
+    "down": "m6g.medium",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "8"
+  },
+  "m6g.xlarge": {
+    "up": "m6g.2xlarge",
+    "down": "m6g.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "m6g.2xlarge": {
+    "up": "m6g.4xlarge",
+    "down": "m6g.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "m6g.4xlarge": {
+    "up": "m6g.8xlarge",
+    "down": "m6g.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "64"
+  },
+  "m6g.8xlarge": {
+    "up": "m6g.12xlarge",
+    "down": "m6g.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "128"
+  },
+  "m6g.12xlarge": {
+    "up": "m6g.16xlarge",
+    "down": "m6g.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "192"
+  },
+  "m6g.16xlarge": {
+    "up": "m6g.24xlarge",
+    "down": "m6g.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "256"
+  },
+  "m6g.24xlarge": {
+    "up": null,
+    "down": "m6g.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "nfu": "192"
+  },
+  "m6g.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "memory": "256"
+  },
+  "m6gd.medium": {
+    "up": "m6gd.large",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "1",
+    "nfu": "2",
+    "memory": "4"
+  },
+  "m6gd.large": {
+    "up": "m6gd.xlarge",
+    "down": "m6gd.medium",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "8"
+  },
+  "m6gd.xlarge": {
+    "up": "m6gd.2xlarge",
+    "down": "m6gd.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "m6gd.2xlarge": {
+    "up": "m6gd.4xlarge",
+    "down": "m6gd.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "m6gd.4xlarge": {
+    "up": "m6gd.8xlarge",
+    "down": "m6gd.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "64"
+  },
+  "m6gd.8xlarge": {
+    "up": "m6gd.12xlarge",
+    "down": "m6gd.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "128"
+  },
+  "m6gd.12xlarge": {
+    "up": "m6gd.16xlarge",
+    "down": "m6gd.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "192"
+  },
+  "m6gd.16xlarge": {
+    "up": "m6gd.24xlarge",
+    "down": "m6gd.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "256"
+  },
+  "m6gd.24xlarge": {
+    "up": null,
+    "down": "m6gd.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "nfu": "192"
+  },
+  "m6gd.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "memory": "256"
+  },
+  "m6i.large": {
+    "up": "m6i.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "8"
+  },
+  "m6i.xlarge": {
+    "up": "m6i.2xlarge",
+    "down": "m6i.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "m6i.2xlarge": {
+    "up": "m6i.4xlarge",
+    "down": "m6i.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "m6i.4xlarge": {
+    "up": "m6i.8xlarge",
+    "down": "m6i.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "64"
+  },
+  "m6i.8xlarge": {
+    "up": "m6i.12xlarge",
+    "down": "m6i.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "128"
+  },
+  "m6i.12xlarge": {
+    "up": "m6i.16xlarge",
+    "down": "m6i.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "192"
+  },
+  "m6i.16xlarge": {
+    "up": "m6i.24xlarge",
+    "down": "m6i.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "256"
+  },
+  "m6i.24xlarge": {
+    "up": "m6i.32xlarge",
+    "down": "m6i.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "384"
+  },
+  "m6i.32xlarge": {
+    "up": null,
+    "down": "m6i.24xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256",
+    "memory": "512"
+  },
+  "m6i.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256",
+    "memory": "512"
+  },
+  "m6id.large": {
+    "up": "m6id.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "8"
+  },
+  "m6id.xlarge": {
+    "up": "m6id.2xlarge",
+    "down": "m6id.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "m6id.2xlarge": {
+    "up": "m6id.4xlarge",
+    "down": "m6id.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "m6id.4xlarge": {
+    "up": "m6id.8xlarge",
+    "down": "m6id.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "64"
+  },
+  "m6id.8xlarge": {
+    "up": "m6id.12xlarge",
+    "down": "m6id.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "128"
+  },
+  "m6id.12xlarge": {
+    "up": "m6id.16xlarge",
+    "down": "m6id.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "192"
+  },
+  "m6id.16xlarge": {
+    "up": "m6id.24xlarge",
+    "down": "m6id.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "256"
+  },
+  "m6id.24xlarge": {
+    "up": "m6id.32xlarge",
+    "down": "m6id.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "384"
+  },
+  "m6id.32xlarge": {
+    "up": null,
+    "down": "m6id.24xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256",
+    "memory": "512"
+  },
+  "m6id.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256",
+    "memory": "512"
+  },
+  "m5a.large": {
+    "up": "m5a.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "8"
+  },
+  "m5a.xlarge": {
+    "up": "m5a.2xlarge",
+    "down": "m5a.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "m5a.2xlarge": {
+    "up": "m5a.4xlarge",
+    "down": "m5a.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "m5a.4xlarge": {
+    "up": "m5a.8xlarge",
+    "down": "m5a.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "64"
+  },
+  "m5a.8xlarge": {
+    "up": "m5a.12xlarge",
+    "down": "m5a.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "128"
+  },
+  "m5a.12xlarge": {
+    "up": "m5a.16xlarge",
+    "down": "m5a.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "192"
+  },
+  "m5a.16xlarge": {
+    "up": "m5a.24xlarge",
+    "down": "m5a.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "256"
+  },
+  "m5a.24xlarge": {
+    "up": null,
+    "down": "m5a.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "384"
+  },
+  "m5ad.large": {
+    "up": "m5ad.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "8"
+  },
+  "m5ad.xlarge": {
+    "up": "m5ad.2xlarge",
+    "down": "m5ad.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "m5ad.2xlarge": {
+    "up": "m5ad.4xlarge",
+    "down": "m5ad.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "m5ad.4xlarge": {
+    "up": "m5ad.8xlarge",
+    "down": "m5ad.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "64"
+  },
+  "m5ad.8xlarge": {
+    "up": "m5ad.12xlarge",
+    "down": "m5ad.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "128"
+  },
+  "m5ad.12xlarge": {
+    "up": "m5ad.16xlarge",
+    "down": "m5ad.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "192"
+  },
+  "m5ad.16xlarge": {
+    "up": "m5ad.24xlarge",
+    "down": "m5ad.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "256"
+  },
+  "m5ad.24xlarge": {
+    "up": null,
+    "down": "m5ad.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "384"
+  },
+  "m5d.large": {
+    "up": "m5d.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "8"
+  },
+  "m5d.xlarge": {
+    "up": "m5d.2xlarge",
+    "down": "m5d.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "m5d.2xlarge": {
+    "up": "m5d.4xlarge",
+    "down": "m5d.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "m5d.4xlarge": {
+    "up": "m5d.8xlarge",
+    "down": "m5d.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "64"
+  },
+  "m5d.8xlarge": {
+    "up": "m5d.12xlarge",
+    "down": "m5d.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "128"
+  },
+  "m5d.12xlarge": {
+    "up": "m5d.16xlarge",
+    "down": "m5d.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "192"
+  },
+  "m5d.16xlarge": {
+    "up": "m5d.24xlarge",
+    "down": "m5d.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "256"
+  },
+  "m5d.24xlarge": {
+    "up": null,
+    "down": "m5d.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "384"
+  },
+  "m5d.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "memory": "384"
+  },
+  "r3.large": {
+    "up": "r3.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "15.25"
+  },
+  "r3.xlarge": {
+    "up": "r3.2xlarge",
+    "down": "r3.large",
+    "superseded": null,
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "30.5"
+  },
+  "r3.2xlarge": {
+    "up": "r3.4xlarge",
+    "down": "r3.xlarge",
+    "superseded": null,
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "61"
+  },
+  "r3.4xlarge": {
+    "up": "r3.8xlarge",
+    "down": "r3.2xlarge",
+    "superseded": null,
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "122"
+  },
+  "r3.8xlarge": {
+    "up": null,
+    "down": "r3.4xlarge",
+    "superseded": null,
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "244"
+  },
+  "r4.large": {
+    "up": "r4.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "15.25"
+  },
+  "r4.xlarge": {
+    "up": "r4.2xlarge",
+    "down": "r4.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "30.5"
+  },
+  "r4.2xlarge": {
+    "up": "r4.4xlarge",
+    "down": "r4.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "61"
+  },
+  "r4.4xlarge": {
+    "up": "r4.8xlarge",
+    "down": "r4.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "122"
+  },
+  "r4.8xlarge": {
+    "up": "r4.16xlarge",
+    "down": "r4.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "244"
+  },
+  "r4.16xlarge": {
+    "up": null,
+    "down": "r4.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "488"
+  },
+  "r5.large": {
+    "up": "r5.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "16"
+  },
+  "r5.xlarge": {
+    "up": "r5.2xlarge",
+    "down": "r5.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "32"
+  },
+  "r5.2xlarge": {
+    "up": "r5.4xlarge",
+    "down": "r5.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "64"
+  },
+  "r5.4xlarge": {
+    "up": "r5.8xlarge",
+    "down": "r5.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "128"
+  },
+  "r5.8xlarge": {
+    "up": "r5.12xlarge",
+    "down": "r5.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "256"
+  },
+  "r5.12xlarge": {
+    "up": "r5.16xlarge",
+    "down": "r5.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "384"
+  },
+  "r5.16xlarge": {
+    "up": "r5.24xlarge",
+    "down": "r5.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "512"
+  },
+  "r5.24xlarge": {
+    "up": null,
+    "down": "r5.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "768"
+  },
+  "r5.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "memory": "768"
+  },
+  "r5a.large": {
+    "up": "r5a.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "16"
+  },
+  "r5a.xlarge": {
+    "up": "r5a.2xlarge",
+    "down": "r5a.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "32"
+  },
+  "r5a.2xlarge": {
+    "up": "r5a.4xlarge",
+    "down": "r5a.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "64"
+  },
+  "r5a.4xlarge": {
+    "up": "r5a.8xlarge",
+    "down": "r5a.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "128"
+  },
+  "r5a.8xlarge": {
+    "up": "r5a.12xlarge",
+    "down": "r5a.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "256"
+  },
+  "r5a.12xlarge": {
+    "up": "r5a.16xlarge",
+    "down": "r5a.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "384"
+  },
+  "r5a.16xlarge": {
+    "up": "r5a.24xlarge",
+    "down": "r5a.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "512"
+  },
+  "r5a.24xlarge": {
+    "up": null,
+    "down": "r5a.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "768"
+  },
+  "r5b.large": {
+    "up": "r5b.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "16"
+  },
+  "r5b.xlarge": {
+    "up": "r5b.2xlarge",
+    "down": "r5b.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "32"
+  },
+  "r5b.2xlarge": {
+    "up": "r5b.4xlarge",
+    "down": "r5b.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "64"
+  },
+  "r5b.4xlarge": {
+    "up": "r5b.8xlarge",
+    "down": "r5b.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "128"
+  },
+  "r5b.8xlarge": {
+    "up": "r5b.12xlarge",
+    "down": "r5b.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "256"
+  },
+  "r5b.12xlarge": {
+    "up": "r5b.16xlarge",
+    "down": "r5b.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "384"
+  },
+  "r5b.16xlarge": {
+    "up": "r5b.24xlarge",
+    "down": "r5b.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "512"
+  },
+  "r5b.24xlarge": {
+    "up": null,
+    "down": "r5b.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "768"
+  },
+  "r5b.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "memory": "768"
+  },
+  "r5ad.large": {
+    "up": "r5ad.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "16"
+  },
+  "r5ad.xlarge": {
+    "up": "r5ad.2xlarge",
+    "down": "r5ad.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "32"
+  },
+  "r5ad.2xlarge": {
+    "up": "r5ad.4xlarge",
+    "down": "r5ad.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "64"
+  },
+  "r5ad.4xlarge": {
+    "up": "r5ad.8xlarge",
+    "down": "r5ad.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "128"
+  },
+  "r5ad.8xlarge": {
+    "up": "r5ad.12xlarge",
+    "down": "r5ad.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "256"
+  },
+  "r5ad.12xlarge": {
+    "up": "r5ad.16xlarge",
+    "down": "r5ad.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "384"
+  },
+  "r5ad.16xlarge": {
+    "up": "r5ad.24xlarge",
+    "down": "r5ad.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "512"
+  },
+  "r5ad.24xlarge": {
+    "up": null,
+    "down": "r5ad.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "768"
+  },
+  "r5n.large": {
+    "up": "r5n.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "16"
+  },
+  "r5n.xlarge": {
+    "up": "r5n.2xlarge",
+    "down": "r5n.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "32"
+  },
+  "r5n.2xlarge": {
+    "up": "r5n.4xlarge",
+    "down": "r5n.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "64"
+  },
+  "r5n.4xlarge": {
+    "up": "r5n.8xlarge",
+    "down": "r5n.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "128"
+  },
+  "r5n.8xlarge": {
+    "up": "r5n.12xlarge",
+    "down": "r5n.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "256"
+  },
+  "r5n.12xlarge": {
+    "up": "r5n.16xlarge",
+    "down": "r5n.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "384"
+  },
+  "r5n.16xlarge": {
+    "up": "r5n.24xlarge",
+    "down": "r5n.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "512"
+  },
+  "r5n.24xlarge": {
+    "up": null,
+    "down": "r5n.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "768"
+  },
+  "r5n.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "memory": "768"
+  },
+  "r5dn.large": {
+    "up": "r5dn.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "16"
+  },
+  "r5dn.xlarge": {
+    "up": "r5dn.2xlarge",
+    "down": "r5dn.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "32"
+  },
+  "r5dn.2xlarge": {
+    "up": "r5dn.4xlarge",
+    "down": "r5dn.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "64"
+  },
+  "r5dn.4xlarge": {
+    "up": "r5dn.8xlarge",
+    "down": "r5dn.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "128"
+  },
+  "r5dn.8xlarge": {
+    "up": "r5dn.12xlarge",
+    "down": "r5dn.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "256"
+  },
+  "r5dn.12xlarge": {
+    "up": "r5dn.16xlarge",
+    "down": "r5dn.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "384"
+  },
+  "r5dn.16xlarge": {
+    "up": "r5dn.24xlarge",
+    "down": "r5dn.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "512"
+  },
+  "r5dn.24xlarge": {
+    "up": null,
+    "down": "r5dn.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "768"
+  },
+  "r5dn.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "memory": "768"
+  },
+  "r5d.large": {
+    "up": "r5d.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "16"
+  },
+  "r5d.xlarge": {
+    "up": "r5d.2xlarge",
+    "down": "r5d.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "32"
+  },
+  "r5d.2xlarge": {
+    "up": "r5d.4xlarge",
+    "down": "r5d.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "64"
+  },
+  "r5d.4xlarge": {
+    "up": "r5d.8xlarge",
+    "down": "r5d.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "128"
+  },
+  "r5d.8xlarge": {
+    "up": "r5d.12xlarge",
+    "down": "r5d.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "256"
+  },
+  "r5d.12xlarge": {
+    "up": "r5d.16xlarge",
+    "down": "r5d.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "384"
+  },
+  "r5d.16xlarge": {
+    "up": "r5d.24xlarge",
+    "down": "r5d.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "512"
+  },
+  "r5d.24xlarge": {
+    "up": null,
+    "down": "r5d.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "768"
+  },
+  "r5d.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "memory": "768"
+  },
+  "r6a.large": {
+    "up": "r6a.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "16"
+  },
+  "r6a.xlarge": {
+    "up": "r6a.2xlarge",
+    "down": "r6a.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "32"
+  },
+  "r6a.2xlarge": {
+    "up": "r6a.4xlarge",
+    "down": "r6a.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "64"
+  },
+  "r6a.4xlarge": {
+    "up": "r6a.8xlarge",
+    "down": "r6a.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "128"
+  },
+  "r6a.8xlarge": {
+    "up": "r6a.12xlarge",
+    "down": "r6a.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "256"
+  },
+  "r6a.12xlarge": {
+    "up": "r6a.16xlarge",
+    "down": "r6a.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "384"
+  },
+  "r6a.16xlarge": {
+    "up": "r6a.24xlarge",
+    "down": "r6a.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "512"
+  },
+  "r6a.24xlarge": {
+    "up": "r6a.32xlarge",
+    "down": "r6a.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "768"
+  },
+  "r6a.32xlarge": {
+    "up": "r6a.48xlarge",
+    "down": "r6a.24xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256",
+    "memory": "1024"
+  },
+  "r6a.48xlarge": {
+    "up": null,
+    "down": "r6a.32xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "192",
+    "nfu": "384",
+    "memory": "1536"
+  },
+  "r6a.metal": {
+    "up": null,
+    "down": "r6a.32xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "192",
+    "nfu": "384",
+    "memory": "1536"
+  },
+  "r6g.medium": {
+    "up": "r6g.large",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "1",
+    "nfu": "2",
+    "memory": "8"
+  },
+  "r6g.large": {
+    "up": "r6g.xlarge",
+    "down": "r6g.medium",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "16"
+  },
+  "r6g.xlarge": {
+    "up": "r6g.2xlarge",
+    "down": "r6g.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "32"
+  },
+  "r6g.2xlarge": {
+    "up": "r6g.4xlarge",
+    "down": "r6g.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "64"
+  },
+  "r6g.4xlarge": {
+    "up": "r6g.8xlarge",
+    "down": "r6g.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "128"
+  },
+  "r6g.8xlarge": {
+    "up": "r6g.12xlarge",
+    "down": "r6g.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "256"
+  },
+  "r6g.12xlarge": {
+    "up": "r6g.16xlarge",
+    "down": "r6g.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "384"
+  },
+  "r6g.16xlarge": {
+    "up": null,
+    "down": "r6g.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "512"
+  },
+  "r6g.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "memory": "512"
+  },
+  "r6gd.medium": {
+    "up": "r6gd.large",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "1",
+    "nfu": "2",
+    "memory": "8"
+  },
+  "r6gd.large": {
+    "up": "r6gd.xlarge",
+    "down": "r6gd.medium",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "16"
+  },
+  "r6gd.xlarge": {
+    "up": "r6gd.2xlarge",
+    "down": "r6gd.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "32"
+  },
+  "r6gd.2xlarge": {
+    "up": "r6gd.4xlarge",
+    "down": "r6gd.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "64"
+  },
+  "r6gd.4xlarge": {
+    "up": "r6gd.8xlarge",
+    "down": "r6gd.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "128"
+  },
+  "r6gd.8xlarge": {
+    "up": "r6gd.12xlarge",
+    "down": "r6gd.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "256"
+  },
+  "r6gd.12xlarge": {
+    "up": "r6gd.16xlarge",
+    "down": "r6gd.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "384"
+  },
+  "r6gd.16xlarge": {
+    "up": null,
+    "down": "r6gd.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "512"
+  },
+  "r6gd.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "memory": "512"
+  },
+  "r6i.large": {
+    "up": "r6i.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "16"
+  },
+  "r6i.xlarge": {
+    "up": "r6i.2xlarge",
+    "down": "r6i.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "32"
+  },
+  "r6i.2xlarge": {
+    "up": "r6i.4xlarge",
+    "down": "r6i.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "64"
+  },
+  "r6i.4xlarge": {
+    "up": "r6i.8xlarge",
+    "down": "r6i.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "128"
+  },
+  "r6i.8xlarge": {
+    "up": "r6i.12xlarge",
+    "down": "r6i.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "256"
+  },
+  "r6i.12xlarge": {
+    "up": "r6i.16xlarge",
+    "down": "r6i.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "384"
+  },
+  "r6i.16xlarge": {
+    "up": "r6i.24xlarge",
+    "down": "r6i.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "512"
+  },
+  "r6i.24xlarge": {
+    "up": "r6i.32xlarge",
+    "down": "r6i.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "768"
+  },
+  "r6i.32xlarge": {
+    "up": null,
+    "down": "r6i.24xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256",
+    "memory": "1024"
+  },
+  "r6i.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256",
+    "memory": "1024"
+  },
+  "r6id.large": {
+    "up": "r6id.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "16"
+  },
+  "r6id.xlarge": {
+    "up": "r6id.2xlarge",
+    "down": "r6id.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "32"
+  },
+  "r6id.2xlarge": {
+    "up": "r6id.4xlarge",
+    "down": "r6id.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "64"
+  },
+  "r6id.4xlarge": {
+    "up": "r6id.8xlarge",
+    "down": "r6id.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "128"
+  },
+  "r6id.8xlarge": {
+    "up": "r6id.12xlarge",
+    "down": "r6id.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "256"
+  },
+  "r6id.12xlarge": {
+    "up": "r6id.16xlarge",
+    "down": "r6id.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "384"
+  },
+  "r6id.16xlarge": {
+    "up": "r6id.24xlarge",
+    "down": "r6id.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "512"
+  },
+  "r6id.24xlarge": {
+    "up": "r6id.32xlarge",
+    "down": "r6id.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "768"
+  },
+  "r6id.32xlarge": {
+    "up": null,
+    "down": "r6id.24xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256",
+    "memory": "1024"
+  },
+  "r6id.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256",
+    "memory": "1024"
+  },
+  "x1.16xlarge": {
+    "up": "x1.32xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "976"
+  },
+  "x1.32xlarge": {
+    "up": null,
+    "down": "x1.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256",
+    "memory": "1952"
+  },
+  "x1e.xlarge": {
+    "up": "x1e.2xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "122"
+  },
+  "x1e.2xlarge": {
+    "up": "x1e.4xlarge",
+    "down": "x1e.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "244"
+  },
+  "x1e.4xlarge": {
+    "up": "x1e.8xlarge",
+    "down": "x1e.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "488"
+  },
+  "x1e.8xlarge": {
+    "up": "x1e.16xlarge",
+    "down": "x1e.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "976"
+  },
+  "x1e.16xlarge": {
+    "up": "x1e.32xlarge",
+    "down": "x1e.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "1952"
+  },
+  "x1e.32xlarge": {
+    "up": null,
+    "down": "x1e.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256",
+    "memory": "3904"
+  },
+  "x2gd.medium": {
+    "up": "x2gd.large",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "1",
+    "nfu": "16",
+    "memory": "16"
+  },
+  "x2gd.large": {
+    "up": "x2gd.xlarge",
+    "down": "x2gd.medium",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "32",
+    "memory": "32"
+  },
+  "x2gd.xlarge": {
+    "up": "x2gd.2xlarge",
+    "down": "x2gd.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "64",
+    "memory": "64"
+  },
+  "x2gd.2xlarge": {
+    "up": "x2gd.4xlarge",
+    "down": "x2gd.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "128",
+    "memory": "128"
+  },
+  "x2gd.4xlarge": {
+    "up": "x2gd.8xlarge",
+    "down": "x2gd.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "256",
+    "memory": "256"
+  },
+  "x2gd.8xlarge": {
+    "up": "x2gd.12xlarge",
+    "down": "x2gd.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "512",
+    "memory": "512"
+  },
+  "x2gd.12xlarge": {
+    "up": "x2gd.16xlarge",
+    "down": "x2gd.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "768",
+    "memory": "768"
+  },
+  "x2gd.16xlarge": {
+    "up": "x2gd.metal",
+    "down": "x2gd.12xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "1024",
+    "memory": "1024"
+  },
+  "x2gd.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "1024",
+    "memory": "1024"
+  },
+  "x2idn.16xlarge": {
+    "up": "x2idn.24xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "1024"
+  },
+  "x2idn.24xlarge": {
+    "up": "x2idn.32xlarge",
+    "down": "x2idn.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "1536"
+  },
+  "x2idn.32xlarge": {
+    "up": null,
+    "down": "x2idn.24xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256",
+    "memory": "2048"
+  },
+  "x2idn.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256",
+    "memory": "2048"
+  },
+  "x2iedn.xlarge": {
+    "up": "x2iedn.2xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "128"
+  },
+  "x2iedn.2xlarge": {
+    "up": "x2iedn.4xlarge",
+    "down": "x2iedn.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "256"
+  },
+  "x2iedn.4xlarge": {
+    "up": "x2iedn.8xlarge",
+    "down": "x2iedn.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "512"
+  },
+  "x2iedn.8xlarge": {
+    "up": "x2iedn.16xlarge",
+    "down": "x2iedn.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "1024"
+  },
+  "x2iedn.16xlarge": {
+    "up": "x2iedn.24xlarge",
+    "down": "x2iedn.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "64",
+    "nfu": "128",
+    "memory": "2048"
+  },
+  "x2iedn.24xlarge": {
+    "up": "x2iedn.32xlarge",
+    "down": "x2iedn.16xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "96",
+    "nfu": "192",
+    "memory": "3072"
+  },
+  "x2iedn.32xlarge": {
+    "up": null,
+    "down": "x2iedn.24xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256",
+    "memory": "4096"
+  },
+  "x2iedn.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "128",
+    "nfu": "256",
+    "memory": "4096"
+  },
+  "x2iezn.2xlarge": {
+    "up": "x2iezn.4xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "256"
+  },
+  "x2iezn.4xlarge": {
+    "up": "x2iezn.6xlarge",
+    "down": "x2iezn.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "16",
+    "nfu": "32",
+    "memory": "512"
+  },
+  "x2iezn.6xlarge": {
+    "up": "x2iezn.8xlarge",
+    "down": "x2iezn.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "24",
+    "nfu": "46",
+    "memory": "768"
+  },
+  "x2iezn.8xlarge": {
+    "up": "x2iezn.12xlarge",
+    "down": "x2iezn.4xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "32",
+    "nfu": "64",
+    "memory": "1024"
+  },
+  "x2iezn.12xlarge": {
+    "up": null,
+    "down": "x2iezn.8xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "1536"
+  },
+  "x2iezn.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "1536"
+  },
+  "z1d.large": {
+    "up": "z1d.xlarge",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "16"
+  },
+  "z1d.xlarge": {
+    "up": "z1d.2xlarge",
+    "down": "z1d.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "32"
+  },
+  "z1d.2xlarge": {
+    "up": "z1d.3xlarge",
+    "down": "z1d.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "64"
+  },
+  "z1d.3xlarge": {
+    "up": "z1d.6xlarge",
+    "down": "z1d.2xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "12",
+    "nfu": "24",
+    "memory": "96"
+  },
+  "z1d.6xlarge": {
+    "up": "z1d.12xlarge",
+    "down": "z1d.3xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "24",
+    "nfu": "48",
+    "memory": "192"
+  },
+  "z1d.12xlarge": {
+    "up": null,
+    "down": "z1d.6xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "nfu": "96",
+    "memory": "384"
+  },
+  "z1d.metal": {
+    "up": null,
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "48",
+    "memory": "384"
+  },
+  "u-6tb1.metal": {
+    "up": "u-9tb1.metal",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "448",
+    "memory": "6144"
+  },
+  "u-9tb1.metal": {
+    "up": "u-12tb1.metal",
+    "down": "u-6tb1.metal",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "448",
+    "memory": "9216"
+  },
+  "u-12tb1.metal": {
+    "up": "u-18tb1.metal",
+    "down": "u-9tb1.metal",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "448",
+    "memory": "12288"
+  },
+  "u-18tb1.metal": {
+    "up": "u-24tb1.metal",
+    "down": "u-12tb1.metal",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "448",
+    "memory": "18432"
+  },
+  "u-24tb1.metal": {
+    "up": null,
+    "down": "u-18tb1.metal",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "vcpu": "448",
+    "memory": "24576"
+  },
+  "t1.micro": {
+    "up": null,
+    "down": null,
+    "superseded": {
+      "regular": "t2.micro",
+      "next_gen": "t3.micro",
+      "burstable": "",
+      "amd": "t3a.micro"
+    },
+    "ec2_classic": true,
+    "enhanced_networking": false,
+    "vcpu": "1",
+    "nfu": "0.5",
+    "memory": "0.613"
+  },
+  "t2.nano": {
+    "up": "t2.micro",
+    "down": null,
+    "superseded": {
+      "regular": "t3.nano",
+      "next_gen": "",
+      "burstable": "",
+      "amd": "t3a.nano"
+    },
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 3,
+      "max_earnable_credits": 72
+    },
+    "vcpu": "1",
+    "nfu": "0.25",
+    "memory": "0.5"
+  },
+  "t2.micro": {
+    "up": "t2.small",
+    "down": "t2.nano",
+    "superseded": {
+      "regular": "t3.micro",
+      "next_gen": "",
+      "burstable": "",
+      "amd": "t3a.micro"
+    },
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 6,
+      "max_earnable_credits": 144
+    },
+    "vcpu": "1",
+    "nfu": "0.5",
+    "memory": "1"
+  },
+  "t2.small": {
+    "up": "t2.medium",
+    "down": "t2.micro",
+    "superseded": {
+      "regular": "t3.small",
+      "next_gen": "",
+      "burstable": "",
+      "amd": "t3a.small"
+    },
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 12,
+      "max_earnable_credits": 288
+    },
+    "vcpu": "1",
+    "nfu": "1",
+    "memory": "2"
+  },
+  "t2.medium": {
+    "up": "t2.large",
+    "down": "t2.small",
+    "superseded": {
+      "regular": "t3.medium",
+      "next_gen": "",
+      "burstable": "",
+      "amd": "t3a.medium"
+    },
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 24,
+      "max_earnable_credits": 576
+    },
+    "vcpu": "2",
+    "nfu": "2",
+    "memory": "4"
+  },
+  "t2.large": {
+    "up": "t2.xlarge",
+    "down": "t2.medium",
+    "superseded": {
+      "regular": "t3.large",
+      "next_gen": "",
+      "burstable": "",
+      "amd": "t3a.large"
+    },
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 36,
+      "max_earnable_credits": 864
+    },
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "8"
+  },
+  "t2.xlarge": {
+    "up": "t2.2xlarge",
+    "down": "t2.large",
+    "superseded": {
+      "regular": "t3.xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": "t3a.xlarge"
+    },
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 54,
+      "max_earnable_credits": 1296
+    },
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "t2.2xlarge": {
+    "up": null,
+    "down": "t2.xlarge",
+    "superseded": {
+      "regular": "t3.2xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": "t3a.2xlarge"
+    },
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 81.6,
+      "max_earnable_credits": 1958.4
+    },
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "t3.nano": {
+    "up": "t3.micro",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 6,
+      "max_earnable_credits": 144
+    },
+    "vcpu": "2",
+    "nfu": "0.25",
+    "memory": "0.5"
+  },
+  "t3.micro": {
+    "up": "t3.small",
+    "down": "t3.nano",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 12,
+      "max_earnable_credits": 288
+    },
+    "vcpu": "2",
+    "nfu": "0.5",
+    "memory": "1"
+  },
+  "t3.small": {
+    "up": "t3.medium",
+    "down": "t3.micro",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 24,
+      "max_earnable_credits": 576
+    },
+    "vcpu": "2",
+    "nfu": "1",
+    "memory": "2"
+  },
+  "t3.medium": {
+    "up": "t3.large",
+    "down": "t3.small",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 24,
+      "max_earnable_credits": 576
+    },
+    "vcpu": "2",
+    "nfu": "2",
+    "memory": "4"
+  },
+  "t3.large": {
+    "up": "t3.xlarge",
+    "down": "t3.medium",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 36,
+      "max_earnable_credits": 864
+    },
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "8"
+  },
+  "t3.xlarge": {
+    "up": "t3.2xlarge",
+    "down": "t3.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 96,
+      "max_earnable_credits": 2304
+    },
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "t3.2xlarge": {
+    "up": null,
+    "down": "t3.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 192,
+      "max_earnable_credits": 4608
+    },
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "t3a.nano": {
+    "up": "t3.micro",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 6,
+      "max_earnable_credits": 144
+    },
+    "vcpu": "2",
+    "nfu": "0.25",
+    "memory": "0.5"
+  },
+  "t3a.micro": {
+    "up": "t3.small",
+    "down": "t3.nano",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 12,
+      "max_earnable_credits": 288
+    },
+    "vcpu": "2",
+    "nfu": "0.5",
+    "memory": "1"
+  },
+  "t3a.small": {
+    "up": "t3.medium",
+    "down": "t3.micro",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 24,
+      "max_earnable_credits": 576
+    },
+    "vcpu": "2",
+    "nfu": "1",
+    "memory": "2"
+  },
+  "t3a.medium": {
+    "up": "t3.large",
+    "down": "t3.small",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 24,
+      "max_earnable_credits": 576
+    },
+    "vcpu": "2",
+    "nfu": "2",
+    "memory": "4"
+  },
+  "t3a.large": {
+    "up": "t3.xlarge",
+    "down": "t3.medium",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 36,
+      "max_earnable_credits": 864
+    },
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "8"
+  },
+  "t3a.xlarge": {
+    "up": "t3.2xlarge",
+    "down": "t3.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 96,
+      "max_earnable_credits": 2304
+    },
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "t3a.2xlarge": {
+    "up": null,
+    "down": "t3.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 192,
+      "max_earnable_credits": 4608
+    },
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "t4g.nano": {
+    "up": "t4g.micro",
+    "down": null,
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 6,
+      "max_earnable_credits": 144
+    },
+    "vcpu": "2",
+    "nfu": "0.25",
+    "memory": "0.5"
+  },
+  "t4g.micro": {
+    "up": "t4g.small",
+    "down": "t4g.nano",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 12,
+      "max_earnable_credits": 288
+    },
+    "vcpu": "2",
+    "nfu": "0.5",
+    "memory": "1"
+  },
+  "t4g.small": {
+    "up": "t4g.medium",
+    "down": "t4g.micro",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 24,
+      "max_earnable_credits": 576
+    },
+    "vcpu": "2",
+    "nfu": "1",
+    "memory": "2"
+  },
+  "t4g.medium": {
+    "up": "t4g.large",
+    "down": "t4g.small",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 24,
+      "max_earnable_credits": 576
+    },
+    "vcpu": "2",
+    "nfu": "2",
+    "memory": "4"
+  },
+  "t4g.large": {
+    "up": "t4g.xlarge",
+    "down": "t4g.medium",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 26,
+      "max_earnable_credits": 864
+    },
+    "vcpu": "2",
+    "nfu": "4",
+    "memory": "8"
+  },
+  "t4g.xlarge": {
+    "up": "t4g.2xlarge",
+    "down": "t4g.large",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 96,
+      "max_earnable_credits": 2304
+    },
+    "vcpu": "4",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "t4g.2xlarge": {
+    "up": null,
+    "down": "t4g.xlarge",
+    "superseded": null,
+    "ec2_classic": false,
+    "enhanced_networking": true,
+    "burst_info": {
+      "credits_per_hour": 192,
+      "max_earnable_credits": 4608
+    },
+    "vcpu": "8",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "db.t1.micro": {
+    "vcpu": "1",
+    "up": null,
+    "down": null,
+    "nfu": "0.5",
+    "memory": "0.613"
+  },
+  "db.t2.micro": {
+    "vcpu": "1",
+    "up": "db.t2.small",
+    "down": null,
+    "nfu": "0.5",
+    "memory": "1"
+  },
+  "db.t2.small": {
+    "vcpu": "1",
+    "up": "db.t2.medium",
+    "down": "db.t2.micro",
+    "nfu": "1",
+    "memory": "2"
+  },
+  "db.t2.medium": {
+    "vcpu": "2",
+    "up": "db.t2.large",
+    "down": "db.t2.small",
+    "nfu": "2",
+    "memory": "4"
+  },
+  "db.t2.large": {
+    "vcpu": "2",
+    "up": "db.t2.xlarge",
+    "down": "db.t2.medium",
+    "nfu": "4",
+    "memory": "8"
+  },
+  "db.t2.xlarge": {
+    "vcpu": "4",
+    "up": "db.t2.2xlarge",
+    "down": "db.t2.large",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "db.t2.2xlarge": {
+    "vcpu": "8",
+    "up": null,
+    "down": "db.t2.xlarge",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "db.t3.micro": {
+    "vcpu": "2",
+    "up": "db.t3.small",
+    "down": null,
+    "nfu": "0.5",
+    "memory": "1"
+  },
+  "db.t3.small": {
+    "vcpu": "2",
+    "up": "db.t3.medium",
+    "down": "db.t3.micro",
+    "nfu": "1",
+    "memory": "2"
+  },
+  "db.t3.medium": {
+    "vcpu": "2",
+    "up": "db.t3.large",
+    "down": "db.t3.small",
+    "nfu": "2",
+    "memory": "4"
+  },
+  "db.t3.large": {
+    "vcpu": "2",
+    "up": "db.t3.xlarge",
+    "down": "db.t3.medium",
+    "nfu": "4",
+    "memory": "8"
+  },
+  "db.t3.xlarge": {
+    "vcpu": "4",
+    "up": "db.t3.2xlarge",
+    "down": "db.t3.large",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "db.t3.2xlarge": {
+    "vcpu": "8",
+    "up": null,
+    "down": "db.t3.xlarge",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "db.t4g.micro": {
+    "vcpu": "2",
+    "up": "db.t4g.small",
+    "down": null,
+    "nfu": "0.5",
+    "memory": "1"
+  },
+  "db.t4g.small": {
+    "vcpu": "2",
+    "up": "db.t4g.medium",
+    "down": "db.t4g.micro",
+    "nfu": "1",
+    "memory": "2"
+  },
+  "db.t4g.medium": {
+    "vcpu": "2",
+    "up": "db.t4g.large",
+    "down": "db.t4g.small",
+    "nfu": "2",
+    "memory": "4"
+  },
+  "db.t4g.large": {
+    "vcpu": "2",
+    "up": "db.t4g.xlarge",
+    "down": "db.t4g.medium",
+    "nfu": "4",
+    "memory": "8"
+  },
+  "db.t4g.xlarge": {
+    "vcpu": "4",
+    "up": "db.t4g.2xlarge",
+    "down": "db.t4g.large",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "db.t4g.2xlarge": {
+    "vcpu": "8",
+    "up": null,
+    "down": "db.t4g.xlarge",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "db.m4.large": {
+    "vcpu": "2",
+    "up": "db.m4.xlarge",
+    "down": null,
+    "nfu": "4",
+    "memory": "8"
+  },
+  "db.m4.xlarge": {
+    "vcpu": "4",
+    "up": "db.m4.2xlarge",
+    "down": "db.m4.large",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "db.m4.2xlarge": {
+    "vcpu": "8",
+    "up": "db.m4.4xlarge",
+    "down": "db.m4.xlarge",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "db.m4.4xlarge": {
+    "vcpu": "16",
+    "up": "db.m4.10xlarge",
+    "down": "db.m4.2xlarge",
+    "nfu": "32",
+    "memory": "64"
+  },
+  "db.m4.10xlarge": {
+    "vcpu": "40",
+    "up": "db.m4.16xlarge",
+    "down": "db.m4.4xlarge",
+    "nfu": "80",
+    "memory": "160"
+  },
+  "db.m4.16xlarge": {
+    "vcpu": "64",
+    "up": null,
+    "down": "db.m4.10xlarge",
+    "nfu": "128",
+    "memory": "256"
+  },
+  "db.m5.large": {
+    "vcpu": "2",
+    "up": "db.m5.xlarge",
+    "down": null,
+    "nfu": "4",
+    "memory": "8"
+  },
+  "db.m5.xlarge": {
+    "vcpu": "4",
+    "up": "db.m5.2xlarge",
+    "down": "db.m5.large",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "db.m5.2xlarge": {
+    "vcpu": "8",
+    "up": "db.m5.4xlarge",
+    "down": "db.m5.xlarge",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "db.m5.4xlarge": {
+    "vcpu": "16",
+    "up": "db.m5.12xlarge",
+    "down": "db.m5.2xlarge",
+    "nfu": "32",
+    "memory": "64"
+  },
+  "db.m5.12xlarge": {
+    "vcpu": "48",
+    "up": "db.m5.16xlarge",
+    "down": "db.m5.4xlarge",
+    "nfu": "96",
+    "memory": "192"
+  },
+  "db.m5.16xlarge": {
+    "vcpu": "64",
+    "up": "db.m5.24xlarge",
+    "down": "db.m5.12xlarge",
+    "nfu": "128",
+    "memory": "256"
+  },
+  "db.m5.24xlarge": {
+    "vcpu": "96",
+    "up": null,
+    "down": "db.m5.16xlarge",
+    "nfu": "192",
+    "memory": "384"
+  },
+  "db.m6g.large": {
+    "vcpu": "2",
+    "up": "db.m6g.xlarge",
+    "down": null,
+    "nfu": "4",
+    "memory": "8"
+  },
+  "db.m6g.xlarge": {
+    "vcpu": "4",
+    "up": "db.m6g.2xlarge",
+    "down": "db.m6g.large",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "db.m6g.2xlarge": {
+    "vcpu": "8",
+    "up": "db.m6g.4xlarge",
+    "down": "db.m6g.xlarge",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "db.m6g.4xlarge": {
+    "vcpu": "16",
+    "up": "db.m6g.8xlarge",
+    "down": "db.m6g.2xlarge",
+    "nfu": "32",
+    "memory": "64"
+  },
+  "db.m6g.8xlarge": {
+    "vcpu": "32",
+    "up": "db.m6g.16xlarge",
+    "down": "db.m6g.4xlarge",
+    "nfu": "64",
+    "memory": "128"
+  },
+  "db.m6g.12xlarge": {
+    "vcpu": "48",
+    "up": "db.m6g.16xlarge",
+    "down": "db.m6g.8xlarge",
+    "nfu": "96",
+    "memory": "192"
+  },
+  "db.m6g.16xlarge": {
+    "vcpu": "64",
+    "up": null,
+    "down": "db.m6g.12xlarge",
+    "nfu": "128",
+    "memory": "256"
+  },
+  "db.m6i.large": {
+    "vcpu": "2",
+    "up": "db.m6i.xlarge",
+    "down": null,
+    "nfu": "4",
+    "memory": "8"
+  },
+  "db.m6i.xlarge": {
+    "vcpu": "4",
+    "up": "db.m6i.2xlarge",
+    "down": "db.m6i.large",
+    "nfu": "8",
+    "memory": "16"
+  },
+  "db.m6i.2xlarge": {
+    "vcpu": "8",
+    "up": "db.m6i.4xlarge",
+    "down": "db.m6i.xlarge",
+    "nfu": "16",
+    "memory": "32"
+  },
+  "db.m6i.4xlarge": {
+    "vcpu": "16",
+    "up": "db.m6i.8xlarge",
+    "down": "db.m6i.2xlarge",
+    "nfu": "32",
+    "memory": "64"
+  },
+  "db.m6i.8xlarge": {
+    "vcpu": "32",
+    "up": "db.m6i.12xlarge",
+    "down": "db.m6i.4xlarge",
+    "nfu": "64",
+    "memory": "128"
+  },
+  "db.m6i.12xlarge": {
+    "vcpu": "48",
+    "up": "db.m6i.16xlarge",
+    "down": "db.m6i.8xlarge",
+    "nfu": "96",
+    "memory": "192"
+  },
+  "db.m6i.16xlarge": {
+    "vcpu": "64",
+    "up": "db.m6i.24xlarge",
+    "down": "db.m6i.12xlarge",
+    "nfu": "128",
+    "memory": "256"
+  },
+  "db.m6i.24xlarge": {
+    "vcpu": "96",
+    "up": "db.m6i.32xlarge",
+    "down": "db.m6i.16xlarge",
+    "nfu": "192",
+    "memory": "384"
+  },
+  "db.m6i.32xlarge": {
+    "vcpu": "128",
+    "up": null,
+    "down": "db.m6i.24xlarge",
+    "nfu": "256",
+    "memory": "512"
+  },
+  "db.r6g.large": {
+    "vcpu": "2",
+    "up": "db.r6g.xlarge",
+    "down": null,
+    "nfu": "4",
+    "memory": "16"
+  },
+  "db.r6g.xlarge": {
+    "vcpu": "4",
+    "up": "db.r6g.2xlarge",
+    "down": "db.r6g.large",
+    "nfu": "8",
+    "memory": "32"
+  },
+  "db.r6g.2xlarge": {
+    "vcpu": "8",
+    "up": "db.r6g.4xlarge",
+    "down": "db.r6g.xlarge",
+    "nfu": "16",
+    "memory": "64"
+  },
+  "db.r6g.4xlarge": {
+    "vcpu": "16",
+    "up": "db.r6g.8xlarge",
+    "down": "db.r6g.2xlarge",
+    "nfu": "32",
+    "memory": "128"
+  },
+  "db.r6g.8xlarge": {
+    "vcpu": "32",
+    "up": "db.r6g.16xlarge",
+    "down": "db.r6g.4xlarge",
+    "nfu": "64",
+    "memory": "256"
+  },
+  "db.r6g.12xlarge": {
+    "vcpu": "48",
+    "up": "db.r6g.16xlarge",
+    "down": "db.r6g.8xlarge",
+    "nfu": "96",
+    "memory": "384"
+  },
+  "db.r6g.16xlarge": {
+    "vcpu": "64",
+    "up": null,
+    "down": "db.r6g.12xlarge",
+    "nfu": "128",
+    "memory": "512"
+  },
+  "db.r4.large": {
+    "vcpu": "2",
+    "up": "db.r4.xlarge",
+    "down": null,
+    "nfu": "4",
+    "memory": "15.25"
+  },
+  "db.r4.xlarge": {
+    "vcpu": "4",
+    "up": "db.r4.2xlarge",
+    "down": "db.r4.large",
+    "nfu": "8",
+    "memory": "30.5"
+  },
+  "db.r4.2xlarge": {
+    "vcpu": "8",
+    "up": "db.r4.4xlarge",
+    "down": "db.r4.xlarge",
+    "nfu": "16",
+    "memory": "61"
+  },
+  "db.r4.4xlarge": {
+    "vcpu": "16",
+    "up": "db.r4.8xlarge",
+    "down": "db.r4.2xlarge",
+    "nfu": "32",
+    "memory": "122"
+  },
+  "db.r4.8xlarge": {
+    "vcpu": "32",
+    "up": "db.r4.16xlarge",
+    "down": "db.r4.4xlarge",
+    "nfu": "64",
+    "memory": "244"
+  },
+  "db.r4.16xlarge": {
+    "vcpu": "64",
+    "up": null,
+    "down": "db.r4.8xlarge",
+    "nfu": "128",
+    "memory": "488"
+  },
+  "db.r5.large": {
+    "vcpu": "2",
+    "up": "db.r5.xlarge",
+    "down": null,
+    "nfu": "4",
+    "memory": "16"
+  },
+  "db.r5.xlarge": {
+    "vcpu": "4",
+    "up": "db.r5.2xlarge",
+    "down": "db.r5.large",
+    "nfu": "8",
+    "memory": "32"
+  },
+  "db.r5.2xlarge": {
+    "vcpu": "8",
+    "up": "db.r5.4xlarge",
+    "down": "db.r5.xlarge",
+    "nfu": "16",
+    "memory": "64"
+  },
+  "db.r5.4xlarge": {
+    "vcpu": "16",
+    "up": "db.r5.8xlarge",
+    "down": "db.r5.2xlarge",
+    "nfu": "32",
+    "memory": "128"
+  },
+  "db.r5.8xlarge": {
+    "vcpu": "32",
+    "up": "db.r5.12xlarge",
+    "down": "db.r5.4xlarge",
+    "nfu": "64",
+    "memory": "256"
+  },
+  "db.r5.12xlarge": {
+    "vcpu": "48",
+    "up": "db.r5.24xlarge",
+    "down": "db.r5.4xlarge",
+    "nfu": "96",
+    "memory": "384"
+  },
+  "db.r5.24xlarge": {
+    "vcpu": "64",
+    "up": null,
+    "down": "db.r5.12xlarge",
+    "nfu": "192",
+    "memory": "768"
+  },
+  "db.x1e.xlarge": {
+    "vcpu": "4",
+    "up": "db.x1e.2xlarge",
+    "down": null,
+    "nfu": "8",
+    "memory": "122"
+  },
+  "db.x1e.2xlarge": {
+    "vcpu": "8",
+    "up": "db.x1e.4xlarge",
+    "down": "db.x1e.xlarge",
+    "nfu": "16",
+    "memory": "244"
+  },
+  "db.x1e.4xlarge": {
+    "vcpu": "16",
+    "up": "db.x1e.8xlarge",
+    "down": "db.x1e.2xlarge",
+    "nfu": "32",
+    "memory": "488"
+  },
+  "db.x1e.8xlarge": {
+    "vcpu": "32",
+    "up": "db.x1e.16xlarge",
+    "down": "db.x1e.4xlarge",
+    "nfu": "64",
+    "memory": "976"
+  },
+  "db.x1e.16xlarge": {
+    "vcpu": "64",
+    "up": "db.x1e.32xlarge",
+    "down": "db.x1e.8xlarge",
+    "nfu": "128",
+    "memory": "1952"
+  },
+  "db.x1e.32xlarge": {
+    "vcpu": "128",
+    "up": null,
+    "down": "db.x1e.16xlarge",
+    "nfu": "256",
+    "memory": "3904"
+  },
+  "db.x1.16xlarge": {
+    "vcpu": "64",
+    "up": "db.x1.32xlarge",
+    "down": null,
+    "nfu": "128",
+    "memory": "976"
+  },
+  "db.x1.32xlarge": {
+    "vcpu": "128",
+    "up": null,
+    "down": "db.x1.16xlarge",
+    "nfu": "256",
+    "memory": "1952"
+  },
+  "db.m1.small": {
+    "vcpu": "1",
+    "up": "db.m1.medium",
+    "down": null,
+    "nfu": "1",
+    "memory": "1.7"
+  },
+  "db.m1.medium": {
+    "vcpu": "1",
+    "up": "db.m1.large",
+    "down": "db.m1.small",
+    "nfu": "2",
+    "memory": "3.75"
+  },
+  "db.m1.large": {
+    "vcpu": "2",
+    "up": "db.m1.xlarge",
+    "down": "db.m1.medium",
+    "nfu": "4",
+    "memory": "7.5"
+  },
+  "db.m1.xlarge": {
+    "vcpu": "4",
+    "up": null,
+    "down": "db.m1.large",
+    "nfu": "8",
+    "memory": "15"
+  },
+  "db.m3.medium": {
+    "vcpu": "1",
+    "up": "db.m3.large",
+    "down": null,
+    "nfu": "2",
+    "memory": "3.75"
+  },
+  "db.m3.large": {
+    "vcpu": "2",
+    "up": "db.m3.xlarge",
+    "down": "db.m3.medium",
+    "nfu": "4",
+    "memory": "7.5"
+  },
+  "db.m3.xlarge": {
+    "vcpu": "4",
+    "up": "db.m3.2xlarge",
+    "down": "db.m3.large",
+    "nfu": "8",
+    "memory": "15"
+  },
+  "db.m3.2xlarge": {
+    "vcpu": "8",
+    "up": null,
+    "down": "db.m3.xlarge",
+    "nfu": "16",
+    "memory": "30"
+  },
+  "db.m2.xlarge": {
+    "vcpu": "2",
+    "up": "db.m2.2xlarge",
+    "down": null,
+    "nfu": "8",
+    "memory": "17.1"
+  },
+  "db.m2.2xlarge": {
+    "vcpu": "4",
+    "up": "db.m2.4xlarge",
+    "down": "db.m2.xlarge",
+    "nfu": "16",
+    "memory": "34.2"
+  },
+  "db.m2.4xlarge": {
+    "vcpu": "8",
+    "up": null,
+    "down": "db.m2.2xlarge",
+    "nfu": "32",
+    "memory": "68.4"
+  },
+  "db.r3.large": {
+    "vcpu": "2",
+    "up": "db.r3.xlarge",
+    "down": null,
+    "nfu": "4",
+    "memory": "15.25"
+  },
+  "db.r3.xlarge": {
+    "vcpu": "4",
+    "up": "db.r3.2xlarge",
+    "down": "db.r3.large",
+    "nfu": "8",
+    "memory": "30.5"
+  },
+  "db.r3.2xlarge": {
+    "vcpu": "8",
+    "up": "db.r3.4xlarge",
+    "down": "db.r3.xlarge",
+    "nfu": "16",
+    "memory": "61"
+  },
+  "db.r3.4xlarge": {
+    "vcpu": "16",
+    "up": "db.r3.8xlarge",
+    "down": "db.r3.2xlarge",
+    "nfu": "32",
+    "memory": "122"
+  },
+  "db.r3.8xlarge": {
+    "vcpu": "32",
+    "up": null,
+    "down": "db.r3.4xlarge",
+    "nfu": "64",
+    "memory": "244"
+  }
 }


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves below -->
Adds Instance Memory field to the existing instance_types.json for AWS. Memory Unit is in Gigabytes (GiB or 1024^3 bytes)

Some Instance Types don't have a Memory field in the updated instance_types.json file, however they did not have a vCPU field previously either. Those Instance Types are as follows:

- 'cc1.4xlarge'
- 'cg1.4xlarge'
- 'g4.large'
- 'g4.2xlarge'
- 'g4.4xlarge'
- 'g4.8xlarge'
- 'g4.16xlarge'
- 'hi1.4xlarge'
- 'm6g.24xlarge'
- 'm6gd.24xlarge'

### Issues Resolved

<!-- List any existing issues this PR resolves below -->
We have customers asking to produce a report of amount of Instance Memory used, similar to the existing Instance vCPUs used policy. To achieve this it will require adding memory to the Instance Types JSON file.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
