### PR TITLE
POL-1174 Update Azure Instance Types JSON to include Memory

### DIFF
--- a/data/azure/instance_types.json
+++ b/data/azure/instance_types.json
@@ -3,37 +3,43 @@
     "up": "Basic_A1",
     "down": null,
     "superseded": null,
-    "vcpu": 1
+    "vcpu": 1,
+    "memory": "0.75"
   },
   "Basic_A1": {
     "up": "Basic_A2",
     "down": "Basic_A0",
     "superseded": null,
-    "vcpu": 1
+    "vcpu": 1,
+    "memory": "1.75"
   },
   "Basic_A2": {
     "up": "Basic_A3",
     "down": "Basic_A1",
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "3.5"
   },
   "Basic_A3": {
     "up": "Basic_A4",
     "down": "Basic_A2",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "7"
   },
   "Basic_A4": {
     "up": null,
     "down": "Basic_A3",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "14"
   },
   "Standard_A0": {
     "up": "Standard_A1",
     "down": null,
     "superseded": null,
-    "vcpu": 1
+    "vcpu": 1,
+    "memory": "0.75"
   },
   "Standard_A1": {
     "up": "Standard_A2",
@@ -41,7 +47,8 @@
     "superseded": {
       "regular": "Standard_A1_v2"
     },
-    "vcpu": 1
+    "vcpu": 1,
+    "memory": "1.75"
   },
   "Standard_A2": {
     "up": "Standard_A3",
@@ -49,7 +56,8 @@
     "superseded": {
       "regular": "Standard_A2_v2"
     },
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "3.5"
   },
   "Standard_A3": {
     "up": "Standard_A4",
@@ -57,7 +65,8 @@
     "superseded": {
       "regular": "Standard_A4_v2"
     },
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "7"
   },
   "Standard_A4": {
     "up": "Standard_A5",
@@ -65,7 +74,8 @@
     "superseded": {
       "regular": "Standard_A8_v2"
     },
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "14"
   },
   "Standard_A5": {
     "up": "Standard_A6",
@@ -73,7 +83,8 @@
     "superseded": {
       "regular": "Standard_A2m_v2"
     },
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "14"
   },
   "Standard_A6": {
     "up": "Standard_A7",
@@ -81,7 +92,8 @@
     "superseded": {
       "regular": "Standard_A4m_v2"
     },
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "28"
   },
   "Standard_A7": {
     "up": "Standard_A8",
@@ -89,7 +101,8 @@
     "superseded": {
       "regular": "Standard_A8m_v2"
     },
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "56"
   },
   "Standard_A8": {
     "up": "Standard_A9",
@@ -123,113 +136,130 @@
     "up": "Standard_A2_v2",
     "down": null,
     "superseded": null,
-    "vcpu": 1
+    "vcpu": 1,
+    "memory": "2"
   },
   "Standard_A2_v2": {
     "up": "Standard_A4_v2",
     "down": "Standard_A1_v2",
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "4"
   },
   "Standard_A4_v2": {
     "up": "Standard_A8_v2",
     "down": "Standard_A2_v2",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "8"
   },
   "Standard_A8_v2": {
     "up": null,
     "down": "Standard_A4_v2",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "16"
   },
   "Standard_A2m_v2": {
     "up": "Standard_A4m_v2",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "16"
   },
   "Standard_A4m_v2": {
     "up": "Standard_A8m_v2",
     "down": "Standard_A2m_v2",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "32"
   },
   "Standard_A8m_v2": {
     "up": null,
     "down": "Standard_A4m_v2",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "64"
   },
   "Standard_B1ls": {
     "up": "Standard_B1s",
     "down": null,
     "superseded": null,
     "vcpu": 1,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "0.5"
   },
   "Standard_B1s": {
     "up": "Standard_B1ms",
     "down": "Standard_B1ls",
     "superseded": null,
     "vcpu": 1,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "1"
   },
   "Standard_B1ms": {
     "up": "Standard_B2s",
     "down": "Standard_B1s",
     "superseded": null,
     "vcpu": 1,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "2"
   },
   "Standard_B2s": {
     "up": "Standard_B2ms",
     "down": "Standard_B1ms",
     "superseded": null,
     "vcpu": 2,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "4"
   },
   "Standard_B2ms": {
     "up": "Standard_B4ms",
     "down": "Standard_B2s",
     "superseded": null,
     "vcpu": 2,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8"
   },
   "Standard_B4ms": {
     "up": "Standard_B8ms",
     "down": "Standard_B2ms",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16"
   },
   "Standard_B8ms": {
     "up": "Standard_B12ms",
     "down": "Standard_B4ms",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32"
   },
   "Standard_B12ms": {
     "up": "Standard_B16ms",
     "down": "Standard_B8ms",
     "superseded": null,
     "vcpu": 12,
-    "nfu": "24"
+    "nfu": "24",
+    "memory": "48"
   },
   "Standard_B16ms": {
     "up": "Standard_B20ms",
     "down": "Standard_B12ms",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "64"
   },
   "Standard_B20ms": {
     "up": null,
     "down": "Standard_B16ms",
     "superseded": null,
     "vcpu": 20,
-    "nfu": "40"
+    "nfu": "40",
+    "memory": "80"
   },
   "Standard_D1": {
     "up": "Standard_D2",
@@ -238,7 +268,8 @@
       "regular": "Standard_D1_v2"
     },
     "vcpu": 1,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "3.5"
   },
   "Standard_D2": {
     "up": "Standard_D3",
@@ -247,7 +278,8 @@
       "regular": "Standard_D2_v3"
     },
     "vcpu": 2,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "7"
   },
   "Standard_D3": {
     "up": null,
@@ -256,7 +288,8 @@
       "regular": "Standard_D4_v3"
     },
     "vcpu": 4,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "14"
   },
   "Standard_D4": {
     "up": null,
@@ -265,7 +298,8 @@
       "regular": "Standard_D8_v3"
     },
     "vcpu": 8,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "28"
   },
   "Standard_D11": {
     "up": "Standard_D12",
@@ -274,7 +308,8 @@
       "regular": "Standard_E2_v3"
     },
     "vcpu": 2,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "14"
   },
   "Standard_D12": {
     "up": "Standard_D13",
@@ -283,7 +318,8 @@
       "regular": "Standard_E4_v3"
     },
     "vcpu": 4,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "28"
   },
   "Standard_D13": {
     "up": "Standard_D14",
@@ -292,7 +328,8 @@
       "regular": "Standard_E8_v3"
     },
     "vcpu": 8,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "56"
   },
   "Standard_D14": {
     "up": null,
@@ -301,14 +338,16 @@
       "regular": "Standard_E16_v3"
     },
     "vcpu": 16,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "112"
   },
   "Standard_D1_v2": {
     "up": "Standard_D2_v2",
     "down": null,
     "superseded": null,
     "vcpu": 1,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "3.5"
   },
   "Standard_D2_v2": {
     "up": "Standard_D3_v2",
@@ -317,7 +356,8 @@
       "regular": "Standard_D2_v3"
     },
     "vcpu": 2,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "7"
   },
   "Standard_D3_v2": {
     "up": "Standard_D4_v2",
@@ -326,7 +366,8 @@
       "regular": "Standard_D4_v3"
     },
     "vcpu": 4,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "14"
   },
   "Standard_D4_v2": {
     "up": "Standard_D5_v2",
@@ -335,7 +376,8 @@
       "regular": "Standard_D8_v3"
     },
     "vcpu": 8,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "28"
   },
   "Standard_D5_v2": {
     "up": null,
@@ -344,7 +386,8 @@
       "regular": "Standard_D16_v3"
     },
     "vcpu": 16,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "56"
   },
   "Standard_D11_v2": {
     "up": "Standard_D12_v2",
@@ -353,7 +396,8 @@
       "regular": "Standard_E2_v3"
     },
     "vcpu": 2,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "14"
   },
   "Standard_D12_v2": {
     "up": "Standard_D13_v2",
@@ -362,7 +406,8 @@
       "regular": "Standard_E4_v3"
     },
     "vcpu": 4,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "28"
   },
   "Standard_D13_v2": {
     "up": "Standard_D14_v2",
@@ -371,7 +416,8 @@
       "regular": "Standard_E8_v3"
     },
     "vcpu": 8,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "56"
   },
   "Standard_D14_v2": {
     "up": "Standard_D15_v2",
@@ -380,14 +426,16 @@
       "regular": "Standard_E16_v3"
     },
     "vcpu": 16,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "112"
   },
   "Standard_D15_v2": {
     "up": null,
     "down": "Standard_D15_v2",
     "superseded": null,
     "vcpu": 20,
-    "nfu": "10"
+    "nfu": "10",
+    "memory": "140"
   },
   "Standard_D2_v2_Promo": {
     "up": "Standard_D3_v2_Promo",
@@ -466,743 +514,860 @@
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "8"
   },
   "Standard_D4s_v3": {
     "up": "Standard_D8s_v3",
     "down": "Standard_D2s_v3",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "16"
   },
   "Standard_D8s_v3": {
     "up": "Standard_D16s_v3",
     "down": "Standard_D4s_v3",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "32"
   },
   "Standard_D16s_v3": {
     "up": "Standard_D32s_v3",
     "down": "Standard_D8s_v3",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "64"
   },
   "Standard_D32s_v3": {
     "up": "Standard_D48s_v3",
     "down": "Standard_D16s_v3",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "128"
   },
   "Standard_D48s_v3": {
     "up": "Standard_D64s_v3",
     "down": "Standard_D32s_v3",
     "superseded": null,
     "vcpu": 48,
-    "nfu": "24"
+    "nfu": "24",
+    "memory": "192"
   },
   "Standard_D64s_v3": {
     "up": null,
     "down": "Standard_D48s_v3",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "256"
   },
   "Standard_D2_v3": {
     "up": "Standard_D4_v3",
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "8"
   },
   "Standard_D4_v3": {
     "up": "Standard_D8_v3",
     "down": "Standard_D2_v3",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "16"
   },
   "Standard_D8_v3": {
     "up": "Standard_D16_v3",
     "down": "Standard_D4_v3",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "32"
   },
   "Standard_D16_v3": {
     "up": "Standard_D32_v3",
     "down": "Standard_D8_v3",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "64"
   },
   "Standard_D32_v3": {
     "up": "Standard_D48_v3",
     "down": "Standard_D16_v3",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "128"
   },
   "Standard_D48_v3": {
     "up": "Standard_D64_v3",
     "down": "Standard_D32_v3",
     "superseded": null,
     "vcpu": 48,
-    "nfu": "24"
+    "nfu": "24",
+    "memory": "192"
   },
   "Standard_D64_v3": {
     "up": null,
     "down": "Standard_D48_v3",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "256"
   },
   "Standard_D2_v4": {
     "up": "Standard_D4_v4",
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "8"
   },
   "Standard_D4_v4": {
     "up": "Standard_D8_v4",
     "down": "Standard_D2_v4",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "16"
   },
   "Standard_D8_v4": {
     "up": "Standard_D16_v4",
     "down": "Standard_D4_v4",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "32"
   },
   "Standard_D16_v4": {
     "up": "Standard_D32_v4",
     "down": "Standard_D8_v4",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "64"
   },
   "Standard_D32_v4": {
     "up": "Standard_D48_v4",
     "down": "Standard_D16_v4",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "128"
   },
   "Standard_D48_v4": {
     "up": "Standard_D64_v4",
     "down": "Standard_D32_v4",
     "superseded": null,
     "vcpu": 48,
-    "nfu": "24"
+    "nfu": "24",
+    "memory": "192"
   },
   "Standard_D64_v4": {
     "up": null,
     "down": "Standard_D48_v4",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "256"
   },
   "Standard_D2_v5": {
     "up": "Standard_D4_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "8"
   },
   "Standard_D4_v5": {
     "up": "Standard_D8_v5",
     "down": "Standard_D2_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "16"
   },
   "Standard_D8_v5": {
     "up": "Standard_D16_v5",
     "down": "Standard_D4_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "32"
   },
   "Standard_D16_v5": {
     "up": "Standard_D32_v5",
     "down": "Standard_D8_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "64"
   },
   "Standard_D32_v5": {
     "up": "Standard_D48_v5",
     "down": "Standard_D16_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "128"
   },
   "Standard_D48_v5": {
     "up": "Standard_D64_v5",
     "down": "Standard_D32_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "192"
   },
   "Standard_D64_v5": {
     "up": "Standard_D96_v5",
     "down": "Standard_D48_v5",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "256"
   },
   "Standard_D96_v5": {
     "up": null,
     "down": "Standard_D64_v5",
     "superseded": null,
-    "vcpu": 96
+    "vcpu": 96,
+    "memory": "384"
   },
   "Standard_D2s_v4": {
     "up": "Standard_D4s_v4",
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "8"
   },
   "Standard_D4s_v4": {
     "up": "Standard_D8s_v4",
     "down": "Standard_D2s_v4",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "16"
   },
   "Standard_D8s_v4": {
     "up": "Standard_D16s_v4",
     "down": "Standard_D4s_v4",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "32"
   },
   "Standard_D16s_v4": {
     "up": "Standard_D32s_v4",
     "down": "Standard_D8s_v4",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "64"
   },
   "Standard_D32s_v4": {
     "up": "Standard_D48s_v4",
     "down": "Standard_D16s_v4",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "128"
   },
   "Standard_D48s_v4": {
     "up": "Standard_D64s_v4",
     "down": "Standard_D32s_v4",
     "superseded": null,
     "vcpu": 48,
-    "nfu": "24"
+    "nfu": "24",
+    "memory": "192"
   },
   "Standard_D64s_v4": {
     "up": null,
     "down": "Standard_D48_v4",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "256"
   },
   "Standard_D2s_v5": {
     "up": "Standard_D4s_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "8"
   },
   "Standard_D4s_v5": {
     "up": "Standard_D8s_v5",
     "down": "Standard_D2s_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "16"
   },
   "Standard_D8s_v5": {
     "up": "Standard_D16s_v5",
     "down": "Standard_D4s_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "32"
   },
   "Standard_D16s_v5": {
     "up": "Standard_D32s_v5",
     "down": "Standard_D8s_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "64"
   },
   "Standard_D32s_v5": {
     "up": "Standard_D48s_v5",
     "down": "Standard_D16s_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "128"
   },
   "Standard_D48s_v5": {
     "up": "Standard_D64s_v5",
     "down": "Standard_D32s_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "192"
   },
   "Standard_D64s_v5": {
     "up": "Standard_D96s_v5",
     "down": "Standard_D48s_v5",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "256"
   },
   "Standard_D96s_v5": {
     "up": null,
     "down": "Standard_D64s_v5",
     "superseded": null,
-    "vcpu": 96
+    "vcpu": 96,
+    "memory": "384"
   },
   "Standard_DC1s_v2": {
     "up": "Standard_DC2s_v2",
     "down": null,
     "superseded": null,
     "vcpu": 1,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "4"
   },
   "Standard_DC2s_v2": {
     "up": "Standard_DC4s_v2",
     "down": "Standard_DC1s_v2",
     "superseded": null,
     "vcpu": 2,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "8"
   },
   "Standard_DC4s_v2": {
     "up": "Standard_DC8_v2",
     "down": "Standard_DC2s_v2",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "16"
   },
   "Standard_DC8_v2": {
     "up": null,
     "down": "Standard_DC4s_v2",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "32"
   },
   "Standard_DC1s_v3": {
     "up": "Standard_DC2s_v3",
     "down": null,
     "superseded": null,
-    "vcpu": 1
+    "vcpu": 1,
+    "memory": "8"
   },
   "Standard_DC2s_v3": {
     "up": "Standard_DC4s_v3",
     "down": "Standard_DC1s_v3",
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "16"
   },
   "Standard_DC4s_v3": {
     "up": "Standard_DC8s_v3",
     "down": "Standard_DC2s_v3",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "32"
   },
   "Standard_DC8s_v3": {
     "up": "Standard_DC16s_v3",
     "down": "Standard_DC4s_v3",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "64"
   },
   "Standard_DC16s_v3": {
     "up": "Standard_DC24s_v3",
     "down": "Standard_DC8s_v3",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "128"
   },
   "Standard_DC24s_v3": {
     "up": "Standard_DC32s_v3",
     "down": "Standard_DC16s_v3",
     "superseded": null,
-    "vcpu": 24
+    "vcpu": 24,
+    "memory": "192"
   },
   "Standard_DC32s_v3": {
     "up": "Standard_DC48s_v3",
     "down": "Standard_DC24s_v3",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "256"
   },
   "Standard_DC48s_v3": {
     "up": null,
     "down": "Standard_DC32s_v3",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "384"
   },
   "Standard_DC1ds_v3": {
     "up": "Standard_DC2ds_v3",
     "down": null,
     "superseded": null,
-    "vcpu": 1
+    "vcpu": 1,
+    "memory": "8"
   },
   "Standard_DC2ds_v3": {
     "up": "Standard_DC4ds_v3",
     "down": "Standard_DC1ds_v3",
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "16"
   },
   "Standard_DC4ds_v3": {
     "up": "Standard_DC8ds_v3",
     "down": "Standard_DC2ds_v3",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "32"
   },
   "Standard_DC8ds_v3": {
     "up": "Standard_DC16ds_v3",
     "down": "Standard_DC4ds_v3",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "64"
   },
   "Standard_DC16ds_v3": {
     "up": "Standard_DC24ds_v3",
     "down": "Standard_DC8ds_v3",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "128"
   },
   "Standard_DC24ds_v3": {
     "up": "Standard_DC32ds_v3",
     "down": "Standard_DC16ds_v3",
     "superseded": null,
-    "vcpu": 24
+    "vcpu": 24,
+    "memory": "192"
   },
   "Standard_DC32ds_v3": {
     "up": "Standard_DC48ds_v3",
     "down": "Standard_DC24ds_v3",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "256"
   },
   "Standard_DC48ds_v3": {
     "up": null,
     "down": "Standard_DC32ds_v3",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "384"
   },
   "Standard_DC2as_v5": {
     "up": "Standard_DC4as_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "8"
   },
   "Standard_DC4as_v5": {
     "up": "Standard_DC8as_v5",
     "down": "Standard_DC2as_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "16"
   },
   "Standard_DC8as_v5": {
     "up": "Standard_DC16as_v5",
     "down": "Standard_DC4as_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "32"
   },
   "Standard_DC16as_v5": {
     "up": "Standard_DC32as_v5",
     "down": "Standard_DC8as_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "64"
   },
   "Standard_DC32as_v5": {
     "up": "Standard_DC48as_v5",
     "down": "Standard_DC16as_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "128"
   },
   "Standard_DC48as_v5": {
     "up": "Standard_DC64as_v5",
     "down": "Standard_DC32as_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "192"
   },
   "Standard_DC64as_v5": {
     "up": "Standard_DC96as_v5",
     "down": "Standard_DC48as_v5",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "256"
   },
   "Standard_DC96as_v5": {
     "up": null,
     "down": "Standard_DC64as_v5",
     "superseded": null,
-    "vcpu": 96
+    "vcpu": 96,
+    "memory": "384"
   },
   "Standard_DC2ads_v5": {
     "up": "Standard_DC4ads_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "8"
   },
   "Standard_DC4ads_v5": {
     "up": "Standard_DC8ads_v5",
     "down": "Standard_DC2ads_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "16"
   },
   "Standard_DC8ads_v5": {
     "up": "Standard_DC16ads_v5",
     "down": "Standard_DC4ads_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "32"
   },
   "Standard_DC16ads_v5": {
     "up": "Standard_DC32ads_v5",
     "down": "Standard_DC8ads_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "64"
   },
   "Standard_DC32ads_v5": {
     "up": "Standard_DC48ads_v5",
     "down": "Standard_DC16ads_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "128"
   },
   "Standard_DC48ads_v5": {
     "up": "Standard_DC64ads_v5",
     "down": "Standard_DC32ads_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "192"
   },
   "Standard_DC64ads_v5": {
     "up": "Standard_DC96ads_v5",
     "down": "Standard_DC48ads_v5",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "256"
   },
   "Standard_DC96ads_v5": {
     "up": null,
     "down": "Standard_DC64ads_v5",
     "superseded": null,
-    "vcpu": 96
+    "vcpu": 96,
+    "memory": "384"
   },
   "Standard_D2ps_v5": {
     "up": "Standard_D4ps_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "8"
   },
   "Standard_D4ps_v5": {
     "up": "Standard_D8ps_v5",
     "down": "Standard_D2ps_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "16"
   },
   "Standard_D8ps_v5": {
     "up": "Standard_D16ps_v5",
     "down": "Standard_D4ps_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "32"
   },
   "Standard_D16ps_v5": {
     "up": "Standard_D32ps_v5",
     "down": "Standard_D8ps_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "64"
   },
   "Standard_D32ps_v5": {
     "up": "Standard_D48ps_v5",
     "down": "Standard_D16ps_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "128"
   },
   "Standard_D48ps_v5": {
     "up": "Standard_D64ps_v5",
     "down": "Standard_D32ps_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "192"
   },
   "Standard_D64ps_v5": {
     "up": null,
     "down": "Standard_D48ps_v5",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "208"
   },
   "Standard_D2pds_v5": {
     "up": "Standard_D4pds_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "8"
   },
   "Standard_D4pds_v5": {
     "up": "Standard_D8pds_v5",
     "down": "Standard_D2pds_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "16"
   },
   "Standard_D8pds_v5": {
     "up": "Standard_D16pds_v5",
     "down": "Standard_D4pds_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "32"
   },
   "Standard_D16pds_v5": {
     "up": "Standard_D32pds_v5",
     "down": "Standard_D8pds_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "64"
   },
   "Standard_D32pds_v5": {
     "up": "Standard_D48pds_v5",
     "down": "Standard_D16pds_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "128"
   },
   "Standard_D48pds_v5": {
     "up": "Standard_D64pds_v5",
     "down": "Standard_D32pds_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "192"
   },
   "Standard_D64pds_v5": {
     "up": null,
     "down": "Standard_D48pds_v5",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "208"
   },
   "Standard_D2pls_v5": {
     "up": "Standard_D4pls_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "4"
   },
   "Standard_D4pls_v5": {
     "up": "Standard_D8pls_v5",
     "down": "Standard_D2pls_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "8"
   },
   "Standard_D8pls_v5": {
     "up": "Standard_D16pls_v5",
     "down": "Standard_D4pls_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "16"
   },
   "Standard_D16pls_v5": {
     "up": "Standard_D32pls_v5",
     "down": "Standard_D8pls_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "32"
   },
   "Standard_D32pls_v5": {
     "up": "Standard_D48pls_v5",
     "down": "Standard_D16pls_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "64"
   },
   "Standard_D48pls_v5": {
     "up": "Standard_D64pls_v5",
     "down": "Standard_D32pls_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "96"
   },
   "Standard_D64pls_v5": {
     "up": null,
     "down": "Standard_D48pls_v5",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "128"
   },
   "Standard_D2plds_v5": {
     "up": "Standard_D4plds_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "4"
   },
   "Standard_D4plds_v5": {
     "up": "Standard_D8plds_v5",
     "down": "Standard_D2plds_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "8"
   },
   "Standard_D8plds_v5": {
     "up": "Standard_D16plds_v5",
     "down": "Standard_D4plds_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "16"
   },
   "Standard_D16plds_v5": {
     "up": "Standard_D32plds_v5",
     "down": "Standard_D8plds_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "32"
   },
   "Standard_D32plds_v5": {
     "up": "Standard_D48plds_v5",
     "down": "Standard_D16plds_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "64"
   },
   "Standard_D48plds_v5": {
     "up": "Standard_D64plds_v5",
     "down": "Standard_D32plds_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "96"
   },
   "Standard_D64plds_v5": {
     "up": null,
     "down": "Standard_D48plds_v5",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "128"
   },
   "Standard_DS1": {
     "up": "Standard_DS2",
     "down": null,
     "superseded": null,
     "vcpu": 1,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "3.5"
   },
   "Standard_DS2": {
     "up": "Standard_DS3",
     "down": "Standard_DS1",
     "superseded": null,
     "vcpu": 2,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "7"
   },
   "Standard_DS3": {
     "up": "Standard_DS4",
     "down": "Standard_DS2",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "14"
   },
   "Standard_DS4": {
     "up": null,
     "down": "Standard_DS3",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "28"
   },
   "Standard_DS11": {
     "up": "Standard_DS12",
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "14"
   },
   "Standard_DS12": {
     "up": "Standard_DS13",
     "down": "Standard_DS11",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "28"
   },
   "Standard_DS13": {
     "up": "Standard_DS14",
     "down": "Standard_DS12",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "56"
   },
   "Standard_DS14": {
     "up": null,
     "down": "Standard_DS13",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "112"
   },
   "Standard_DS1_v2": {
     "up": "Standard_DS2_v2",
     "down": null,
     "superseded": null,
     "vcpu": 1,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "3.5"
   },
   "Standard_DS2_v2": {
     "up": "Standard_DS3_v2",
@@ -1211,7 +1376,8 @@
       "regular": "Standard_D2s_v3"
     },
     "vcpu": 2,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "7"
   },
   "Standard_DS3_v2": {
     "up": "Standard_DS4_v2",
@@ -1220,7 +1386,8 @@
       "regular": "Standard_D4s_v3"
     },
     "vcpu": 4,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "14"
   },
   "Standard_DS4_v2": {
     "up": "Standard_DS5_v2",
@@ -1229,7 +1396,8 @@
       "regular": "Standard_D8s_v3"
     },
     "vcpu": 8,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "28"
   },
   "Standard_DS5_v2": {
     "up": null,
@@ -1238,42 +1406,48 @@
       "regular": "Standard_D16s_v3"
     },
     "vcpu": 16,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "56"
   },
   "Standard_DS11_v2": {
     "up": "Standard_DS12_v2",
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "14"
   },
   "Standard_DS12_v2": {
     "up": "Standard_DS13_v2",
     "down": "Standard_DS11_v2",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "28"
   },
   "Standard_DS13_v2": {
     "up": "Standard_DS14_v2",
     "down": "Standard_DS12_v2",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "56"
   },
   "Standard_DS14_v2": {
     "up": "Standard_DS15_v2",
     "down": "Standard_DS13_v2",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "112"
   },
   "Standard_DS15_v2": {
     "up": null,
     "down": "Standard_DS14_v2",
     "superseded": null,
     "vcpu": 20,
-    "nfu": "10"
+    "nfu": "10",
+    "memory": "140"
   },
   "Standard_DS2_v2_Promo": {
     "up": "Standard_DS3_v2_Promo",
@@ -1336,1504 +1510,1738 @@
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "8"
   },
   "Standard_D4a_v4": {
     "up": "Standard_D8a_v4",
     "down": "Standard_D2a_v4",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "16"
   },
   "Standard_D8a_v4": {
     "up": "Standard_D16a_v4",
     "down": "Standard_D4a_v4",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "32"
   },
   "Standard_D16a_v4": {
     "up": "Standard_D32a_v4",
     "down": "Standard_D8a_v4",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "64"
   },
   "Standard_D32a_v4": {
     "up": "Standard_D48a_v4",
     "down": "Standard_D16a_v4",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "128"
   },
   "Standard_D48a_v4": {
     "up": "Standard_D64a_v4",
     "down": "Standard_D32a_v4",
     "superseded": null,
     "vcpu": 48,
-    "nfu": "24"
+    "nfu": "24",
+    "memory": "192"
   },
   "Standard_D64a_v4": {
     "up": "Standard_D96a_v4",
     "down": "Standard_D48a_v4",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "256"
   },
   "Standard_D96a_v4": {
     "up": null,
     "down": "Standard_D64a_v4",
     "superseded": null,
     "vcpu": 96,
-    "nfu": "48"
+    "nfu": "48",
+    "memory": "384"
   },
   "Standard_D2as_v4": {
     "up": "Standard_D4as_v4",
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "8"
   },
   "Standard_D4as_v4": {
     "up": "Standard_D8as_v4",
     "down": "Standard_D2as_v4",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "16"
   },
   "Standard_D8as_v4": {
     "up": "Standard_D16as_v4",
     "down": "Standard_D4as_v4",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "32"
   },
   "Standard_D16as_v4": {
     "up": "Standard_D32as_v4",
     "down": "Standard_D8as_v4",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "64"
   },
   "Standard_D32as_v4": {
     "up": "Standard_D48as_v4",
     "down": "Standard_D16as_v4",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "128"
   },
   "Standard_D48as_v4": {
     "up": "Standard_D64as_v4",
     "down": "Standard_D32as_v4",
     "superseded": null,
     "vcpu": 48,
-    "nfu": "24"
+    "nfu": "24",
+    "memory": "192"
   },
   "Standard_D64as_v4": {
     "up": "Standard_D96as_v4",
     "down": "Standard_D48as_v4",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "256"
   },
   "Standard_D96as_v4": {
     "up": null,
     "down": "Standard_D64as_v4",
     "superseded": null,
     "vcpu": 96,
-    "nfu": "48"
+    "nfu": "48",
+    "memory": "384"
   },
   "Standard_D2d_v4": {
     "up": "Standard_D4d_v4",
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "8"
   },
   "Standard_D4d_v4": {
     "up": "Standard_D8d_v4",
     "down": "Standard_D2d_v4",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "16"
   },
   "Standard_D8d_v4": {
     "up": "Standard_D16d_v4",
     "down": "Standard_D4d_v4",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "32"
   },
   "Standard_D16d_v4": {
     "up": "Standard_D32d_v4",
     "down": "Standard_D8d_v4",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "64"
   },
   "Standard_D32d_v4": {
     "up": "Standard_D48d_v4",
     "down": "Standard_D16d_v4",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "128"
   },
   "Standard_D48d_v4": {
     "up": "Standard_D64d_v4",
     "down": "Standard_D32d_v4",
     "superseded": null,
     "vcpu": 48,
-    "nfu": "24"
+    "nfu": "24",
+    "memory": "192"
   },
   "Standard_D64d_v4": {
     "up": null,
     "down": "Standard_D48d_v4",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "256"
   },
   "Standard_D2d_v5": {
     "up": "Standard_D4d_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "8"
   },
   "Standard_D4d_v5": {
     "up": "Standard_D8d_v5",
     "down": "Standard_D2d_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "16"
   },
   "Standard_D8d_v5": {
     "up": "Standard_D16d_v5",
     "down": "Standard_D4d_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "32"
   },
   "Standard_D16d_v5": {
     "up": "Standard_D32d_v5",
     "down": "Standard_D8d_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "64"
   },
   "Standard_D32d_v5": {
     "up": "Standard_D48d_v5",
     "down": "Standard_D16d_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "128"
   },
   "Standard_D48d_v5": {
     "up": "Standard_D64d_v5",
     "down": "Standard_D32d_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "192"
   },
   "Standard_D64d_v5": {
     "up": "Standard_D96d_v5",
     "down": "Standard_D48d_v5",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "256"
   },
   "Standard_D96d_v5": {
     "up": null,
     "down": "Standard_D64d_v5",
     "superseded": null,
-    "vcpu": 96
+    "vcpu": 96,
+    "memory": "384"
   },
   "Standard_D2ds_v4": {
     "up": "Standard_D4ds_v4",
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "8"
   },
   "Standard_D4ds_v4": {
     "up": "Standard_D8ds_v4",
     "down": "Standard_D2ds_v4",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "16"
   },
   "Standard_D8ds_v4": {
     "up": "Standard_D16ds_v4",
     "down": "Standard_D4ds_v4",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "32"
   },
   "Standard_D16ds_v4": {
     "up": "Standard_D32ds_v4",
     "down": "Standard_D8ds_v4",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "64"
   },
   "Standard_D32ds_v4": {
     "up": "Standard_D48ds_v4",
     "down": "Standard_D16ds_v4",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "128"
   },
   "Standard_D48ds_v4": {
     "up": "Standard_D64ds_v4",
     "down": "Standard_D32ds_v4",
     "superseded": null,
     "vcpu": 48,
-    "nfu": "24"
+    "nfu": "24",
+    "memory": "192"
   },
   "Standard_D64ds_v4": {
     "up": null,
     "down": "Standard_D48ds_v4",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "256"
   },
   "Standard_E2_v4": {
     "up": "Standard_E4_v4",
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "16"
   },
   "Standard_E4_v4": {
     "up": "Standard_E8_v4",
     "down": "Standard_E2_v4",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "32"
   },
   "Standard_E8_v4": {
     "up": "Standard_E16_v4",
     "down": "Standard_E4_v4",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "64"
   },
   "Standard_E16_v4": {
     "up": "Standard_E20_v4",
     "down": "Standard_E8_v4",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "128"
   },
   "Standard_E20_v4": {
     "up": "Standard_E32_v4",
     "down": "Standard_E16_v4",
     "superseded": null,
     "vcpu": 20,
-    "nfu": "10"
+    "nfu": "10",
+    "memory": "160"
   },
   "Standard_E32_v4": {
     "up": "Standard_E48_v4",
     "down": "Standard_E20_v4",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "256"
   },
   "Standard_E48_v4": {
     "up": "Standard_E64_v4",
     "down": "Standard_E32_v4",
     "superseded": null,
     "vcpu": 48,
-    "nfu": "24"
+    "nfu": "24",
+    "memory": "384"
   },
   "Standard_E64_v4": {
     "up": null,
     "down": "Standard_E48_v4",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "504"
   },
   "Standard_E2_v5": {
     "up": "Standard_E4_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "16"
   },
   "Standard_E4_v5": {
     "up": "Standard_E8_v5",
     "down": "Standard_E2_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "32"
   },
   "Standard_E8_v5": {
     "up": "Standard_E16_v5",
     "down": "Standard_E4_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "64"
   },
   "Standard_E16_v5": {
     "up": "Standard_E20_v5",
     "down": "Standard_E8_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "128"
   },
   "Standard_E20_v5": {
     "up": "Standard_E32_v5",
     "down": "Standard_E16_v5",
     "superseded": null,
-    "vcpu": 20
+    "vcpu": 20,
+    "memory": "160"
   },
   "Standard_E32_v5": {
     "up": "Standard_E48_v5",
     "down": "Standard_E20_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "256"
   },
   "Standard_E48_v5": {
     "up": "Standard_E64_v5",
     "down": "Standard_E32_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "384"
   },
   "Standard_E64_v5": {
     "up": "Standard_E96_v5",
     "down": "Standard_E48_v5",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "512"
   },
   "Standard_E96_v5": {
     "up": "Standard_E104i_v5",
     "down": "Standard_E64_v5",
     "superseded": null,
-    "vcpu": 96
+    "vcpu": 96,
+    "memory": "672"
   },
   "Standard_E104i_v5": {
     "up": null,
     "down": "Standard_E96_v5",
     "superseded": null,
-    "vcpu": 104
+    "vcpu": 104,
+    "memory": "672"
   },
   "Standard_E2s_v5": {
     "up": "Standard_E4s_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "16"
   },
   "Standard_E4s_v5": {
     "up": "Standard_E8s_v5",
     "down": "Standard_E2s_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "32"
   },
   "Standard_E8s_v5": {
     "up": "Standard_E16s_v5",
     "down": "Standard_E4s_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "64"
   },
   "Standard_E16s_v5": {
     "up": "Standard_E20s_v5",
     "down": "Standard_E8s_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "128"
   },
   "Standard_E20s_v5": {
     "up": "Standard_E32s_v5",
     "down": "Standard_E16s_v5",
     "superseded": null,
-    "vcpu": 20
+    "vcpu": 20,
+    "memory": "160"
   },
   "Standard_E32s_v5": {
     "up": "Standard_E48s_v5",
     "down": "Standard_E20s_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "256"
   },
   "Standard_E48s_v5": {
     "up": "Standard_E64s_v5",
     "down": "Standard_E32s_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "384"
   },
   "Standard_E64s_v5": {
     "up": "Standard_E96s_v5",
     "down": "Standard_E48s_v5",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "512"
   },
   "Standard_E96s_v5": {
     "up": "Standard_E104is_v5",
     "down": "Standard_E64s_v5",
     "superseded": null,
-    "vcpu": 96
+    "vcpu": 96,
+    "memory": "672"
   },
   "Standard_E104is_v5": {
     "up": null,
     "down": "Standard_E96s_v5",
     "superseded": null,
-    "vcpu": 104
+    "vcpu": 104,
+    "memory": "672"
   },
   "Standard_E2bds_v5": {
     "up": "Standard_E4bds_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "16"
   },
   "Standard_E4bds_v5": {
     "up": "Standard_E8bds_v5",
     "down": "Standard_E2bds_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "32"
   },
   "Standard_E8bds_v5": {
     "up": "Standard_E16bds_v5",
     "down": "Standard_E4bds_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "64"
   },
   "Standard_E16bds_v5": {
     "up": "Standard_E32bds_v5",
     "down": "Standard_E8bds_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "128"
   },
   "Standard_E32bds_v5": {
     "up": "Standard_E48bds_v5",
     "down": "Standard_E16bds_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "256"
   },
   "Standard_E48bds_v5": {
     "up": "Standard_E64bds_v5",
     "down": "Standard_E32bds_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "384"
   },
   "Standard_E64bds_v5": {
     "up": null,
     "down": "Standard_E48bds_v5",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "512"
   },
   "Standard_E2bs_v5": {
     "up": "Standard_E4bs_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "16"
   },
   "Standard_E4bs_v5": {
     "up": "Standard_E8bs_v5",
     "down": "Standard_E2bs_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "32"
   },
   "Standard_E8bs_v5": {
     "up": "Standard_E16bs_v5",
     "down": "Standard_E4bs_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "64"
   },
   "Standard_E16bs_v5": {
     "up": "Standard_E32bs_v5",
     "down": "Standard_E8bs_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "128"
   },
   "Standard_E32bs_v5": {
     "up": "Standard_E48bs_v5",
     "down": "Standard_E16bs_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "256"
   },
   "Standard_E48bs_v5": {
     "up": "Standard_E64bs_v5",
     "down": "Standard_E32bs_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "384"
   },
   "Standard_E64bs_v5": {
     "up": null,
     "down": "Standard_E48bs_v5",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "512"
   },
   "Standard_E8d_v5": {
     "up": "Standard_E16d_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "64"
   },
   "Standard_E16d_v5": {
     "up": "Standard_E20d_v5",
     "down": "Standard_E8d_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "128"
   },
   "Standard_E20d_v5": {
     "up": "Standard_E32d_v5",
     "down": "Standard_E16d_v5",
     "superseded": null,
-    "vcpu": 24
+    "vcpu": 24,
+    "memory": "160"
   },
   "Standard_E32d_v5": {
     "up": "Standard_E48d_v5",
     "down": "Standard_E20d_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "256"
   },
   "Standard_E48d_v5": {
     "up": "Standard_E64d_v5",
     "down": "Standard_E32d_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "384"
   },
   "Standard_E64d_v5": {
     "up": "Standard_E96d_v5",
     "down": "Standard_E48d_v5",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "512"
   },
   "Standard_E96d_v5": {
     "up": "Standard_E104id_v5",
     "down": "Standard_E64d_v5",
     "superseded": null,
-    "vcpu": 96
+    "vcpu": 96,
+    "memory": "672"
   },
   "Standard_E104id_v5": {
     "up": null,
     "down": "Standard_E96d_v5",
     "superseded": null,
-    "vcpu": 104
+    "vcpu": 104,
+    "memory": "672"
   },
   "Standard_E2ds_v5": {
     "up": "Standard_E4ds_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "16"
   },
   "Standard_E4ds_v5": {
     "up": "Standard_E8ds_v5",
     "down": "Standard_E2ds_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "32"
   },
   "Standard_E8ds_v5": {
     "up": "Standard_E16ds_v5",
     "down": "Standard_E4ds_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "64"
   },
   "Standard_E16ds_v5": {
     "up": "Standard_E20ds_v5",
     "down": "Standard_E8ds_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "128"
   },
   "Standard_E20ds_v5": {
     "up": "Standard_E32ds_v5",
     "down": "Standard_E16ds_v5",
     "superseded": null,
-    "vcpu": 20
+    "vcpu": 20,
+    "memory": "160"
   },
   "Standard_E32ds_v5": {
     "up": "Standard_E48ds_v5",
     "down": "Standard_E20ds_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "256"
   },
   "Standard_E48ds_v5": {
     "up": "Standard_E64ds_v5",
     "down": "Standard_E32ds_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "384"
   },
   "Standard_E64ds_v5": {
     "up": "Standard_E96ds_v5",
     "down": "Standard_E48ds_v5",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "512"
   },
   "Standard_E96ds_v5": {
     "up": null,
     "down": "Standard_E64ds_v5",
     "superseded": null,
-    "vcpu": 96
+    "vcpu": 96,
+    "memory": "672"
   },
   "Standard_E104ids_v5": {
     "up": null,
     "down": null,
     "superseded": null,
-    "vcpu": 104
+    "vcpu": 104,
+    "memory": "672"
   },
   "Standard_EC2as_v5": {
     "up": "Standard_EC4as_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "16"
   },
   "Standard_EC4as_v5": {
     "up": "Standard_EC8as_v5",
     "down": "Standard_EC2as_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "32"
   },
   "Standard_EC8as_v5": {
     "up": "Standard_EC16as_v5",
     "down": "Standard_EC4as_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "64"
   },
   "Standard_EC16as_v5": {
     "up": "Standard_EC20as_v5",
     "down": "Standard_EC8as_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "128"
   },
   "Standard_EC20as_v5": {
     "up": "Standard_EC32as_v5",
     "down": "Standard_EC16as_v5",
     "superseded": null,
-    "vcpu": 20
+    "vcpu": 20,
+    "memory": "160"
   },
   "Standard_EC32as_v5": {
     "up": "Standard_EC48as_v5",
     "down": "Standard_EC20as_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "256"
   },
   "Standard_EC48as_v5": {
     "up": "Standard_EC64as_v5",
     "down": "Standard_EC32as_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "384"
   },
   "Standard_EC64as_v5": {
     "up": "Standard_EC96as_v5",
     "down": "Standard_EC48as_v5",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "512"
   },
   "Standard_EC96as_v5": {
     "up": null,
     "down": "Standard_EC64as_v5",
     "superseded": null,
-    "vcpu": 96
+    "vcpu": 96,
+    "memory": "672"
   },
   "Standard_EC2ads_v5": {
     "up": "Standard_EC4ads_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "16"
   },
   "Standard_EC4ads_v5": {
     "up": "Standard_EC8ads_v5",
     "down": "Standard_EC2ads_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "32"
   },
   "Standard_EC8ads_v5": {
     "up": "Standard_EC16ads_v5",
     "down": "Standard_EC4ads_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "64"
   },
   "Standard_EC16ads_v5": {
     "up": "Standard_EC20ads_v5",
     "down": "Standard_EC8ads_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "128"
   },
   "Standard_EC20ads_v5": {
     "up": "Standard_EC32ads_v5",
     "down": "Standard_EC16ads_v5",
     "superseded": null,
-    "vcpu": 20
+    "vcpu": 20,
+    "memory": "160"
   },
   "Standard_EC32ads_v5": {
     "up": "Standard_EC48ads_v5",
     "down": "Standard_EC20ads_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "256"
   },
   "Standard_EC48ads_v5": {
     "up": "Standard_EC64ads_v5",
     "down": "Standard_EC32ads_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "384"
   },
   "Standard_EC64ads_v5": {
     "up": "Standard_EC96ads_v5",
     "down": "Standard_EC48ads_v5",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "512"
   },
   "Standard_EC96ads_v5": {
     "up": null,
     "down": "Standard_EC64ads_v5",
     "superseded": null,
-    "vcpu": 96
+    "vcpu": 96,
+    "memory": "672"
   },
   "Standard_E2ps_v5": {
     "up": "Standard_E4ps_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "16"
   },
   "Standard_E4ps_v5": {
     "up": "Standard_E8ps_v5",
     "down": "Standard_E2ps_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "32"
   },
   "Standard_E8ps_v5": {
     "up": "Standard_E16ps_v5",
     "down": "Standard_E4ps_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "64"
   },
   "Standard_E16ps_v5": {
     "up": "Standard_E20ps_v5",
     "down": "Standard_E8ps_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "128"
   },
   "Standard_E20ps_v5": {
     "up": "Standard_E32ps_v5",
     "down": "Standard_E16ps_v5",
     "superseded": null,
-    "vcpu": 20
+    "vcpu": 20,
+    "memory": "160"
   },
   "Standard_E32ps_v5": {
     "up": null,
     "down": "Standard_E20ps_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "208"
   },
   "Standard_E2pds_v5": {
     "up": "Standard_E4pds_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "16"
   },
   "Standard_E4pds_v5": {
     "up": "Standard_E8pds_v5",
     "down": "Standard_E2pds_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "32"
   },
   "Standard_E8pds_v5": {
     "up": "Standard_E16pds_v5",
     "down": "Standard_E4pds_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "64"
   },
   "Standard_E16pds_v5": {
     "up": "Standard_E20pds_v5",
     "down": "Standard_E8pds_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "128"
   },
   "Standard_E20pds_v5": {
     "up": "Standard_E32pds_v5",
     "down": "Standard_E16pds_v5",
     "superseded": null,
-    "vcpu": 20
+    "vcpu": 20,
+    "memory": "160"
   },
   "Standard_E32pds_v5": {
     "up": null,
     "down": "Standard_E20pds_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "208"
   },
   "Standard_M32ms_v2": {
     "up": "Standard_M64ms_v2",
     "down": null,
     "superseded": null,
     "vcpu": 32,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "875"
   },
   "Standard_M64ms_v2": {
     "up": "Standard_M128ms_v2",
     "down": "Standard_M32ms_v2",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "1792"
   },
   "Standard_M128ms_v2": {
     "up": null,
     "down": "Standard_M64ms_v2",
     "superseded": null,
     "vcpu": 128,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "3892"
   },
   "Standard_M64s_v2": {
     "up": "Standard_M128s_v2",
     "down": null,
     "superseded": null,
     "vcpu": 64,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "1024"
   },
   "Standard_M128s_v2": {
     "up": null,
     "down": "Standard_M64s_v2",
     "superseded": null,
     "vcpu": 128,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "2048"
   },
   "Standard_M192is_v2": {
     "up": null,
     "down": null,
     "superseded": null,
     "vcpu": 192,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "2048"
   },
   "Standard_M192ims_v2": {
     "up": null,
     "down": null,
     "superseded": null,
     "vcpu": 192,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "4096"
   },
   "Standard_M32dms_v2": {
     "up": "Standard_M64dms_v2",
     "down": null,
     "superseded": null,
     "vcpu": 32,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "875"
   },
   "Standard_M64dms_v2": {
     "up": "Standard_M128dms_v2",
     "down": "Standard_M32dms_v2",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "1792"
   },
   "Standard_M128dms_v2": {
     "up": null,
     "down": "Standard_M64dms_v2",
     "superseded": null,
     "vcpu": 128,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "3892"
   },
   "Standard_M64ds_v2": {
     "up": "Standard_M128ds_v2",
     "down": null,
     "superseded": null,
     "vcpu": 64,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "1024"
   },
   "Standard_M128ds_v2": {
     "up": null,
     "down": "Standard_M64ds_v2",
     "superseded": null,
     "vcpu": 128,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "2048"
   },
   "Standard_M192ids_v2": {
     "up": null,
     "down": null,
     "superseded": null,
     "vcpu": 192,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "2048"
   },
   "Standard_M192idms_v2": {
     "up": null,
     "down": null,
     "superseded": null,
     "vcpu": 192,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "4096"
   },
   "Standard_M8-2ms": {
     "up": "Standard_M8-4ms",
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "218.75"
   },
   "Standard_M8-4ms": {
     "up": null,
     "down": "Standard_M8-2ms",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "218.75"
   },
   "Standard_M16-4ms": {
     "up": "Standard_M16-8ms",
     "down": null,
     "superseded": null,
     "vcpu": 4,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "437.5"
   },
   "Standard_M16-8ms": {
     "up": null,
     "down": "Standard_M16-4ms",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "437.5"
   },
   "Standard_M32-8ms": {
     "up": "Standard_M32-16ms",
     "down": null,
     "superseded": null,
     "vcpu": 8,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "875"
   },
   "Standard_M32-16ms": {
     "up": null,
     "down": "Standard_M32-8ms",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "875"
   },
   "Standard_M64-16ms": {
     "up": "Standard_M64-32ms",
     "down": null,
     "superseded": null,
     "vcpu": 16,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "1792"
   },
   "Standard_M64-32ms": {
     "up": null,
     "down": "Standard_M64-16ms",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "1792"
   },
   "Standard_M128-32ms": {
     "up": "Standard_M128-64ms",
     "down": null,
     "superseded": null,
     "vcpu": 32,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "3892"
   },
   "Standard_M128-64ms": {
     "up": null,
     "down": "Standard_M128-32ms",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "3892"
   },
   "Standard_E4-2s_v3": {
     "up": null,
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "32"
   },
   "Standard_E8-2s_v3": {
     "up": "Standard_E8-4s_v3",
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "64"
   },
   "Standard_E8-4s_v3": {
     "up": null,
     "down": "Standard_E8-2s_v3",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "64"
   },
   "Standard_E16-4s_v3": {
     "up": "Standard_E16-8s_v3",
     "down": null,
     "superseded": null,
     "vcpu": 4,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "128"
   },
   "Standard_E16-8s_v3": {
     "up": null,
     "down": "Standard_E16-4s_v3",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "128"
   },
   "Standard_E32-8s_v3": {
     "up": "Standard_E32-16s_v3",
     "down": null,
     "superseded": null,
     "vcpu": 8,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "256"
   },
   "Standard_E32-16s_v3": {
     "up": null,
     "down": "Standard_E32-8s_v3",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "256"
   },
   "Standard_E64-16s_v3": {
     "up": "Standard_E64-32s_v3",
     "down": null,
     "superseded": null,
     "vcpu": 16,
-    "nfu": "28.8"
+    "nfu": "28.8",
+    "memory": "432"
   },
   "Standard_E64-32s_v3": {
     "up": null,
     "down": "Standard_E64-16s_v3",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "28.8"
+    "nfu": "28.8",
+    "memory": "432"
   },
   "Standard_E4-2s_v4": {
     "up": null,
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "32"
   },
   "Standard_E8-2s_v4": {
     "up": "Standard_E8-4s_v4",
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "64"
   },
   "Standard_E8-4s_v4": {
     "up": null,
     "down": "Standard_E8-2s_v4",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "64"
   },
   "Standard_E16-4s_v4": {
     "up": "Standard_E16-8s_v4",
     "down": null,
     "superseded": null,
     "vcpu": 4,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "128"
   },
   "Standard_E16-8s_v4": {
     "up": null,
     "down": "Standard_E16-4s_v4",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "128"
   },
   "Standard_E32-8s_v4": {
     "up": "Standard_E32-16s_v4",
     "down": null,
     "superseded": null,
     "vcpu": 8,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "256"
   },
   "Standard_E32-16s_v4": {
     "up": null,
     "down": "Standard_E32-8s_v4",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "256"
   },
   "Standard_E64-16s_v4": {
     "up": "Standard_E64-32s_v4",
     "down": null,
     "superseded": null,
     "vcpu": 16,
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "504"
   },
   "Standard_E64-32s_v4": {
     "up": null,
     "down": "Standard_E64-16s_v4",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "504"
   },
   "Standard_E4-2ds_v4": {
     "up": null,
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "32"
   },
   "Standard_E8-2ds_v4": {
     "up": "Standard_E8-4ds_v4",
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "64"
   },
   "Standard_E8-4ds_v4": {
     "up": null,
     "down": "Standard_E8-2ds_v4",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "64"
   },
   "Standard_E16-4ds_v4": {
     "up": "Standard_E16-8ds_v4",
     "down": null,
     "superseded": null,
     "vcpu": 4,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "128"
   },
   "Standard_E16-8ds_v4": {
     "up": null,
     "down": "Standard_E16-4ds_v4",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "128"
   },
   "Standard_E32-8ds_v4": {
     "up": "Standard_E32-16ds_v4",
     "down": null,
     "superseded": null,
     "vcpu": 8,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "256"
   },
   "Standard_E32-16ds_v4": {
     "up": null,
     "down": "Standard_E32-8ds_v4",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "256"
   },
   "Standard_E64-16ds_v4": {
     "up": "Standard_E64-32ds_v4",
     "down": null,
     "superseded": null,
     "vcpu": 16,
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "504"
   },
   "Standard_E64-32ds_v4": {
     "up": null,
     "down": "Standard_E64-16ds_v4",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "504"
   },
   "Standard_E4-2s_v5": {
     "up": null,
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "32"
   },
   "Standard_E8-2s_v5": {
     "up": "Standard_E8-4s_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "64"
   },
   "Standard_E8-4s_v5": {
     "up": null,
     "down": "Standard_E8-2s_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "64"
   },
   "Standard_E16-4s_v5": {
     "up": "Standard_E16-8s_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "128"
   },
   "Standard_E16-8s_v5": {
     "up": null,
     "down": "Standard_E16-4s_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "128"
   },
   "Standard_E32-8s_v5": {
     "up": "Standard_E32-16s_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "256"
   },
   "Standard_E32-16s_v5": {
     "up": null,
     "down": "Standard_E32-8s_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "256"
   },
   "Standard_E64-16s_v5": {
     "up": "Standard_E64-32s_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "512"
   },
   "Standard_E64-32s_v5": {
     "up": null,
     "down": "Standard_E64-16s_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "512"
   },
   "Standard_E96-24s_v5": {
     "up": "Standard_E96-48s_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 24
+    "vcpu": 24,
+    "memory": "672"
   },
   "Standard_E96-48s_v5": {
     "up": null,
     "down": "Standard_E96-24s_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "672"
   },
   "Standard_E4-2ds_v5": {
     "up": null,
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "32"
   },
   "Standard_E8-2ds_v5": {
     "up": "Standard_E8-4ds_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "64"
   },
   "Standard_E8-4ds_v5": {
     "up": null,
     "down": "Standard_E8-2ds_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "64"
   },
   "Standard_E16-4ds_v5": {
     "up": "Standard_E16-8ds_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "128"
   },
   "Standard_E16-8ds_v5": {
     "up": null,
     "down": "Standard_E16-4ds_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "128"
   },
   "Standard_E32-8ds_v5": {
     "up": "Standard_E32-16ds_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "256"
   },
   "Standard_E32-16ds_v5": {
     "up": null,
     "down": "Standard_E32-8ds_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "256"
   },
   "Standard_E64-16ds_v5": {
     "up": "Standard_E64-32ds_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "512"
   },
   "Standard_E64-32ds_v5": {
     "up": null,
     "down": "Standard_E64-16ds_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "512"
   },
   "Standard_E96-24ds_v5": {
     "up": "Standard_E96-48ds_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 24
+    "vcpu": 24,
+    "memory": "672"
   },
   "Standard_E96-48ds_v5": {
     "up": null,
     "down": "Standard_E96-24ds_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "672"
   },
   "Standard_E4-2as_v4": {
     "up": null,
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "32"
   },
   "Standard_E8-2as_v4": {
     "up": "Standard_E8-4as_v4",
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "64"
   },
   "Standard_E8-4as_v4": {
     "up": null,
     "down": "Standard_E8-2as_v4",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "64"
   },
   "Standard_E16-4as_v4": {
     "up": "Standard_E16-8as_v4",
     "down": null,
     "superseded": null,
     "vcpu": 4,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "128"
   },
   "Standard_E16-8as_v4": {
     "up": null,
     "down": "Standard_E16-4as_v4",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "128"
   },
   "Standard_E32-8as_v4": {
     "up": "Standard_E32-16as_v4",
     "down": null,
     "superseded": null,
     "vcpu": 8,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "256"
   },
   "Standard_E32-16as_v4": {
     "up": null,
     "down": "Standard_E32-8as_v4",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "256"
   },
   "Standard_E64-16as_v4": {
     "up": "Standard_E64-32as_v4",
     "down": null,
     "superseded": null,
     "vcpu": 16,
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "512"
   },
   "Standard_E64-32as_v4": {
     "up": null,
     "down": "Standard_E64-16as_v4",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "512"
   },
   "Standard_E96-24as_v4": {
     "up": "Standard_E96-48as_v4",
     "down": null,
     "superseded": null,
     "vcpu": 24,
-    "nfu": "48"
+    "nfu": "48",
+    "memory": "672"
   },
   "Standard_E96-48as_v4": {
     "up": null,
     "down": "Standard_E96-24as_v4",
     "superseded": null,
     "vcpu": 48,
-    "nfu": "48"
+    "nfu": "48",
+    "memory": "672"
   },
   "Standard_E4-2ads_v5": {
     "up": null,
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "32"
   },
   "Standard_E8-2ads_v5": {
     "up": "Standard_E8-4ads_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "64"
   },
   "Standard_E8-4ads_v5": {
     "up": null,
     "down": "Standard_E8-2ads_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "64"
   },
   "Standard_E16-4ads_v5": {
     "up": "Standard_E16-8ads_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "128"
   },
   "Standard_E16-8ads_v5": {
     "up": null,
     "down": "Standard_E16-4ads_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "128"
   },
   "Standard_E32-8ads_v5": {
     "up": "Standard_E32-16ads_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "256"
   },
   "Standard_E32-16ads_v5": {
     "up": null,
     "down": "Standard_E32-8ads_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "256"
   },
   "Standard_E64-16ads_v5": {
     "up": "Standard_E64-32ads_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "512"
   },
   "Standard_E64-32ads_v5": {
     "up": null,
     "down": "Standard_E64-16ads_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "512"
   },
   "Standard_E96-24ads_v5": {
     "up": "Standard_E96-48ads_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 24
+    "vcpu": 24,
+    "memory": "672"
   },
   "Standard_E96-48ads_v5": {
     "up": null,
     "down": "Standard_E96-24ads_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "672"
   },
   "Standard_E4-2as_v5": {
     "up": null,
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "32"
   },
   "Standard_E8-2as_v5": {
     "up": "Standard_E8-4as_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "64"
   },
   "Standard_E8-4as_v5": {
     "up": null,
     "down": "Standard_E8-2as_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "64"
   },
   "Standard_E16-4as_v5": {
     "up": "Standard_E16-8as_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "128"
   },
   "Standard_E16-8as_v5": {
     "up": null,
     "down": "Standard_E16-4as_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "128"
   },
   "Standard_E32-8as_v5": {
     "up": "Standard_E32-16as_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "256"
   },
   "Standard_E32-16as_v5": {
     "up": null,
     "down": "Standard_E32-8as_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "256"
   },
   "Standard_E64-16as_v5": {
     "up": "Standard_E64-32as_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "512"
   },
   "Standard_E64-32as_v5": {
     "up": null,
     "down": "Standard_E64-16as_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "512"
   },
   "Standard_E96-24as_v5": {
     "up": "Standard_E96-48as_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 24
+    "vcpu": 24,
+    "memory": "672"
   },
   "Standard_E96-48as_v5": {
     "up": null,
     "down": "Standard_E96-24as_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "672"
   },
   "Standard_GS4-4": {
     "up": "Standard_GS4-8",
@@ -2864,310 +3272,356 @@
     "down": null,
     "superseded": null,
     "vcpu": 1,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "14"
   },
   "Standard_DS12-1_v2": {
     "up": "Standard_DS12-2_v2",
     "down": null,
     "superseded": null,
     "vcpu": 1,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "28"
   },
   "Standard_DS12-2_v2": {
     "up": null,
     "down": "Standard_DS12-1_v2",
     "superseded": null,
     "vcpu": 2,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "28"
   },
   "Standard_DS13-2_v2": {
     "up": "Standard_DS13-4_v2",
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "56"
   },
   "Standard_DS13-4_v2": {
     "up": null,
     "down": "Standard_DS13-2_v2",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "56"
   },
   "Standard_DS14-4_v2": {
     "up": "Standard_DS14-8_v2",
     "down": null,
     "superseded": null,
     "vcpu": 4,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "112"
   },
   "Standard_DS14-8_v2": {
     "up": null,
     "down": "Standard_DS14-4_v2",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "112"
   },
   "Standard_M416-208s_v2": {
     "up": null,
     "down": null,
     "superseded": null,
     "vcpu": 208,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "5700"
   },
   "Standard_M416-208ms_v2": {
     "up": null,
     "down": null,
     "superseded": null,
     "vcpu": 208,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "11400"
   },
   "Standard_L8s_v3": {
     "up": "Standard_L16s_v3",
     "down": null,
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "64"
   },
   "Standard_L16s_v3": {
     "up": "Standard_L32s_v3",
     "down": "Standard_L8s_v3",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "128"
   },
   "Standard_L32s_v3": {
     "up": "Standard_L48s_v3",
     "down": "Standard_L16s_v3",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "256"
   },
   "Standard_L48s_v3": {
     "up": "Standard_L64s_v3",
     "down": "Standard_L32s_v3",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "384"
   },
   "Standard_L64s_v3": {
     "up": "Standard_L80s_v3",
     "down": "Standard_L48s_v3",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "512"
   },
   "Standard_L80s_v3": {
     "up": null,
     "down": "Standard_L64s_v3",
     "superseded": null,
-    "vcpu": 80
+    "vcpu": 80,
+    "memory": "640"
   },
   "Standard_L8as_v3": {
     "up": "Standard_L16as_v3",
     "down": null,
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "64"
   },
   "Standard_L16as_v3": {
     "up": "Standard_L32as_v3",
     "down": "Standard_L8as_v3",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "128"
   },
   "Standard_L32as_v3": {
     "up": "Standard_L48as_v3",
     "down": "Standard_L16as_v3",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "256"
   },
   "Standard_L48as_v3": {
     "up": "Standard_L64as_v3",
     "down": "Standard_L32as_v3",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "384"
   },
   "Standard_L64as_v3": {
     "up": "Standard_L80as_v3",
     "down": "Standard_L48as_v3",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "512"
   },
   "Standard_L80as_v3": {
     "up": null,
     "down": "Standard_L64as_v3",
     "superseded": null,
-    "vcpu": 80
+    "vcpu": 80,
+    "memory": "640"
   },
   "Standard_E2_v3": {
     "up": "Standard_E4_v3",
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "16"
   },
   "Standard_E4_v3": {
     "up": "Standard_E8_v3",
     "down": "Standard_E2_v3",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "32"
   },
   "Standard_E8_v3": {
     "up": "Standard_E16_v3",
     "down": "Standard_E4_v3",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "64"
   },
   "Standard_E16_v3": {
     "up": "Standard_E20_v3",
     "down": "Standard_E8_v3",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "128"
   },
   "Standard_E20_v3": {
     "up": "Standard_E32_v3",
     "down": "Standard_E16_v3",
     "superseded": null,
     "vcpu": 20,
-    "nfu": "10"
+    "nfu": "10",
+    "memory": "160"
   },
   "Standard_E32_v3": {
     "up": "Standard_E48_v3",
     "down": "Standard_E20_v3",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "256"
   },
   "Standard_E48_v3": {
     "up": "Standard_E64_v3",
     "down": "Standard_E32_v3",
     "superseded": null,
     "vcpu": 48,
-    "nfu": "24"
+    "nfu": "24",
+    "memory": "384"
   },
   "Standard_E64_v3": {
     "up": null,
     "down": "Standard_E48_v3",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "28.8"
+    "nfu": "28.8",
+    "memory": "432"
   },
   "Standard_E64i_v3": {
     "up": null,
     "down": "Standard_E48_v3",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "432"
   },
   "Standard_E2ds_v4": {
     "up": "Standard_E4ds_v4",
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "16"
   },
   "Standard_E4ds_v4": {
     "up": "Standard_E8ds_v4",
     "down": "Standard_E2ds_v4",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "32"
   },
   "Standard_E8ds_v4": {
     "up": "Standard_E16ds_v4",
     "down": "Standard_E4ds_v4",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "64"
   },
   "Standard_E16ds_v4": {
     "up": "Standard_E20ds_v4",
     "down": "Standard_E8ds_v4",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "128"
   },
   "Standard_E20ds_v4": {
     "up": "Standard_E32ds_v4",
     "down": "Standard_E16ds_v4",
     "superseded": null,
     "vcpu": 20,
-    "nfu": "10"
+    "nfu": "10",
+    "memory": "160"
   },
   "Standard_E32ds_v4": {
     "up": "Standard_E48ds_v4",
     "down": "Standard_E20ds_v4",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "256"
   },
   "Standard_E48ds_v4": {
     "up": "Standard_E64ds_v4",
     "down": "Standard_E32ds_v4",
     "superseded": null,
     "vcpu": 48,
-    "nfu": "24"
+    "nfu": "24",
+    "memory": "384"
   },
   "Standard_E64ds_v4": {
     "up": "Standard_E80ids_v4",
     "down": "Standard_E48ds_v4",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "504"
   },
   "Standard_E80ids_v4": {
     "up": null,
     "down": "Standard_E64ds_v4",
     "superseded": null,
     "vcpu": 80,
-    "nfu": "1.25"
+    "nfu": "1.25",
+    "memory": "504"
   },
   "Standard_E2d_v4": {
     "up": "Standard_E4d_v4",
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "16"
   },
   "Standard_E4d_v4": {
     "up": "Standard_E8d_v4",
     "down": "Standard_E2d_v4",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "32"
   },
   "Standard_E8d_v4": {
     "up": "Standard_E16d_v4",
     "down": "Standard_E4d_v4",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "64"
   },
   "Standard_E16d_v4": {
     "up": "Standard_E20d_v4",
     "down": "Standard_E8d_v4",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "128"
   },
   "Standard_E20d_v4": {
     "up": "Standard_E32d_v4",
     "down": "Standard_E16d_v4",
     "superseded": null,
     "vcpu": 20,
-    "nfu": "10"
+    "nfu": "10",
+    "memory": "160"
   },
   "Standard_E32d_v4": {
     "up": "Standard_E48d_v4",
     "down": "Standard_E20d_v4",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "256"
   },
   "Standard_E48d_v4": {
     "up": "Standard_E64d_v4",
     "down": "Standard_E32d_v4",
     "superseded": null,
     "vcpu": 48,
-    "nfu": "24"
+    "nfu": "24",
+    "memory": "384"
   },
   "Standard_E64d_v4 ": {
     "up": null,
@@ -3181,256 +3635,294 @@
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "16"
   },
   "Standard_E4s_v3": {
     "up": "Standard_E8s_v3",
     "down": "Standard_E2s_v3",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "32"
   },
   "Standard_E8s_v3": {
     "up": "Standard_E16s_v3",
     "down": "Standard_E4s_v3",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "64"
   },
   "Standard_E16s_v3": {
     "up": "Standard_E20s_v3",
     "down": "Standard_E8s_v3",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "128"
   },
   "Standard_E20s_v3": {
     "up": "Standard_E32s_v3",
     "down": "Standard_E16s_v3",
     "superseded": null,
     "vcpu": 20,
-    "nfu": "10"
+    "nfu": "10",
+    "memory": "160"
   },
   "Standard_E32s_v3": {
     "up": "Standard_E48s_v3",
     "down": "Standard_E20s_v3",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "256"
   },
   "Standard_E48s_v3": {
     "up": "Standard_E64s_v3",
     "down": "Standard_E32s_v3",
     "superseded": null,
     "vcpu": 48,
-    "nfu": "24"
+    "nfu": "24",
+    "memory": "384"
   },
   "Standard_E64s_v3": {
     "up": null,
     "down": "Standard_E48s_v3",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "28.8"
+    "nfu": "28.8",
+    "memory": "432"
   },
   "Standard_E64is_v3": {
     "up": null,
     "down": "Standard_E48s_v3",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "432"
   },
   "Standard_G1": {
     "up": "Standard_G2",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "28"
   },
   "Standard_G2": {
     "up": "Standard_G3",
     "down": "Standard_G1",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "56"
   },
   "Standard_G3": {
     "up": "Standard_G4",
     "down": "Standard_G2",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "112"
   },
   "Standard_G4": {
     "up": "Standard_G5",
     "down": "Standard_G3",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "224"
   },
   "Standard_G5": {
     "up": null,
     "down": "Standard_G4",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "448"
   },
   "Standard_GS1": {
     "up": "Standard_GS2",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "28"
   },
   "Standard_GS2": {
     "up": "Standard_GS3",
     "down": "Standard_GS1",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "56"
   },
   "Standard_GS3": {
     "up": "Standard_GS4",
     "down": "Standard_GS2",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "112"
   },
   "Standard_GS4": {
     "up": "Standard_GS5",
     "down": "Standard_GS3",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "224"
   },
   "Standard_GS5": {
     "up": null,
     "down": "Standard_GS4",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "448"
   },
   "Standard_L4s": {
     "up": "Standard_L8s",
     "down": null,
     "superseded": null,
     "vcpu": 4,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "32"
   },
   "Standard_L8s": {
     "up": "Standard_L16s",
     "down": "Standard_L4s",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "64"
   },
   "Standard_L16s": {
     "up": "Standard_L32s",
     "down": "Standard_L8s",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "128"
   },
   "Standard_L32s": {
     "up": null,
     "down": "Standard_L16s",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "256"
   },
   "Standard_L8s_v2": {
     "up": "Standard_L16s_v2",
     "down": null,
     "superseded": null,
     "vcpu": 8,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "64"
   },
   "Standard_L16s_v2": {
     "up": "Standard_L32s_v2",
     "down": "Standard_L8s_v2",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "128"
   },
   "Standard_L32s_v2": {
     "up": "Standard_L48s_v2",
     "down": "Standard_L16s_v2",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "256"
   },
   "Standard_L48s_v2": {
     "up": "Standard_L64s_v2",
     "down": "Standard_L32s_v2",
     "superseded": null,
     "vcpu": 48,
-    "nfu": "6"
+    "nfu": "6",
+    "memory": "384"
   },
   "Standard_L64s_v2": {
     "up": "Standard_L80s_v2",
     "down": "Standard_L48s_v2",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "512"
   },
   "Standard_L80s_v2": {
     "up": null,
     "down": "Standard_L64s_v2",
     "superseded": null,
     "vcpu": 80,
-    "nfu": "10"
+    "nfu": "10",
+    "memory": "640"
   },
   "Standard_E2s_v4": {
     "up": "Standard_E4s_v4",
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "16"
   },
   "Standard_E4s_v4": {
     "up": "Standard_E8s_v4",
     "down": "Standard_E2s_v4",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "32"
   },
   "Standard_E8s_v4": {
     "up": "Standard_E16s_v4",
     "down": "Standard_E4s_v4",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "64"
   },
   "Standard_E16s_v4": {
     "up": "Standard_E20s_v4",
     "down": "Standard_E8s_v4",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "128"
   },
   "Standard_E20s_v4": {
     "up": "Standard_E32s_v4",
     "down": "Standard_E16s_v4",
     "superseded": null,
     "vcpu": 20,
-    "nfu": "10"
+    "nfu": "10",
+    "memory": "160"
   },
   "Standard_E32s_v4": {
     "up": "Standard_E48s_v4",
     "down": "Standard_E20s_v4",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "256"
   },
   "Standard_E48s_v4": {
     "up": "Standard_E64s_v4",
     "down": "Standard_E32s_v4",
     "superseded": null,
     "vcpu": 48,
-    "nfu": "24"
+    "nfu": "24",
+    "memory": "384"
   },
   "Standard_E64s_v4": {
     "up": "Standard_E80is_v4",
     "down": "Standard_E48s_v4",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "504"
   },
   "Standard_E80is_v4": {
     "up": null,
     "down": "Standard_E64s_v4",
     "superseded": null,
     "vcpu": 80,
-    "nfu": "1.25"
+    "nfu": "1.25",
+    "memory": "504"
   },
   "Standard_E2as_v4": {
     "up": "Standard_E4as_v4",
@@ -3439,7 +3931,8 @@
       "regular": "Standard_E2ads_v5"
     },
     "vcpu": 2,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "16"
   },
   "Standard_E4as_v4": {
     "up": "Standard_E8as_v4",
@@ -3448,7 +3941,8 @@
       "regular": "Standard_E4ads_v5"
     },
     "vcpu": 4,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "32"
   },
   "Standard_E8as_v4": {
     "up": "Standard_E16as_v4",
@@ -3457,7 +3951,8 @@
       "regular": "Standard_E8ads_v5"
     },
     "vcpu": 8,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "64"
   },
   "Standard_E16as_v4": {
     "up": "Standard_E20as_v4",
@@ -3466,7 +3961,8 @@
       "regular": "Standard_E16ads_v5"
     },
     "vcpu": 16,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "128"
   },
   "Standard_E20as_v4": {
     "up": "Standard_E32as_v4",
@@ -3475,7 +3971,8 @@
       "regular": "Standard_E20ads_v5"
     },
     "vcpu": 20,
