### PR TITLE
POL-1183 AWS Old Snapshots RDS Duplicate Fix

### DIFF
--- a/cost/aws/old_snapshots/CHANGELOG.md
+++ b/cost/aws/old_snapshots/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v8.2
+
+- Fixed issue where duplicate results would sometimes occur for RDS DB snapshots.
+
 ## v8.1
 
 - Updated policy to use new source for currency information. Policy functionality is unchanged.
@@ -134,13 +138,11 @@
 ## v2.13
 
 - Improve error handling and debug logging so that errors from taking action are actually surfaced
-- Add a `param_log_to_cm_audit_entries` parameter to control whether action debug logging is sent to CM Audit
-  Entries; this should be left set to No on Flexera EU
+- Add a `param_log_to_cm_audit_entries` parameter to control whether action debug logging is sent to CM Audit Entries; this should be left set to No on Flexera EU
 
 ## v2.12
 
-- Add a parameter to override the Flexera One org ID to use when querying Optima for cases when the project is not
-  in the same org where the AWS bill is registered in Optima
+- Add a parameter to override the Flexera One org ID to use when querying Optima for cases when the project is not in the same org where the AWS bill is registered in Optima
 
 ## v2.11
 
@@ -160,8 +162,7 @@
 
 ## v2.7
 
-- Use `DescribeSnapshots` instead of `DescribeRegions` to more accurately check if the call is enabled by the
-  Service Control Policy in each region
+- Use `DescribeSnapshots` instead of `DescribeRegions` to more accurately check if the call is enabled by the Service Control Policy in each region
 
 ## v2.6
 

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -38,9 +38,9 @@ parameter "param_snapshot_age" do
   type "number"
   category "Policy Settings"
   label "Snapshot Age Threshold"
-  default 30
   description "The number of days since the snapshot was created to consider a snapshot old."
   min_value 1
+  default 30
 end
 
 parameter "param_snapshot_include_ami" do
@@ -74,8 +74,8 @@ parameter "param_regions_list" do
   type "list"
   category "Filters"
   label "Allow/Deny Regions List"
-  allowed_pattern /^([a-zA-Z-_]+-[a-zA-Z0-9-_]+-[0-9-_]+,*|)+$/
   description "A list of allowed or denied regions. See the README for more details."
+  allowed_pattern /^([a-zA-Z-_]+-[a-zA-Z0-9-_]+-[0-9-_]+,*|)+$/
   default []
 end
 
@@ -163,16 +163,6 @@ pagination "pagination_aws" do
   end
 end
 
-pagination "pagination_aws_describesnapshots_xml" do
-  get_page_marker do
-    body_path "//DescribeSnapshotsResponse/nextToken"
-  end
-  set_page_marker do
-    query "NextToken"
-  end
-end
-
-# https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html
 pagination "pagination_aws_describeimages_xml" do
   get_page_marker do
     body_path "//DescribeImagesResponse/nextToken"
@@ -182,7 +172,6 @@ pagination "pagination_aws_describeimages_xml" do
   end
 end
 
-# https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBSnapshots.html
 pagination "pagination_aws_describe_db_snapshots_xml" do
   get_page_marker do
     body_path "//DescribeDBSnapshotsResponse/DescribeDBSnapshotsResult/Marker"
@@ -192,7 +181,6 @@ pagination "pagination_aws_describe_db_snapshots_xml" do
   end
 end
 
-# https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBClusterSnapshots.html
 pagination "pagination_aws_describe_db_cluster_snapshots_xml" do
   get_page_marker do
     body_path "//DescribeDBClusterSnapshotsResponse/DescribeDBClusterSnapshotsResult/Marker"
@@ -268,9 +256,9 @@ datasource "ds_get_caller_identity" do
     verb "GET"
     host "sts.amazonaws.com"
     path "/"
-    header "User-Agent", "RS Policies"
     query "Action", "GetCallerIdentity"
     query "Version", "2011-06-15"
+    header "User-Agent", "RS Policies"
   end
   result do
     encoding "xml"
@@ -308,9 +296,9 @@ datasource "ds_billing_centers" do
     auth $auth_flexera
     host rs_optima_host
     path join(["/analytics/orgs/", rs_org_id, "/billing_centers"])
+    query "view", "allocation_table"
     header "Api-Version", "1.0"
     header "User-Agent", "RS Policies"
-    query "view", "allocation_table"
     ignore_status [403]
   end
   result do
@@ -498,10 +486,10 @@ datasource "ds_describe_db_snapshots_unfiltered" do
     pagination $pagination_aws_describe_db_snapshots_xml
     host join(["rds.", val(iter_item, "region"), ".amazonaws.com"])
     path "/"
-    header "User-Agent", "RS Policies"
-    header "Content-Type", "text/xml"
     query "Action", "DescribeDBSnapshots"
     query "Version", "2014-10-31"
+    header "User-Agent", "RS Policies"
+    header "Content-Type", "text/xml"
     ignore_status [403, 404]
   end
   result do
@@ -560,10 +548,10 @@ datasource "ds_describe_db_cluster_snapshots" do
     pagination $pagination_aws_describe_db_cluster_snapshots_xml
     host join(["rds.", val(iter_item, "region"), ".amazonaws.com"])
     path "/"
-    header "User-Agent", "RS Policies"
-    header "Content-Type", "text/xml"
     query "Action", "DescribeDBClusterSnapshots"
     query "Version", "2014-10-31"
+    header "User-Agent", "RS Policies"
+    header "Content-Type", "text/xml"
     ignore_status [403, 404]
   end
   result do
