### PR TITLE
POL-1219 Update policies referencing Microsoft ISF Ratio CSV

### DIFF
--- a/cost/azure/reserved_instances/utilization/CHANGELOG.md
+++ b/cost/azure/reserved_instances/utilization/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v3.1.1
 
-- Fixed Microsoft VM Size Flexibility URL which prevented the policy from completing without error. Policy functionality is unchanged.
+- Fixed Microsoft VM Size Flexibility URL which prevented the policy from completing without error.
 
 ## v3.1
 

--- a/cost/azure/reserved_instances/utilization/CHANGELOG.md
+++ b/cost/azure/reserved_instances/utilization/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v3.1.1
 
-- Fixed Microsoft VM Size Flexibility URL which prevented the policy from completing without error.
+- Fixed Microsoft VM Size Flexibility URL which prevented the policy from completing without error. Policy functionality is unchanged.
 
 ## v3.1
 

--- a/cost/azure/reserved_instances/utilization/CHANGELOG.md
+++ b/cost/azure/reserved_instances/utilization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.1
+
+- Updated Microsoft URL referencing Azure Virtual Machine Families and ISF Ratios. Policy functionality is unchanged.
+
 ## v3.1
 
 - Updated policy to use new source for currency information. Policy functionality is unchanged.

--- a/cost/azure/reserved_instances/utilization/CHANGELOG.md
+++ b/cost/azure/reserved_instances/utilization/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v3.1.1
 
-- Updated Microsoft URL referencing Azure Virtual Machine Families and ISF Ratios. Policy functionality is unchanged.
+- Fixed Microsoft VM Size Flexibility URL which prevented the policy from completing without error. Policy functionality is unchanged.
 
 ## v3.1
 

--- a/cost/azure/reserved_instances/utilization/README.md
+++ b/cost/azure/reserved_instances/utilization/README.md
@@ -1,17 +1,17 @@
 # Azure Reserved Instances Utilization
 
-## What it does
+## What It Does
 