-    "nfu": "10"
+    "nfu": "10",
+    "memory": "160"
   },
   "Standard_E32as_v4": {
     "up": "Standard_E48as_v4",
@@ -3484,7 +3981,8 @@
       "regular": "Standard_E32ads_v5"
     },
     "vcpu": 32,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "256"
   },
   "Standard_E48as_v4": {
     "up": "Standard_E64as_v4",
@@ -3493,7 +3991,8 @@
       "regular": "Standard_E48ads_v5"
     },
     "vcpu": 48,
-    "nfu": "24"
+    "nfu": "24",
+    "memory": "384"
   },
   "Standard_E64as_v4": {
     "up": "Standard_E96as_v4",
@@ -3502,7 +4001,8 @@
       "regular": "Standard_E64ads_v5"
     },
     "vcpu": 64,
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "432"
   },
   "Standard_E96as_v4": {
     "up": null,
@@ -3513,196 +4013,224 @@
       }
     },
     "vcpu": 96,
-    "nfu": "48"
+    "nfu": "48",
+    "memory": "672"
   },
   "Standard_E2a_v4": {
     "up": "Standard_E4a_v4",
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "16"
   },
   "Standard_E4a_v4": {
     "up": "Standard_E8a_v4",
     "down": "Standard_E2a_v4",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "32"
   },
   "Standard_E8a_v4": {
     "up": "Standard_E16a_v4",
     "down": "Standard_E4a_v4",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "64"
   },
   "Standard_E16a_v4": {
     "up": "Standard_E20a_v4",
     "down": "Standard_E8a_v4",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "128"
   },
   "Standard_E20a_v4": {
     "up": "Standard_E32a_v4",
     "down": "Standard_E16a_v4",
     "superseded": null,
     "vcpu": 20,
-    "nfu": "10"
+    "nfu": "10",
+    "memory": "160"
   },
   "Standard_E32a_v4": {
     "up": "Standard_E48a_v4",
     "down": "Standard_E20a_v4",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "256"
   },
   "Standard_E48a_v4": {
     "up": "Standard_E64a_v4",
     "down": "Standard_E32a_v4",
     "superseded": null,
     "vcpu": 48,
-    "nfu": "24"
+    "nfu": "24",
+    "memory": "384"
   },
   "Standard_E64a_v4": {
     "up": "Standard_E96a_v4",
     "down": "Standard_E48a_v4",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "432"
   },
   "Standard_E96a_v4": {
     "up": null,
     "down": "Standard_E64a_v4",
     "superseded": null,
     "vcpu": 96,
-    "nfu": "48"
+    "nfu": "48",
+    "memory": "672"
   },
   "Standard_F1": {
     "up": "Standard_F2",
     "down": null,
     "superseded": null,
     "vcpu": 1,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "2"
   },
   "Standard_F2": {
     "up": "Standard_F4",
     "down": "Standard_F1",
     "superseded": null,
     "vcpu": 2,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "4"
   },
   "Standard_F4": {
     "up": "Standard_F8",
     "down": "Standard_F2",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8"
   },
   "Standard_F8": {
     "up": "Standard_F16",
     "down": "Standard_F4",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16"
   },
   "Standard_F16": {
     "up": null,
     "down": "Standard_F8",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32"
   },
   "Standard_F1s": {
     "up": "Standard_F2s",
     "down": null,
     "superseded": null,
     "vcpu": 1,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "2"
   },
   "Standard_F2s": {
     "up": "Standard_F4s",
     "down": "Standard_F1s",
     "superseded": null,
     "vcpu": 2,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "4"
   },
   "Standard_F4s": {
     "up": "Standard_F8s",
     "down": "Standard_F2s",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "8"
   },
   "Standard_F8s": {
     "up": "Standard_F16s",
     "down": "Standard_F4s",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "16"
   },
   "Standard_F16s": {
     "up": null,
     "down": "Standard_F8s",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "32"
   },
   "Standard_F2s_v2": {
     "up": "Standard_F4s_v2",
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "4"
   },
   "Standard_F4s_v2": {
     "up": "Standard_F8s_v2",
     "down": "Standard_F2s_v2",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "8"
   },
   "Standard_F8s_v2": {
     "up": "Standard_F16s_v2",
     "down": "Standard_F4s_v2",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "16"
   },
   "Standard_F16s_v2": {
     "up": "Standard_F32s_v2",
     "down": "Standard_F8s_v2",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "32"
   },
   "Standard_F32s_v2": {
     "up": "Standard_F48s_v2",
     "down": "Standard_F16s_v2",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "64"
   },
   "Standard_F48s_v2": {
     "up": "Standard_F64s_v2",
     "down": "Standard_F32s_v2",
     "superseded": null,
     "vcpu": 48,
-    "nfu": "24"
+    "nfu": "24",
+    "memory": "96"
   },
   "Standard_F64s_v2": {
     "up": "Standard_F72s_v2",
     "down": "Standard_F48s_v2",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "128"
   },
   "Standard_F72s_v2": {
     "up": null,
     "down": "Standard_F64s_v2",
     "superseded": null,
     "vcpu": 72,
-    "nfu": "36"
+    "nfu": "36",
+    "memory": "144"
   },
   "Standard_H8": {
     "up": "Standard_H8m",
@@ -3753,7 +4281,8 @@
       "regular": "Standard_HB120rs_v2"
     },
     "vcpu": 60,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "240"
   },
   "Standard_NC6": {
     "up": "Standard_NC12",
@@ -3762,7 +4291,8 @@
       "regular": "Standard_NC4as_T4_v3"
     },
     "vcpu": 6,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "56"
   },
   "Standard_NC12": {
     "up": "Standard_NC24",
@@ -3771,7 +4301,8 @@
       "regular": "Standard_NC16as_T4_v3"
     },
     "vcpu": 12,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "112"
   },
   "Standard_NC24": {
     "up": null,
@@ -3780,7 +4311,8 @@
       "regular": "Standard_NC64as_T4_v3"
     },
     "vcpu": 24,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "224"
   },
   "Standard_NC24r": {
     "up": null,
@@ -3789,7 +4321,8 @@
       "regular": "Standard_ND96amsr_A100_v4"
     },
     "vcpu": 24,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "224"
   },
   "Standard_NC6s_v2": {
     "up": "Standard_NC12s_v2",
@@ -3798,7 +4331,8 @@
       "regular": "Standard_NC24ads_A100_v4"
     },
     "vcpu": 6,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "112"
   },
   "Standard_NC12s_v2": {
     "up": "Standard_NC24s_v2",
@@ -3807,7 +4341,8 @@
       "regular": "Standard_NC48ads_A100_v4"
     },
     "vcpu": 12,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "224"
   },
   "Standard_NC24s_v2": {
     "up": "Standard_NC24rs_v2",
@@ -3816,7 +4351,8 @@
       "regular": "Standard_NC96ads_A100_v4"
     },
     "vcpu": 24,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "448"
   },
   "Standard_NC24rs_v2": {
     "up": null,
@@ -3825,276 +4361,316 @@
       "regular": "Standard_ND96amsr_A100_v4"
     },
     "vcpu": 24,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "448"
   },
   "Standard_NC6s_v3": {
     "up": "Standard_NC12s_v3",
     "down": null,
     "superseded": null,
     "vcpu": 6,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "112"
   },
   "Standard_NC12s_v3": {
     "up": "Standard_NC24s_v3",
     "down": "Standard_NC6s_v3",
     "superseded": null,
     "vcpu": 12,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "224"
   },
   "Standard_NC24s_v3": {
     "up": "Standard_NC24rs_v3",
     "down": "Standard_NC12s_v3",
     "superseded": null,
     "vcpu": 24,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "448"
   },
   "Standard_NC24rs_v3": {
     "up": null,
     "down": null,
     "superseded": null,
     "vcpu": 24,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "448"
   },
   "Standard_NC4as_T4_v3": {
     "up": "Standard_NC8as_T4_v3",
     "down": null,
     "superseded": null,
     "vcpu": 4,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "28"
   },
   "Standard_NC8as_T4_v3": {
     "up": "Standard_NC16as_T4_v3",
     "down": "Standard_NC4as_T4_v3",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "56"
   },
   "Standard_NC16as_T4_v3": {
     "up": "Standard_NC64as_T4_v3",
     "down": "Standard_NC8as_T4_v3",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "110"
   },
   "Standard_NC64as_T4_v3": {
     "up": null,
     "down": "Standard_NC16as_T4_v3",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "440"
   },
   "Standard_NC24ads_A100_v4": {
     "up": "Standard_NC48ads_A100_v4",
     "down": null,
     "superseded": null,
-    "vcpu": 24
+    "vcpu": 24,
+    "memory": "220"
   },
   "Standard_NC48ads_A100_v4": {
     "up": "Standard_NC96ads_A100_v4",
     "down": "Standard_NC24ads_A100_v4",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "440"
   },
   "Standard_NC96ads_A100_v4": {
     "up": null,
     "down": "Standard_NC48ads_A100_v4",
     "superseded": null,
-    "vcpu": 96
+    "vcpu": 96,
+    "memory": "880"
   },
   "Standard_ND96asr_v4": {
     "up": null,
     "down": null,
     "superseded": null,
     "vcpu": 96,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "900"
   },
   "Standard_ND96amsr_A100_v4": {
     "up": null,
     "down": null,
     "superseded": null,
-    "vcpu": 96
+    "vcpu": 96,
+    "memory": "1924"
   },
   "Standard_ND40rs_v2": {
     "up": null,
     "down": null,
     "superseded": null,
     "vcpu": 40,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "672"
   },
   "Standard_M8ms": {
     "up": "Standard_M16ms",
     "down": null,
     "superseded": null,
     "vcpu": 8,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "219"
   },
   "Standard_M16ms": {
     "up": "Standard_M32ms",
     "down": "Standard_M8ms",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "438"
   },
   "Standard_M32ms": {
     "up": "Standard_M64ms",
     "down": "Standard_M16ms",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "875"
   },
   "Standard_M64ms": {
     "up": "Standard_M128ms",
     "down": "Standard_M32ms",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "1792"
   },
   "Standard_M128ms": {
     "up": null,
     "down": "Standard_M64ms",
     "superseded": null,
     "vcpu": 128,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "3892"
   },
   "Standard_M32ls": {
     "up": "Standard_M64ls",
     "down": null,
     "superseded": null,
     "vcpu": 32,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "256"
   },
   "Standard_M64ls": {
     "up": null,
     "down": "Standard_M32ls",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "1.8846875"
+    "nfu": "1.8846875",
+    "memory": "512"
   },
   "Standard_M32ts": {
     "up": null,
     "down": null,
     "superseded": null,
     "vcpu": 32,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "192"
   },
   "Standard_M64s": {
     "up": "Standard_M128s",
     "down": null,
     "superseded": null,
     "vcpu": 64,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "1024"
   },
   "Standard_M128s": {
     "up": null,
     "down": "Standard_M64s",
     "superseded": null,
     "vcpu": 128,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "2048"
   },
   "Standard_M64": {
     "up": "Standard_M128",
     "down": null,
     "superseded": null,
     "vcpu": 64,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "1750"
   },
   "Standard_M128": {
     "up": null,
     "down": "Standard_M64",
     "superseded": null,
     "vcpu": 128,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "3800"
   },
   "Standard_M64m": {
     "up": "Standard_M128m",
     "down": null,
     "superseded": null,
     "vcpu": 64,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "1792"
   },
   "Standard_M128m": {
     "up": null,
     "down": "Standard_M64m",
     "superseded": null,
     "vcpu": 128,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "3892"
   },
   "Standard_ND6s": {
     "up": "Standard_ND12s",
     "down": null,
     "superseded": null,
     "vcpu": 6,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "112"
   },
   "Standard_ND12s": {
     "up": "Standard_ND24s",
     "down": "Standard_ND6s",
     "superseded": null,
     "vcpu": 12,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "224"
   },
   "Standard_ND24s": {
     "up": "Standard_ND24rs",
     "down": "Standard_ND12s",
     "superseded": null,
     "vcpu": 24,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "448"
   },
   "Standard_ND24rs": {
     "up": null,
     "down": null,
     "superseded": null,
     "vcpu": 24,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "448"
   },
   "Standard_NV4as_v4": {
     "up": "Standard_NV8as_v4",
     "down": null,
     "superseded": null,
     "vcpu": 4,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "14"
   },
   "Standard_NV8as_v4": {
     "up": "Standard_NV16as_v4",
     "down": "Standard_NV4as_v4",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "28"
   },
   "Standard_NV16as_v4": {
     "up": "Standard_NV32as_v4",
     "down": "Standard_NV8as_v4",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "56"
   },
   "Standard_NV32as_v4": {
     "up": null,
     "down": "Standard_NV16as_v4",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "112"
   },
   "Standard_NV12s_v3": {
     "up": "Standard_NV24s_v3",
     "down": null,
     "superseded": null,
     "vcpu": 12,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "112"
   },
   "Standard_NV24s_v3": {
     "up": "Standard_NV48s_v3",
     "down": "Standard_NV12s_v3",
     "superseded": null,
     "vcpu": 24,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "224"
   },
   "Standard_NV48s_v3": {
     "up": null,
     "down": "Standard_NV24s_v3",
     "superseded": null,
     "vcpu": 48,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "448"
   },
   "Standard_NV6": {
     "up": "Standard_NV12",
@@ -4103,7 +4679,8 @@
       "regular": "Standard_NV16as_v4"
     },
     "vcpu": 6,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "56"
   },
   "Standard_NV12": {
     "up": "Standard_NV24",
@@ -4112,7 +4689,8 @@
       "regular": "Standard_NV32as_v4"
     },
     "vcpu": 12,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "112"
   },
   "Standard_NV24": {
     "up": null,
@@ -4121,124 +4699,144 @@
       "regular": "Standard_NV48s_v3"
     },
     "vcpu": 24,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "224"
   },
   "Standard_NV6ads_A10_v5": {
     "up": "Standard_NV12ads_A10_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 6
+    "vcpu": 6,
+    "memory": "55"
   },
   "Standard_NV12ads_A10_v5": {
     "up": "Standard_NV18ads_A10_v5",
     "down": "Standard_NV6ads_A10_v5",
     "superseded": null,
-    "vcpu": 12
+    "vcpu": 12,
+    "memory": "110"
   },
   "Standard_NV18ads_A10_v5": {
     "up": "Standard_NV36ads_A10_v5",
     "down": "Standard_NV12ads_A10_v5",
     "superseded": null,
-    "vcpu": 18
+    "vcpu": 18,
+    "memory": "220"
   },
   "Standard_NV36ads_A10_v5": {
     "up": "Standard_NV36adms_A10_v5",
     "down": "Standard_NV18ads_A10_v5",
     "superseded": null,
-    "vcpu": 36
+    "vcpu": 36,
+    "memory": "440"
   },
   "Standard_NV36adms_A10_v5": {
     "up": "Standard_NV72ads_A10_v5",
     "down": "Standard_NV36ads_A10_v5",
     "superseded": null,
-    "vcpu": 36
+    "vcpu": 36,
+    "memory": "880"
   },
   "Standard_NV72ads_A10_v5": {
     "up": null,
     "down": "Standard_NV36adms_A10_v5",
     "superseded": null,
-    "vcpu": 72
+    "vcpu": 72,
+    "memory": "880"
   },
   "Standard_NP10s": {
     "up": "Standard_NP20s",
     "down": null,
     "superseded": null,
     "vcpu": 10,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "192"
   },
   "Standard_NP20s": {
     "up": "Standard_NP40s",
     "down": "Standard_NP10s",
     "superseded": null,
     "vcpu": 20,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "384"
   },
   "Standard_NP40s": {
     "up": null,
     "down": "Standard_NP20s",
     "superseded": null,
     "vcpu": 40,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "768"
   },
   "Standard_E2ads_v5": {
     "up": "Standard_E4ads_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "16"
   },
   "Standard_E4ads_v5": {
     "up": "Standard_E8ads_v5",
     "down": "Standard_E2ads_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "32"
   },
   "Standard_E8ads_v5": {
     "up": "Standard_E16ads_v5",
     "down": "Standard_E4ads_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "64"
   },
   "Standard_E16ads_v5": {
     "up": "Standard_E20ads_v5",
     "down": "Standard_E8ads_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "128"
   },
   "Standard_E20ads_v5": {
     "up": "Standard_E32ads_v5",
     "down": "Standard_E16ads_v5",
     "superseded": null,
-    "vcpu": 20
+    "vcpu": 20,
+    "memory": "160"
   },
   "Standard_E32ads_v5": {
     "up": "Standard_E48ads_v5",
     "down": "Standard_E20ads_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "256"
   },
   "Standard_E48ads_v5": {
     "up": "Standard_E64ads_v5",
     "down": "Standard_E32ads_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "384"
   },
   "Standard_E64ads_v5": {
     "up": "Standard_E96ads_v5",
     "down": "Standard_E48ads_v5",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "512"
   },
   "Standard_E96ads_v5": {
     "up": "Standard_E112iads_v5",
     "down": "Standard_E64ads_v5",
     "superseded": null,
-    "vcpu": 96
+    "vcpu": 96,
+    "memory": "672"
   },
   "Standard_E112iads_v5": {
     "up": null,
     "down": "Standard_E96ads_v5",
     "superseded": null,
-    "vcpu": 112
+    "vcpu": 112,
+    "memory": "672"
   },
   "Standard_NV6_Promo": {
     "up": "Standard_NV12_Promo",
@@ -4271,409 +4869,475 @@
     "up": "Standard_D4ds_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "8"
   },
   "Standard_D4ds_v5": {
     "up": "Standard_D8ds_v5",
     "down": "Standard_D2ds_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "16"
   },
   "Standard_D8ds_v5": {
     "up": "Standard_D16ds_v5",
     "down": "Standard_D4ds_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "32"
   },
   "Standard_D16ds_v5": {
     "up": "Standard_D32ds_v5",
     "down": "Standard_D8ds_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "64"
   },
   "Standard_D32ds_v5": {
     "up": "Standard_D48ds_v5",
     "down": "Standard_D16ds_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "128"
   },
   "Standard_D48ds_v5": {
     "up": "Standard_D64ds_v5",
     "down": "Standard_D32ds_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "192"
   },
   "Standard_D64ds_v5": {
     "up": "Standard_D96ds_v5",
     "down": "Standard_D48ds_v5",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "256"
   },
   "Standard_D96ds_v5": {
     "up": null,
     "down": "Standard_D64ds_v5",
     "superseded": null,
-    "vcpu": 96
+    "vcpu": 96,
+    "memory": "384"
   },
   "Standard_M208ms_v2": {
     "up": "Standard_M208s_v2",
     "down": null,
     "superseded": null,
     "vcpu": 208,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "5700"
   },
   "Standard_M208s_v2": {
     "up": "Standard_M416ms_v2",
     "down": "Standard_M208ms_v2",
     "superseded": null,
     "vcpu": 208,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "2850"
   },
   "Standard_M416ms_v2": {
     "up": "Standard_M416s_v2",
     "down": "Standard_M208s_v2",
     "superseded": null,
     "vcpu": 416,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "11400"
   },
   "Standard_M416s_v2": {
     "up": null,
     "down": "Standard_M416ms_v2",
     "superseded": null,
     "vcpu": 416,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "5700"
   },
   "Standard_D2ads_v5": {
     "up": "Standard_D4ads_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "8"
   },
   "Standard_D4ads_v5": {
     "up": "Standard_D8ads_v5",
     "down": "Standard_D2ads_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "16"
   },
   "Standard_D8ads_v5": {
     "up": "Standard_D16ads_v5",
     "down": "Standard_D4ads_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "32"
   },
   "Standard_D16ads_v5": {
     "up": "Standard_D32ads_v5",
     "down": "Standard_D8ads_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "64"
   },
   "Standard_D32ads_v5": {
     "up": "Standard_D48ads_v5",
     "down": "Standard_D16ads_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "128"
   },
   "Standard_D48ads_v5": {
     "up": "Standard_D64ads_v5",
     "down": "Standard_D32ads_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "192"
   },
   "Standard_D64ads_v5": {
     "up": "Standard_D96ads_v5",
     "down": "Standard_D48ads_v5",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "256"
   },
   "Standard_D96ads_v5": {
     "up": null,
     "down": "Standard_D64ads_v5",
     "superseded": null,
-    "vcpu": 96
+    "vcpu": 96,
+    "memory": "384"
   },
   "Standard_FX4mds": {
     "up": "Standard_FX12mds",
     "down": null,
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "84"
   },
   "Standard_FX12mds": {
     "up": "Standard_FX24mds",
     "down": "Standard_FX4mds",
     "superseded": null,
-    "vcpu": 12
+    "vcpu": 12,
+    "memory": "252"
   },
   "Standard_FX24mds": {
     "up": "Standard_FX36mds",
     "down": "Standard_FX12mds",
     "superseded": null,
-    "vcpu": 24
+    "vcpu": 24,
+    "memory": "504"
   },
   "Standard_FX36mds": {
     "up": "Standard_FX48mds",
     "down": "Standard_FX24mds",
     "superseded": null,
-    "vcpu": 36
+    "vcpu": 36,
+    "memory": "756"
   },
   "Standard_FX48mds": {
     "up": null,
     "down": "Standard_FX36mds",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "1008"
   },
   "Standard_D2as_v5": {
     "up": "Standard_D4as_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "8"
   },
   "Standard_D4as_v5": {
     "up": "Standard_D8as_v5",
     "down": "Standard_D2as_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "16"
   },
   "Standard_D8as_v5": {
     "up": "Standard_D16as_v5",
     "down": "Standard_D4as_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "32"
   },
   "Standard_D16as_v5": {
     "up": "Standard_D32as_v5",
     "down": "Standard_D8as_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "64"
   },
   "Standard_D32as_v5": {
     "up": "Standard_D48as_v5",
     "down": "Standard_D16as_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "128"
   },
   "Standard_D48as_v5": {
     "up": "Standard_D64as_v5",
     "down": "Standard_D32as_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "192"
   },
   "Standard_D64as_v5": {
     "up": "Standard_D96as_v5",
     "down": "Standard_D48as_v5",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "256"
   },
   "Standard_D96as_v5": {
     "up": null,
     "down": "Standard_D64as_v5",
     "superseded": null,
-    "vcpu": 96
+    "vcpu": 96,
+    "memory": "384"
   },
   "Standard_HB120-16rs_v2": {
     "up": "Standard_HB120-32rs_v2",
     "down": null,
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "456"
   },
   "Standard_HB120-32rs_v2": {
     "up": "Standard_HB120-64rs_v2",
     "down": "Standard_HB120-16rs_v2",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "456"
   },
   "Standard_HB120-64rs_v2": {
     "up": "Standard_HB120-96rs_v2",
     "down": "Standard_HB120-32rs_v2",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "456"
   },
   "Standard_HB120-96rs_v2": {
     "up": "Standard_HB120rs_v2",
     "down": "Standard_HB120-64rs_v2",
     "superseded": null,
-    "vcpu": 96
+    "vcpu": 96,
+    "memory": "456"
   },
   "Standard_HB120rs_v2": {
     "up": null,
     "down": "Standard_HB120-96rs_v2",
     "superseded": null,
     "vcpu": 120,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "480"
   },
   "Standard_HB120rs_v3": {
     "up": "Standard_HB120-96rs_v3",
     "down": null,
     "superseded": null,
     "vcpu": 120,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "448"
   },
   "Standard_HB120-96rs_v3": {
     "up": "Standard_HB120-64rs_v3",
     "down": "Standard_HB120rs_v3",
     "superseded": null,
     "vcpu": 96,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "456"
   },
   "Standard_HB120-64rs_v3": {
     "up": "Standard_HB120-32rs_v3",
     "down": "Standard_HB120-96rs_v3",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "456"
   },
   "Standard_HB120-32rs_v3": {
     "up": "Standard_HB120-16rs_v3",
     "down": "Standard_HB120-64rs_v3",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "456"
   },
   "Standard_HB120-16rs_v3": {
     "up": null,
     "down": "Standard_HB120-32rs_v3",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "456"
   },
   "Standard_HB176-24rs_v4": {
     "up": "Standard_HB176-48rs_v4",
     "down": null,
     "superseded": null,
-    "vcpu": 24
+    "vcpu": 24,
+    "memory": "768"
   },
   "Standard_HB176-48rs_v4": {
     "up": "Standard_HB176-96rs_v4",
     "down": "Standard_HB176-24rs_v4",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "768"
   },
   "Standard_HB176-96rs_v4": {
     "up": "Standard_HB176-144rs_v4",
     "down": "Standard_HB176-48rs_v4",
     "superseded": null,
-    "vcpu": 96
+    "vcpu": 96,
+    "memory": "768"
   },
   "Standard_HB176-144rs_v4": {
     "up": "Standard_HB176rs_v4",
     "down": "Standard_HB176-96rs_v4",
     "superseded": null,
-    "vcpu": 144
+    "vcpu": 144,
+    "memory": "768"
   },
   "Standard_HB176rs_v4": {
     "up": null,
     "down": "Standard_HB176-144rs_v4",
     "superseded": null,
-    "vcpu": 176
+    "vcpu": 176,
+    "memory": "768"
   },
   "Standard_HC44rs": {
     "up": "Standard_HC44-16rs",
     "down": null,
     "superseded": null,
     "vcpu": 44,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "352"
   },
   "Standard_HC44-16rs": {
     "up": "Standard_HC44-32rs",
     "down": "Standard_HC44rs",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "352"
   },
   "Standard_HC44-32rs": {
     "up": null,
     "down": "Standard_HC44-16rs",
     "superseded": null,
     "vcpu": 32,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "352"
   },
   "Standard_HX176-24rs": {
     "up": "Standard_HX176-48rs",
     "down": null,
     "superseded": null,
-    "vcpu": 24
+    "vcpu": 24,
+    "memory": "1408"
   },
   "Standard_HX176-48rs": {
     "up": "Standard_HX176-96rs",
     "down": "Standard_HX176-24rs",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "1408"
   },
   "Standard_HX176-96rs": {
     "up": "Standard_HX176-144rs",
     "down": "Standard_HX176-48rs",
     "superseded": null,
-    "vcpu": 96
+    "vcpu": 96,
+    "memory": "1408"
   },
   "Standard_HX176-144rs": {
     "up": "Standard_HX176rs",
     "down": "Standard_HX176-96rs",
     "superseded": null,
-    "vcpu": 144
+    "vcpu": 144,
+    "memory": "1408"
   },
   "Standard_HX176rs": {
     "up": null,
     "down": "Standard_HX176-144rs",
     "superseded": null,
-    "vcpu": 176
+    "vcpu": 176,
+    "memory": "1408"
   },
   "Standard_E2as_v5": {
     "up": "Standard_E4as_v5",
     "down": null,
     "superseded": null,
-    "vcpu": 2
+    "vcpu": 2,
+    "memory": "16"
   },
   "Standard_E4as_v5": {
     "up": "Standard_E8as_v5",
     "down": "Standard_E2as_v5",
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "32"
   },
   "Standard_E8as_v5": {
     "up": "Standard_E16as_v5",
     "down": "Standard_E4as_v5",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "64"
   },
   "Standard_E16as_v5": {
     "up": "Standard_E20as_v5",
     "down": "Standard_E8as_v5",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "128"
   },
   "Standard_E20as_v5": {
     "up": "Standard_E32as_v5",
     "down": "Standard_E16as_v5",
     "superseded": null,
-    "vcpu": 20
+    "vcpu": 20,
+    "memory": "160"
   },
   "Standard_E32as_v5": {
     "up": "Standard_E48as_v5",
     "down": "Standard_E20as_v5",
     "superseded": null,
-    "vcpu": 32
+    "vcpu": 32,
+    "memory": "256"
   },
   "Standard_E48as_v5": {
     "up": "Standard_E64as_v5",
     "down": "Standard_E32as_v5",
     "superseded": null,
-    "vcpu": 48
+    "vcpu": 48,
+    "memory": "384"
   },
   "Standard_E64as_v5": {
     "up": "Standard_E96as_v5",
     "down": "Standard_E48as_v5",
     "superseded": null,
-    "vcpu": 64
+    "vcpu": 64,
+    "memory": "512"
   },
   "Standard_E96as_v5": {
     "up": "Standard_E112ias_v5",
     "down": "Standard_E64as_v5",
     "superseded": null,
-    "vcpu": 96
+    "vcpu": 96,
+    "memory": "672"
   },
   "Standard_E112ias_v5": {
     "up": null,
     "down": "Standard_E96as_v5",
     "superseded": null,
-    "vcpu": 112
+    "vcpu": 112,
+    "memory": "672"
   }
 }

