### PR TITLE
POL-1221 Usage Report Policies - Update BC Filter to support Child Billing Centers

### DIFF
--- a/operational/aws/total_instance_hours/CHANGELOG.md
+++ b/operational/aws/total_instance_hours/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.1.0
+
+- Fixed issue where only top-level billing centers could be filtered on. Policy now additionally supports filtering on child billing centers.
+
 ## v4.0
 
 - Added ability to filter the report for a list of Billing Centers that can either be allowed or denied.

--- a/operational/aws/total_instance_hours/aws_usage_instance_hours_used.pt
+++ b/operational/aws/total_instance_hours/aws_usage_instance_hours_used.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "4.0",
+  version: "4.1.0",
   provider: "AWS",
   service: "Compute",
   policy_set: "Usage Report"
@@ -98,27 +98,65 @@ datasource "ds_billing_centers" do
   end
 end
 
-#GET TOP-LEVEL BILLING CENTERS
-datasource "ds_top_level_bcs" do
-  run_script $js_top_level_bcs, $ds_billing_centers
+#FILTER USING BILLING CENTERS PARAMETER IF APPLICABLE
+datasource "ds_filtered_billing_centers" do
+  run_script $js_filtered_billing_centers, $ds_billing_centers, $param_bc_allow_or_deny, $param_bc_list
 end
 
-script "js_top_level_bcs", type: "javascript" do
-  parameters "ds_billing_centers"
+script "js_filtered_billing_centers", type: "javascript" do
+  parameters "ds_billing_centers", "param_bc_allow_or_deny", "param_bc_list"
   result "result"
   code <<-EOS
-  filtered_bcs = _.filter(ds_billing_centers, function(bc) {
-    return bc['parent_id'] == null || bc['parent_id'] == undefined
-  })
 
-  result = _.compact(_.pluck(filtered_bcs, 'id'))
+  //Define Billing Center list if applicable
+  var allow_deny_test = { "Allow": true, "Deny": false }
+
+  if (param_bc_list.length > 0) {
+
+    //Filter BC List based on BC List Parameter and whether to Allow/Deny
+    var billing_center_list = _.filter(ds_billing_centers, function(bc) {
+      if (param_bc_allow_or_deny == "Allow") {
+        return _.contains(param_bc_list, bc.id) == allow_deny_test[param_bc_allow_or_deny] || _.contains(param_bc_list, bc.name) == allow_deny_test[param_bc_allow_or_deny]
+      } else {
+        return _.contains(param_bc_list, bc.id) == allow_deny_test[param_bc_allow_or_deny] && _.contains(param_bc_list, bc.name) == allow_deny_test[param_bc_allow_or_deny]
+      }
+    })
+
+    //Check that there are no child billing centers specified that conflict with parent billing centers specified
+    var bc_ids = _.map(billing_center_list, function(bc) { return bc.id.toLowerCase() })
+
+    var conflicting_child_bcs = _.filter(billing_center_list, function(bc) {
+      if (!(bc.parent_id == null || bc.parent_id == undefined)) {
+        return _.contains(bc_ids, bc.parent_id.toLowerCase())
+      }
+    })
+
+    //If there are conflicting child/parent BCs then ignore the child BC and take the parent BC
+    if (conflicting_child_bcs != undefined) {
+      var conflicting_child_bc_ids = _.pluck(conflicting_child_bcs, "id")
+      
+      var filtered_bc_list = _.reject(billing_center_list, function(bc) {
+        return _.contains(conflicting_child_bc_ids, bc.id)
+      })
+      result = _.compact(_.pluck(filtered_bc_list, 'id'))
+    } else {
+      result = _.compact(_.pluck(billing_center_list, 'id'))
+    }
+    
+  } else {
+    var billing_center_list = _.filter(ds_billing_centers, function(bc) {
+      return bc['parent_id'] == null || bc['parent_id'] == undefined
+    })
+
+    result = _.compact(_.pluck(billing_center_list, 'id'))
+  }
   EOS
 end
 
 #GET USAGE DATA FOR INSTANCE TYPES
 datasource "ds_usage_data" do
   request do
-    run_script $js_usage_data, $ds_top_level_bcs, $ds_billing_centers, $param_regions_allow_or_deny, $param_regions_list, $param_bc_allow_or_deny, $param_bc_list, rs_org_id, rs_optima_host
+    run_script $js_usage_data, $ds_filtered_billing_centers, $param_regions_allow_or_deny, $param_regions_list, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -134,36 +172,17 @@ datasource "ds_usage_data" do
 end
 
 script "js_usage_data", type: "javascript" do
-  parameters "ds_top_level_bcs", "ds_billing_centers", "param_regions_allow_or_deny", "param_regions_list", "param_bc_allow_or_deny", "param_bc_list", "org_id", "optima_host"
+  parameters "ds_filtered_billing_centers", "param_regions_allow_or_deny", "param_regions_list", "org_id", "optima_host"
   result "request"
   code <<-EOS
   //Get Start and End dates
