### PR TITLE
POL-1180 Dangerfile Indentation Test Fix

### DIFF
--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -173,7 +173,7 @@ def policy_bad_indentation?(file)
 
       indent_level += 2 if line.strip.end_with?(" do") || line.start_with?("info(")
 
-      eos_block = true if line.include?("<<-")
+      eos_block = true if line.include?("<<-") && line.include?("code")
       define_block = true if line.start_with?("define ") && line.strip.end_with?(" do")
 
     # If we're within one of these blocks, at least make sure we're 2 spaces indented

--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -151,6 +151,7 @@ def policy_bad_indentation?(file)
   fail_message = ""
 
   indent_level = 0
+  code_block = false
   eos_block = false
   define_block = false
 
@@ -161,10 +162,11 @@ def policy_bad_indentation?(file)
     indentation = line.match(/\A\s*/).to_s.length
 
     # Skip blocks of EOS/EOF text and define blocks, since these contain arbitrarily spaced code/text
+    code_block = false if code_block && line.strip == "EOS" || line.strip == "EOF"
     eos_block = false if eos_block && line.strip == "EOS" || line.strip == "EOF"
     define_block = false if define_block && line.start_with?("end")
 
-    if !eos_block && !define_block
+    if !code_block && !define_block && !eos_block
       indent_level -= 2 if line.strip == "end" || line.strip == ")"
 
       if indentation != indent_level && !line.strip.empty? && line.strip != "EOS" && line.strip != "EOF"
@@ -174,11 +176,12 @@ def policy_bad_indentation?(file)
       indent_level += 2 if line.strip.end_with?(" do") || line.start_with?("info(")
 
       # We only check EOS blocks if they are for the code field
-      eos_block = true if line.include?("<<-") && line.include?("code")
+      code_block = true if line.include?("<<-") && line.include?("code")
+      eos_block = true if line.include?("<<-") && !line.include?("code")
       define_block = true if line.start_with?("define ") && line.strip.end_with?(" do")
 
     # If we're within one of these blocks, at least make sure we're 2 spaces indented
-    elsif (eos_block || define_block) && indentation < 2 && !line.strip.empty?
+    elsif (code_block || define_block) && indentation < 2 && !line.strip.empty?
       fail_message += "Line #{line_number.to_s}: Expected indentation of at least two spaces within code/text block.\n"
     end
   end

--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -173,6 +173,7 @@ def policy_bad_indentation?(file)
 
       indent_level += 2 if line.strip.end_with?(" do") || line.start_with?("info(")
 
+      # We only check EOS blocks if they are for the code field
       eos_block = true if line.include?("<<-") && line.include?("code")
       define_block = true if line.start_with?("define ") && line.strip.end_with?(" do")
 

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots.pt
@@ -703,10 +703,10 @@ policy "pol_azure_old_snapshots" do
   validate_each $ds_azure_snapshots_incident do
     summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Azure Old Snapshots Found"
     detail_template <<-'EOS'
-**Potential Monthly Savings:** {{ with index data 0 }}{{ .total_savings }}{{ end }}
+    **Potential Monthly Savings:** {{ with index data 0 }}{{ .total_savings }}{{ end }}
 
-{{ with index data 0 }}{{ .message }}{{ end }}
-EOS
+    {{ with index data 0 }}{{ .message }}{{ end }}
+    EOS
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_snapshot

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots.pt
@@ -590,108 +590,108 @@ script "js_azure_snapshots_incident", type:"javascript" do
   parameters "ds_azure_old_snapshots", "ds_azure_snapshots_region_filtered", "ds_azure_snapshot_costs_grouped", "ds_applied_policy", "ds_currency", "param_min_savings", "param_snapshot_age"
   result "result"
   code <<-'EOS'
