### PR TITLE
POL-1185 Dangerfile Outdated Terminology Update

### DIFF
--- a/.dangerfile/general_tests.rb
+++ b/.dangerfile/general_tests.rb
@@ -114,17 +114,17 @@ def general_outdated_terminology?(file)
   # Store contents of file for direct analysis
   file_text = File.read(file)
 
-  # Exclude Dangerfile to avoid false errors due to this test and other similar tests
-  if !file.include?("Dangerfile") && !file.include?(".dangerfile")
+  # Exclude files not worth checking
+  if !file.include?("Dangerfile") && !file.include?(".dangerfile") && !file.start_with?("data/") && !file.start_with?("tools/")
     file_text.each_line.with_index do |line, index|
       line_number = index + 1
       test_line = line.strip.downcase
 
-      if test_line.include?(" rs ") || test_line.include?("rightscale")
+      if test_line.include?(" rs ") || test_line.include?(" rightscale ")
         fail_message += "Line #{line_number.to_s}: Reference to `RightScale` found. Recommended replacements: `Flexera`, `Flexera CCO`, `Flexera Automation`\n\n"
       end
 
-      if test_line.include?("optima")
+      if test_line.include?(" optima ")
         fail_message += "Line #{line_number.to_s}: Reference to `Optima` found. Recommended replacements: `Flexera`, `Flexera CCO`, `Cloud Cost Optimization`\n\n"
       end
     end


### PR DESCRIPTION
### Description

Updates Outdated Terminology test for Dangerfile to look only for instances of "rightscale" and "optima" surrounded by whitespace so that false positives are not raised for built-in policy constructs like `rs_optima_host` or for API endpoints that are still in active use.

Also updates test to ignore contents of data/ and tools/ since these are autogenerated assets. Issues should be corrected in the actual source files, not in generated assets and tools.
