### PR TITLE
POL-1196 Update AWS Usage Report policies to include BC Filter and Region Filter

### DIFF
--- a/operational/aws/total_instance_hours/CHANGELOG.md
+++ b/operational/aws/total_instance_hours/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.0
+
+- Added ability to filter the report for a list of Billing Centers that can either be allowed or denied.
+- Added ability to filter the report for a list of Regions that can either be allowed or denied.
+
 ## v3.2
 
 - Updated policy metadata to correctly identify it as an AWS policy

--- a/operational/aws/total_instance_hours/README.md
+++ b/operational/aws/total_instance_hours/README.md
@@ -14,9 +14,9 @@ This policy allows the user to specify a *Region* to filter results by, and will
 
 This policy has the following input parameters required when launching the policy.
 
-- *Allow/Deny Regions* - Allow or Deny entered regions.
-- *Allow/Deny Regions List* - A list of allowed or denied regions. Example: 'US West (Oregon)'. Leave blank to check all regions.
-- *Allow/Deny Billing Centers* - Allow or Deny entered Billing Centers.
+- *Allow/Deny Regions* - Whether to treat `Allow/Deny Regions List` parameter as allow or deny list. Has no effect if `Allow/Deny Regions List` is left empty.
+- *Allow/Deny Regions List* - A list of allowed or denied regions. Example: `US West (Oregon)`. Leave blank to check all regions.
+- *Allow/Deny Billing Centers* - Whether to treat `Allow/Deny Billing Center List` parameter as allow or deny list. Has no effect if `Allow/Deny Billing Center List` is left empty.
 - *Allow/Deny Billing Center List* - A list of allowed or denied Billing Center names/IDs. Leave blank to check all Billing Centers.
 - *Email addresses to notify* - A list of email addresses to notify.
 

--- a/operational/aws/total_instance_hours/README.md
+++ b/operational/aws/total_instance_hours/README.md
@@ -14,7 +14,10 @@ This policy allows the user to specify a *Region* to filter results by, and will
 
 This policy has the following input parameters required when launching the policy.
 
-- *Region* - Name of the AWS Region to filter by. Example: 'US West (Oregon)'. Leave this blank for 'Organization' scope.
+- *Allow/Deny Regions* - Allow or Deny entered regions.
+- *Allow/Deny Regions List* - A list of allowed or denied regions. Example: 'US West (Oregon)'. Leave blank to check all regions.
+- *Allow/Deny Billing Centers* - Allow or Deny entered Billing Centers.
+- *Allow/Deny Billing Center List* - A list of allowed or denied Billing Center names/IDs. Leave blank to check all Billing Centers.
 - *Email addresses to notify* - A list of email addresses to notify.
 
 ## Policy Actions

--- a/operational/aws/total_instance_hours/aws_usage_instance_hours_used.pt
+++ b/operational/aws/total_instance_hours/aws_usage_instance_hours_used.pt
@@ -21,7 +21,7 @@ parameter "param_email" do
   type "list"
   category "Policy Settings"
   label "Email addresses to notify"
-  description "A list of email addresses to notify."
+  description "Email addresses of the recipients you wish to notify when new incidents are created"
   default []
 end
 

--- a/operational/aws/total_instance_hours/aws_usage_instance_hours_used.pt
+++ b/operational/aws/total_instance_hours/aws_usage_instance_hours_used.pt
@@ -25,12 +25,38 @@ parameter "param_email" do
   default []
 end
 
-parameter "param_region" do
+parameter "param_regions_allow_or_deny" do
   type "string"
-  category "Policy Settings"
-  label "Region"
-  description "Name of the AWS Region to filter by. Example: 'US West (Oregon)'. Leave this blank for 'Organization' scope"
-  default ""
+  category "Filters"
+  label "Allow/Deny Regions"
+  description "Allow or Deny entered regions."
+  allowed_values "Allow", "Deny"
+  default "Allow"
+end
+
+parameter "param_regions_list" do
+  type "list"
+  category "Filters"
+  label "Allow/Deny Regions List"
+  description "A list of allowed or denied regions. Example: 'US West (Oregon)'. Leave blank to check all regions."
+  default []
+end
+
+parameter "param_bc_allow_or_deny" do
+  type "string"
+  category "Filters"
+  label "Allow/Deny Billing Centers"
+  description "Allow or Deny entered Billing Centers."
+  allowed_values "Allow", "Deny"
+  default "Allow"
+end
+
+parameter "param_bc_list" do
+  type "list"
+  category "Filters"
+  label "Allow/Deny Billing Center List"
+  description "A list of allowed or denied Billing Center names/IDs. Leave blank to check all Billing Centers."
+  default []
 end
 
 ###############################################################################
@@ -40,7 +66,7 @@ end
 #AUTHENTICATE WITH FLEXERA/OPTIMA
 credentials "auth_flexera" do
   schemes "oauth2"
-  label "flexera"
+  label "Flexera"
   description "Select Flexera One OAuth2 credentials"
   tags "provider=flexera"
 end

--- a/operational/aws/total_instance_hours/aws_usage_instance_hours_used.pt
+++ b/operational/aws/total_instance_hours/aws_usage_instance_hours_used.pt
@@ -63,7 +63,7 @@ end
 # Authentication
 ###############################################################################
 
-#AUTHENTICATE WITH FLEXERA/OPTIMA
+#AUTHENTICATE WITH FLEXERA
 credentials "auth_flexera" do
   schemes "oauth2"
   label "Flexera"

--- a/operational/aws/total_instance_hours/aws_usage_instance_hours_used.pt
+++ b/operational/aws/total_instance_hours/aws_usage_instance_hours_used.pt
@@ -99,23 +99,26 @@ datasource "ds_billing_centers" do
 end
 
 #GET TOP-LEVEL BILLING CENTERS
-datasource "ds_top_level_billing_centers" do
-  run_script $js_top_level_billing_centers, $ds_billing_centers
+datasource "ds_top_level_bcs" do
+  run_script $js_top_level_bcs, $ds_billing_centers
 end
 
-script "js_top_level_billing_centers", type: "javascript" do
-  parameters "billing_centers"
-  result "filtered_billing_centers"
+script "js_top_level_bcs", type: "javascript" do
+  parameters "ds_billing_centers"
+  result "result"
   code <<-EOS
-  var filtered_billing_centers =
-    _.reject(billing_centers, function(bc){ return bc.parent_id != null })
+  filtered_bcs = _.filter(ds_billing_centers, function(bc) {
+    return bc['parent_id'] == null || bc['parent_id'] == undefined
+  })
+
+  result = _.compact(_.pluck(filtered_bcs, 'id'))
   EOS
 end
 
 #GET USAGE DATA FOR INSTANCE TYPES
 datasource "ds_usage_data" do
   request do
-    run_script $js_usage_data, $ds_top_level_billing_centers, $param_region, rs_org_id, rs_optima_host
+    run_script $js_usage_data, $ds_top_level_bcs, $ds_billing_centers, $param_regions_allow_or_deny, $param_regions_list, $param_bc_allow_or_deny, $param_bc_list, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -131,45 +134,80 @@ datasource "ds_usage_data" do
 end
 
 script "js_usage_data", type: "javascript" do