--- a/data/azure/instance_types.json
+++ b/data/azure/instance_types.json
@@ -3259,25 +3259,29 @@
     "up": "Standard_GS4-8",
     "down": null,
     "superseded": null,
-    "vcpu": 4
+    "vcpu": 4,
+    "memory": "224"
   },
   "Standard_GS4-8": {
     "up": null,
     "down": "Standard_GS4-4",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "224"
   },
   "Standard_GS5-8": {
     "up": "Standard_GS5-16",
     "down": null,
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "448"
   },
   "Standard_GS5-16": {
     "up": null,
     "down": "Standard_GS5-8",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "448"
   },
   "Standard_DS11-1_v2": {
     "up": null,

--- a/data/azure/instance_types.json
+++ b/data/azure/instance_types.json
@@ -108,13 +108,15 @@
     "up": "Standard_A9",
     "down": "Standard_A7",
     "superseded": null,
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "56"
   },
   "Standard_A9": {
     "up": "Standard_A10",
     "down": "Standard_A8",
     "superseded": null,
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "112"
   },
   "Standard_A10": {
     "up": "Standard_A11",
@@ -122,7 +124,8 @@
     "superseded": {
       "regular": "Standard_H8"
     },
-    "vcpu": 8
+    "vcpu": 8,
+    "memory": "56"
   },
   "Standard_A11": {
     "up": null,
@@ -130,7 +133,8 @@
     "superseded": {
       "regular": "Standard_H16"
     },
-    "vcpu": 16
+    "vcpu": 16,
+    "memory": "112"
   },
   "Standard_A1_v2": {
     "up": "Standard_A2_v2",

--- a/data/azure/instance_types.json
+++ b/data/azure/instance_types.json
@@ -4254,42 +4254,48 @@
     "down": null,
     "superseded": null,
     "vcpu": 8,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "56"
   },
   "Standard_H8m": {
     "up": "Standard_H16",
     "down": "Standard_H8",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "112"
   },
   "Standard_H16": {
     "up": "Standard_H16m",
     "down": "Standard_H8m",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "112"
   },
   "Standard_H16m": {
     "up": "Standard_H16mr",
     "down": "Standard_H16",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "224"
   },
   "Standard_H16r": {
     "up": "Standard_H16mr",
     "down": "Standard_H16",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "112"
   },
   "Standard_H16mr": {
     "up": null,
     "down": "Standard_H16r",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "224"
   },
   "Standard_HB60rs": {
     "up": null,

--- a/data/azure/instance_types.json
+++ b/data/azure/instance_types.json
@@ -1466,56 +1466,64 @@
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "7"
   },
   "Standard_DS3_v2_Promo": {
     "up": "Standard_DS4_v2_Promo",
     "down": "Standard_DS2_v2_Promo",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "14"
   },
   "Standard_DS4_v2_Promo": {
     "up": "Standard_DS5_v2_Promo",
     "down": "Standard_DS3_v2_Promo",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "28"
   },
   "Standard_DS5_v2_Promo": {
     "up": null,
     "down": "Standard_DS4_v2_Promo",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "56"
   },
   "Standard_DS11_v2_Promo": {
     "up": "Standard_DS12_v2_Promo",
     "down": null,
     "superseded": null,
     "vcpu": 2,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "14"
   },
   "Standard_DS12_v2_Promo": {
     "up": "Standard_DS13_v2_Promo",
     "down": "Standard_DS11_v2_Promo",
     "superseded": null,
     "vcpu": 4,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "28"
   },
   "Standard_DS13_v2_Promo": {
     "up": "Standard_DS14_v2_Promo",
     "down": "Standard_DS12_v2_Promo",
     "superseded": null,
     "vcpu": 8,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "56"
   },
   "Standard_DS14_v2_Promo": {
     "up": null,
     "down": "Standard_DS13_v2_Promo",
     "superseded": null,
     "vcpu": 16,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "112"
   },
   "Standard_D2a_v4": {
     "up": "Standard_D4a_v4",

--- a/data/azure/instance_types.json
+++ b/data/azure/instance_types.json
@@ -448,7 +448,8 @@
       "regular": "Standard_D2_v3"
     },
     "vcpu": 2,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "7"
   },
   "Standard_D3_v2_Promo": {
     "up": "Standard_D4_v2_Promo",
@@ -457,7 +458,8 @@
       "regular": "Standard_D4_v3"
     },
     "vcpu": 4,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "14"
   },
   "Standard_D4_v2_Promo": {
     "up": "Standard_D5_v2_Promo",
@@ -466,7 +468,8 @@
       "regular": "Standard_D8_v3"
     },
     "vcpu": 8,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "28"
   },
   "Standard_D5_v2_Promo": {
     "up": null,
@@ -475,7 +478,8 @@
       "regular": "Standard_D16_v3"
     },
     "vcpu": 16,
