### PR TITLE
feat: Add params for github repo for Policy Sync PT

### DIFF
--- a/tools/policy_master_permission_generation/validated_policy_templates.yaml
+++ b/tools/policy_master_permission_generation/validated_policy_templates.yaml
@@ -88,3 +88,4 @@ validated_policy_templates:
 -  "./cost/flexera/cco/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt"
 -  "./cost/flexera/cco/budget_v_actual_spend_report/budget_v_actual_spend_report.pt"
 -  "./cost/flexera/cco/budget_v_actual/monthly_budget_v_actual.pt"
+-  "./tools/policy_sync/policy_sync.pt"

--- a/tools/policy_sync/CHANGELOG.md
+++ b/tools/policy_sync/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## v1.18.0
+## v2.0.0
 
 - Added parameters for the Policy Template Github Repo to enable this to be used for other repos without modifying Policy Template
+- Renamed parameters to align with on Policy Developement testing and best practices
 
 ## v1.17
 

--- a/tools/policy_sync/CHANGELOG.md
+++ b/tools/policy_sync/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v1.18.0
+
+- Added parameters for the Policy Template Github Repo to enable this to be used for other repos without modifying Policy Template
+
 ## v1.17
 
 - Changed the source of active policy list from S3 to GitHub

--- a/tools/policy_sync/CHANGELOG.md
+++ b/tools/policy_sync/CHANGELOG.md
@@ -1,4 +1,4 @@
-# CHANGELOG
+# Changelog
 
 ## v1.18.0
 
@@ -28,11 +28,11 @@
 
 - updated README.md rightscale documentation links with docs.flexera documentation links
 
-## 1.11
+## v1.11
 
 - Adding `param_branch` to support automatic publishing to the EU Shard.
 
-## 1.10
+## v1.10
 
 - fix an issue with publishing
 

--- a/tools/policy_sync/policy_sync.pt
+++ b/tools/policy_sync/policy_sync.pt
@@ -1,8 +1,8 @@
 name "Policy Template Synchronization"
 rs_pt_ver 20180301
 type "policy"