@@ -747,12 +735,12 @@ datasource "ds_get_snapshot_ami" do
     pagination $pagination_aws_describeimages_xml
     host join(["ec2.", val(iter_item, "region"), ".amazonaws.com"])
     path "/"
-    header "User-Agent", "RS Policies"
-    header "Content-Type", "text/xml"
     query "Action", "DescribeImages"
     query "Version", "2016-11-15"
     query "Filter.1.Name", "owner-id"
     query "Filter.1.Value.1", val($ds_aws_account, 'id')
+    header "User-Agent", "RS Policies"
+    header "Content-Type", "text/xml"
     ignore_status [403, 404]
   end
   result do

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "8.1",
+  version: "8.2",
   provider: "AWS",
   service: "Storage",
   policy_set: "Old Snapshots",
@@ -15,7 +15,7 @@ info(
 )
 
 ###############################################################################
-# User inputs
+# Parameters
 ###############################################################################
 
 parameter "param_email" do
@@ -491,7 +491,7 @@ script "js_describe_snapshots", type: "javascript" do
 EOS
 end
 
-datasource "ds_describe_db_snapshots" do
+datasource "ds_describe_db_snapshots_unfiltered" do
   iterate $ds_regions
   request do
     auth $auth_aws
@@ -526,6 +526,31 @@ datasource "ds_describe_db_snapshots" do
       field "parentType", "DB Instance"
     end
   end
+end
+
+datasource "ds_describe_db_snapshots" do
+  run_script $js_describe_db_snapshots, $ds_describe_db_snapshots_unfiltered
+end
+
+script "js_describe_db_snapshots", type:"javascript" do
+  parameters "ds_describe_db_snapshots_unfiltered"
+  result "result"
+  code <<-EOS
+  result = []
+  sorted_by_parent = {}
+
+  _.each(ds_describe_db_snapshots_unfiltered, function(snapshot) {
+    parent = snapshot["parentId"]
+
+    if (sorted_by_parent[parent] == undefined) { sorted_by_parent[parent] = [] }
+    sorted_by_parent[parent].push(snapshot)
+  })
+
+  _.each(_.keys(sorted_by_parent), function(parent) {
+    sorted_parents = _.sortBy(sorted_by_parent[parent], "startTime").reverse()
+    result.push(sorted_parents[0])
+  })
+EOS
 end
 
 datasource "ds_describe_db_cluster_snapshots" do

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -429,7 +429,7 @@ end
 datasource "ds_describe_snapshots" do
   iterate $ds_regions
   request do
-    run_script $js_describe_snapshots, val(iter_item,"region"), $ds_aws_account
+    run_script $js_describe_snapshots, val(iter_item, "region"), $ds_aws_account
   end
   result do
     encoding "xml"
@@ -749,7 +749,7 @@ datasource "ds_get_snapshot_ami" do
       field "region", val(iter_item, "region")
       field "imageId", xpath(col_item, "imageId")
       field "ownerId", xpath(col_item, "ownerId")
-      field "snapshotIds",  xpath(col_item, "blockDeviceMapping/item/*//snapshotId", "array")
+      field "snapshotIds", xpath(col_item, "blockDeviceMapping/item/*//snapshotId", "array")
     end
   end
 end
@@ -1181,7 +1181,7 @@ define delete_snapshots($data, $param_snapshot_include_ami) return $all_response
   end
 
   if inspect($$errors) != "null"
-    raise join($$errors,"\n")
+    raise join($$errors, "\n")
   end
 end
 
@@ -1327,7 +1327,7 @@ datasource "ds_get_policy" do
     auth $auth_flexera
     host rs_governance_host
     ignore_status [404]
-    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", switch(ne(meta_parent_policy_id,""), meta_parent_policy_id, policy_id) ])
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", switch(ne(meta_parent_policy_id, ""), meta_parent_policy_id, policy_id) ])
     header "Api-Version", "1.0"
   end
   result do

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
@@ -8,7 +8,7 @@ tenancy "single"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "8.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "8.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false"
 )
 

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
@@ -72,9 +72,9 @@ parameter "param_snapshot_age" do
   type "number"
   category "Policy Settings"
   label "Snapshot Age Threshold"
-  default 30
   description "The number of days since the snapshot was created to consider a snapshot old."
   min_value 1
+  default 30
 end
 
 parameter "param_snapshot_include_ami" do
@@ -108,8 +108,8 @@ parameter "param_regions_list" do
   type "list"
   category "Filters"
   label "Allow/Deny Regions List"
-  allowed_pattern /^([a-zA-Z-_]+-[a-zA-Z0-9-_]+-[0-9-_]+,*|)+$/
   description "A list of allowed or denied regions. See the README for more details."
+  allowed_pattern /^([a-zA-Z-_]+-[a-zA-Z0-9-_]+-[0-9-_]+,*|)+$/
   default []
 end
 


### PR DESCRIPTION
### Description

The AWS API endpoint for gathering RDS snapshots will return a value for each instance of an iterative snapshot of a single RDS resource. This means a snapshot for a single RDS resource that only appears in the bill once would be returned by the API several times, even though each instance returned by the API was just a version of a single snapshot.

This fix adds new logic to account for this. When these iterative snapshots are found, only the most recent one is considered during the analysis instead of all of them. As a result, if someone has a daily backup of an RDS instance, the same instance with the same dollar value in the bill doesn't appear several times in the results, greatly inflating them. This also means that such snapshots will not be reported erroneously simply because their oldest iteration is > 30 days.

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=66047e637566c288f2dac424

### Contribution Check List

- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