-This Policy Template leverages the Azure Cost Management APIs ([Reservation Transactions](https://learn.microsoft.com/en-us/rest/api/consumption/reservation-transactions/list?view=rest-consumption-2023-05-01&tabs=HTTP) and [Reservation Summaries](https://learn.microsoft.com/en-us/rest/api/consumption/reservations-summaries/list?view=rest-consumption-2023-05-01&tabs=HTTP#reservationsummariesdailywithbillingaccountid)). It will notify only if utilization of a Reserved Instance (RI) falls below the value specified in the `Show Reservations with utilization below this value (%)` field. It examines the RI utilization for the prior 7 days or 30 days (starting from 2 days ago) in making this determination.
+This Policy Template leverages the Azure Cost Management APIs ([Reservation Transactions](https://learn.microsoft.com/en-us/rest/api/consumption/reservation-transactions/list?view=rest-consumption-2023-05-01&tabs=HTTP) and [Reservation Summaries](https://learn.microsoft.com/en-us/rest/api/consumption/reservations-summaries/list?view=rest-consumption-2023-05-01&tabs=HTTP#reservationsummariesdailywithbillingaccountid)). It will notify only if utilization of a Reserved Instance (RI) falls below the value specified in the `Maximum Reservation Utilization Threshold` field. It examines the RI utilization for the prior 7 days or 30 days (starting from 2 days ago) in making this determination.
 
 ## Input Parameters
 
 This policy has the following input parameters required when launching the policy.
 
 - *Azure Endpoint* - Azure Endpoint to access resources
-- *Look Back Period* - The number of days of past Azure Reservation Utilization data to analyze
-- *Show Reservations with utilization below this value (%)* - Number between 1 and 100
-- *Email addresses* - A list of email addresses to notify
+- *Look Back Period* - Number of days of prior Azure Reservation usage to analyze.
+- *Maximum Reservation Utilization Threshold* - Show Reservations with utilization below this value (%).
+- *Email addresses to notify* - A list of email addresses to notify.
 
 ## Policy Actions
 

--- a/cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt
+++ b/cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt
@@ -26,8 +26,8 @@ parameter "param_email" do
 end
 
 parameter "param_azure_endpoint" do
-  category "Policy Settings"
   type "string"
+  category "Policy Settings"
   label "Azure Endpoint"
   description "Azure Endpoint to access resources"
   allowed_values "management.azure.com", "management.chinacloudapi.cn"
@@ -35,9 +35,10 @@ parameter "param_azure_endpoint" do
 end
 
 parameter "param_utilization" do
-  category "Policy Settings"
-  label "Show Reservations with utilization below this value (%)"
   type "number"
+  category "Policy Settings"
+  label "Maximum Reservation Utilization Threshold"
+  description "Show Reservations with utilization below this value (%)"
   min_value 1
   max_value 100
   default 100

--- a/cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt
+++ b/cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt
@@ -643,8 +643,6 @@ EOS
     escalate $esc_email
     check eq(size(val(data, "reservation_details")), 0)
     export "reservation_details" do
-    # check eq(1, 0)
-    # export do
       resource_level false
       field "agreementType" do
         label "Agreement Type"

--- a/cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt
+++ b/cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt
@@ -47,10 +47,10 @@ end
 parameter "param_lookback_period" do
   type "string"
   category "Reservation Settings"
-  description "Number of days of prior Azure Reservation usage to analyze."
   label "Look Back Period"
+  description "Number of days of prior Azure Reservation usage to analyze."
+  allowed_values "Last 7 days", "Last 30 days"
   default "Last 7 days"
-  allowed_values "Last 7 days", "Last 30 days" 
 end
 
 ###############################################################################

--- a/cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt
+++ b/cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt
@@ -17,16 +17,16 @@ info(
 # Parameters
 ###############################################################################
 
-parameter "param_utilization" do
-  category "RI"
-  label "Show Reservations with utilization below this value (%)"
-  type "number"
-  min_value 1
-  max_value 100
-  default 100
+parameter "param_email" do
+  type "list"
+  category "Policy Settings"
+  label "Email addresses"
+  description "A list of email addresses to notify."
+  default []
 end
 
 parameter "param_azure_endpoint" do
+  category "Policy Settings"
   type "string"
   label "Azure Endpoint"
   description "Azure Endpoint to access resources"
@@ -34,21 +34,22 @@ parameter "param_azure_endpoint" do
   default "management.azure.com"
 end
 
-parameter "param_lookback_period" do
-  category "Savings Plan"
-  label "Look Back Period"
-  default "Last 7 days"
-  description "The number of days of past Azure Reservation Utilization data to analyze"
-  allowed_values "Last 7 days", "Last 30 days"
-  type "string"
+parameter "param_utilization" do
+  category "Policy Settings"
+  label "Show Reservations with utilization below this value (%)"
+  type "number"
+  min_value 1
+  max_value 100
+  default 100
 end
 
-parameter "param_email" do
-  type "list"
-  category "Policy Settings"
-  label "Email addresses"
-  description "A list of email addresses to notify."
-  default []
+parameter "param_lookback_period" do
+  type "string"
+  category "Reservation Settings"
+  description "Number of days of prior Azure Reservation usage to analyze."
+  label "Look Back Period"
+  default "Last 7 days"
+  allowed_values "Last 7 days", "Last 30 days" 
 end
 
 ###############################################################################

--- a/cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt
+++ b/cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt
@@ -20,8 +20,8 @@ info(
 parameter "param_email" do
   type "list"
   category "Policy Settings"
-  label "Email addresses"
-  description "A list of email addresses to notify."
+  label "Email addresses to notify"
+  description "Email addresses of the recipients you wish to notify when new incidents are created"
   default []
 end
 

--- a/cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt
+++ b/cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt
@@ -135,10 +135,10 @@ end
 
 #IDENTIFY WHETHER ENTERPRISE AGREEMENT (EA) OR MICROSOFT CUSTOMER AGREEMENT (MCA)
 datasource "ds_billing_details" do
-  run_script $js_get_billing_details, $ds_billing_profiles, $ds_billing_accounts
+  run_script $js_billing_details, $ds_billing_profiles, $ds_billing_accounts
 end
 
-script "js_get_billing_details", type: "javascript" do
+script "js_billing_details", type: "javascript" do
   parameters "ds_billing_profiles", "ds_billing_accounts"
   result "result"
   code <<-EOS
@@ -450,10 +450,10 @@ end
 
 #CALCULATE AVERAGE UTILIZATION OVER LOOKBACK PERIOD FOR EACH RESERVATION ORDER ID
 datasource "ds_reduced_reservation_summaries" do
-  run_script $js_reduce_reservation_summaries, $ds_reservation_summaries
+  run_script $js_reduced_reservation_summaries, $ds_reservation_summaries
 end
 
-script "js_reduce_reservation_summaries", type: "javascript" do
+script "js_reduced_reservation_summaries", type: "javascript" do
   parameters "ds_reservation_summaries"
   result "result"
   code <<-EOS
@@ -517,10 +517,10 @@ end
 
 #COMBINE CHARGES DETAILS AND SUMMARY DETAILS FOR RESERVATIONS
 datasource "ds_reservation_purchase_details" do
-  run_script $js_combine_reservation_details, $ds_reduced_reservation_transactions, $ds_reduced_reservation_summaries, $ds_isf_ratio_csv, $ds_currency_reference, $param_utilization
+  run_script $js_reservation_purchase_details, $ds_reduced_reservation_transactions, $ds_reduced_reservation_summaries, $ds_isf_ratio_csv, $ds_currency_reference, $param_utilization
 end
 
-script "js_combine_reservation_details", type: "javascript" do
+script "js_reservation_purchase_details", type: "javascript" do
   parameters "reservation_transactions_data", "reservation_summaries_data", "isf_ratio_csv", "currency_reference", "param_utilization"
   result "all_data"
   code <<-'EOS'

--- a/cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt
+++ b/cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt
@@ -142,8 +142,6 @@ script "js_get_billing_details", type: "javascript" do
   code <<-EOS
     result = []
 
-    console.log("Billing Accounts:", ds_billing_accounts)
-    console.log("Billing Profiles:", ds_billing_profiles)
     _.each(ds_billing_accounts, function(acc) {
       if (acc.agreementType == "EnterpriseAgreement") {
         result.push({
@@ -261,7 +259,6 @@ script "js_reduce_reservation_transactions_data", type: "javascript" do
       //get the purchase date (the first event date) and expiration date for the reservation
       var first_month = _.last(charges_grouped_by_reservation_order[order])
       var purchase_date = first_month.eventDate
-      //console.log("First Month: " + first_month.eventDate, "Last Month: " + _.first(charges_grouped_by_reservation_order[order]).eventDate)
 
       var term_years = 1
       if (first_month.term == "P3Y") {
@@ -270,7 +267,6 @@ script "js_reduce_reservation_transactions_data", type: "javascript" do
       var expiration_date = new Date(purchase_date)
       expiration_date.setFullYear(expiration_date.getFullYear() + term_years)
       expiration_date = expiration_date.toISOString()
-      //console.log("Purchase Date: " + purchase_date, "Expiration Date: " + expiration_date, "Term: " + first_month.term)
 
       //get the monthlyAmount for the most recent date
       var most_recent_month = _.first(_.filter(charges_grouped_by_reservation_order[order], function(ord) { return ord.eventType == "Purchase" }))

--- a/cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt
+++ b/cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt
@@ -214,9 +214,9 @@ script "js_reservation_transactions", type: "javascript" do
     //Get start and end date (past 30 days)
     var date = new Date()
     date.setDate(date.getDate() - 2)
-    var end_date = date.toISOString().slice(0,10)
+    var end_date = date.toISOString().slice(0, 10)
     date.setDate(date.getDate() - 1094)
-    var start_date = date.toISOString().slice(0,10)
+    var start_date = date.toISOString().slice(0, 10)
 
     //Create Filter Query Param value
     var filter_query = "properties/eventDate ge " + start_date + " AND properties/eventDate le " + end_date

--- a/cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt
+++ b/cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt
@@ -638,8 +638,8 @@ policy "pol_azure_active_reserved_instances" do
     detail_template <<-EOS
 {{data.message}}
 EOS
-    escalate $esc_email
     check eq(size(val(data, "reservation_details")), 0)
+    escalate $esc_email
     export "reservation_details" do
       resource_level false
       field "agreementType" do

--- a/cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt
+++ b/cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt
@@ -7,7 +7,7 @@ severity "medium"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.1",
+  version: "3.1.1",
   provider: "Azure",
   service: "Compute",
   policy_set: ""
@@ -166,8 +166,6 @@ script "js_get_billing_details", type: "javascript" do
     })
   EOS
 end
-
-
 
 #GET RESERVATION TRANSACTION DETAILS - https://learn.microsoft.com/en-us/rest/api/consumption/reservation-transactions/list?tabs=HTTP
 #Details on Migration from EA - https://learn.microsoft.com/en-us/azure/cost-management-billing/automate/migrate-ea-reporting-arm-apis-overview
@@ -452,7 +450,6 @@ script "js_get_reservation_summaries", type: "javascript" do
   EOS
 end
 
-
 #CALCULATE AVERAGE UTILIZATION OVER LOOKBACK PERIOD FOR EACH RESERVATION ORDER ID
 datasource "ds_reduced_reservation_summaries" do
   run_script $js_reduce_reservation_summaries, $ds_reservation_summaries
@@ -512,8 +509,8 @@ end
 #GET DATA WITH INSTANCE FAMILIES FOR INSTANCE TYPES
 datasource "ds_isf_ratio_csv" do
   request do
-    host "isfratio.blob.core.windows.net"
-    path "/isfratio/ISFRatio.csv"
+    host "aka.ms"
+    path "/isf"
   end
   result do
     encoding "text"

--- a/cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt
+++ b/cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt
@@ -634,7 +634,7 @@ end
 # Policy
 ###############################################################################
 
-policy "policy_azure_active_reserved_instances" do
+policy "pol_azure_active_reserved_instances" do
   validate $ds_reservation_purchase_details do
     summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data.reservation_details }} active Azure Reserved Instances - {{ parameters.param_lookback_period }}"
     detail_template <<-EOS

--- a/cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt
+++ b/cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt
@@ -171,7 +171,7 @@ end
 datasource "ds_reservation_transactions" do
   iterate $ds_billing_details
   request do
-    run_script $js_get_reservation_transactions, $param_azure_endpoint, val(iter_item, "id")
+    run_script $js_reservation_transactions, val(iter_item, "id"), $param_azure_endpoint
   end
   result do
     encoding "json"
@@ -206,8 +206,8 @@ datasource "ds_reservation_transactions" do
   end
 end
 
-script "js_get_reservation_transactions", type: "javascript" do
-  parameters "param_azure_endpoint", "ds_billing_account_id"
+script "js_reservation_transactions", type: "javascript" do
+  parameters "ds_billing_account_id", "param_azure_endpoint"
   result "request"
   code <<-EOS
     //Get start and end date (past 30 days)
@@ -239,10 +239,10 @@ end
 
 #REMOVE DUPLICATE DATA
 datasource "ds_reduced_reservation_transactions" do
-  run_script $js_reduce_reservation_transactions_data, $ds_reservation_transactions
+  run_script $js_reduced_reservation_transactions, $ds_reservation_transactions
 end
 
-script "js_reduce_reservation_transactions_data", type: "javascript" do
+script "js_reduced_reservation_transactions", type: "javascript" do
   parameters "ds_reservation_transactions"
   result "result"
   code <<-'EOS'
@@ -323,10 +323,10 @@ end
 
 #GET INDIVIDUAL DATES WITHIN LOOKBACK PERIOD - without doing this leads to this error: "The response is too large and exceeds the maximum permissible limit. Reduce the date range in the request and try again."
 datasource "ds_lookback_period_dates" do
-  run_script $js_get_lookback_period_dates, $param_lookback_period
+  run_script $js_lookback_period_dates, $param_lookback_period
 end
 
-script "js_get_lookback_period_dates", type: "javascript" do
+script "js_lookback_period_dates", type: "javascript" do
   parameters "param_lookback_period"
   result "result"
   code <<-EOS
@@ -363,10 +363,10 @@ end
 
 #GET BILLING ACCOUNT-LOOKBACK PERIOD COMBINATIONS REQUIRED FOR MICROSOFT AZURE RESERVATION SUMMARIES DETAILS API CALL
 datasource "ds_billing_account_lookback_period_combinations" do
-  run_script $js_get_billing_account_lookback_period_combinations, $ds_billing_details, $ds_lookback_period_dates
+  run_script $js_billing_account_lookback_period_combinations, $ds_billing_details, $ds_lookback_period_dates
 end
 
-script "js_get_billing_account_lookback_period_combinations", type: "javascript" do
+script "js_billing_account_lookback_period_combinations", type: "javascript" do
   parameters "ds_billing_accounts", "ds_lookback_period_dates"
   result "result"
   code <<-EOS
@@ -390,7 +390,7 @@ end
 datasource "ds_reservation_summaries" do
   iterate $ds_billing_account_lookback_period_combinations
   request do
-    run_script $js_get_reservation_summaries, $param_azure_endpoint, val(iter_item, "billingAccountId"), val(iter_item, "agreementType"), val(iter_item, "lookbackPeriodDateRange")
+    run_script $js_reservation_summaries, val(iter_item, "billingAccountId"), val(iter_item, "agreementType"), val(iter_item, "lookbackPeriodDateRange"), $param_azure_endpoint 
   end
   result do
     encoding "json"
@@ -410,8 +410,8 @@ datasource "ds_reservation_summaries" do
   end
 end
 
-script "js_get_reservation_summaries", type: "javascript" do
-  parameters "param_azure_endpoint", "ds_billing_account_id", "ds_agreement_type", "ds_lookback_period_date_range"
+script "js_reservation_summaries", type: "javascript" do
+  parameters "ds_billing_account_id", "ds_agreement_type", "ds_lookback_period_date_range", "param_azure_endpoint"
   result "request"
   code <<-EOS
     //API query params are structured differently depending on Agreement Type (MCA vs EA)

--- a/operational/azure/total_instance_hours/CHANGELOG.md
+++ b/operational/azure/total_instance_hours/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.0.1
+
+- Updated Microsoft URL referencing Azure Virtual Machine Families and ISF Ratios. Policy functionality is unchanged.
+
 ## v2.0
 
 - Added ability to filter the report for a list of Billing Centers that can either be allowed or denied.

--- a/operational/azure/total_instance_hours/azure_usage_instance_hours_used.pt
+++ b/operational/azure/total_instance_hours/azure_usage_instance_hours_used.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "2.0",
+  version: "2.0.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Usage Report"
@@ -246,8 +246,8 @@ end
 #GET DATA WITH NORMALIZATION FACTOR UNITS FOR INSTANCE TYPES
 datasource "ds_isf_ratio_csv" do
   request do
-    host "isfratio.blob.core.windows.net"
-    path "/isfratio/ISFRatio.csv"
+    host "aka.ms"
+    path "/isf"
   end
   result do
     encoding "text"

--- a/operational/azure/total_instance_memory/CHANGELOG.md
+++ b/operational/azure/total_instance_memory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.0.1
+
+- Updated Microsoft URL referencing Azure Virtual Machine Families and ISF Ratios. Policy functionality is unchanged.
+
 ## v2.0
 
 - Added ability to filter the report for a list of Billing Centers that can either be allowed or denied.

--- a/operational/azure/total_instance_memory/azure_usage_instance_memory_used.pt
+++ b/operational/azure/total_instance_memory/azure_usage_instance_memory_used.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "2.0",
+  version: "2.0.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Usage Report"
@@ -256,8 +256,8 @@ end
 #GET DATA WITH INSTANCE FAMILY FOR INSTANCE TYPES
 datasource "ds_isf_ratio_csv" do
   request do
-    host "isfratio.blob.core.windows.net"
-    path "/isfratio/ISFRatio.csv"
+    host "aka.ms"
+    path "/isf"
   end
   result do
     encoding "text"

--- a/operational/azure/total_instance_vcpus/CHANGELOG.md
+++ b/operational/azure/total_instance_vcpus/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.0.1
+
+- Updated Microsoft URL referencing Azure Virtual Machine Families and ISF Ratios. Policy functionality is unchanged.
+
 ## v2.0
 
 - Added ability to filter the report for a list of Billing Centers that can either be allowed or denied.

--- a/operational/azure/total_instance_vcpus/azure_usage_instance_vcpus_used.pt
+++ b/operational/azure/total_instance_vcpus/azure_usage_instance_vcpus_used.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "2.0",
+  version: "2.0.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Usage Report"
@@ -256,8 +256,8 @@ end
 #GET DATA WITH INSTANCE FAMILY FOR INSTANCE TYPES
 datasource "ds_isf_ratio_csv" do
   request do
-    host "isfratio.blob.core.windows.net"
-    path "/isfratio/ISFRatio.csv"
+    host "aka.ms"
+    path "/isf"
   end
   result do
     encoding "text"


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves below -->
Microsoft provides a CSV file which has a mapping of instance types, their respective Instance Families, and their respective normalization factor unit.

The CSV is available via a URL, however the current URL (https://isfratio.blob.core.windows.net/isfratio/ISFRatio.csv) no longer works and has been replaced with a new URL (https://aka.ms/isf)

This is causing several policies to fail.

### Issues Resolved

<!-- List any existing issues this PR resolves below -->
This is a change to update the URL for all policies referencing this CSV file, thereby fixing the policies.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->
Tested in two customer tenants - policy is working as it previously did after the URL change.

### Contribution Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