-short_description "A policy to manage policy template. See the [README](https://github.com/flexera-public/policy_templates/tree/master/tools/policy_sync/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
-long_description "This Policy Template can be used to synchronize (upload, overwrite, or alert) RS built-in policy templates in your account. See the [README](https://github.com/flexera-public/policy_templates/tree/master/tools/policy_sync/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "This Policy Template can be used to synchronize (upload, overwrite, or alert) RS built-in policy templates in your account. See the [README](https://github.com/flexera-public/policy_templates/tree/master/tools/policy_sync/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+long_description ""
 severity "low"
 category "Operational"
 default_frequency "15 minutes"

--- a/tools/policy_sync/policy_sync.pt
+++ b/tools/policy_sync/policy_sync.pt
@@ -108,8 +108,8 @@ datasource "ds_current_policy_template_list" do
     verb "GET"
     host rs_governance_host
     path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
-    header "Api-Version", "1.0"
     query "view", "extended"
+    header "Api-Version", "1.0"
   end
   result do
     collect jmes_path(response, "items") do
@@ -221,9 +221,9 @@ policy "pol_upload_policy_templates" do
 | {{ .name }} | {{.file_name}} | {{.repo_version}} | {{.account_version}} | {{.version_upgradeable}} | {{.policy_id}} | {{ .change_log }} |
 {{ end -}}
 EOS
+    check logic_not(val(item, "version_upgradeable"))
     escalate $esc_send_email
     escalate $esc_upload_new_policy_templates
-    check logic_not(val(item, "version_upgradeable"))
   end
 end
 

--- a/tools/policy_sync/policy_sync.pt
+++ b/tools/policy_sync/policy_sync.pt
@@ -21,38 +21,41 @@ info(
 
 parameter "param_email" do
   type "list"
-  label "Email addresses of the recipients you wish to notify"
   category "Policy Settings"
+  label "Email addresses of the recipients you wish to notify"
+  description "Email addresses of the recipients you wish to notify"
   default []
-  min_length 1
 end
 
 parameter "param_template_git_org_repo_name" do
   type "string"
-  label "Organization and Repo Name (org/repo_name_) to find the policy template files"
   category "Policy Settings"
+  label "Organization and Repo Name (org/repo_name_) to find the policy template files"
+  description "Organization and Repo Name (org/repo_name_) to find the policy template files"
   default "flexera-public/policy_templates"
 end
 
 parameter "param_github_active_list_path" do
   type "string"
-  label "Path to the active policy list json file"
   category "Policy Settings"
+  label "Path to the active policy list json file"
+  description "Path to the active policy list json file"
   default "data/active_policy_list/active_policy_list.json"
 end
 
 parameter "param_branch" do
   type "string"
-  label "Branch Name"
   category "Policy Settings"
+  label "Branch Name"
+  description "Branch Name"
   default "master"
 end
 
 parameter "param_publish" do
   type "number"
-  label "Publish Template"
   category "Policy Settings"
-  description "Publish Template, 0:False, 1:True"
+  label "Publish Template"
+  description "Publish Template"
   default 0
   allowed_values 0, 1
 end
@@ -60,6 +63,7 @@ end
 parameter "param_force_upgrade" do
   type "number"
   label "Force Upgrade"
+  description "Force Upgrade"
   category "Policy Settings"
   description "Force Upgrade, 0:False, 1:True"
   default 0
@@ -125,79 +129,79 @@ script "js_combined_policy_list", type: "javascript" do
   parameters "active_policy_list", "current_policy_list", "param_force_upgrade", "param_branch", "param_template_git_org_repo_name"
   result "policy_list"
   code <<-EOS
-  var policy_list = [];
-  var old_policy_list = {};
-  var github_raw_url = 'https://raw.githubusercontent.com/'+param_template_git_org_repo_name+'/' + param_branch + '/';
+var policy_list = [];
+var old_policy_list = {};
+var github_raw_url = 'https://raw.githubusercontent.com/'+param_template_git_org_repo_name+'/' + param_branch + '/';
 
-  // create a map of published templates
-  for (var index = 0; index < current_policy_list.length; index++) {
-    var current_policy = current_policy_list[index];
-    old_policy_list[current_policy.name] = current_policy;
+// create a map of published templates
+for (var index = 0; index < current_policy_list.length; index++) {
+  var current_policy = current_policy_list[index];
+  old_policy_list[current_policy.name] = current_policy;
+}
+
+// loop through active policies from s3 json file
+for ( var i = 0; i < active_policy_list.length; i++) {
+  var active_policy = active_policy_list[i]
+  // map catalog policy with json list
+  var account_policy_template = old_policy_list[active_policy.name]
+
+  if (account_policy_template){
+    // By default assume version is 0.0
+    var account_version = "0.0"
+    var policy_id = account_policy_template.id
+    // Attempt to get account template version from policy template metadata
+    if ( account_policy_template.info && _.isString(account_policy_template.info.version) ) {
+      account_version = account_policy_template.info.version
+    }
+    // Next attempt to use long_description
+    if ( account_version == "0.0" ) {
+      // Only attempt if it's set
+      if (_.isString(account_policy_template.long_description) ) {
+        var account_version = account_policy_template.long_description
+      }
+      // Look for string "Version" and extract the version from that
+      if ( account_version.search(/Version/i) != -1 ) {
+        var version_str = account_version.split(' ')
+        var account_version = version_str[version_str.length -1]
+      }
+    }
+  } else {
+    // Else, assume it's a new template id and version 0.0
+    var policy_id = 0
+    var account_version = "0.0"
   }
 
-  // loop through active policies from s3 json file
-  for ( var i = 0; i < active_policy_list.length; i++) {
-    var active_policy = active_policy_list[i]
-    // map catalog policy with json list
-    var account_policy_template = old_policy_list[active_policy.name]
+  var a_version = account_version.toString().split('.')
+  var r_version = active_policy.version.toString().split('.')
 
-    if (account_policy_template){
-      // By default assume version is 0.0
-      var account_version = "0.0"
-      var policy_id = account_policy_template.id
-      // Attempt to get account template version from policy template metadata
-      if ( account_policy_template.info && _.isString(account_policy_template.info.version) ) {
-        account_version = account_policy_template.info.version
-      }
-      // Next attempt to use long_description
-      if ( account_version == "0.0" ) {
-        // Only attempt if it's set
-        if (_.isString(account_policy_template.long_description) ) {
-          var account_version = account_policy_template.long_description
-        }
-        // Look for string "Version" and extract the version from that
-        if ( account_version.search(/Version/i) != -1 ) {
-          var version_str = account_version.split(' ')
-          var account_version = version_str[version_str.length -1]
-        }
-      }
-    } else {
-      // Else, assume it's a new template id and version 0.0
-      var policy_id = 0
-      var account_version = "0.0"
-    }
+  var version_upgradeable = false
+  curr_major_version = parseInt(a_version[0])
+  curr_minor_version = parseInt(a_version[1])
+  new_major_version = parseInt(r_version[0])
+  new_minor_version = parseInt(r_version[1])
 
-    var a_version = account_version.toString().split('.')
-    var r_version = active_policy.version.toString().split('.')
-
-    var version_upgradeable = false
-    curr_major_version = parseInt(a_version[0])
-    curr_minor_version = parseInt(a_version[1])
-    new_major_version = parseInt(r_version[0])
-    new_minor_version = parseInt(r_version[1])
-
-    if (curr_major_version == new_major_version ) {
-      if (curr_minor_version < new_minor_version) {
-          var version_upgradeable = true
-      }
+  if (curr_major_version == new_major_version ) {
+    if (curr_minor_version < new_minor_version) {
+        var version_upgradeable = true
     }
-    else if (curr_major_version < new_major_version) {
-      var version_upgradeable = true
-    }
-    if (param_force_upgrade == 1 ) {
-      var version_upgradeable = true
-    }
-    policy_list.push({
-      name: active_policy.name,
-      file_name: active_policy.file_name,
-      repo_version: active_policy.version,
-      account_version: account_version,
-      account_policy_template: account_policy_template,
-      version_upgradeable: version_upgradeable,
-      policy_id: policy_id,
-      change_log: github_raw_url.concat(active_policy.change_log)
-    })
   }
+  else if (curr_major_version < new_major_version) {
+    var version_upgradeable = true
+  }
+  if (param_force_upgrade == 1 ) {
+    var version_upgradeable = true
+  }
+  policy_list.push({
+    name: active_policy.name,
+    file_name: active_policy.file_name,
+    repo_version: active_policy.version,
+    account_version: account_version,
+    account_policy_template: account_policy_template,
+    version_upgradeable: version_upgradeable,
+    policy_id: policy_id,
+    change_log: github_raw_url.concat(active_policy.change_log)
+  })
+}
 EOS
 end
 
@@ -217,9 +221,8 @@ policy "pol_upload_policy_templates" do
 | {{ .name }} | {{.file_name}} | {{.repo_version}} | {{.account_version}} | {{.version_upgradeable}} | {{.policy_id}} | {{ .change_log }} |
 {{ end -}}
 EOS
-
-    escalate $esc_report_policy_templates_update
-    escalate $esc_upload_new_policy_templates
+    escalate $escalation_send_email
+    escalate $escalation_upload_new_policy_templates
     check logic_not(val(item, "version_upgradeable"))
   end
 end
@@ -228,11 +231,17 @@ end
 # Escalations
 ###############################################################################
 
-escalation "esc_upload_new_policy_templates" do
+escalation "escalation_upload_new_policy_templates" do
   run "upload_template", data, rs_project_id, rs_governance_host, $param_publish, rs_org_id, $param_branch, $param_template_git_org_repo_name
+  automatic false
+  label "Upload/Publish Policy Templates"
+  description "Upload (and optionally Publish) New Policy Templates"
 end
 
-escalation "esc_report_policy_templates_update" do
+escalation "escalation_send_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
   email $param_email
 end
 

--- a/tools/policy_sync/policy_sync.pt
+++ b/tools/policy_sync/policy_sync.pt
@@ -23,6 +23,7 @@ parameter "param_email" do
   type "list"
   label "Email addresses of the recipients you wish to notify"
   category "Policy Settings"
+  default []
   min_length 1
 end
 
@@ -53,7 +54,7 @@ parameter "param_publish" do
   category "Policy Settings"
   description "Publish Template, 0:False, 1:True"
   default 0
-  allowed_values 0,1
+  allowed_values 0, 1
 end
 
 parameter "param_force_upgrade" do
@@ -62,7 +63,7 @@ parameter "param_force_upgrade" do
   category "Policy Settings"
   description "Force Upgrade, 0:False, 1:True"
   default 0
-  allowed_values 0,1
+  allowed_values 0, 1
 end
 
 ###############################################################################
@@ -84,7 +85,7 @@ datasource "ds_active_policy_list" do
   request do
     verb "GET"
     host "raw.githubusercontent.com"
-    path join([$param_template_git_org_repo_name,"/",$param_branch,"/",$param_github_active_list_path])
+    path join([$param_template_git_org_repo_name, "/", $param_branch, "/", $param_github_active_list_path])
     header "User-Agent", "RS Policies"
   end
   result do
@@ -92,7 +93,7 @@ datasource "ds_active_policy_list" do
       field "name", jmes_path(col_item, "name")
       field "file_name", jmes_path(col_item, "file_name")
       field "version", jmes_path(col_item, "version")
-      field "change_log", jmes_path(col_item,"change_log")
+      field "change_log", jmes_path(col_item, "change_log")
     end
   end
 end
@@ -102,12 +103,12 @@ datasource "ds_current_policy_template_list" do
     auth $auth_flexera
     verb "GET"
     host rs_governance_host
-    path join(["/api/governance/projects/",rs_project_id,"/policy_templates"])
+    path join(["/api/governance/projects/", rs_project_id, "/policy_templates"])
     header "Api-Version", "1.0"
     query "view", "extended"
   end
   result do
-    collect jmes_path(response,"items") do
+    collect jmes_path(response, "items") do
       field "id", jmes_path(col_item, "id")
       field "name", jmes_path(col_item, "name")
       field "long_description", jmes_path(col_item, "long_description")
@@ -117,10 +118,10 @@ datasource "ds_current_policy_template_list" do
 end
 
 datasource "ds_combined_policy_list" do
-  run_script $js_combine_policy_lists, $ds_active_policy_list, $ds_current_policy_template_list, $param_force_upgrade, $param_branch, $param_template_git_org_repo_name
+  run_script $js_combined_policy_list, $ds_active_policy_list, $ds_current_policy_template_list, $param_force_upgrade, $param_branch, $param_template_git_org_repo_name
 end
 
-script "js_combine_policy_lists", type: "javascript" do
+script "js_combined_policy_list", type: "javascript" do
   parameters "active_policy_list", "current_policy_list", "param_force_upgrade", "param_branch", "param_template_git_org_repo_name"
   result "policy_list"
   code <<-EOS
@@ -208,7 +209,6 @@ policy "pol_upload_policy_templates" do
   validate_each $ds_combined_policy_list do
     summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} Policy Templates Updated"
     detail_template <<-EOS
-
 # Policy Templates Updated
 
 | Name | File Name | Repo Version | Published Version | Version Upgradeable | Policy ID | ChangeLog |
@@ -245,7 +245,7 @@ define upload_template($data, $project_id, $param_governance_host, $param_publis
   $response_array = []
   foreach $item in $data do
     sub on_error: skip do
-      $url = join(["https://raw.githubusercontent.com/",$param_template_git_org_repo_name,"/", $param_branch, "/",  to_s($item["file_name"])])
+      $url = join(["https://raw.githubusercontent.com/", $param_template_git_org_repo_name, "/", $param_branch, "/", to_s($item["file_name"])])
       $url_array << $url
 
       $policy_request = http_get(
@@ -253,14 +253,14 @@ define upload_template($data, $project_id, $param_governance_host, $param_publis
         url: $url
       )
       $policy_source = $policy_request["body"]
-      $file_name = last(split($item["file_name"],'/'))
+      $file_name = last(split($item["file_name"], '/'))
 
       $create_response = http_request(
         auth: $$auth_flexera,
         verb: "post",
         https: true,
         host: $param_governance_host,
-        href: join(["/api/governance/projects/",$project_id,"/policy_templates"]),
+        href: join(["/api/governance/projects/", $project_id, "/policy_templates"]),
         headers: { "Api-Version": "1.0" },
         body: { "source": $policy_source, filename: $file_name }
       )
@@ -291,7 +291,7 @@ define upload_template($data, $project_id, $param_governance_host, $param_publis
           verb: "post",
           https: true,
           host: $param_governance_host,
-          href: join(["/api/governance/orgs/",$rs_org_id,"/published_templates"]),
+          href: join(["/api/governance/orgs/", $rs_org_id, "/published_templates"]),
           headers: { "Api-Version": "1.0" },
           body: { "template_href": $policy_template_href }
         )

--- a/tools/policy_sync/policy_sync.pt
+++ b/tools/policy_sync/policy_sync.pt
@@ -2,6 +2,7 @@ name "Policy Template Synchronization"
 rs_pt_ver 20180301
 type "policy"
 short_description "A policy to manage policy template. See the [README](https://github.com/flexera-public/policy_templates/tree/master/tools/policy_sync/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+long_description "This Policy Template can be used to synchronize (upload, overwrite, or alert) RS built-in policy templates in your account. See the [README](https://github.com/flexera-public/policy_templates/tree/master/tools/policy_sync/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 severity "low"
 category "Operational"
 default_frequency "15 minutes"
@@ -13,33 +14,42 @@ info(
   policy_set: "N/A"
 )
 
+###############################################################################
+# Parameters
+###############################################################################
+
 parameter "param_email" do
   type "list"
   label "Email addresses of the recipients you wish to notify"
+  category "Policy Settings"
   min_length 1
 end
 
 parameter "param_template_git_org_repo_name" do
   type "string"
   label "Organization and Repo Name (org/repo_name_) to find the policy template files"
+  category "Policy Settings"
   default "flexera-public/policy_templates"
 end
 
 parameter "param_github_active_list_path" do
   type "string"
   label "Path to the active policy list json file"
+  category "Policy Settings"
   default "data/active_policy_list/active_policy_list.json"
 end
 
 parameter "param_branch" do
   type "string"
   label "Branch Name"
+  category "Policy Settings"
   default "master"
 end
 
 parameter "param_publish" do
   type "number"
   label "Publish Template"
+  category "Policy Settings"
   description "Publish Template, 0:False, 1:True"
   default 0
   allowed_values 0,1
@@ -48,10 +58,15 @@ end
 parameter "force_upgrade" do
   type "number"
   label "Force Upgrade"
+  category "Policy Settings"
   description "Force Upgrade, 0:False, 1:True"
   default 0
   allowed_values 0,1
 end
+
+###############################################################################
+# Authentication
+###############################################################################
 
 credentials "auth_flexera" do
   schemes "oauth2"
@@ -59,6 +74,10 @@ credentials "auth_flexera" do
   description "Select Flexera One OAuth2 credentials"
   tags "provider=flexera"
 end
+
+###############################################################################
+# Datasources & Scripts
+###############################################################################
 
 datasource "ds_active_policy_list" do
   request do
@@ -180,6 +199,34 @@ script "js_combine_policy_lists", type: "javascript" do
 EOS
 end
 
+###############################################################################
+# Policy
+###############################################################################
+
+policy "upload_policy_templates" do
+  validate_each $ds_combined_policy_list do
+    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} Policy Templates Updated"
+    detail_template <<-EOS
+
+# Policy Templates Updated
+
+| Name | File Name | Repo Version | Published Version | Version Upgradeable | Policy ID | ChangeLog |
+| ---- | --------- | ------------ | ---------------- | ------------------ | --------- | --------- |
+{{ range data -}}
+| {{ .name }} | {{.file_name}} | {{.repo_version}} | {{.account_version}} | {{.version_upgradeable}} | {{.policy_id}} | {{ .change_log }} |
+{{ end -}}
+EOS
+
+    escalate $report_policy_templates_update
+    escalate $upload_new_policy_templates
+    check logic_not(val(item, "version_upgradeable"))
+  end
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
 escalation "upload_new_policy_templates" do
   run "upload_template", data, rs_project_id, rs_governance_host, $param_publish, rs_org_id, $param_branch, $param_template_git_org_repo_name
 end
@@ -187,6 +234,10 @@ end
 escalation "report_policy_templates_update" do
   email $param_email
 end
+
+###############################################################################
+# Cloud Workflow
+###############################################################################
 
 define upload_template($data, $project_id, $param_governance_host, $param_publish, $rs_org_id, $param_branch, $param_template_git_org_repo_name) return $url_array, $response_array do
   $url_array = []
@@ -258,25 +309,5 @@ define upload_template($data, $project_id, $param_governance_host, $param_publis
         end
       end
     end
-  end
-end
-
-policy "upload_policy_templates" do
-  validate_each $ds_combined_policy_list do
-    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} Policy Templates Updated"
-    detail_template <<-EOS
-
-# Policy Templates Updated
-
-| Name | File Name | Repo Version | Published Version | Version Upgradeable | Policy ID | ChangeLog |
-| ---- | --------- | ------------ | ---------------- | ------------------ | --------- | --------- |
-{{ range data -}}
-| {{ .name }} | {{.file_name}} | {{.repo_version}} | {{.account_version}} | {{.version_upgradeable}} | {{.policy_id}} | {{ .change_log }} |
-{{ end -}}
-EOS
-
-    escalate $report_policy_templates_update
-    escalate $upload_new_policy_templates
-    check logic_not(val(item, "version_upgradeable"))
   end
 end

--- a/tools/policy_sync/policy_sync.pt
+++ b/tools/policy_sync/policy_sync.pt
@@ -221,8 +221,8 @@ policy "pol_upload_policy_templates" do
 | {{ .name }} | {{.file_name}} | {{.repo_version}} | {{.account_version}} | {{.version_upgradeable}} | {{.policy_id}} | {{ .change_log }} |
 {{ end -}}
 EOS
-    escalate $escalation_send_email
-    escalate $escalation_upload_new_policy_templates
+    escalate $esc_send_email
+    escalate $esc_upload_new_policy_templates
     check logic_not(val(item, "version_upgradeable"))
   end
 end
@@ -231,14 +231,14 @@ end
 # Escalations
 ###############################################################################
 
-escalation "escalation_upload_new_policy_templates" do
+escalation "esc_upload_new_policy_templates" do
   run "upload_template", data, rs_project_id, rs_governance_host, $param_publish, rs_org_id, $param_branch, $param_template_git_org_repo_name
   automatic false
   label "Upload/Publish Policy Templates"
   description "Upload (and optionally Publish) New Policy Templates"
 end
 
-escalation "escalation_send_email" do
+escalation "esc_send_email" do
   automatic true
   label "Send Email"
   description "Send incident email"

--- a/tools/policy_sync/policy_sync.pt
+++ b/tools/policy_sync/policy_sync.pt
@@ -6,7 +6,7 @@ severity "low"
 category "Operational"
 default_frequency "15 minutes"
 info(
-  version: "1.17",
+  version: "1.18.0",
   publish: "false",
   provider: "Flexera",
   service: "Policy Engine",
@@ -19,11 +19,22 @@ parameter "param_email" do
   min_length 1
 end
 
+parameter "param_template_git_org_repo_name" do
+  type "string"
+  label "Organization and Repo Name (org/repo_name_) to find the policy template files"
+  default "flexera-public/policy_templates"
+end
+
+parameter "param_github_active_list_path" do
+  type "string"
+  label "Path to the active policy list json file"
+  default "data/active_policy_list/active_policy_list.json"
+end
+
 parameter "param_branch" do
   type "string"
   label "Branch Name"
   default "master"
-  allowed_values "master", "EU_Policies"
 end
 
 parameter "param_publish" do
@@ -53,7 +64,7 @@ datasource "ds_active_policy_list" do
   request do
     verb "GET"
     host "raw.githubusercontent.com"
-    path "/flexera-public/policy_templates/master/data/active_policy_list/active_policy_list.json"
+    path join([$param_template_git_org_repo_name,"/",$param_branch,"/",$param_github_active_list_path])
     header "User-Agent", "RS Policies"
   end
   result do
@@ -86,16 +97,16 @@ datasource "ds_current_policy_template_list" do
 end
 
 datasource "ds_combined_policy_list" do
-  run_script $js_combine_policy_lists, $ds_active_policy_list, $ds_current_policy_template_list, $force_upgrade, $param_branch
+  run_script $js_combine_policy_lists, $ds_active_policy_list, $ds_current_policy_template_list, $force_upgrade, $param_branch, $param_template_git_org_repo_name
 end
 
 script "js_combine_policy_lists", type: "javascript" do
-  parameters "active_policy_list", "current_policy_list", "force_upgrade", "param_branch"
+  parameters "active_policy_list", "current_policy_list", "force_upgrade", "param_branch", "param_template_git_org_repo_name"
   result "policy_list"
   code <<-EOS
   var policy_list = [];
   var old_policy_list = {};
-  var github_raw_url = 'https://raw.githubusercontent.com/flexera-public/policy_templates/' + param_branch + '/';
+  var github_raw_url = 'https://raw.githubusercontent.com/'+param_template_git_org_repo_name+'/' + param_branch + '/';
 
   // create a map of published templates
   for (var index = 0; index < current_policy_list.length; index++) {
@@ -170,19 +181,19 @@ EOS
 end
 
 escalation "upload_new_policy_templates" do
-  run "upload_template", data, rs_project_id, rs_governance_host, $param_publish, rs_org_id, $param_branch
+  run "upload_template", data, rs_project_id, rs_governance_host, $param_publish, rs_org_id, $param_branch, $param_template_git_org_repo_name
 end
 
 escalation "report_policy_templates_update" do
   email $param_email
 end
 
-define upload_template($data, $project_id, $param_governance_host, $param_publish, $rs_org_id, $param_branch) return $url_array, $response_array do
+define upload_template($data, $project_id, $param_governance_host, $param_publish, $rs_org_id, $param_branch, $param_template_git_org_repo_name) return $url_array, $response_array do
   $url_array = []
   $response_array = []
   foreach $item in $data do
     sub on_error: skip do
-      $url = join(["https://raw.githubusercontent.com/flexera-public/policy_templates/", $param_branch, "/",  to_s($item["file_name"])])
+      $url = join(["https://raw.githubusercontent.com/",$param_template_git_org_repo_name,"/", $param_branch, "/",  to_s($item["file_name"])])
       $url_array << $url
 
       $policy_request = http_get(

--- a/tools/policy_sync/policy_sync.pt
+++ b/tools/policy_sync/policy_sync.pt
@@ -7,10 +7,11 @@ severity "low"
 category "Operational"
 default_frequency "15 minutes"
 info(
-  version: "1.18.0",
+  version: "2.0.0",
   publish: "false",
   provider: "Flexera",
   service: "Policy Engine",
+  publish: "false",
   policy_set: "N/A"
 )
 
@@ -55,7 +56,7 @@ parameter "param_publish" do
   allowed_values 0,1
 end
 
-parameter "force_upgrade" do
+parameter "param_force_upgrade" do
   type "number"
   label "Force Upgrade"
   category "Policy Settings"
@@ -116,11 +117,11 @@ datasource "ds_current_policy_template_list" do
 end
 
 datasource "ds_combined_policy_list" do
-  run_script $js_combine_policy_lists, $ds_active_policy_list, $ds_current_policy_template_list, $force_upgrade, $param_branch, $param_template_git_org_repo_name
+  run_script $js_combine_policy_lists, $ds_active_policy_list, $ds_current_policy_template_list, $param_force_upgrade, $param_branch, $param_template_git_org_repo_name
 end
 
 script "js_combine_policy_lists", type: "javascript" do
-  parameters "active_policy_list", "current_policy_list", "force_upgrade", "param_branch", "param_template_git_org_repo_name"
+  parameters "active_policy_list", "current_policy_list", "param_force_upgrade", "param_branch", "param_template_git_org_repo_name"
   result "policy_list"
   code <<-EOS
   var policy_list = [];
@@ -182,7 +183,7 @@ script "js_combine_policy_lists", type: "javascript" do
     else if (curr_major_version < new_major_version) {
       var version_upgradeable = true
     }
-    if (force_upgrade == 1 ) {
+    if (param_force_upgrade == 1 ) {
       var version_upgradeable = true
     }
     policy_list.push({
@@ -203,7 +204,7 @@ end
 # Policy
 ###############################################################################
 
-policy "upload_policy_templates" do
+policy "pol_upload_policy_templates" do
   validate_each $ds_combined_policy_list do
     summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} Policy Templates Updated"
     detail_template <<-EOS
@@ -217,8 +218,8 @@ policy "upload_policy_templates" do
 {{ end -}}
 EOS
 
-    escalate $report_policy_templates_update
-    escalate $upload_new_policy_templates
+    escalate $esc_report_policy_templates_update
+    escalate $esc_upload_new_policy_templates
     check logic_not(val(item, "version_upgradeable"))
   end
 end
@@ -227,11 +228,11 @@ end
 # Escalations
 ###############################################################################
 
-escalation "upload_new_policy_templates" do
+escalation "esc_upload_new_policy_templates" do
   run "upload_template", data, rs_project_id, rs_governance_host, $param_publish, rs_org_id, $param_branch, $param_template_git_org_repo_name
 end
 
-escalation "report_policy_templates_update" do
+escalation "esc_report_policy_templates_update" do
   email $param_email
 end
 

--- a/tools/policy_sync/policy_sync.pt
+++ b/tools/policy_sync/policy_sync.pt
@@ -62,9 +62,8 @@ end
 
 parameter "param_force_upgrade" do
   type "number"
-  label "Force Upgrade"
-  description "Force Upgrade"
   category "Policy Settings"
+  label "Force Upgrade"
   description "Force Upgrade, 0:False, 1:True"
   allowed_values 0, 1
   default 0

--- a/tools/policy_sync/policy_sync.pt
+++ b/tools/policy_sync/policy_sync.pt
@@ -56,8 +56,8 @@ parameter "param_publish" do
   category "Policy Settings"
   label "Publish Template"
   description "Publish Template"
-  default 0
   allowed_values 0, 1
+  default 0
 end
 
 parameter "param_force_upgrade" do
@@ -66,8 +66,8 @@ parameter "param_force_upgrade" do
   description "Force Upgrade"
   category "Policy Settings"
   description "Force Upgrade, 0:False, 1:True"
-  default 0
   allowed_values 0, 1
+  default 0
 end
 
 ###############################################################################

--- a/tools/policy_sync/policy_sync.pt
+++ b/tools/policy_sync/policy_sync.pt
@@ -1,7 +1,7 @@
 name "Policy Template Synchronization"
 rs_pt_ver 20180301
 type "policy"
-short_description "This Policy Template can be used to synchronize (upload, overwrite, or alert) RS built-in policy templates in your account. See the [README](https://github.com/flexera-public/policy_templates/tree/master/tools/policy_sync/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "This Policy Template can be used to synchronize (upload, overwrite, or alert) policy templates in your account from GitHub. See the [README](https://github.com/flexera-public/policy_templates/tree/master/tools/policy_sync/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 severity "low"
 category "Operational"

--- a/tools/policy_sync/policy_sync.pt
+++ b/tools/policy_sync/policy_sync.pt
@@ -232,10 +232,10 @@ end
 ###############################################################################
 
 escalation "esc_upload_new_policy_templates" do
-  run "upload_template", data, rs_project_id, rs_governance_host, $param_publish, rs_org_id, $param_branch, $param_template_git_org_repo_name
   automatic false
   label "Upload/Publish Policy Templates"
   description "Upload (and optionally Publish) New Policy Templates"
+  run "upload_template", data, rs_project_id, rs_governance_host, $param_publish, rs_org_id, $param_branch, $param_template_git_org_repo_name
 end
 
 escalation "esc_send_email" do


### PR DESCRIPTION
### Description

Added parameters for the Policy Template Github Repo to enable this to be used for other repos without modifying Policy Template

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=6601da3c3ad5094c46961f0d

<img width="773" alt="image" src="https://github.com/flexera-public/policy_templates/assets/1490015/61b58be6-87c3-41cb-a968-b45f30849847">

Example overriding defaults to use data from a public repo (this is for a customer PoC):

https://github.com/bryankaraffa/friendly-engine

### Contribution Check List

- [X] New functionality includes testing.
- ~[ ] New functionality has been documented in the README if applicable~
- [X] New functionality has been documented in CHANGELOG.MD
