### PR TITLE
SQ-7228 Incorrect currency code and inflated savings bug

### DIFF
--- a/cost/azure/savings_realized/CHANGELOG.md
+++ b/cost/azure/savings_realized/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.9
+
+- Added parameter to select between showing the currency code or the currency symbol in the incident report
+
 ## v3.8
 
 - Added support for organizations with Microsoft MCA accounts

--- a/cost/azure/savings_realized/CHANGELOG.md
+++ b/cost/azure/savings_realized/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v3.9
 
 - Added parameter to select between showing the currency code or the currency symbol in the incident report
+- Fixed a bug introduced at v3.8 that made the policy show greater savings: if there were no MCA bill connections the policy still pulled aggregated costs thus making the savings bigger.
 
 ## v3.8
 

--- a/cost/azure/savings_realized/CHANGELOG.md
+++ b/cost/azure/savings_realized/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v3.9
+## v3.9.0
 
 - Added parameter to select between showing the currency code or the currency symbol in the incident report
 - Fixed a bug introduced at v3.8 that made the policy show greater savings: if there were no MCA bill connections the policy still pulled aggregated costs thus making the savings bigger.

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "monthly"
 info(
-  version: "3.8",
+  version: "3.9",
   provider: "Azure",
   service: "Compute",
   policy_set: "Savings Realized"
@@ -56,6 +56,15 @@ parameter "param_chart_type" do
   description "The type of bar chart to view savings realized data by"
   allowed_values "Grouped Bar Chart", "Stacked Bar Chart"
   default "Grouped Bar Chart"
+end
+
+parameter "param_chart_currency" do
+  type "string"
+  category "Policy Settings"
+  label "Chart currency format"
+  description "The format to show the currency in the chart"
+  allowed_values "Symbol (e.g. $)", "Code (e.g. USD)"
+  default "Symbol (e.g. $)"
 end
 
 ###############################################################################
@@ -730,6 +739,14 @@ script "js_savings_realized", type: "javascript" do
 EOS
 end
 
+datasource "ds_currency_reference" do
+  request do
+    host "raw.githubusercontent.com"
+    path "/flexera-public/policy_templates/master/data/currency/currency_reference.json"
+    header "User-Agent", "RS Policies"
+  end
+end
+
 datasource "ds_currency_code" do
   request do
     auth $auth_flexera
@@ -747,13 +764,25 @@ datasource "ds_currency_code" do
 end
 
 datasource "ds_chart_data" do
-  run_script $js_chart_data, $ds_savings_realized, $ds_applied_policy, $ds_currency_code, $param_chart_type
+  run_script $js_chart_data, $ds_savings_realized, $ds_applied_policy, $ds_currency_reference, $ds_currency_code, $param_chart_type, $param_chart_currency
 end
 
 script "js_chart_data", type: "javascript" do
-  parameters "ds_savings_realized", "ds_applied_policy", "ds_currency_code", "param_chart_type"
+  parameters "ds_savings_realized", "ds_applied_policy", "ds_currency_reference", "ds_currency_code", "param_chart_type", "param_chart_currency"
   result "result"
   code <<-'EOS'
+  // Get currency code or symbol
+  currency_data = ds_currency_reference[ds_currency_code.value]
+  currency = currency_data.code
+  switch (param_chart_currency) {
+    case "Code (e.g. USD)":
+      currency = currency_data.code
+      break;
+    case "Symbol (e.g. $)":
+      currency = currency_data.symbol_native
+      break;
+  }
+
   // Create report data
   result = []
   savings_by_month = _.groupBy(ds_savings_realized, 'month')
@@ -831,7 +860,7 @@ script "js_chart_data", type: "javascript" do
       chart_image: encodeURI("chof=.png"),
       chart_y_axis: encodeURI("chxt=y,x"),
       chart_axis_label: encodeURI(chart_axis_labels),
-      chart_axis_format: encodeURI("chxs=0N*c" + ds_currency_code.value + "0sz*|1,min40"),
+      chart_axis_format: encodeURI("chxs=0N" + currency + " *0sz*|1,min40"),
       chart_line_style: encodeURI("chls=3|3|3|3|3|3|3|3|3|3|3"),
       chart_line_color: encodeURI("chco=1f5ab8,55b81f,198038,b28600,1192e8,009d9a,005d5d,007d79"),
       chart_data_scale: encodeURI("chds=a"),

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -345,7 +345,7 @@ datasource "ds_aggregated_costs_new_ri" do
   end
 end
 
-datasource "ds_aggregated_costs_mca_encbi_base" do
+datasource "ds_aggregated_costs_mca_encbi_base_optima" do
   request do
     run_script $js_get_aggregated_costs, $ds_bill_connections_mca_encbi, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "mca_encbi_base"
   end
@@ -361,7 +361,11 @@ datasource "ds_aggregated_costs_mca_encbi_base" do
   end
 end
 
-datasource "ds_aggregated_costs_mca_encbi_ri" do
+datasource "ds_aggregated_costs_mca_encbi_base" do
+  run_script $js_empty_aggregated_costs_if_no_bill_connections, $ds_bill_connections_mca_encbi, $ds_aggregated_costs_mca_encbi_base_optima
+end
+
+datasource "ds_aggregated_costs_mca_encbi_ri_optima" do
   request do
     run_script $js_get_aggregated_costs, $ds_bill_connections_mca_encbi, $ds_filtered_bcs, $param_period_start, $param_period_end, rs_org_id, rs_optima_host, "mca_encbi_ri"
   end
@@ -375,6 +379,21 @@ datasource "ds_aggregated_costs_mca_encbi_ri" do
       field "month", jmes_path(col_item, "timestamp")
     end
   end
+end
+
+datasource "ds_aggregated_costs_mca_encbi_ri" do
+  run_script $js_empty_aggregated_costs_if_no_bill_connections, $ds_bill_connections_mca_encbi, $ds_aggregated_costs_mca_encbi_ri_optima
+end
+
+script "js_empty_aggregated_costs_if_no_bill_connections", type: "javascript" do
+  parameters "bill_connections", "aggregated_costs"
+  result "result"
+  code <<-EOS
+  result = []
+  if (bill_connections.length > 0) {
+    result = aggregated_costs
+  }
+EOS
 end
 
 script "js_get_aggregated_costs", type: "javascript" do

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "monthly"
 info(
-  version: "3.9",
+  version: "3.9.0",
   provider: "Azure",
   service: "Compute",
   policy_set: "Savings Realized"

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -199,7 +199,6 @@ script "js_filtered_bcs", type: "javascript" do
 EOS
 end
 
-
 # Gather list of bill connections from Flexera data
 datasource "ds_bill_connections" do
   request do


### PR DESCRIPTION
### Description

- Adds a new parameter that lets the user decide on the format for the currency shown in the incident's chart: code (e.g. USD) or symbol (e.g. $).
- Fixes a bug that showed inflated savings on the instances.

### Issues Resolved

https://flexera.atlassian.net/browse/SQ-7228

### Link to Example Applied Policy

https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/107982?policyId=66353ae2e2d700d7f57fe119

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