-  start_date = new Date(), end_date = new Date()
+  var start_date = new Date(), end_date = new Date()
   start_date.setMonth(start_date.getMonth() - 12)
   end_date.setMonth(end_date.getMonth())
 
   //Define Billing Center list if applicable
-  var billing_center_ids = []
+  var billing_center_ids = ds_filtered_billing_centers
   var allow_deny_test = { "Allow": true, "Deny": false }
-
-  if (param_bc_list.length > 0) {
-    billing_center_ids = _.filter(ds_top_level_bcs, function(bc) {
-      var bc_name = ""
-      var matched_bc = _.find(ds_billing_centers, function(data) { return bc == data.id })
-
-      if (matched_bc != undefined) {
-        bc_name = matched_bc.name
-
-        if (param_bc_allow_or_deny == "Allow") {
-          return _.contains(param_bc_list, bc) == allow_deny_test[param_bc_allow_or_deny] || _.contains(param_bc_list, bc_name) == allow_deny_test[param_bc_allow_or_deny]
-        } else {
-          return _.contains(param_bc_list, bc) == allow_deny_test[param_bc_allow_or_deny] && _.contains(param_bc_list, bc_name) == allow_deny_test[param_bc_allow_or_deny]
-        }
-      }
-    })
-  } else {
-    billing_center_ids = ds_top_level_bcs
-  }
 
   //Define Expressions for API Filter 
   var expressions = [

--- a/operational/aws/total_instance_memory/CHANGELOG.md
+++ b/operational/aws/total_instance_memory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1.0
+
+- Fixed issue where only top-level billing centers could be filtered on. Policy now additionally supports filtering on child billing centers.
+
 ## v2.0
 
 - Added ability to filter the report for a list of Billing Centers that can either be allowed or denied.

--- a/operational/aws/total_instance_memory/aws_usage_instance_memory_used.pt
+++ b/operational/aws/total_instance_memory/aws_usage_instance_memory_used.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "2.0",
+  version: "2.1.0",
   provider: "AWS",
   service: "Compute",
   policy_set: "Usage Report"
@@ -98,27 +98,65 @@ datasource "ds_billing_centers" do
   end
 end
 
-#GET TOP-LEVEL BILLING CENTERS
-datasource "ds_top_level_bcs" do
-  run_script $js_top_level_bcs, $ds_billing_centers
+#FILTER USING BILLING CENTERS PARAMETER IF APPLICABLE
+datasource "ds_filtered_billing_centers" do
+  run_script $js_filtered_billing_centers, $ds_billing_centers, $param_bc_allow_or_deny, $param_bc_list
 end
 
-script "js_top_level_bcs", type: "javascript" do
-  parameters "ds_billing_centers"
+script "js_filtered_billing_centers", type: "javascript" do
+  parameters "ds_billing_centers", "param_bc_allow_or_deny", "param_bc_list"
   result "result"
   code <<-EOS
-  filtered_bcs = _.filter(ds_billing_centers, function(bc) {
-    return bc['parent_id'] == null || bc['parent_id'] == undefined
-  })
 
-  result = _.compact(_.pluck(filtered_bcs, 'id'))
+  //Define Billing Center list if applicable
+  var allow_deny_test = { "Allow": true, "Deny": false }
+
+  if (param_bc_list.length > 0) {
+
+    //Filter BC List based on BC List Parameter and whether to Allow/Deny
+    var billing_center_list = _.filter(ds_billing_centers, function(bc) {
+      if (param_bc_allow_or_deny == "Allow") {
+        return _.contains(param_bc_list, bc.id) == allow_deny_test[param_bc_allow_or_deny] || _.contains(param_bc_list, bc.name) == allow_deny_test[param_bc_allow_or_deny]
+      } else {
+        return _.contains(param_bc_list, bc.id) == allow_deny_test[param_bc_allow_or_deny] && _.contains(param_bc_list, bc.name) == allow_deny_test[param_bc_allow_or_deny]
+      }
+    })
+
+    //Check that there are no child billing centers specified that conflict with parent billing centers specified
+    var bc_ids = _.map(billing_center_list, function(bc) { return bc.id.toLowerCase() })
+
+    var conflicting_child_bcs = _.filter(billing_center_list, function(bc) {
+      if (!(bc.parent_id == null || bc.parent_id == undefined)) {
+        return _.contains(bc_ids, bc.parent_id.toLowerCase())
+      }
+    })
+
+    //If there are conflicting child/parent BCs then ignore the child BC and take the parent BC
+    if (conflicting_child_bcs != undefined) {
+      var conflicting_child_bc_ids = _.pluck(conflicting_child_bcs, "id")
+      
+      var filtered_bc_list = _.reject(billing_center_list, function(bc) {
+        return _.contains(conflicting_child_bc_ids, bc.id)
+      })
+      result = _.compact(_.pluck(filtered_bc_list, 'id'))
+    } else {
+      result = _.compact(_.pluck(billing_center_list, 'id'))
+    }
+    
+  } else {
+    var billing_center_list = _.filter(ds_billing_centers, function(bc) {
+      return bc['parent_id'] == null || bc['parent_id'] == undefined
+    })
+
+    result = _.compact(_.pluck(billing_center_list, 'id'))
+  }
   EOS
 end
 
 #GET USAGE DATA FOR INSTANCE TYPES
 datasource "ds_usage_data" do
   request do
-    run_script $js_usage_data, $ds_top_level_bcs, $ds_billing_centers, $param_regions_allow_or_deny, $param_regions_list, $param_bc_allow_or_deny, $param_bc_list, rs_org_id, rs_optima_host
+    run_script $js_usage_data, $ds_filtered_billing_centers, $param_regions_allow_or_deny, $param_regions_list, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -134,36 +172,17 @@ datasource "ds_usage_data" do
 end
 
 script "js_usage_data", type: "javascript" do
-  parameters "ds_top_level_bcs", "ds_billing_centers", "param_regions_allow_or_deny", "param_regions_list", "param_bc_allow_or_deny", "param_bc_list", "org_id", "optima_host"
+  parameters "ds_filtered_billing_centers", "param_regions_allow_or_deny", "param_regions_list", "org_id", "optima_host"
   result "request"
   code <<-EOS
   //Get Start and End dates
-  start_date = new Date(), end_date = new Date()
+  var start_date = new Date(), end_date = new Date()
   start_date.setMonth(start_date.getMonth() - 12)
   end_date.setMonth(end_date.getMonth())
 
   //Define Billing Center list if applicable
-  var billing_center_ids = []
+  var billing_center_ids = ds_filtered_billing_centers
   var allow_deny_test = { "Allow": true, "Deny": false }
-
-  if (param_bc_list.length > 0) {
-    billing_center_ids = _.filter(ds_top_level_bcs, function(bc) {
-      var bc_name = ""
-      var matched_bc = _.find(ds_billing_centers, function(data) { return bc == data.id })
-
-      if (matched_bc != undefined) {
-        bc_name = matched_bc.name
-
-        if (param_bc_allow_or_deny == "Allow") {
-          return _.contains(param_bc_list, bc) == allow_deny_test[param_bc_allow_or_deny] || _.contains(param_bc_list, bc_name) == allow_deny_test[param_bc_allow_or_deny]
-        } else {
-          return _.contains(param_bc_list, bc) == allow_deny_test[param_bc_allow_or_deny] && _.contains(param_bc_list, bc_name) == allow_deny_test[param_bc_allow_or_deny]
-        }
-      }
-    })
-  } else {
-    billing_center_ids = ds_top_level_bcs
-  }
 
   //Define Expressions for API Filter 
   var expressions = [

--- a/operational/aws/total_instance_vcpus/CHANGELOG.md
+++ b/operational/aws/total_instance_vcpus/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.1.0
+
+- Fixed issue where only top-level billing centers could be filtered on. Policy now additionally supports filtering on child billing centers.
+
 ## v4.0
 
 - Added ability to filter the report for a list of Billing Centers that can either be allowed or denied.

--- a/operational/aws/total_instance_vcpus/aws_usage_instance_vcpus_used.pt
+++ b/operational/aws/total_instance_vcpus/aws_usage_instance_vcpus_used.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "4.0",
+  version: "4.1.0",
   provider: "AWS",
   service: "Compute",
   policy_set: "Usage Report"
@@ -98,27 +98,65 @@ datasource "ds_billing_centers" do
   end
 end
 
-#GET TOP-LEVEL BILLING CENTERS
-datasource "ds_top_level_bcs" do
-  run_script $js_top_level_bcs, $ds_billing_centers
+#FILTER USING BILLING CENTERS PARAMETER IF APPLICABLE
+datasource "ds_filtered_billing_centers" do
+  run_script $js_filtered_billing_centers, $ds_billing_centers, $param_bc_allow_or_deny, $param_bc_list
 end
 
-script "js_top_level_bcs", type: "javascript" do
-  parameters "ds_billing_centers"
+script "js_filtered_billing_centers", type: "javascript" do
+  parameters "ds_billing_centers", "param_bc_allow_or_deny", "param_bc_list"
   result "result"
   code <<-EOS
-  filtered_bcs = _.filter(ds_billing_centers, function(bc) {
-    return bc['parent_id'] == null || bc['parent_id'] == undefined
-  })
 
-  result = _.compact(_.pluck(filtered_bcs, 'id'))
+  //Define Billing Center list if applicable
+  var allow_deny_test = { "Allow": true, "Deny": false }
+
+  if (param_bc_list.length > 0) {
+
+    //Filter BC List based on BC List Parameter and whether to Allow/Deny
+    var billing_center_list = _.filter(ds_billing_centers, function(bc) {
+      if (param_bc_allow_or_deny == "Allow") {
+        return _.contains(param_bc_list, bc.id) == allow_deny_test[param_bc_allow_or_deny] || _.contains(param_bc_list, bc.name) == allow_deny_test[param_bc_allow_or_deny]
+      } else {
+        return _.contains(param_bc_list, bc.id) == allow_deny_test[param_bc_allow_or_deny] && _.contains(param_bc_list, bc.name) == allow_deny_test[param_bc_allow_or_deny]
+      }
+    })
+
+    //Check that there are no child billing centers specified that conflict with parent billing centers specified
+    var bc_ids = _.map(billing_center_list, function(bc) { return bc.id.toLowerCase() })
+
+    var conflicting_child_bcs = _.filter(billing_center_list, function(bc) {
+      if (!(bc.parent_id == null || bc.parent_id == undefined)) {
+        return _.contains(bc_ids, bc.parent_id.toLowerCase())
+      }
+    })
+
+    //If there are conflicting child/parent BCs then ignore the child BC and take the parent BC
+    if (conflicting_child_bcs != undefined) {
+      var conflicting_child_bc_ids = _.pluck(conflicting_child_bcs, "id")
+      
+      var filtered_bc_list = _.reject(billing_center_list, function(bc) {
+        return _.contains(conflicting_child_bc_ids, bc.id)
+      })
+      result = _.compact(_.pluck(filtered_bc_list, 'id'))
+    } else {
+      result = _.compact(_.pluck(billing_center_list, 'id'))
+    }
+    
+  } else {
+    var billing_center_list = _.filter(ds_billing_centers, function(bc) {
+      return bc['parent_id'] == null || bc['parent_id'] == undefined
+    })
+
+    result = _.compact(_.pluck(billing_center_list, 'id'))
+  }
   EOS
 end
 
 #GET USAGE DATA FOR INSTANCE TYPES
 datasource "ds_usage_data" do
   request do
-    run_script $js_usage_data, $ds_top_level_bcs, $ds_billing_centers, $param_regions_allow_or_deny, $param_regions_list, $param_bc_allow_or_deny, $param_bc_list, rs_org_id, rs_optima_host
+    run_script $js_usage_data, $ds_filtered_billing_centers, $param_regions_allow_or_deny, $param_regions_list, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -134,36 +172,17 @@ datasource "ds_usage_data" do
 end
 
 script "js_usage_data", type: "javascript" do
-  parameters "ds_top_level_bcs", "ds_billing_centers", "param_regions_allow_or_deny", "param_regions_list", "param_bc_allow_or_deny", "param_bc_list", "org_id", "optima_host"
+  parameters "ds_filtered_billing_centers", "param_regions_allow_or_deny", "param_regions_list", "org_id", "optima_host"
   result "request"
   code <<-EOS
   //Get Start and End dates
-  start_date = new Date(), end_date = new Date()
+  var start_date = new Date(), end_date = new Date()
   start_date.setMonth(start_date.getMonth() - 12)
   end_date.setMonth(end_date.getMonth())
 
   //Define Billing Center list if applicable
-  var billing_center_ids = []
+  var billing_center_ids = ds_filtered_billing_centers
   var allow_deny_test = { "Allow": true, "Deny": false }
-
-  if (param_bc_list.length > 0) {
-    billing_center_ids = _.filter(ds_top_level_bcs, function(bc) {
-      var bc_name = ""
-      var matched_bc = _.find(ds_billing_centers, function(data) { return bc == data.id })
-
-      if (matched_bc != undefined) {
-        bc_name = matched_bc.name
-
-        if (param_bc_allow_or_deny == "Allow") {
-          return _.contains(param_bc_list, bc) == allow_deny_test[param_bc_allow_or_deny] || _.contains(param_bc_list, bc_name) == allow_deny_test[param_bc_allow_or_deny]
-        } else {
-          return _.contains(param_bc_list, bc) == allow_deny_test[param_bc_allow_or_deny] && _.contains(param_bc_list, bc_name) == allow_deny_test[param_bc_allow_or_deny]
-        }
-      }
-    })
-  } else {
-    billing_center_ids = ds_top_level_bcs
-  }
 
   //Define Expressions for API Filter 
   var expressions = [

--- a/operational/azure/total_instance_hours/CHANGELOG.md
+++ b/operational/azure/total_instance_hours/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1.1
+
+- Fixed issue where only top-level billing centers could be filtered on. Policy now additionally supports filtering on child billing centers.
+
 ## v2.0.1
 
 - Updated Microsoft URL referencing Azure Virtual Machine Families and ISF Ratios. Policy functionality is unchanged.

--- a/operational/azure/total_instance_hours/azure_usage_instance_hours_used.pt
+++ b/operational/azure/total_instance_hours/azure_usage_instance_hours_used.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "2.0.1",
+  version: "2.1.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Usage Report"
@@ -98,27 +98,65 @@ datasource "ds_billing_centers" do
   end  
 end
   
-#GET TOP-LEVEL BILLING CENTERS
-datasource "ds_top_level_bcs" do
-  run_script $js_top_level_bcs, $ds_billing_centers
+#FILTER USING BILLING CENTERS PARAMETER IF APPLICABLE
+datasource "ds_filtered_billing_centers" do
+  run_script $js_filtered_billing_centers, $ds_billing_centers, $param_bc_allow_or_deny, $param_bc_list
 end
 
-script "js_top_level_bcs", type: "javascript" do
-  parameters "ds_billing_centers"
+script "js_filtered_billing_centers", type: "javascript" do
+  parameters "ds_billing_centers", "param_bc_allow_or_deny", "param_bc_list"
   result "result"
   code <<-EOS
-  filtered_bcs = _.filter(ds_billing_centers, function(bc) {
-    return bc['parent_id'] == null || bc['parent_id'] == undefined
-  })
 
-  result = _.compact(_.pluck(filtered_bcs, 'id'))
+  //Define Billing Center list if applicable
+  var allow_deny_test = { "Allow": true, "Deny": false }
+
+  if (param_bc_list.length > 0) {
+
+    //Filter BC List based on BC List Parameter and whether to Allow/Deny
+    var billing_center_list = _.filter(ds_billing_centers, function(bc) {
+      if (param_bc_allow_or_deny == "Allow") {
+        return _.contains(param_bc_list, bc.id) == allow_deny_test[param_bc_allow_or_deny] || _.contains(param_bc_list, bc.name) == allow_deny_test[param_bc_allow_or_deny]
+      } else {
+        return _.contains(param_bc_list, bc.id) == allow_deny_test[param_bc_allow_or_deny] && _.contains(param_bc_list, bc.name) == allow_deny_test[param_bc_allow_or_deny]
+      }
+    })
+
+    //Check that there are no child billing centers specified that conflict with parent billing centers specified
+    var bc_ids = _.map(billing_center_list, function(bc) { return bc.id.toLowerCase() })
+
+    var conflicting_child_bcs = _.filter(billing_center_list, function(bc) {
+      if (!(bc.parent_id == null || bc.parent_id == undefined)) {
+        return _.contains(bc_ids, bc.parent_id.toLowerCase())
+      }
+    })
+
+    //If there are conflicting child/parent BCs then ignore the child BC and take the parent BC
+    if (conflicting_child_bcs != undefined) {
+      var conflicting_child_bc_ids = _.pluck(conflicting_child_bcs, "id")
+      
+      var filtered_bc_list = _.reject(billing_center_list, function(bc) {
+        return _.contains(conflicting_child_bc_ids, bc.id)
+      })
+      result = _.compact(_.pluck(filtered_bc_list, 'id'))
+    } else {
+      result = _.compact(_.pluck(billing_center_list, 'id'))
+    }
+    
+  } else {
+    var billing_center_list = _.filter(ds_billing_centers, function(bc) {
+      return bc['parent_id'] == null || bc['parent_id'] == undefined
+    })
+
+    result = _.compact(_.pluck(billing_center_list, 'id'))
+  }
   EOS
 end
 
 #GET USAGE DATA FOR INSTANCE TYPES
 datasource "ds_usage_data" do
   request do
-    run_script $js_usage_data, $ds_top_level_bcs, $ds_billing_centers, $param_regions_allow_or_deny, $param_regions_list, $param_bc_allow_or_deny, $param_bc_list, rs_org_id, rs_optima_host
+    run_script $js_usage_data, $ds_filtered_billing_centers, $param_regions_allow_or_deny, $param_regions_list, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -134,7 +172,7 @@ datasource "ds_usage_data" do
 end
 
 script "js_usage_data", type: "javascript" do
-  parameters "ds_top_level_bcs", "ds_billing_centers", "param_regions_allow_or_deny", "param_regions_list", "param_bc_allow_or_deny", "param_bc_list", "org_id", "optima_host"
+  parameters "ds_filtered_billing_centers", "param_regions_allow_or_deny", "param_regions_list", "org_id", "optima_host"
   result "request"
   code <<-EOS
   //Get Start and End dates
@@ -143,27 +181,8 @@ script "js_usage_data", type: "javascript" do
   end_date.setMonth(end_date.getMonth())
 
   //Define Billing Center list if applicable
-  var billing_center_ids = []
+  var billing_center_ids = ds_filtered_billing_centers
   var allow_deny_test = { "Allow": true, "Deny": false }
-
-  if (param_bc_list.length > 0) {
-    billing_center_ids = _.filter(ds_top_level_bcs, function(bc) {
-      var bc_name = ""
-      var matched_bc = _.find(ds_billing_centers, function(data) { return bc == data.id })
-      
-      if (matched_bc != undefined) {
-        bc_name = matched_bc.name
-
-        if (param_bc_allow_or_deny == "Allow") {
-          return _.contains(param_bc_list, bc) == allow_deny_test[param_bc_allow_or_deny] || _.contains(param_bc_list, bc_name) == allow_deny_test[param_bc_allow_or_deny]
-        } else {
-          return _.contains(param_bc_list, bc) == allow_deny_test[param_bc_allow_or_deny] && _.contains(param_bc_list, bc_name) == allow_deny_test[param_bc_allow_or_deny]
-        }
-      }
-    })
-  } else {
-    billing_center_ids = ds_top_level_bcs
-  }
 
   //Define Expressions for API Filter 
   var expressions = [

--- a/operational/azure/total_instance_hours/azure_usage_instance_hours_used.pt
+++ b/operational/azure/total_instance_hours/azure_usage_instance_hours_used.pt
@@ -95,9 +95,9 @@ datasource "ds_billing_centers" do
       field "ancestor_ids", jmes_path(col_item, "ancestor_ids")
       field "allocation_table", jmes_path(col_item, "allocation_table")
     end
-  end  
+  end
 end
-  
+
 #FILTER USING BILLING CENTERS PARAMETER IF APPLICABLE
 datasource "ds_filtered_billing_centers" do
   run_script $js_filtered_billing_centers, $ds_billing_centers, $param_bc_allow_or_deny, $param_bc_list

--- a/operational/azure/total_instance_memory/CHANGELOG.md
+++ b/operational/azure/total_instance_memory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1.1
+
+- Fixed issue where only top-level billing centers could be filtered on. Policy now additionally supports filtering on child billing centers.
+
 ## v2.0.1
 
 - Updated Microsoft URL referencing Azure Virtual Machine Families and ISF Ratios. Policy functionality is unchanged.

--- a/operational/azure/total_instance_memory/azure_usage_instance_memory_used.pt
+++ b/operational/azure/total_instance_memory/azure_usage_instance_memory_used.pt
@@ -95,7 +95,7 @@ datasource "ds_billing_centers" do
       field "ancestor_ids", jmes_path(col_item, "ancestor_ids")
       field "allocation_table", jmes_path(col_item, "allocation_table")
     end
-  end  
+  end
 end
 
 #FILTER USING BILLING CENTERS PARAMETER IF APPLICABLE

--- a/operational/azure/total_instance_memory/azure_usage_instance_memory_used.pt
+++ b/operational/azure/total_instance_memory/azure_usage_instance_memory_used.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "2.0.1",
+  version: "2.1.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Usage Report"
@@ -97,28 +97,66 @@ datasource "ds_billing_centers" do
     end
   end  
 end
-  
-#GET TOP-LEVEL BILLING CENTERS
-datasource "ds_top_level_bcs" do
-  run_script $js_top_level_bcs, $ds_billing_centers
+
+#FILTER USING BILLING CENTERS PARAMETER IF APPLICABLE
+datasource "ds_filtered_billing_centers" do
+  run_script $js_filtered_billing_centers, $ds_billing_centers, $param_bc_allow_or_deny, $param_bc_list
 end
 
-script "js_top_level_bcs", type: "javascript" do
-  parameters "ds_billing_centers"
+script "js_filtered_billing_centers", type: "javascript" do
+  parameters "ds_billing_centers", "param_bc_allow_or_deny", "param_bc_list"
   result "result"
   code <<-EOS
-  filtered_bcs = _.filter(ds_billing_centers, function(bc) {
-    return bc['parent_id'] == null || bc['parent_id'] == undefined
-  })
 
-  result = _.compact(_.pluck(filtered_bcs, 'id'))
+  //Define Billing Center list if applicable
+  var allow_deny_test = { "Allow": true, "Deny": false }
+
+  if (param_bc_list.length > 0) {
+
+    //Filter BC List based on BC List Parameter and whether to Allow/Deny
+    var billing_center_list = _.filter(ds_billing_centers, function(bc) {
+      if (param_bc_allow_or_deny == "Allow") {
+        return _.contains(param_bc_list, bc.id) == allow_deny_test[param_bc_allow_or_deny] || _.contains(param_bc_list, bc.name) == allow_deny_test[param_bc_allow_or_deny]
+      } else {
+        return _.contains(param_bc_list, bc.id) == allow_deny_test[param_bc_allow_or_deny] && _.contains(param_bc_list, bc.name) == allow_deny_test[param_bc_allow_or_deny]
+      }
+    })
+
+    //Check that there are no child billing centers specified that conflict with parent billing centers specified
+    var bc_ids = _.map(billing_center_list, function(bc) { return bc.id.toLowerCase() })
+
+    var conflicting_child_bcs = _.filter(billing_center_list, function(bc) {
+      if (!(bc.parent_id == null || bc.parent_id == undefined)) {
+        return _.contains(bc_ids, bc.parent_id.toLowerCase())
+      }
+    })
+
+    //If there are conflicting child/parent BCs then ignore the child BC and take the parent BC
+    if (conflicting_child_bcs != undefined) {
+      var conflicting_child_bc_ids = _.pluck(conflicting_child_bcs, "id")
+      
+      var filtered_bc_list = _.reject(billing_center_list, function(bc) {
+        return _.contains(conflicting_child_bc_ids, bc.id)
+      })
+      result = _.compact(_.pluck(filtered_bc_list, 'id'))
+    } else {
+      result = _.compact(_.pluck(billing_center_list, 'id'))
+    }
+    
+  } else {
+    var billing_center_list = _.filter(ds_billing_centers, function(bc) {
+      return bc['parent_id'] == null || bc['parent_id'] == undefined
+    })
+
+    result = _.compact(_.pluck(billing_center_list, 'id'))
+  }
   EOS
 end
 
 #GET USAGE DATA FOR INSTANCE TYPES
 datasource "ds_usage_data" do
   request do
-    run_script $js_usage_data, $ds_top_level_bcs, $ds_billing_centers, $param_regions_allow_or_deny, $param_regions_list, $param_bc_allow_or_deny, $param_bc_list, rs_org_id, rs_optima_host
+    run_script $js_usage_data, $ds_filtered_billing_centers, $param_regions_allow_or_deny, $param_regions_list, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -134,7 +172,7 @@ datasource "ds_usage_data" do
 end
 
 script "js_usage_data", type: "javascript" do
-  parameters "ds_top_level_bcs", "ds_billing_centers", "param_regions_allow_or_deny", "param_regions_list", "param_bc_allow_or_deny", "param_bc_list", "org_id", "optima_host"
+  parameters "ds_filtered_billing_centers", "param_regions_allow_or_deny", "param_regions_list", "org_id", "optima_host"
   result "request"
   code <<-EOS
   //Get Start and End dates
@@ -143,27 +181,8 @@ script "js_usage_data", type: "javascript" do
   end_date.setMonth(end_date.getMonth())
 
   //Define Billing Center list if applicable
-  var billing_center_ids = []
+  var billing_center_ids = ds_filtered_billing_centers
   var allow_deny_test = { "Allow": true, "Deny": false }
-
-  if (param_bc_list.length > 0) {
-    billing_center_ids = _.filter(ds_top_level_bcs, function(bc) {
-      var bc_name = ""
-      var matched_bc = _.find(ds_billing_centers, function(data) { return bc == data.id })
-      
-      if (matched_bc != undefined) {
-        bc_name = matched_bc.name
-
-        if (param_bc_allow_or_deny == "Allow") {
-          return _.contains(param_bc_list, bc) == allow_deny_test[param_bc_allow_or_deny] || _.contains(param_bc_list, bc_name) == allow_deny_test[param_bc_allow_or_deny]
-        } else {
-          return _.contains(param_bc_list, bc) == allow_deny_test[param_bc_allow_or_deny] && _.contains(param_bc_list, bc_name) == allow_deny_test[param_bc_allow_or_deny]
-        }
-      }
-    })
-  } else {
-    billing_center_ids = ds_top_level_bcs
-  }
 
   //Define Expressions for API Filter 
   var expressions = [

--- a/operational/azure/total_instance_vcpus/CHANGELOG.md
+++ b/operational/azure/total_instance_vcpus/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1.1
+
+- Fixed issue where only top-level billing centers could be filtered on. Policy now additionally supports filtering on child billing centers.
+
 ## v2.0.1
 
 - Updated Microsoft URL referencing Azure Virtual Machine Families and ISF Ratios. Policy functionality is unchanged.

--- a/operational/azure/total_instance_vcpus/azure_usage_instance_vcpus_used.pt
+++ b/operational/azure/total_instance_vcpus/azure_usage_instance_vcpus_used.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "2.0.1",
+  version: "2.1.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Usage Report"
@@ -98,27 +98,65 @@ datasource "ds_billing_centers" do
   end  
 end
   
-#GET TOP-LEVEL BILLING CENTERS
-datasource "ds_top_level_bcs" do
-  run_script $js_top_level_bcs, $ds_billing_centers
+#FILTER USING BILLING CENTERS PARAMETER IF APPLICABLE
+datasource "ds_filtered_billing_centers" do
+  run_script $js_filtered_billing_centers, $ds_billing_centers, $param_bc_allow_or_deny, $param_bc_list
 end
 
-script "js_top_level_bcs", type: "javascript" do
-  parameters "ds_billing_centers"
+script "js_filtered_billing_centers", type: "javascript" do
+  parameters "ds_billing_centers", "param_bc_allow_or_deny", "param_bc_list"
   result "result"
   code <<-EOS
-  filtered_bcs = _.filter(ds_billing_centers, function(bc) {
-    return bc['parent_id'] == null || bc['parent_id'] == undefined
-  })
 
-  result = _.compact(_.pluck(filtered_bcs, 'id'))
+  //Define Billing Center list if applicable
+  var allow_deny_test = { "Allow": true, "Deny": false }
+
+  if (param_bc_list.length > 0) {
+
+    //Filter BC List based on BC List Parameter and whether to Allow/Deny
+    var billing_center_list = _.filter(ds_billing_centers, function(bc) {
+      if (param_bc_allow_or_deny == "Allow") {
+        return _.contains(param_bc_list, bc.id) == allow_deny_test[param_bc_allow_or_deny] || _.contains(param_bc_list, bc.name) == allow_deny_test[param_bc_allow_or_deny]
+      } else {
+        return _.contains(param_bc_list, bc.id) == allow_deny_test[param_bc_allow_or_deny] && _.contains(param_bc_list, bc.name) == allow_deny_test[param_bc_allow_or_deny]
+      }
+    })
+
+    //Check that there are no child billing centers specified that conflict with parent billing centers specified
+    var bc_ids = _.map(billing_center_list, function(bc) { return bc.id.toLowerCase() })
+
+    var conflicting_child_bcs = _.filter(billing_center_list, function(bc) {
+      if (!(bc.parent_id == null || bc.parent_id == undefined)) {
+        return _.contains(bc_ids, bc.parent_id.toLowerCase())
+      }
+    })
+
+    //If there are conflicting child/parent BCs then ignore the child BC and take the parent BC
+    if (conflicting_child_bcs != undefined) {
+      var conflicting_child_bc_ids = _.pluck(conflicting_child_bcs, "id")
+      
+      var filtered_bc_list = _.reject(billing_center_list, function(bc) {
+        return _.contains(conflicting_child_bc_ids, bc.id)
+      })
+      result = _.compact(_.pluck(filtered_bc_list, 'id'))
+    } else {
+      result = _.compact(_.pluck(billing_center_list, 'id'))
+    }
+    
+  } else {
+    var billing_center_list = _.filter(ds_billing_centers, function(bc) {
+      return bc['parent_id'] == null || bc['parent_id'] == undefined
+    })
+
+    result = _.compact(_.pluck(billing_center_list, 'id'))
+  }
   EOS
 end
 
 #GET USAGE DATA FOR INSTANCE TYPES
 datasource "ds_usage_data" do
   request do
-    run_script $js_usage_data, $ds_top_level_bcs, $ds_billing_centers, $param_regions_allow_or_deny, $param_regions_list, $param_bc_allow_or_deny, $param_bc_list, rs_org_id, rs_optima_host
+    run_script $js_usage_data, $ds_filtered_billing_centers, $param_regions_allow_or_deny, $param_regions_list, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -134,7 +172,7 @@ datasource "ds_usage_data" do
 end
 
 script "js_usage_data", type: "javascript" do
-  parameters "ds_top_level_bcs", "ds_billing_centers", "param_regions_allow_or_deny", "param_regions_list", "param_bc_allow_or_deny", "param_bc_list", "org_id", "optima_host"
+  parameters "ds_filtered_billing_centers", "param_regions_allow_or_deny", "param_regions_list", "org_id", "optima_host"
   result "request"
   code <<-EOS
   //Get Start and End dates
@@ -143,27 +181,8 @@ script "js_usage_data", type: "javascript" do
   end_date.setMonth(end_date.getMonth())
 
   //Define Billing Center list if applicable
-  var billing_center_ids = []
+  var billing_center_ids = ds_filtered_billing_centers
   var allow_deny_test = { "Allow": true, "Deny": false }
-
-  if (param_bc_list.length > 0) {
-    billing_center_ids = _.filter(ds_top_level_bcs, function(bc) {
-      var bc_name = ""
-      var matched_bc = _.find(ds_billing_centers, function(data) { return bc == data.id })
-      
-      if (matched_bc != undefined) {
-        bc_name = matched_bc.name
-
-        if (param_bc_allow_or_deny == "Allow") {
-          return _.contains(param_bc_list, bc) == allow_deny_test[param_bc_allow_or_deny] || _.contains(param_bc_list, bc_name) == allow_deny_test[param_bc_allow_or_deny]
-        } else {
-          return _.contains(param_bc_list, bc) == allow_deny_test[param_bc_allow_or_deny] && _.contains(param_bc_list, bc_name) == allow_deny_test[param_bc_allow_or_deny]
-        }
-      }
-    })
-  } else {
-    billing_center_ids = ds_top_level_bcs
-  }
 
   //Define Expressions for API Filter 
   var expressions = [

--- a/operational/azure/total_instance_vcpus/azure_usage_instance_vcpus_used.pt
+++ b/operational/azure/total_instance_vcpus/azure_usage_instance_vcpus_used.pt
@@ -95,9 +95,9 @@ datasource "ds_billing_centers" do
       field "ancestor_ids", jmes_path(col_item, "ancestor_ids")
       field "allocation_table", jmes_path(col_item, "allocation_table")
     end
-  end  
+  end
 end
-  
+
 #FILTER USING BILLING CENTERS PARAMETER IF APPLICABLE
 datasource "ds_filtered_billing_centers" do
   run_script $js_filtered_billing_centers, $ds_billing_centers, $param_bc_allow_or_deny, $param_bc_list


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves below -->
Usage Reports for AWS and Azure (e.g., Amount of Instance Memory Used, Number of Instance vCPUs Used, etc.) currently allow the user to define a list of Billing Centers to report on which can either be allowed/filtered in or denied/filtered out.

The current logic only supports filtering on top-level billing centers, which means that child billing centers cannot be specifically reported on.

This is a change to add support for filtering on child billing centers when applying the policy to generate a report.

### Issues Resolved

<!-- List any existing issues this PR resolves below -->
Fixes issue where only top-level billing centers could be filtered on. Policy now additionally supports filtering on child billing centers.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->
Tested in customer tenant, and working as expected. Some examples below of chart produced in policy incident:

AWS Instance vCPUs Used (all Billing Centers i.e., no BC filter) - demonstrating previous functionality still works:
![image](https://github.com/flexera-public/policy_templates/assets/92175447/38308027-d8fc-4ed5-8fff-cd06f9eb3684)

Azure Instance Memory Used (for one Child Billing Center) - demonstrating new functionality works:
![image](https://github.com/flexera-public/policy_templates/assets/92175447/a3fbd1c2-61e6-4507-ad8f-da3525f50595)

### Contribution Check List

- [x] New functionality includes testing.
- [ ] ~~New functionality has been documented in the README if applicable~~
- [x] New functionality has been documented in CHANGELOG.MD
