### PR TITLE
POL-1214 - fix: error for tag_dimension_tag_keys not defined

### DIFF
--- a/compliance/aws/untagged_resources/CHANGELOG.md
+++ b/compliance/aws/untagged_resources/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.1.1
+
+- Fix bug for `ReferenceError: 'tag_dimension_tag_keys' is not defined`
+
 ## v5.1.0
 
 - Added parameter for *Consider Tag Dimensions* to help mitigate/prevent seeing results for resources which have the tag key/tag value through a normalized Tag Dimension

--- a/compliance/aws/untagged_resources/aws_untagged_resources.pt
+++ b/compliance/aws/untagged_resources/aws_untagged_resources.pt
@@ -7,7 +7,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.1.0",
+  version: "5.1.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Untagged Resources"
@@ -442,12 +442,15 @@ script "js_aws_resources_missing_tags", type:"javascript" do
           if (tag_dimension != undefined) {
             // Pluck tag keys from the tag dimension
             tag_dimension_tag_keys = _.pluck(tag_dimension['tags'], 'key')
-            // Plug tag keys from the resource
-            resource_tag_keys = _.keys(resource_tags)
-            // Check if the resource has any of the tag keys which are normalized under the tag dimension
-            if (_.intersection(tag_dimension_tag_keys, resource_tag_keys).length > 0) {
-              // If there is a resource tag matching tag key under the tag dimension, then remove the tag from missing tags result for the resource
-              missing_tags_result = _.without(missing_tags_result, missing_tag)
+            // Check if we found a value for the tag dimension
+            if (typeof tag_dimension_tag_keys != "undefined") {
+              // Plug tag keys from the resource
+              resource_tag_keys = _.keys(resource_tags)
+              // Check if the resource has any of the tag keys which are normalized under the tag dimension
+              if (_.intersection(tag_dimension_tag_keys, resource_tag_keys).length > 0) {
+                // If there is a resource tag matching tag key under the tag dimension, then remove the tag from missing tags result for the resource
+                missing_tags_result = _.without(missing_tags_result, missing_tag)
+              }
             }
           }
         });
@@ -457,8 +460,6 @@ script "js_aws_resources_missing_tags", type:"javascript" do
         new_resource = resource
         new_resource['tags'] = resource_tags
         new_resource['missing_tags'] = missing_tags_result
-        new_resource['__debug__'] = tag_dimension_tag_keys
-        // new_resource['tag_dimension_tag_keys_string'] = tag_dimension_tag_keys.join(', ')
         result.push(new_resource)
       }
     })


### PR DESCRIPTION


### Description

Fixes error `ReferenceError: 'tag_dimension_tag_keys' is not defined`

### Issues Resolved

https://flexera.atlassian.net/browse/POL-1214

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=662adbe9f5c05009ea60a63d

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