-    "nfu": "16"
+    "nfu": "16",
+    "memory": "56"
   },
   "Standard_D11_v2_Promo": {
     "up": "Standard_D12_v2_Promo",
@@ -484,7 +488,8 @@
       "regular": "Standard_E2_v3"
     },
     "vcpu": 2,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "14"
   },
   "Standard_D12_v2_Promo": {
     "up": "Standard_D13_v2_Promo",
@@ -493,7 +498,8 @@
       "regular": "Standard_E4_v3"
     },
     "vcpu": 4,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "28"
   },
   "Standard_D13_v2_Promo": {
     "up": "Standard_D14_v2_Promo",
@@ -502,7 +508,8 @@
       "regular": "Standard_E8_v3"
     },
     "vcpu": 8,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "56"
   },
   "Standard_D14_v2_Promo": {
     "up": null,
@@ -511,7 +518,8 @@
       "regular": "Standard_E16_v3"
     },
     "vcpu": 16,
-    "nfu": "8"
+    "nfu": "8",
+    "memory": "112"
   },
   "Standard_D2s_v3": {
     "up": "Standard_D4s_v3",

--- a/data/azure/instance_types.json
+++ b/data/azure/instance_types.json
@@ -3644,7 +3644,8 @@
     "down": "Standard_E48d_v4",
     "superseded": null,
     "vcpu": 64,
-    "nfu": "32"
+    "nfu": "32",
+    "memory": "504"
   },
   "Standard_E2s_v3": {
     "up": "Standard_E4s_v3",

--- a/data/azure/instance_types.json
+++ b/data/azure/instance_types.json
@@ -4868,7 +4868,8 @@
       "regular": "Standard_NV16as_v4"
     },
     "vcpu": 6,