-  parameters "top_level_billing_centers", "region", "org_id", "optima_host"
+  parameters "ds_top_level_bcs", "ds_billing_centers", "param_regions_allow_or_deny", "param_regions_list", "param_bc_allow_or_deny", "param_bc_list", "org_id", "optima_host"
   result "request"
   code <<-EOS
-  //Billing Center IDs into array
-  billing_center_ids = []
-  _.each(top_level_billing_centers, function(bc){
-    billing_center_ids.push(bc.id)
-  })
-
   //Get Start and End dates
   start_date = new Date(), end_date = new Date()
-  start_date.setMonth(start_date.getMonth() - 13)
-  end_date.setMonth(end_date.getMonth() - 1)
+  start_date.setMonth(start_date.getMonth() - 12)
+  end_date.setMonth(end_date.getMonth())
 
-  //get expressions for payload based on region parameter
-  expressions = []
-  if( region == "" ){
-    expressions = [
-      { "dimension": "category", "type": "equal", "value": "Compute" },
-      { "dimension": "resource_type", "type":"equal", "value":"Compute Instance" },
-      { "dimension": "vendor", "type":"equal", "value":"AWS" },
-      {
-        "type": "not",
-        "expression": { "dimension": "instance_type", "type": "equal", "value": "None" }
+  //Define Billing Center list if applicable
+  var billing_center_ids = []
+  var allow_deny_test = { "Allow": true, "Deny": false }
+
+  if (param_bc_list.length > 0) {
+    billing_center_ids = _.filter(ds_top_level_bcs, function(bc) {
+      var bc_name = ""
+      var matched_bc = _.find(ds_billing_centers, function(data) { return bc == data.id })
+
+      if (matched_bc != undefined) {
+        bc_name = matched_bc.name
+
+        if (param_bc_allow_or_deny == "Allow") {
+          return _.contains(param_bc_list, bc) == allow_deny_test[param_bc_allow_or_deny] || _.contains(param_bc_list, bc_name) == allow_deny_test[param_bc_allow_or_deny]
+        } else {
+          return _.contains(param_bc_list, bc) == allow_deny_test[param_bc_allow_or_deny] && _.contains(param_bc_list, bc_name) == allow_deny_test[param_bc_allow_or_deny]
+        }
       }
-    ]
+    })
   } else {
-    expressions = [
-      { "dimension": "category", "type": "equal", "value": "Compute" },
-      { "dimension": "resource_type", "type":"equal", "value":"Compute Instance" },
-      { "dimension": "vendor", "type":"equal", "value":"AWS" },
-      { "dimension": "region", "type": "equal", "value": region },
-      {
-        "type": "not",
-        "expression": { "dimension": "instance_type", "type": "equal", "value": "None" }
-      }
-    ]
+    billing_center_ids = ds_top_level_bcs
   }
 
+  //Define Expressions for API Filter 
+  var expressions = [
+    { "dimension": "category", "type": "equal", "value": "Compute" },
+    { "dimension": "resource_type", "type":"equal", "value":"Compute Instance" },
+    { "dimension": "vendor", "type":"equal", "value":"AWS" },
+    {
+      "type": "not",
+      "expression": { "dimension": "instance_type", "type": "equal", "value": "None" }
+    }
+  ]
+
+  //Get Regions list if applicable
+  if (param_regions_list.length > 0) {
+    
+    var regions_filter_list = []
+    _.each(param_regions_list, function(reg) {
+        var region_dimension = { "dimension": "region", "type": "equal", "value": reg }
+        regions_filter_list.push(region_dimension)
+    })
+
+    var region_filter_json = {}
+    if (param_regions_allow_or_deny == "Deny") {
+      
+      region_filter_json = {
+        "type": "not",
+        "expression": {
+          "type": "or",
+          "expressions": regions_filter_list
+        }
+      }
+      expressions.push(region_filter_json)
+
+    } else {
+      
+      region_filter_json = {
+        "type": "or",
+        "expressions": regions_filter_list
+      }
+      expressions.push(region_filter_json)
+
+    }
+  }
+  
   //POST JSON payload
   payload = {
     "billing_center_ids": billing_center_ids,
@@ -178,6 +216,7 @@ script "js_usage_data", type: "javascript" do
       "expressions": expressions
     },
     "dimensions": [
+      "billing_center_id",
       "instance_type",
       "usage_unit"
     ],
@@ -193,13 +232,13 @@ script "js_usage_data", type: "javascript" do
   //Request
   request = {
     auth: "auth_flexera",
+    verb: "POST",
     host: optima_host,
     path: "/bill-analysis/orgs/" + org_id + "/costs/aggregated",
-    verb: "POST",
-    body_fields: payload,
     headers: {
       "User-Agent": "RS Policies",
-    }
+    },
+    body_fields: payload
   }
   EOS
 end

--- a/operational/aws/total_instance_hours/aws_usage_instance_hours_used.pt
+++ b/operational/aws/total_instance_hours/aws_usage_instance_hours_used.pt
@@ -253,7 +253,6 @@ datasource "ds_aws_instance_size_map" do
   end
 end
 
-
 #GROUP INSTANCE TYPES INTO INSTANCE FAMILIES AND CALCULATE INSTANCE HOURS
 datasource "ds_instance_hours_per_fam" do
   run_script $js_instance_hours_per_fam, $ds_aws_instance_size_map, $ds_usage_data
@@ -269,9 +268,11 @@ script "js_instance_hours_per_fam", type: "javascript" do
   //Get Normalization Factor units from Instance Data json
   var instance_types = _.keys(aws_instance_data)
   var nfu_ratios = []
-  _.each(instance_types, function(inst){
+  _.each(instance_types, function(inst){ 
     var nfu = aws_instance_data[inst].nfu
-    if(aws_instance_data[inst].nfu == null){ nfu = 1 }
+    if (aws_instance_data[inst].nfu == null) {
+      nfu = 1
+    }
     nfu_ratios.push({
       "instance_type": inst,
       "nfu": nfu
@@ -279,25 +280,26 @@ script "js_instance_hours_per_fam", type: "javascript" do
   })
 
   //Enrich current data with Instance Family, and then calculate Normalized Instance Hours using NFU
-  _.each(usage_data, function(data){
-    data["instance_family"] = data.instance_type.split(".")[0]
-    _.each(nfu_ratios, function(ratio){
-      if(data.instance_type == ratio.instance_type ){
-        data["normalized_instance_hours"] = data.usage_amount * ratio.nfu
-      }
+  _.each(usage_data, function(data) {
+    var matched_instance_data = _.find(nfu_ratios, function(ratio) {
+      return data.instance_type == ratio.instance_type
     })
+    if (matched_instance_data) {
+      data["normalized_instance_hours"] = data.usage_amount * matched_instance_data.nfu
+      data["instance_family"] = data.instance_type.split(".")[0]
+    }
   })
 
   //For each month, sum Instance Hours for each Instance Family
-  month = _.pluck(_.uniq(usage_data, function (data) { return data.month }), "month")
-  inst_family = _.pluck(_.uniq(usage_data, function (data) { return data.instance_family }), "instance_family")
+  var month = _.pluck(_.uniq(usage_data, function (data) { return data.month }), "month")
+  var inst_family = _.pluck(_.uniq(usage_data, function (data) { return data.instance_family }), "instance_family")
 
-  _.each(month, function (mo) {
-    _.each(inst_family, function (fam) {
-      total_inst_hrs = 0
-      _.each(usage_data, function (data) {
+  _.each(month, function(mo) {
+    _.each(inst_family, function(fam) {
+      var total_inst_hrs = 0
+      _.each(usage_data, function(data) {
         if (data.month == mo && data.instance_family == fam) {
-          if(data.normalized_instance_hours == null){
+          if (data.normalized_instance_hours == null) {
             data.normalized_instance_hours = 0
           }
           total_inst_hrs += data.normalized_instance_hours
@@ -312,10 +314,10 @@ script "js_instance_hours_per_fam", type: "javascript" do
   })
 
   //Get highest 8 Instance Families for Instance Hours used
-  inst_hr_totals_per_fam = []
-  _.each(inst_family, function (fam) {
+  var inst_hr_totals_per_fam = []
+  _.each(inst_family, function(fam) {
     total_inst_hrs_12_months = 0
-    _.each(temp_result, function (data) {
+    _.each(temp_result, function(data) {
       if (data.instance_family == fam) {
         total_inst_hrs_12_months += data.total_instance_hours
       }
@@ -326,14 +328,14 @@ script "js_instance_hours_per_fam", type: "javascript" do
     })
   })
 
-  top_8_inst_fams = _.last(_.pluck(_.sortBy(inst_hr_totals_per_fam, "total_inst_hrs_12_months"), "instance_family"), [8])
+  var top_8_inst_fams = _.last(_.pluck(_.sortBy(inst_hr_totals_per_fam, "total_inst_hrs_12_months"), "instance_family"), [8])
 
   //If Instance Family is not in 8 highest Hours used, then put into "Other" category
   _.each(month, function (mo) {
-    total_inst_hrs_other = 0
+    var total_inst_hrs_other = 0
     _.each(temp_result, function (data) {
       if (data.month == mo) {
-        exists = _.find(top_8_inst_fams, function (inst_fam) { return inst_fam == data.instance_family })
+        var exists = _.find(top_8_inst_fams, function (inst_fam) { return inst_fam == data.instance_family })
         if (exists == null) {
           total_inst_hrs_other += data.total_instance_hours
         } else {
@@ -356,28 +358,28 @@ end
 
 #CHART CREATION
 datasource "ds_chart_creation" do
-  run_script $js_chart_creation, $ds_instance_hours_per_fam, $param_region
+  run_script $js_chart_creation, $ds_instance_hours_per_fam, $param_regions_allow_or_deny, $param_regions_list
 end
 
 script "js_chart_creation", type: "javascript" do
-  parameters "inst_hrs_data", "param_region"
-  result "report"
+  parameters "inst_hrs_data", "param_regions_allow_or_deny", "param_regions_list"
+  result "result"
   code <<-EOS
 
   //Group data by Instance Family
   group_by_inst_fam =
   _.groupBy(inst_hrs_data, function(data){ return data.instance_family })
-  report = inst_hrs_data
+  result = inst_hrs_data
 
   //Create chart axis labels
-  chart_axis_labels =
+  var chart_axis_labels =
   ("chxl=1:," +
     _.uniq(inst_hrs_data, function(data) { return data.month })
     .map(function(data){ return data.month.substring(0, 7) })
   ).split(",").join("|")
 
   //Create legend
-  chart_legend = "chdl="
+  var chart_legend = "chdl="
   var i = 0
   for (var key in group_by_inst_fam) {
     chart_legend += key
@@ -386,7 +388,7 @@ script "js_chart_creation", type: "javascript" do
   }
 
   //Create chart dataset
-  chart_data = "chd=t:"
+  var chart_data = "chd=t:"
   var count_1 = 0
   _.each(group_by_inst_fam, function(o){
     var count_2 = 0
@@ -400,15 +402,11 @@ script "js_chart_creation", type: "javascript" do
   })
 
   //Create Chart Title
-  policy_title = "Total Instance Hours Used Per Instance Family For " + param_region
-  chart_title = "chtt=" + policy_title
-  if( param_region == "" ){
-    policy_title = "Total Instance Hours Used Per Instance Family"
-    chart_title = "chtt=" + policy_title
-  }
+  var policy_title = "Total Instance Hours Used Per Instance Family"
+  var chart_title = "chtt=" + policy_title
 
   //Whole Chart object
-  chart = {
+  var chart = {
     chart_type: encodeURI("cht=bvs"),
     chart_size: encodeURI("chs=900x500"),
     chart_data: encodeURI(chart_data),
@@ -426,7 +424,7 @@ script "js_chart_creation", type: "javascript" do
     policy_title: policy_title
   }
 
-  report[0]["chart_dimensions"] = chart
+  result[0]["chart_dimensions"] = chart
   EOS
 end
 

--- a/operational/aws/total_instance_hours/aws_usage_instance_hours_used.pt
+++ b/operational/aws/total_instance_hours/aws_usage_instance_hours_used.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "3.2",
+  version: "4.0",
   provider: "AWS",
   service: "Compute",
   policy_set: "Usage Report"

--- a/operational/aws/total_instance_hours/aws_usage_instance_hours_used.pt
+++ b/operational/aws/total_instance_hours/aws_usage_instance_hours_used.pt
@@ -268,10 +268,10 @@ script "js_instance_hours_per_fam", type: "javascript" do
   //Get Normalization Factor units from Instance Data json
   var instance_types = _.keys(aws_instance_data)
   var nfu_ratios = []
-  _.each(instance_types, function(inst){ 
-    var nfu = aws_instance_data[inst].nfu
-    if (aws_instance_data[inst].nfu == null) {
-      nfu = 1
+  _.each(instance_types, function(inst) { 
+    var nfu = 1
+    if (aws_instance_data[inst].nfu) {
+      nfu = aws_instance_data[inst].nfu
     }
     nfu_ratios.push({
       "instance_type": inst,

--- a/operational/aws/total_instance_hours/aws_usage_instance_hours_used.pt
+++ b/operational/aws/total_instance_hours/aws_usage_instance_hours_used.pt
@@ -268,7 +268,7 @@ script "js_instance_hours_per_fam", type: "javascript" do
   //Get Normalization Factor units from Instance Data json
   var instance_types = _.keys(aws_instance_data)
   var nfu_ratios = []
-  _.each(instance_types, function(inst) { 
+  _.each(instance_types, function(inst) {
     var nfu = 1
     if (aws_instance_data[inst].nfu) {
       nfu = aws_instance_data[inst].nfu
@@ -291,8 +291,8 @@ script "js_instance_hours_per_fam", type: "javascript" do
   })
 
   //For each month, sum Instance Hours for each Instance Family
-  var month = _.pluck(_.uniq(usage_data, function (data) { return data.month }), "month")
-  var inst_family = _.pluck(_.uniq(usage_data, function (data) { return data.instance_family }), "instance_family")
+  var month = _.pluck(_.uniq(usage_data, function(data) { return data.month }), "month")
+  var inst_family = _.pluck(_.uniq(usage_data, function(data) { return data.instance_family }), "instance_family")
 
   _.each(month, function(mo) {
     _.each(inst_family, function(fam) {
@@ -367,15 +367,15 @@ script "js_chart_creation", type: "javascript" do
   code <<-EOS
 
   //Group data by Instance Family
-  group_by_inst_fam =
-  _.groupBy(inst_hrs_data, function(data){ return data.instance_family })
+  var group_by_inst_fam =
+  _.groupBy(inst_hrs_data, function(data) { return data.instance_family })
   result = inst_hrs_data
 
   //Create chart axis labels
   var chart_axis_labels =
   ("chxl=1:," +
     _.uniq(inst_hrs_data, function(data) { return data.month })
-    .map(function(data){ return data.month.substring(0, 7) })
+    .map(function(data) { return data.month.substring(0, 7) })
   ).split(",").join("|")
 
   //Create legend
@@ -390,15 +390,15 @@ script "js_chart_creation", type: "javascript" do
   //Create chart dataset
   var chart_data = "chd=t:"
   var count_1 = 0
-  _.each(group_by_inst_fam, function(o){
+  _.each(group_by_inst_fam, function(o) {
     var count_2 = 0
-    _.each(o, function(p){
+    _.each(o, function(p) {
       chart_data = chart_data + p.total_instance_hours
       count_2++
-      if (count_2 < _.size(o)){ chart_data = chart_data + "," }
+      if (count_2 < _.size(o)) { chart_data = chart_data + "," }
     })
     count_1++
-    if (count_1 < _.size(group_by_inst_fam)){ chart_data = chart_data + "|" }
+    if (count_1 < _.size(group_by_inst_fam)) { chart_data = chart_data + "|" }
   })
 
   //Create Chart Title

--- a/operational/aws/total_instance_memory/CHANGELOG.md
+++ b/operational/aws/total_instance_memory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.0
+
+- Added ability to filter the report for a list of Billing Centers that can either be allowed or denied.
+
 ## v1.0
 
 - Initial release

--- a/operational/aws/total_instance_memory/README.md
+++ b/operational/aws/total_instance_memory/README.md
@@ -14,7 +14,10 @@ This policy allows the user to specify a *Region* to filter results by, and will
 
 This policy has the following input parameters required when launching the policy.
 
-- *Region* - Name of the AWS Region to filter by. Example: 'US West (Oregon)'. Leave this blank for 'Organization' scope.
+- *Allow/Deny Regions* - Allow or Deny entered regions.
+- *Allow/Deny Regions List* - A list of allowed or denied regions. Example: 'US East'. Leave blank to check all regions.
+- *Allow/Deny Billing Centers* - Allow or Deny entered Billing Centers.
+- *Allow/Deny Billing Center List* - A list of allowed or denied Billing Center names/IDs. Leave blank to check all Billing Centers.
 - *Email addresses to notify* - A list of email addresses to notify.
 
 ## Policy Actions

--- a/operational/aws/total_instance_memory/README.md
+++ b/operational/aws/total_instance_memory/README.md
@@ -14,9 +14,9 @@ This policy allows the user to specify a *Region* to filter results by, and will
 
 This policy has the following input parameters required when launching the policy.
 
-- *Allow/Deny Regions* - Allow or Deny entered regions.
-- *Allow/Deny Regions List* - A list of allowed or denied regions. Example: 'US West (Oregon)'. Leave blank to check all regions.
-- *Allow/Deny Billing Centers* - Allow or Deny entered Billing Centers.
+- *Allow/Deny Regions* - Whether to treat `Allow/Deny Regions List` parameter as allow or deny list. Has no effect if `Allow/Deny Regions List` is left empty.
+- *Allow/Deny Regions List* - A list of allowed or denied regions. Example: `US West (Oregon)`. Leave blank to check all regions.
+- *Allow/Deny Billing Centers* - Whether to treat `Allow/Deny Billing Center List` parameter as allow or deny list. Has no effect if `Allow/Deny Billing Center List` is left empty.
 - *Allow/Deny Billing Center List* - A list of allowed or denied Billing Center names/IDs. Leave blank to check all Billing Centers.
 - *Email addresses to notify* - A list of email addresses to notify.
 

--- a/operational/aws/total_instance_memory/README.md
+++ b/operational/aws/total_instance_memory/README.md
@@ -15,7 +15,7 @@ This policy allows the user to specify a *Region* to filter results by, and will
 This policy has the following input parameters required when launching the policy.
 
 - *Allow/Deny Regions* - Allow or Deny entered regions.
-- *Allow/Deny Regions List* - A list of allowed or denied regions. Example: 'US East'. Leave blank to check all regions.
+- *Allow/Deny Regions List* - A list of allowed or denied regions. Example: 'US West (Oregon)'. Leave blank to check all regions.
 - *Allow/Deny Billing Centers* - Allow or Deny entered Billing Centers.
 - *Allow/Deny Billing Center List* - A list of allowed or denied Billing Center names/IDs. Leave blank to check all Billing Centers.
 - *Email addresses to notify* - A list of email addresses to notify.

--- a/operational/aws/total_instance_memory/aws_usage_instance_memory_used.pt
+++ b/operational/aws/total_instance_memory/aws_usage_instance_memory_used.pt
@@ -97,7 +97,7 @@ datasource "ds_billing_centers" do
     end
   end  
 end
-  
+
 #GET TOP-LEVEL BILLING CENTERS
 datasource "ds_top_level_bcs" do
   run_script $js_top_level_bcs, $ds_billing_centers
@@ -268,7 +268,7 @@ script "js_instance_memory_per_fam", type: "javascript" do
   //Get Memory counts from Instance Data json
   instance_types = _.keys(aws_instance_data)
   var memory_data = []
-  _.each(instance_types, function(inst) {   
+  _.each(instance_types, function(inst) {
     var mem_count = 0
     if (aws_instance_data[inst].memory) {
       mem_count = aws_instance_data[inst].memory
@@ -437,7 +437,7 @@ policy "pol_inst_memory_per_inst_fam" do
     summary_template "AWS Usage Report - Amount of Instance Memory Used (Normalized - past 12 months)"
     detail_template <<-EOS
 # AWS - {{ with index data 0 }}{{ .chart_dimensions.policy_title }}{{ end }} Report
-![Instance Memory Used Per Instance Family Chart](https://image-charts.com/chart?{{ with index data 0 }}{{ .chart_dimensions.chart_data }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_size }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_type }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_image }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_title }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_label_position }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_axis }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_axis_label }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_line_style }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_line_color }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_data_scale }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_legend_size }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_legend }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_axis_format }}{{ end }})
+![Instance Memory Used Per Instance Family Chart](https://api.image-charts-auth.flexeraeng.com/ic-function?rs_org_id={{ rs_org_id }}&rs_project_id={{ rs_project_id }}&{{ with index data 0 }}{{ .chart_dimensions.chart_data }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_size }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_type }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_image }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_title }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_label_position }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_axis }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_axis_label }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_line_style }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_line_color }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_data_scale }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_legend_size }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_legend }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_axis_format }}{{ end }})
 ___
 ###### Policy Applied in Account: {{ rs_project_name }} (Account ID: {{ rs_project_id }}) within Org: {{ rs_org_name }} (Org ID: {{ rs_org_id }})
 EOS

--- a/operational/aws/total_instance_memory/aws_usage_instance_memory_used.pt
+++ b/operational/aws/total_instance_memory/aws_usage_instance_memory_used.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "1.0",
+  version: "2.0",
   provider: "AWS",
   service: "Compute",
   policy_set: "Usage Report"
@@ -39,6 +39,23 @@ parameter "param_regions_list" do
   category "Filters"
   label "Allow/Deny Regions List"
   description "A list of allowed or denied regions. Example: 'US West (Oregon)'. Leave blank to check all regions."
+  default []
+end
+
+parameter "param_bc_allow_or_deny" do
+  type "string"
+  category "Filters"
+  label "Allow/Deny Billing Centers"
+  description "Allow or Deny entered Billing Centers."
+  allowed_values "Allow", "Deny"
+  default "Allow"
+end
+
+parameter "param_bc_list" do
+  type "list"
+  category "Filters"
+  label "Allow/Deny Billing Center List"
+  description "A list of allowed or denied Billing Center names/IDs. Leave blank to check all Billing Centers."
   default []
 end
 
@@ -101,7 +118,7 @@ end
 #GET USAGE DATA FOR INSTANCE TYPES
 datasource "ds_usage_data" do
   request do
-    run_script $js_usage_data, $ds_top_level_bcs, $param_regions_allow_or_deny, $param_regions_list, rs_org_id, rs_optima_host
+    run_script $js_usage_data, $ds_top_level_bcs, $ds_billing_centers, $param_regions_allow_or_deny, $param_regions_list, $param_bc_allow_or_deny, $param_bc_list, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -117,13 +134,36 @@ datasource "ds_usage_data" do
 end
 
 script "js_usage_data", type: "javascript" do
-  parameters "ds_top_level_bcs", "param_regions_allow_or_deny", "param_regions_list", "org_id", "optima_host"
+  parameters "ds_top_level_bcs", "ds_billing_centers", "param_regions_allow_or_deny", "param_regions_list", "param_bc_allow_or_deny", "param_bc_list", "org_id", "optima_host"
   result "request"
   code <<-EOS
   //Get Start and End dates
   start_date = new Date(), end_date = new Date()
-  start_date.setMonth(start_date.getMonth() - 13)
-  end_date.setMonth(end_date.getMonth() - 1)
+  start_date.setMonth(start_date.getMonth() - 12)
+  end_date.setMonth(end_date.getMonth())
+
+  //Define Billing Center list if applicable
+  var billing_center_ids = []
+  var allow_deny_test = { "Allow": true, "Deny": false }
+
+  if (param_bc_list.length > 0) {
+    billing_center_ids = _.filter(ds_top_level_bcs, function(bc) {
+      var bc_name = ""
+      var matched_bc = _.find(ds_billing_centers, function(data) { return bc == data.id })
+
+      if (matched_bc != undefined) {
+        bc_name = matched_bc.name
+
+        if (param_bc_allow_or_deny == "Allow") {
+          return _.contains(param_bc_list, bc) == allow_deny_test[param_bc_allow_or_deny] || _.contains(param_bc_list, bc_name) == allow_deny_test[param_bc_allow_or_deny]
+        } else {
+          return _.contains(param_bc_list, bc) == allow_deny_test[param_bc_allow_or_deny] && _.contains(param_bc_list, bc_name) == allow_deny_test[param_bc_allow_or_deny]
+        }
+      }
+    })
+  } else {
+    billing_center_ids = ds_top_level_bcs
+  }
 
   //Define Expressions for API Filter 
   var expressions = [
@@ -170,12 +210,13 @@ script "js_usage_data", type: "javascript" do
   
   //POST JSON payload
   payload = {
-    "billing_center_ids": ds_top_level_bcs,
+    "billing_center_ids": billing_center_ids,
     "filter": {
       "type": "and",
       "expressions": expressions
     },
     "dimensions": [
+      "billing_center_id",
       "instance_type",
       "usage_unit"
     ],

--- a/operational/aws/total_instance_memory/aws_usage_instance_memory_used.pt
+++ b/operational/aws/total_instance_memory/aws_usage_instance_memory_used.pt
@@ -95,7 +95,7 @@ datasource "ds_billing_centers" do
       field "ancestor_ids", jmes_path(col_item, "ancestor_ids")
       field "allocation_table", jmes_path(col_item, "allocation_table")
     end
-  end  
+  end
 end
 
 #GET TOP-LEVEL BILLING CENTERS

--- a/operational/aws/total_instance_vcpus/CHANGELOG.md
+++ b/operational/aws/total_instance_vcpus/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.0
+
+- Added ability to filter the report for a list of Billing Centers that can either be allowed or denied.
+- Added ability to filter the report for a list of Regions that can either be allowed or denied.
+
 ## v3.2
 
 - Updated policy metadata to correctly identify it as an AWS policy

--- a/operational/aws/total_instance_vcpus/README.md
+++ b/operational/aws/total_instance_vcpus/README.md
@@ -14,7 +14,10 @@ This policy allows the user to specify a *Region* to filter results by, and will
 
 This policy has the following input parameters required when launching the policy.
 
-- *Region* - Name of the AWS Region to filter by. Example: 'US West (Oregon)'. Leave this blank for 'Organization' scope.
+- *Allow/Deny Regions* - Allow or Deny entered regions.
+- *Allow/Deny Regions List* - A list of allowed or denied regions. Example: 'US East'. Leave blank to check all regions.
+- *Allow/Deny Billing Centers* - Allow or Deny entered Billing Centers.
+- *Allow/Deny Billing Center List* - A list of allowed or denied Billing Center names/IDs. Leave blank to check all Billing Centers.
 - *Email addresses to notify* - A list of email addresses to notify.
 
 ## Policy Actions

--- a/operational/aws/total_instance_vcpus/README.md
+++ b/operational/aws/total_instance_vcpus/README.md
@@ -15,7 +15,7 @@ This policy allows the user to specify a *Region* to filter results by, and will
 This policy has the following input parameters required when launching the policy.
 
 - *Allow/Deny Regions* - Allow or Deny entered regions.
-- *Allow/Deny Regions List* - A list of allowed or denied regions. Example: 'US East'. Leave blank to check all regions.
+- *Allow/Deny Regions List* - A list of allowed or denied regions. Example: 'US West (Oregen)'. Leave blank to check all regions.
 - *Allow/Deny Billing Centers* - Allow or Deny entered Billing Centers.
 - *Allow/Deny Billing Center List* - A list of allowed or denied Billing Center names/IDs. Leave blank to check all Billing Centers.
 - *Email addresses to notify* - A list of email addresses to notify.

--- a/operational/aws/total_instance_vcpus/README.md
+++ b/operational/aws/total_instance_vcpus/README.md
@@ -14,9 +14,9 @@ This policy allows the user to specify a *Region* to filter results by, and will
 
 This policy has the following input parameters required when launching the policy.
 
-- *Allow/Deny Regions* - Allow or Deny entered regions.
-- *Allow/Deny Regions List* - A list of allowed or denied regions. Example: 'US West (Oregen)'. Leave blank to check all regions.
-- *Allow/Deny Billing Centers* - Allow or Deny entered Billing Centers.
+- *Allow/Deny Regions* - Whether to treat `Allow/Deny Regions List` parameter as allow or deny list. Has no effect if `Allow/Deny Regions List` is left empty.
+- *Allow/Deny Regions List* - A list of allowed or denied regions. Example: `US West (Oregon)`. Leave blank to check all regions.
+- *Allow/Deny Billing Centers* - Whether to treat `Allow/Deny Billing Center List` parameter as allow or deny list. Has no effect if `Allow/Deny Billing Center List` is left empty.
 - *Allow/Deny Billing Center List* - A list of allowed or denied Billing Center names/IDs. Leave blank to check all Billing Centers.
 - *Email addresses to notify* - A list of email addresses to notify.
 

--- a/operational/aws/total_instance_vcpus/aws_usage_instance_vcpus_used.pt
+++ b/operational/aws/total_instance_vcpus/aws_usage_instance_vcpus_used.pt
@@ -292,7 +292,7 @@ script "js_instance_vcpus_per_fam", type: "javascript" do
 
   //For each month, sum Instance Hours for each Instance Family
   var month = _.pluck(_.uniq(usage_data, function(data){ return data.month }), "month")
-  inst_family = _.pluck(_.uniq(usage_data, function(data){ return data.instance_family }), "instance_family")
+  var inst_family = _.pluck(_.uniq(usage_data, function(data){ return data.instance_family }), "instance_family")
 
   _.each(month, function(mo) {
     _.each(inst_family, function(fam) {
@@ -328,14 +328,14 @@ script "js_instance_vcpus_per_fam", type: "javascript" do
     })
   })
 
-  top_8_inst_fams = _.last(_.pluck(_.sortBy(vcpu_totals_per_fam, "total_vcpus_12_months"), "instance_family" ), [8])
+  var top_8_inst_fams = _.last(_.pluck(_.sortBy(vcpu_totals_per_fam, "total_vcpus_12_months"), "instance_family" ), [8])
 
   //If Instance Family is not in 8 highest vCPUs used, then put into "Other" category
   _.each(month, function(mo) {
     var total_vcpus_other = 0
     _.each(temp_result, function(data) {
       if (data.month == mo ) {
-        exists = _.find(top_8_inst_fams, function(inst_fam){ return inst_fam == data.instance_family })
+        var exists = _.find(top_8_inst_fams, function(inst_fam){ return inst_fam == data.instance_family })
         if (exists == null) {
           total_vcpus_other += data.total_vcpu_count
         } else {

--- a/operational/aws/total_instance_vcpus/aws_usage_instance_vcpus_used.pt
+++ b/operational/aws/total_instance_vcpus/aws_usage_instance_vcpus_used.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "3.2",
+  version: "4.0",
   provider: "AWS",
   service: "Compute",
   policy_set: "Usage Report"
@@ -21,26 +21,52 @@ parameter "param_email" do
   type "list"
   category "Policy Settings"
   label "Email addresses to notify"
-  description "A list of email addresses to notify."
+  description "Email addresses of the recipients you wish to notify when new incidents are created"
   default []
 end
 
-parameter "param_region" do
+parameter "param_regions_allow_or_deny" do
   type "string"
-  category "Policy Settings"
-  label "Region"
-  description "Name of the AWS Region to filter by. Example: 'US West (Oregon)'. Leave this blank for 'Organization' scope"
-  default ""
+  category "Filters"
+  label "Allow/Deny Regions"
+  description "Allow or Deny entered regions."
+  allowed_values "Allow", "Deny"
+  default "Allow"
+end
+
+parameter "param_regions_list" do
+  type "list"
+  category "Filters"
+  label "Allow/Deny Regions List"
+  description "A list of allowed or denied regions. Example: 'US West (Oregon)'. Leave blank to check all regions."
+  default []
+end
+
+parameter "param_bc_allow_or_deny" do
+  type "string"
+  category "Filters"
+  label "Allow/Deny Billing Centers"
+  description "Allow or Deny entered Billing Centers."
+  allowed_values "Allow", "Deny"
+  default "Allow"
+end
+
+parameter "param_bc_list" do
+  type "list"
+  category "Filters"
+  label "Allow/Deny Billing Center List"
+  description "A list of allowed or denied Billing Center names/IDs. Leave blank to check all Billing Centers."
+  default []
 end
 
 ###############################################################################
 # Authentication
 ###############################################################################
 
-#AUTHENTICATE WITH FEXERA/OPTIMA
+#AUTHENTICATE WITH FLEXERA
 credentials "auth_flexera" do
   schemes "oauth2"
-  label "flexera"
+  label "Flexera"
   description "Select Flexera One OAuth2 credentials"
   tags "provider=flexera"
 end
@@ -69,27 +95,30 @@ datasource "ds_billing_centers" do
       field "ancestor_ids", jmes_path(col_item, "ancestor_ids")
       field "allocation_table", jmes_path(col_item, "allocation_table")
     end
-  end
+  end  
 end
 
 #GET TOP-LEVEL BILLING CENTERS
-datasource "ds_top_level_billing_centers" do
-  run_script $js_top_level_billing_centers, $ds_billing_centers
+datasource "ds_top_level_bcs" do
+  run_script $js_top_level_bcs, $ds_billing_centers
 end
 
-script "js_top_level_billing_centers", type: "javascript" do
-  parameters "billing_centers"
-  result "filtered_billing_centers"
+script "js_top_level_bcs", type: "javascript" do
+  parameters "ds_billing_centers"
+  result "result"
   code <<-EOS
-  var filtered_billing_centers =
-    _.reject(billing_centers, function(bc){ return bc.parent_id != null })
+  filtered_bcs = _.filter(ds_billing_centers, function(bc) {
+    return bc['parent_id'] == null || bc['parent_id'] == undefined
+  })
+
+  result = _.compact(_.pluck(filtered_bcs, 'id'))
   EOS
 end
 
 #GET USAGE DATA FOR INSTANCE TYPES
 datasource "ds_usage_data" do
   request do
-    run_script $js_usage_data, $ds_top_level_billing_centers, $param_region, rs_org_id, rs_optima_host
+    run_script $js_usage_data, $ds_top_level_bcs, $ds_billing_centers, $param_regions_allow_or_deny, $param_regions_list, $param_bc_allow_or_deny, $param_bc_list, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -105,45 +134,80 @@ datasource "ds_usage_data" do
 end
 
 script "js_usage_data", type: "javascript" do
-  parameters "top_level_billing_centers", "region", "org_id", "optima_host"
+  parameters "ds_top_level_bcs", "ds_billing_centers", "param_regions_allow_or_deny", "param_regions_list", "param_bc_allow_or_deny", "param_bc_list", "org_id", "optima_host"
   result "request"
   code <<-EOS
-  //Billing Center IDs into array
-  billing_center_ids = []
-  _.each(top_level_billing_centers, function(bc){
-    billing_center_ids.push(bc.id)
-  })
-
   //Get Start and End dates
   start_date = new Date(), end_date = new Date()
-  start_date.setMonth(start_date.getMonth() - 13)
-  end_date.setMonth(end_date.getMonth() - 1)
+  start_date.setMonth(start_date.getMonth() - 12)
+  end_date.setMonth(end_date.getMonth())
 
-  //get expressions for payload based on region parameter
-  expressions = []
-  if( region == "" ){
-    expressions = [
-      { "dimension": "category", "type": "equal", "value": "Compute" },
-      { "dimension": "resource_type", "type":"equal", "value":"Compute Instance" },
-      { "dimension": "vendor", "type":"equal", "value":"AWS" },
-      {
-        "type": "not",
-        "expression": { "dimension": "instance_type", "type": "equal", "value": "None" }
+  //Define Billing Center list if applicable
+  var billing_center_ids = []
+  var allow_deny_test = { "Allow": true, "Deny": false }
+
+  if (param_bc_list.length > 0) {
+    billing_center_ids = _.filter(ds_top_level_bcs, function(bc) {
+      var bc_name = ""
+      var matched_bc = _.find(ds_billing_centers, function(data) { return bc == data.id })
+
+      if (matched_bc != undefined) {
+        bc_name = matched_bc.name
+
+        if (param_bc_allow_or_deny == "Allow") {
+          return _.contains(param_bc_list, bc) == allow_deny_test[param_bc_allow_or_deny] || _.contains(param_bc_list, bc_name) == allow_deny_test[param_bc_allow_or_deny]
+        } else {
+          return _.contains(param_bc_list, bc) == allow_deny_test[param_bc_allow_or_deny] && _.contains(param_bc_list, bc_name) == allow_deny_test[param_bc_allow_or_deny]
+        }
       }
-    ]
+    })
   } else {
-    expressions = [
-      { "dimension": "category", "type": "equal", "value": "Compute" },
-      { "dimension": "resource_type", "type":"equal", "value":"Compute Instance" },
-      { "dimension": "vendor", "type":"equal", "value":"AWS" },
-      { "dimension": "region", "type": "equal", "value": region },
-      {
-        "type": "not",
-        "expression": { "dimension": "instance_type", "type": "equal", "value": "None" }
-      }
-    ]
+    billing_center_ids = ds_top_level_bcs
   }
 
+  //Define Expressions for API Filter 
+  var expressions = [
+    { "dimension": "category", "type": "equal", "value": "Compute" },
+    { "dimension": "resource_type", "type":"equal", "value":"Compute Instance" },
+    { "dimension": "vendor", "type":"equal", "value":"AWS" },
+    {
+      "type": "not",
+      "expression": { "dimension": "instance_type", "type": "equal", "value": "None" }
+    }
+  ]
+
+  //Get Regions list if applicable
+  if (param_regions_list.length > 0) {
+    
+    var regions_filter_list = []
+    _.each(param_regions_list, function(reg) {
+        var region_dimension = { "dimension": "region", "type": "equal", "value": reg }
+        regions_filter_list.push(region_dimension)
+    })
+
+    var region_filter_json = {}
+    if (param_regions_allow_or_deny == "Deny") {
+      
+      region_filter_json = {
+        "type": "not",
+        "expression": {
+          "type": "or",
+          "expressions": regions_filter_list
+        }
+      }
+      expressions.push(region_filter_json)
+
+    } else {
+      
+      region_filter_json = {
+        "type": "or",
+        "expressions": regions_filter_list
+      }
+      expressions.push(region_filter_json)
+
+    }
+  }
+  
   //POST JSON payload
   payload = {
     "billing_center_ids": billing_center_ids,
@@ -152,6 +216,7 @@ script "js_usage_data", type: "javascript" do
       "expressions": expressions
     },
     "dimensions": [
+      "billing_center_id",
       "instance_type",
       "usage_unit"
     ],
@@ -167,13 +232,13 @@ script "js_usage_data", type: "javascript" do
   //Request
   request = {
     auth: "auth_flexera",
+    verb: "POST",
     host: optima_host,
     path: "/bill-analysis/orgs/" + org_id + "/costs/aggregated",
-    verb: "POST",
-    body_fields: payload,
     headers: {
       "User-Agent": "RS Policies",
-    }
+    },
+    body_fields: payload
   }
   EOS
 end
@@ -203,9 +268,11 @@ script "js_instance_vcpus_per_fam", type: "javascript" do
   //Get vCPU counts from Instance Data json
   instance_types = _.keys(aws_instance_data)
   var vcpu_data = []
-  _.each(instance_types, function(inst){
-    var vcpu_count = aws_instance_data[inst].vcpu
-    if(aws_instance_data[inst].vcpu == null){ vcpu = 0 }
+  _.each(instance_types, function(inst) {
+    var vcpu_count = 0
+    if (aws_instance_data[inst].vcpu) { 
+      vcpu_count = aws_instance_data[inst].vcpu
+    }
     vcpu_data.push({
       "instance_type": inst,
       "vcpu_count": vcpu_count
@@ -213,25 +280,26 @@ script "js_instance_vcpus_per_fam", type: "javascript" do
   })
 
   //Enrich current data with Instance Family, and then vCPU count.  - //then calculate Normalized Instance Hours using NFU
-  _.each(usage_data, function(data){
-    data["instance_family"] = data.instance_type.split(".")[0]
-    _.each(vcpu_data, function(vcpu){
-      if(data.instance_type == vcpu.instance_type ){
-        data["vcpu_count"] = (data.usage_amount / 730 ) * vcpu.vcpu_count //Normalize Usage Amount (divide by 730 ) to get more accurate vCPU count
-      }
+  _.each(usage_data, function(data) {
+    var matched_instance_data = _.find(vcpu_data, function(vcpu) {
+      return data.instance_type == vcpu.instance_type
     })
+    if (matched_instance_data) {
+      data["vcpu_count"] = (data.usage_amount / 730 ) * matched_instance_data.vcpu_count //Normalize Usage Amount (divide by 730 ) to get more accurate vCPU count
+      data["instance_family"] = data.instance_type.split(".")[0]
+    }
   })
 
   //For each month, sum Instance Hours for each Instance Family
-  month = _.pluck( _.uniq(usage_data, function(data){ return data.month }), "month" )
-  inst_family = _.pluck( _.uniq(usage_data, function(data){ return data.instance_family }), "instance_family" )
+  var month = _.pluck(_.uniq(usage_data, function(data){ return data.month }), "month")
+  inst_family = _.pluck(_.uniq(usage_data, function(data){ return data.instance_family }), "instance_family")
 
-  _.each(month, function(mo){
-    _.each(inst_family, function(fam){
-      total_vcpu_count = 0
-      _.each(usage_data, function(data){
-        if(data.month == mo && data.instance_family == fam){
-          if(data.vcpu_count == null){
+  _.each(month, function(mo) {
+    _.each(inst_family, function(fam) {
+      var total_vcpu_count = 0
+      _.each(usage_data, function(data) {
+        if (data.month == mo && data.instance_family == fam) {
+          if (data.vcpu_count == null) {
             data.vcpu_count = 0
           }
           total_vcpu_count += data.vcpu_count
@@ -246,11 +314,11 @@ script "js_instance_vcpus_per_fam", type: "javascript" do
   })
 
   //Get highest 8 Instance Families for vCPUs used
-  vcpu_totals_per_fam = []
-  _.each(inst_family, function(fam){
+  var vcpu_totals_per_fam = []
+  _.each(inst_family, function(fam) {
     total_vcpus_12_months = 0
-    _.each(temp_result, function(data){
-      if(data.instance_family == fam){
+    _.each(temp_result, function(data) {
+      if (data.instance_family == fam) {
         total_vcpus_12_months += data.total_vcpu_count
       }
     })
@@ -263,12 +331,12 @@ script "js_instance_vcpus_per_fam", type: "javascript" do
   top_8_inst_fams = _.last(_.pluck(_.sortBy(vcpu_totals_per_fam, "total_vcpus_12_months"), "instance_family" ), [8])
 
   //If Instance Family is not in 8 highest vCPUs used, then put into "Other" category
-  _.each(month, function(mo){
-    total_vcpus_other = 0
-    _.each(temp_result, function(data){
-      if(data.month == mo ){
+  _.each(month, function(mo) {
+    var total_vcpus_other = 0
+    _.each(temp_result, function(data) {
+      if (data.month == mo ) {
         exists = _.find(top_8_inst_fams, function(inst_fam){ return inst_fam == data.instance_family })
-        if(exists == null){
+        if (exists == null) {
           total_vcpus_other += data.total_vcpu_count
         } else {
           result.push({
@@ -290,28 +358,28 @@ end
 
 #CHART CREATION
 datasource "ds_chart_creation" do
-  run_script $js_chart_creation, $ds_instance_vcpus_per_fam, $param_region
+  run_script $js_chart_creation, $ds_instance_vcpus_per_fam, $param_regions_allow_or_deny, $param_regions_list
 end
 
 script "js_chart_creation", type: "javascript" do
-  parameters "inst_vcpu_data", "param_region"
-  result "report"
+  parameters "inst_vcpu_data", "param_regions_allow_or_deny", "param_regions_list"
+  result "result"
   code <<-EOS
 
   //Group data by Instance Family
-  group_by_inst_fam =
-  _.groupBy(inst_vcpu_data, function(data){ return data.instance_family })
-  report = inst_vcpu_data
+  var group_by_inst_fam =
+  _.groupBy(inst_vcpu_data, function(data) { return data.instance_family })
+  result = inst_vcpu_data
 
   //Create chart axis labels
-  chart_axis_labels =
+  var chart_axis_labels =
   ("chxl=1:," +
     _.uniq(inst_vcpu_data, function(data) { return data.month })
-    .map(function(data){ return data.month.substring(0, 7) })
+    .map(function(data) { return data.month.substring(0, 7) })
   ).split(",").join("|")
 
   //Create legend
-  chart_legend = "chdl="
+  var chart_legend = "chdl="
   var i = 0
   for (var key in group_by_inst_fam) {
     chart_legend += key
@@ -320,29 +388,25 @@ script "js_chart_creation", type: "javascript" do
   }
 
   //Create chart dataset
-  chart_data = "chd=t:"
+  var chart_data = "chd=t:"
   var count_1 = 0
-  _.each(group_by_inst_fam, function(o){
+  _.each(group_by_inst_fam, function(o) {
     var count_2 = 0
-    _.each(o, function(p){
+    _.each(o, function(p) {
       chart_data = chart_data + p.total_vcpu_count
       count_2++
-      if (count_2 < _.size(o)){ chart_data = chart_data + "," }
+      if (count_2 < _.size(o)) { chart_data = chart_data + "," }
     })
     count_1++
-    if (count_1 < _.size(group_by_inst_fam)){ chart_data = chart_data + "|" }
+    if (count_1 < _.size(group_by_inst_fam)) { chart_data = chart_data + "|" }
   })
 
   //Create Chart Title
-  policy_title = "Total Instance vCPUs Used Per Instance Family For " + param_region
-  chart_title = "chtt=" + policy_title
-  if( param_region == "" ){
-    policy_title = "Total Instance vCPUs Used Per Instance Family"
-    chart_title = "chtt=" + policy_title
-  }
+  var policy_title = "Total Instance vCPUs Used Per Instance Family"
+  var chart_title = "chtt=" + policy_title
 
   //Whole Chart object
-  chart = {
+  var chart = {
     chart_type: encodeURI("cht=bvs"),
     chart_size: encodeURI("chs=900x500"),
     chart_data: encodeURI(chart_data),
@@ -360,7 +424,7 @@ script "js_chart_creation", type: "javascript" do
     policy_title: policy_title
   }
 
-  report[0]["chart_dimensions"] = chart
+  result[0]["chart_dimensions"] = chart
   EOS
 end
 

--- a/operational/aws/total_instance_vcpus/aws_usage_instance_vcpus_used.pt
+++ b/operational/aws/total_instance_vcpus/aws_usage_instance_vcpus_used.pt
@@ -95,7 +95,7 @@ datasource "ds_billing_centers" do
       field "ancestor_ids", jmes_path(col_item, "ancestor_ids")
       field "allocation_table", jmes_path(col_item, "allocation_table")
     end
-  end  
+  end
 end
 
 #GET TOP-LEVEL BILLING CENTERS

--- a/operational/aws/total_instance_vcpus/aws_usage_instance_vcpus_used.pt
+++ b/operational/aws/total_instance_vcpus/aws_usage_instance_vcpus_used.pt
@@ -328,13 +328,13 @@ script "js_instance_vcpus_per_fam", type: "javascript" do
     })
   })
 
-  var top_8_inst_fams = _.last(_.pluck(_.sortBy(vcpu_totals_per_fam, "total_vcpus_12_months"), "instance_family" ), [8])
+  var top_8_inst_fams = _.last(_.pluck(_.sortBy(vcpu_totals_per_fam, "total_vcpus_12_months"), "instance_family"), [8])
 
   //If Instance Family is not in 8 highest vCPUs used, then put into "Other" category
   _.each(month, function(mo) {
     var total_vcpus_other = 0
     _.each(temp_result, function(data) {
-      if (data.month == mo ) {
+      if (data.month == mo) {
         var exists = _.find(top_8_inst_fams, function(inst_fam){ return inst_fam == data.instance_family })
         if (exists == null) {
           total_vcpus_other += data.total_vcpu_count


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves below -->
This is a change to add parameters which allow the user to filter (Allow or Deny) for a list of Billing Centers and a list of Regions to report on. This parameter will be added to the following Usage Report policies:

- AWS Usage Report - Number of Instance Hours Used
- AWS Usage Report - Number of Instance vCPUs Used
- AWS Usage Report - Amount of Instance Memory Used

### Issues Resolved

<!-- List any existing issues this PR resolves below -->
- Adds functionality to make the policy more valuable to customers who may want to produce a Usage Report for specific Billing Centers and/or Regions.
- Brings these policies in line with their Azure counterparts.
- Resolves inaccuracies in the policy template Readme files regarding the listed input parameters.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->
Applied policy in customer tenant. Some examples:

No filters:
![image](https://github.com/flexera-public/policy_templates/assets/92175447/91b86042-6e0d-4ab2-b422-9ee80e067ffe)

Allowing specific regions, denying specific BCs:
![image](https://github.com/flexera-public/policy_templates/assets/92175447/39d05ece-27ec-4dd6-98bf-dde73bfbbb48)

Denying specific regions, allowing specific BCs:
![image](https://github.com/flexera-public/policy_templates/assets/92175447/55480a8c-28f4-4e5a-9ffd-5b72b50e2669)

### Contribution Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