-// Function for formatting currency numbers later
-function formatNumber(number, separator) {
-  var numString = number.toString()
-  var values = numString.split(".")
-  var formatted_number = ''
+  // Function for formatting currency numbers later
+  function formatNumber(number, separator) {
+    var numString = number.toString()
+    var values = numString.split(".")
+    var formatted_number = ''
 
-  while (values[0].length > 3) {
-    var chunk = values[0].substr(-3)
-    values[0] = values[0].substr(0, values[0].length - 3)
-    formatted_number = separator + chunk + formatted_number
+    while (values[0].length > 3) {
+      var chunk = values[0].substr(-3)
+      values[0] = values[0].substr(0, values[0].length - 3)
+      formatted_number = separator + chunk + formatted_number
+    }
+
+    if (values[0].length > 0) { formatted_number = values[0] + formatted_number }
+
+    if (values[1] == undefined) { return formatted_number }
+
+    return formatted_number + "." + values[1]
   }
 
-  if (values[0].length > 0) { formatted_number = values[0] + formatted_number }
+  result = []
 
-  if (values[1] == undefined) { return formatted_number }
+  total_savings = 0.0
 
-  return formatted_number + "." + values[1]
-}
+  _.each(ds_azure_old_snapshots, function(snapshot) {
+    savings = ds_azure_snapshot_costs_grouped[snapshot['resourceID'].toLowerCase()]
 
-result = []
+    if (savings == null || savings == undefined) {
+      savings = 0.0
+    }
 
-total_savings = 0.0
+    if (savings >= param_min_savings) {
+      total_savings += savings
 
-_.each(ds_azure_old_snapshots, function(snapshot) {
-  savings = ds_azure_snapshot_costs_grouped[snapshot['resourceID'].toLowerCase()]
+      recommendationDetails = [
+        "Delete Azure snapshot ", snapshot["resourceName"], " ",
+        "in Azure Subscription ", snapshot["subscriptionName"],
+        " (", snapshot["subscriptionID"], ")"
+      ].join('')
 
-  if (savings == null || savings == undefined) {
-    savings = 0.0
-  }
+      result.push({
+        accountID: snapshot["subscriptionID"],
+        accountName: snapshot["subscriptionName"],
+        resourceID: snapshot['resourceID'],
+        resourceName: snapshot['resourceName'],
+        resourceGroup: snapshot['resourceGroup'],
+        resourceType: snapshot['resourceType'],
+        region: snapshot['region'],
+        age: snapshot['age'],
+        tags: snapshot['tags'],
+        service: snapshot['service'],
+        size: snapshot['size'],
+        savings: parseFloat(savings.toFixed(3)),
+        savingsCurrency: ds_currency['symbol'],
+        recommendationDetails: recommendationDetails,
+        lookbackPeriod: param_snapshot_age,
+        // These are to avoid errors when we hash_exclude these fields
+        total_savings: '',
+        message: '',
+        policy_name: ''
+      })
+    }
+  })
 
-  if (savings >= param_min_savings) {
-    total_savings += savings
+  // Message for incident output
+  total_snapshots = ds_azure_snapshots_region_filtered.length.toString()
+  total_old_snapshots = result.length.toString()
+  old_snapshots_percentage = (total_old_snapshots / total_snapshots * 100).toFixed(2).toString() + '%'
 
-    recommendationDetails = [
-      "Delete Azure snapshot ", snapshot["resourceName"], " ",
-      "in Azure Subscription ", snapshot["subscriptionName"],
-      " (", snapshot["subscriptionID"], ")"
-    ].join('')
+  days_noun = "days"
+  if (param_snapshot_age == 1) { days_noun = "day" }
 
-    result.push({
-      accountID: snapshot["subscriptionID"],
-      accountName: snapshot["subscriptionName"],
-      resourceID: snapshot['resourceID'],
-      resourceName: snapshot['resourceName'],
-      resourceGroup: snapshot['resourceGroup'],
-      resourceType: snapshot['resourceType'],
-      region: snapshot['region'],
-      age: snapshot['age'],
-      tags: snapshot['tags'],
-      service: snapshot['service'],
-      size: snapshot['size'],
-      savings: parseFloat(savings.toFixed(3)),
-      savingsCurrency: ds_currency['symbol'],
-      recommendationDetails: recommendationDetails,
-      lookbackPeriod: param_snapshot_age,
-      // These are to avoid errors when we hash_exclude these fields
-      total_savings: '',
-      message: '',
-      policy_name: ''
-    })
-  }
-})
+  findings = [
+    "Out of ", total_snapshots, " snapshots analyzed, ",
+    total_old_snapshots, " (", old_snapshots_percentage,
+    ") are older than ", param_snapshot_age, " ", days_noun, " ",
+    "and are recommended for deletion.\n\n"
+  ].join('')
 
-// Message for incident output
-total_snapshots = ds_azure_snapshots_region_filtered.length.toString()
-total_old_snapshots = result.length.toString()
-old_snapshots_percentage = (total_old_snapshots / total_snapshots * 100).toFixed(2).toString() + '%'
+  disclaimer = "The above settings can be modified by editing the applied policy and changing the appropriate parameters.\n\n"
 
-days_noun = "days"
-if (param_snapshot_age == 1) { days_noun = "day" }
+  savings_message = [
+    ds_currency['symbol'], ' ',
+    formatNumber(parseFloat(total_savings).toFixed(2), ds_currency['separator'])
+  ].join('')
 
-findings = [
-  "Out of ", total_snapshots, " snapshots analyzed, ",
-  total_old_snapshots, " (", old_snapshots_percentage,
-  ") are older than ", param_snapshot_age, " ", days_noun, " ",
-  "and are recommended for deletion.\n\n"
-].join('')
+  // Sort by descending order of savings value
+  result = _.sortBy(result, function(item) { return item['savings'] * -1 })
 
-disclaimer = "The above settings can be modified by editing the applied policy and changing the appropriate parameters.\n\n"
+  // Dummy item to ensure that the check statement in the policy executes at least once
+  result.push({
+    resourceID: "",
+    total_savings: "",
+    message: "",
+    tags: "",
+    age: "",
+    savings: "",
+    savingsCurrency: ""
+  })
 
-savings_message = [
-  ds_currency['symbol'], ' ',
-  formatNumber(parseFloat(total_savings).toFixed(2), ds_currency['separator'])
-].join('')
-
-// Sort by descending order of savings value
-result = _.sortBy(result, function(item) { return item['savings'] * -1 })
-
-// Dummy item to ensure that the check statement in the policy executes at least once
-result.push({
-  resourceID: "",
-  total_savings: "",
-  message: "",
-  tags: "",
-  age: "",
-  savings: "",
-  savingsCurrency: ""
-})
-
-result[0]['total_savings'] = savings_message
-result[0]['message'] = findings + disclaimer
-result[0]['policy_name'] = ds_applied_policy['name']
+  result[0]['total_savings'] = savings_message
+  result[0]['message'] = findings + disclaimer
+  result[0]['policy_name'] = ds_applied_policy['name']
 EOS
 end
 

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots.pt
@@ -590,108 +590,108 @@ script "js_azure_snapshots_incident", type:"javascript" do
   parameters "ds_azure_old_snapshots", "ds_azure_snapshots_region_filtered", "ds_azure_snapshot_costs_grouped", "ds_applied_policy", "ds_currency", "param_min_savings", "param_snapshot_age"
   result "result"
   code <<-'EOS'
-  // Function for formatting currency numbers later
-  function formatNumber(number, separator) {
-    var numString = number.toString()
-    var values = numString.split(".")
-    var formatted_number = ''
+// Function for formatting currency numbers later
+function formatNumber(number, separator) {
+  var numString = number.toString()
+  var values = numString.split(".")
+  var formatted_number = ''
 
-    while (values[0].length > 3) {
-      var chunk = values[0].substr(-3)
-      values[0] = values[0].substr(0, values[0].length - 3)
-      formatted_number = separator + chunk + formatted_number
-    }
-
-    if (values[0].length > 0) { formatted_number = values[0] + formatted_number }
-
-    if (values[1] == undefined) { return formatted_number }
-
-    return formatted_number + "." + values[1]
+  while (values[0].length > 3) {
+    var chunk = values[0].substr(-3)
+    values[0] = values[0].substr(0, values[0].length - 3)
+    formatted_number = separator + chunk + formatted_number
   }
 
-  result = []
+  if (values[0].length > 0) { formatted_number = values[0] + formatted_number }
 
-  total_savings = 0.0
+  if (values[1] == undefined) { return formatted_number }
 
-  _.each(ds_azure_old_snapshots, function(snapshot) {
-    savings = ds_azure_snapshot_costs_grouped[snapshot['resourceID'].toLowerCase()]
+  return formatted_number + "." + values[1]
+}
 
-    if (savings == null || savings == undefined) {
-      savings = 0.0
-    }
+result = []
 
-    if (savings >= param_min_savings) {
-      total_savings += savings
+total_savings = 0.0
 
-      recommendationDetails = [
-        "Delete Azure snapshot ", snapshot["resourceName"], " ",
-        "in Azure Subscription ", snapshot["subscriptionName"],
-        " (", snapshot["subscriptionID"], ")"
-      ].join('')
+_.each(ds_azure_old_snapshots, function(snapshot) {
+  savings = ds_azure_snapshot_costs_grouped[snapshot['resourceID'].toLowerCase()]
 
-      result.push({
-        accountID: snapshot["subscriptionID"],
-        accountName: snapshot["subscriptionName"],
-        resourceID: snapshot['resourceID'],
-        resourceName: snapshot['resourceName'],
-        resourceGroup: snapshot['resourceGroup'],
-        resourceType: snapshot['resourceType'],
-        region: snapshot['region'],
-        age: snapshot['age'],
-        tags: snapshot['tags'],
-        service: snapshot['service'],
-        size: snapshot['size'],
-        savings: parseFloat(savings.toFixed(3)),
-        savingsCurrency: ds_currency['symbol'],
-        recommendationDetails: recommendationDetails,
-        lookbackPeriod: param_snapshot_age,
-        // These are to avoid errors when we hash_exclude these fields
-        total_savings: '',
-        message: '',
-        policy_name: ''
-      })
-    }
-  })
+  if (savings == null || savings == undefined) {
+    savings = 0.0
+  }
 
-  // Message for incident output
-  total_snapshots = ds_azure_snapshots_region_filtered.length.toString()
-  total_old_snapshots = result.length.toString()
-  old_snapshots_percentage = (total_old_snapshots / total_snapshots * 100).toFixed(2).toString() + '%'
+  if (savings >= param_min_savings) {
+    total_savings += savings
 
-  days_noun = "days"
-  if (param_snapshot_age == 1) { days_noun = "day" }
+    recommendationDetails = [
+      "Delete Azure snapshot ", snapshot["resourceName"], " ",
+      "in Azure Subscription ", snapshot["subscriptionName"],
+      " (", snapshot["subscriptionID"], ")"
+    ].join('')
 
-  findings = [
-    "Out of ", total_snapshots, " snapshots analyzed, ",
-    total_old_snapshots, " (", old_snapshots_percentage,
-    ") are older than ", param_snapshot_age, " ", days_noun, " ",
-    "and are recommended for deletion.\n\n"
-  ].join('')
+    result.push({
+      accountID: snapshot["subscriptionID"],
+      accountName: snapshot["subscriptionName"],
+      resourceID: snapshot['resourceID'],
+      resourceName: snapshot['resourceName'],
+      resourceGroup: snapshot['resourceGroup'],
+      resourceType: snapshot['resourceType'],
+      region: snapshot['region'],
+      age: snapshot['age'],
+      tags: snapshot['tags'],
+      service: snapshot['service'],
+      size: snapshot['size'],
+      savings: parseFloat(savings.toFixed(3)),
+      savingsCurrency: ds_currency['symbol'],
+      recommendationDetails: recommendationDetails,
+      lookbackPeriod: param_snapshot_age,
+      // These are to avoid errors when we hash_exclude these fields
+      total_savings: '',
+      message: '',
+      policy_name: ''
+    })
+  }
+})
 
-  disclaimer = "The above settings can be modified by editing the applied policy and changing the appropriate parameters.\n\n"
+// Message for incident output
+total_snapshots = ds_azure_snapshots_region_filtered.length.toString()
+total_old_snapshots = result.length.toString()
+old_snapshots_percentage = (total_old_snapshots / total_snapshots * 100).toFixed(2).toString() + '%'
 
-  savings_message = [
-    ds_currency['symbol'], ' ',
-    formatNumber(parseFloat(total_savings).toFixed(2), ds_currency['separator'])
-  ].join('')
+days_noun = "days"
+if (param_snapshot_age == 1) { days_noun = "day" }
 
-  // Sort by descending order of savings value
-  result = _.sortBy(result, function(item) { return item['savings'] * -1 })
+findings = [
+  "Out of ", total_snapshots, " snapshots analyzed, ",
+  total_old_snapshots, " (", old_snapshots_percentage,
+  ") are older than ", param_snapshot_age, " ", days_noun, " ",
+  "and are recommended for deletion.\n\n"
+].join('')
 
-  // Dummy item to ensure that the check statement in the policy executes at least once
-  result.push({
-    resourceID: "",
-    total_savings: "",
-    message: "",
-    tags: "",
-    age: "",
-    savings: "",
-    savingsCurrency: ""
-  })
+disclaimer = "The above settings can be modified by editing the applied policy and changing the appropriate parameters.\n\n"
 
-  result[0]['total_savings'] = savings_message
-  result[0]['message'] = findings + disclaimer
-  result[0]['policy_name'] = ds_applied_policy['name']
+savings_message = [
+  ds_currency['symbol'], ' ',
+  formatNumber(parseFloat(total_savings).toFixed(2), ds_currency['separator'])
+].join('')
+
+// Sort by descending order of savings value
+result = _.sortBy(result, function(item) { return item['savings'] * -1 })
+
+// Dummy item to ensure that the check statement in the policy executes at least once
+result.push({
+  resourceID: "",
+  total_savings: "",
+  message: "",
+  tags: "",
+  age: "",
+  savings: "",
+  savingsCurrency: ""
+})
+
+result[0]['total_savings'] = savings_message
+result[0]['message'] = findings + disclaimer
+result[0]['policy_name'] = ds_applied_policy['name']
 EOS
 end
 
@@ -703,10 +703,10 @@ policy "pol_azure_old_snapshots" do
   validate_each $ds_azure_snapshots_incident do
     summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Azure Old Snapshots Found"
     detail_template <<-'EOS'
-    **Potential Monthly Savings:** {{ with index data 0 }}{{ .total_savings }}{{ end }}
+**Potential Monthly Savings:** {{ with index data 0 }}{{ .total_savings }}{{ end }}
 
-    {{ with index data 0 }}{{ .message }}{{ end }}
-    EOS
+{{ with index data 0 }}{{ .message }}{{ end }}
+EOS
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_snapshot


### PR DESCRIPTION
### Description

Modifies Dangerfile indentation test for policies to only check indentation for EOS/EOF if it's for JavaScript code to avoid issues with lack of indentation due to a need to properly render markup/markdown languages for other fields.

### Contribution Check List

- [X] New functionality includes testing.