-    "nfu": "1"
+    "nfu": "1",
+    "memory": "56"
   },
   "Standard_NV12_Promo": {
     "up": "Standard_NV24_Promo",
@@ -4877,7 +4878,8 @@
       "regular": "Standard_NV32as_v4"
     },
     "vcpu": 12,
-    "nfu": "2"
+    "nfu": "2",
+    "memory": "112"
   },
   "Standard_NV24_Promo": {
     "up": null,
@@ -4886,7 +4888,8 @@
       "regular": "Standard_NV48s_v3"
     },
     "vcpu": 24,
-    "nfu": "4"
+    "nfu": "4",
+    "memory": "224"
   },
   "Standard_D2ds_v5": {
     "up": "Standard_D4ds_v5",


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves below -->
Adds Instance Memory field to the existing instance_types.json for Azure. Memory Unit is in Gigabytes (GiB or 1024^3 bytes)

The Memory amount for some instances have been added to the file by hand through various sources. The list of instances is as follows:

-	Standard A8
-	Standard A9
-	Standard A10
-	Standard A11
-	Standard D2 v2 Promo
-	Standard D3 v2 Promo
-	Standard D4 v2 Promo
-	Standard D5 v2 Promo
-	Standard D11 v2 Promo
-	Standard D12 v2 Promo
-	Standard d13 v2 Promo
-	Standard D14 v2 Promo
-	Standard GS4-4
-	Standard GS4-8
-	Standard GS5-8
-	Standard GS5-16
-	Standard E64d v4
-	Standard H8
-	Standard H8m
-	Standard H16
-	Standard H16m
-	Standard H16r
-	Standard H16mr
-	Standard NV6 Promo
-	Standard NV12 Promo
-	Standard NV24 Promo 

Sources for memory data for each VM listed above is as follows:

- Standard A8-A11 - https://learn.microsoft.com/en-us/azure/cloud-services/cloud-services-sizes-specs#a-series
- Standard Dv2 Series Promo - https://azure.microsoft.com/en-gb/pricing/calculator/ (assuming Promo is precursor to GA Dv2 Series
- Standard GS Series – various sources but mostly cloudprice.net e.g., https://cloudprice.net/vm/Standard_GS5-16 
- Standard E64d v4 - https://learn.microsoft.com/en-us/azure/virtual-machines/edv4-edsv4-series
- Standard H series - https://azure.microsoft.com/en-us/blog/availability-of-h-series-vms-in-microsoft-azure/ 
- Standard NV Series Promo - https://learn.microsoft.com/en-us/azure/virtual-machines/nv-series (assuming Promo is precursor to GA NV Series)

### Issues Resolved

<!-- List any existing issues this PR resolves below -->
We have customers asking to produce a report of amount of Instance Memory used, similar to the existing Instance vCPUs used policy. To achieve this it will require adding memory to the Instance Types JSON file.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
