### PR TITLE
FOPTS-3836 Fix: cloud_cost_anomaly_alerts.pt incident link

### DIFF
--- a/cost/flexera/cco/cloud_cost_anomaly_alerts/CHANGELOG.md
+++ b/cost/flexera/cco/cloud_cost_anomaly_alerts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.6
+
+- Fixed bug where incident link was redirecting to wrong url
+
 ## v3.5
 
 - Updated policy metadata to make it more clear what Flexera service the policy is for

--- a/cost/flexera/cco/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
+++ b/cost/flexera/cco/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
@@ -30,9 +30,9 @@ parameter "param_days" do
   category "Policy Settings"
   label "Time Period"
   description "Number of days back to analyze for anomalies"
-  default 30
   min_value 1
   max_value 31
+  default 30
 end
 
 parameter "param_min_spend" do
@@ -40,8 +40,8 @@ parameter "param_min_spend" do
   category "Policy Settings"
   label "Minimum Period Spend"
   description "Minimum spend over the time period required to include anomaly in results"
-  default 1000
   min_value 0
+  default 1000
 end
 
 parameter "param_cost_metric" do
@@ -49,8 +49,8 @@ parameter "param_cost_metric" do
   category "Policy Settings"
   label "Cost Metric"
   description "Cost metric to use when analyzing spend for anomalies"
-  default "Amortized Unblended"
   allowed_values "Unamortized Unblended", "Amortized Unblended", "Unamortized Blended", "Amortized Blended"
+  default "Amortized Unblended"
 end
 
 parameter "param_dimensions" do
@@ -66,8 +66,8 @@ parameter "param_anomaly_limit" do
   category "Policy Settings"
   label "Cost Anomaly Limit"
   description "Number of anomalies to include in the incident"
-  default 10
   min_value 1
+  default 10
 end
 
 parameter "param_window_size" do
@@ -75,8 +75,8 @@ parameter "param_window_size" do
   category "Anomaly Settings"
   label "Window Size"
   description "Window size to use for Bollinger Bands"
-  default 10
   min_value 0
+  default 10
 end
 
 parameter "param_standard_deviations" do
@@ -84,8 +84,8 @@ parameter "param_standard_deviations" do
   category "Anomaly Settings"
   label "Standard Deviations"
   description "Number of standard deviations for the Bollinger Band"
-  default 2
   min_value 0
+  default 2
 end
 
 ###############################################################################
@@ -172,9 +172,9 @@ datasource "ds_billing_centers" do
     auth $auth_flexera
     host rs_optima_host
     path join(["/analytics/orgs/", rs_org_id, "/billing_centers"])
+    query "view", "allocation_table"
     header "Api-Version", "1.0"
     header "User-Agent", "RS Policies"
-    query "view", "allocation_table"
     ignore_status [403]
   end
   result do

--- a/cost/flexera/cco/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
+++ b/cost/flexera/cco/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
@@ -492,8 +492,7 @@ policy "pol_anomaly_alert" do
         {{ end }}
       {{ end }}
     EOS
-    # check eq(size(val(data, "anomalies")), 0)
-    check false
+    check eq(size(val(data, "anomalies")), 0)
     escalate $esc_email
     export "anomalies" do
       resource_level true

--- a/cost/flexera/cco/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
+++ b/cost/flexera/cco/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.5",
+  version: "3.6",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization"
@@ -478,7 +478,7 @@ policy "pol_anomaly_alert" do
   validate $ds_filter_anomalies do
     summary_template "{{ data.policy_name }}: {{ len data.anomalies}} Cloud Cost Anomalies Detected"
     detail_template <<-EOS
-      ### **[View Detailed Report]({{ data.link }})**
+      ### [View Detailed Report]({{ data.link }})
       \n
       #### Dimension(s):
       {{ range data.used_dimensions }}
@@ -492,7 +492,8 @@ policy "pol_anomaly_alert" do
         {{ end }}
       {{ end }}
     EOS
-    check eq(size(val(data, "anomalies")), 0)
+    # check eq(size(val(data, "anomalies")), 0)
+    check false
     escalate $esc_email
     export "anomalies" do
       resource_level true


### PR DESCRIPTION
### Description

Currently when we click on the incident link of `cloud_cost_anomaly_alerts.pt` in mail, we get this error in the dashboard:

`Load Anomalies failed at this time`

The issue is happening because the link is including `)**` at the end of the url, once it's removed it returns the proper result to page.

### Issues Resolved

Incident URL in mail.

### Link to Example Applied Policy

https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/60073?policyId=66203f3be6626311ea1adc0b

### Contribution Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
