### PR TITLE
FOPTS-3939 Update: List of cheaper regions for Azure and AWS vendors

### DIFF
--- a/cost/flexera/cco/cheaper_regions/CHANGELOG.md
+++ b/cost/flexera/cco/cheaper_regions/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v2.4
+## v2.4.0
 
 - Updated list of cheaper regions for Azure and AWS vendors.
 

--- a/cost/flexera/cco/cheaper_regions/CHANGELOG.md
+++ b/cost/flexera/cco/cheaper_regions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.4
+
+- Updated list of cheaper regions for Azure and AWS vendors.
+
 ## v2.3
 
 - Updated policy metadata to make it more clear what Flexera service the policy is for

--- a/cost/flexera/cco/cheaper_regions/README.md
+++ b/cost/flexera/cco/cheaper_regions/README.md
@@ -8,6 +8,8 @@ This Policy Template determines which regions have cheaper alternatives by speci
 
 This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).
 
+### Credential Configuration
+
 - [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
   - `billing_center_viewer`
   - `policy_designer`

--- a/cost/flexera/cco/cheaper_regions/README.md
+++ b/cost/flexera/cco/cheaper_regions/README.md
@@ -9,7 +9,7 @@ This Policy Template determines which regions have cheaper alternatives by speci
 This policy has the following input parameters required when launching the policy.
 
 - *Billing Center Name* - The list of Billing centers to check against
-- *Email addresses of the recipients you wish to notify* - A list of email addresses to notify
+- *Email Addresses* - A list of email addresses to notify
 
 ## Policy Actions
 

--- a/cost/flexera/cco/cheaper_regions/README.md
+++ b/cost/flexera/cco/cheaper_regions/README.md
@@ -11,6 +11,12 @@ This policy has the following input parameters required when launching the polic
 - *Billing Center Name* - The list of Billing centers to check against
 - *Email addresses of the recipients you wish to notify* - A list of email addresses to notify
 
+## Policy Actions
+
+The following policy actions are taken on any resources found to be out of compliance.
+
+- Send an email report
+
 ## Prerequisites
 
 This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).

--- a/cost/flexera/cco/cheaper_regions/README.md
+++ b/cost/flexera/cco/cheaper_regions/README.md
@@ -1,8 +1,15 @@
 # Cheaper Regions Policy
 
-## What it does
+## What It Does
 
 This Policy Template determines which regions have cheaper alternatives by specifying the expensive region name and the cheaper region name for analysis
+
+## Input Parameters
+
+This policy has the following input parameters required when launching the policy.
+
+- *Billing Center Name* - The list of Billing centers to check against
+- *Email addresses of the recipients you wish to notify* - A list of email addresses to notify
 
 ## Prerequisites
 
@@ -21,13 +28,6 @@ The [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automati
 ## Functional Details
 
 - This policy uses a hash to determine existing regions and newer compatible cheaper regions. It checks the billing center and reports on cheaper regions.
-
-### Input Parameters
-
-This policy has the following input parameters required when launching the policy.
-
-- *Billing Center Name* - The list of Billing centers to check against
-- *Email addresses of the recipients you wish to notify* - A list of email addresses to notify
 
 ## Supported Clouds
 

--- a/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
+++ b/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
@@ -18,7 +18,6 @@ info(
 # Permissions
 ###############################################################################
 
-
 ###############################################################################
 # Parameters
 ###############################################################################
@@ -29,8 +28,8 @@ parameter "param_email" do
 end
 
 parameter "param_billing_centers" do
-  label "Billing Center Name"
   type "list"
+  label "Billing Center Name"
   min_length 1
 end
 
@@ -68,9 +67,9 @@ datasource "ds_billing_centers" do
     auth $auth_flexera
     host rs_optima_host
     path join(["/analytics/orgs/",rs_org_id,"/billing_centers"])
+    query "view", "allocation_table"
     header "Api-Version", "1.0"
     header "User-Agent", "RS Policies"
-    query "view", "allocation_table"
   end
   result do
     encoding "json"
@@ -90,9 +89,9 @@ datasource "ds_cloud_vendor_accounts" do
     auth $auth_flexera
     host rs_optima_host
     path join(["/bill-analysis/orgs/",rs_org_id,"/cloud_vendor_accounts"])
+    query "cloud_vendor", "aws"
     header "Api-Version", "0.1"
     header "User-Agent", "RS Policies"
-    query "cloud_vendor", "aws"
   end
   result do
     encoding "json"
@@ -339,7 +338,7 @@ policy "policy_cheaper_regions" do
   validate_each $ds_new_bc_cost_name do
     summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} rows with cheaper data"
     check eq(0,1)
-    escalate $email
+    escalate $esc_email
     export do
       resource_level true
       field "billing_center_name" do
@@ -374,7 +373,7 @@ end
 # Escalations
 ###############################################################################
 
-escalation "email" do
+escalation "esc_email" do
   automatic true
   label "Send Email"
   description "Send incident email"

--- a/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
+++ b/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
@@ -15,13 +15,10 @@ info(
 )
 
 ###############################################################################
-# Permissions
-###############################################################################
-
-###############################################################################
 # Parameters
 ###############################################################################
 
+# No default value, user input required
 parameter "param_email" do
   type "list"
   category "Policy Settings"
@@ -29,6 +26,7 @@ parameter "param_email" do
   description "A list of email addresses to notify."
 end
 
+# No default value, user input required
 parameter "param_billing_centers" do
   type "list"
   category "Filters"
@@ -95,7 +93,7 @@ end
 
 datasource "ds_new_bc_costs" do
   request do
-    run_script $js_new_costs_request, $ds_billing_centers, $param_billing_centers, rs_optima_host, rs_org_id
+    run_script $js_new_bc_costs, $ds_billing_centers, $param_billing_centers, rs_optima_host, rs_org_id
   end
   result do
     encoding "json"
@@ -112,13 +110,13 @@ datasource "ds_new_bc_costs" do
 end
 
 datasource "ds_new_bc_cost_name" do
-  run_script $js_merge_bc_name, $ds_new_bc_costs, $ds_billing_centers, $ds_cloud_vendor_accounts
+  run_script $js_new_bc_cost_name, $ds_new_bc_costs, $ds_billing_centers, $ds_cloud_vendor_accounts
 end
 
 ###############################################################################
 # Scripts
 ###############################################################################
-script "js_new_costs_request", type: "javascript" do
+script "js_new_bc_costs", type: "javascript" do
   parameters "ds_billing_centers", "param_billing_centers", "rs_optima_host", "org_id"
   result "request"
   code <<-EOS
@@ -233,7 +231,7 @@ script "js_new_costs_request", type: "javascript" do
   EOS
 end
 
-script "js_merge_bc_name", type: "javascript" do
+script "js_new_bc_cost_name", type: "javascript" do
   parameters "new_bc_costs", "billing_centers", "ds_cloud_vendor_accounts"
   result "results"
   code <<-EOS

--- a/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
+++ b/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
@@ -23,7 +23,7 @@ parameter "param_email" do
   category "Policy Settings"
   label "Email addresses of the recipients you wish to notify"
   description "A list of email addresses to notify."
-  # No default value, user input required
+  default []
 end
 
 parameter "param_billing_centers" do
@@ -49,6 +49,15 @@ end
 ###############################################################################
 # Datasources & Scripts
 ###############################################################################
+
+datasource "ds_applied_policy" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    header "Api-Version", "1.0"
+  end
+end
 
 datasource "ds_aws_regions_reference" do
   request do
@@ -133,13 +142,6 @@ datasource "ds_new_bc_costs" do
   end
 end
 
-datasource "ds_new_bc_cost_name" do
-  run_script $js_new_bc_cost_name, $ds_new_bc_costs, $ds_billing_centers, $ds_cloud_vendor_accounts, $ds_aws_regions_reference, $ds_azure_regions_reference, $ds_google_regions_reference
-end
-
-###############################################################################
-# Scripts
-###############################################################################
 script "js_new_bc_costs", type: "javascript" do
   parameters "ds_billing_centers", "param_billing_centers", "rs_optima_host", "org_id"
   result "request"
@@ -255,8 +257,12 @@ script "js_new_bc_costs", type: "javascript" do
   EOS
 end
 
+datasource "ds_new_bc_cost_name" do
+  run_script $js_new_bc_cost_name, $ds_new_bc_costs, $ds_billing_centers, $ds_cloud_vendor_accounts, $ds_aws_regions_reference, $ds_azure_regions_reference, $ds_google_regions_reference, $ds_applied_policy
+end
+
 script "js_new_bc_cost_name", type: "javascript" do
-  parameters "new_bc_costs", "billing_centers", "ds_cloud_vendor_accounts", "ds_aws_regions_reference", "ds_azure_regions_reference", "ds_google_regions_reference"
+  parameters "new_bc_costs", "billing_centers", "ds_cloud_vendor_accounts", "ds_aws_regions_reference", "ds_azure_regions_reference", "ds_google_regions_reference", "ds_applied_policy"
   result "results"
   code <<-EOS
     var results = []
@@ -361,7 +367,11 @@ script "js_new_bc_cost_name", type: "javascript" do
       }
       }
     }
-EOS
+
+    if (results.length > 0) {
+      results[0]['policy_name'] = ds_applied_policy['name']
+    }
+  EOS
 end
 
 ###############################################################################
@@ -369,9 +379,9 @@ end
 ###############################################################################
 
 policy "pol_cheaper_regions" do
-  validate_each $ds_new_bc_cost_name do
-    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} rows with cheaper data"
-    check eq(0, 1)
+  validate $ds_new_bc_cost_name do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Cheaper Regions Found"
+    check eq(size(data), 0)
     escalate $esc_email
     export do
       resource_level true

--- a/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
+++ b/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
@@ -271,9 +271,9 @@ script "js_new_bc_cost_name", type: "javascript" do
     var azure_cheaper_regions = { "regions": {} }
     
     _.each(azure_supported_regions, function (supportedRegion) {
-        const region = _.findWhere(ds_azure_regions_reference, { region: supportedRegion.region })
+        var region = _.findWhere(ds_azure_regions_reference, { region: supportedRegion.region })
     
-        const cheaperRegion = _.findWhere(ds_azure_regions_reference, { region: supportedRegion.cheaper })
+        var cheaperRegion = _.findWhere(ds_azure_regions_reference, { region: supportedRegion.cheaper })
     
         if (region != undefined && cheaperRegion != undefined) {
             azure_cheaper_regions["regions"][region.name] = cheaperRegion.name
@@ -287,9 +287,9 @@ script "js_new_bc_cost_name", type: "javascript" do
     var ec2_cheaper_regions = { "regions": {} }
     
     _.each(ec2_supported_regions, function (supportedRegion) {
-        const region = _.findWhere(ds_aws_regions_reference, { region: supportedRegion.region })
+        var region = _.findWhere(ds_aws_regions_reference, { region: supportedRegion.region })
     
-        const cheaperRegion = _.findWhere(ds_aws_regions_reference, { region: supportedRegion.cheaper })
+        var cheaperRegion = _.findWhere(ds_aws_regions_reference, { region: supportedRegion.cheaper })
     
         if (region != undefined && cheaperRegion != undefined) {
             ec2_cheaper_regions["regions"][region.name] = cheaperRegion.name
@@ -303,9 +303,9 @@ script "js_new_bc_cost_name", type: "javascript" do
     var google_cheaper_regions = { "regions": {} }
     
     _.each(google_supported_regions, function (supportedRegion) {
-        const region = _.findWhere(ds_google_regions_reference, { region: supportedRegion.region })
+        var region = _.findWhere(ds_google_regions_reference, { region: supportedRegion.region })
     
-        const cheaperRegion = _.findWhere(ds_google_regions_reference, { region: supportedRegion.cheaper })
+        var cheaperRegion = _.findWhere(ds_google_regions_reference, { region: supportedRegion.cheaper })
     
         if (region != undefined && cheaperRegion != undefined) {
             google_cheaper_regions["regions"][region.region] = cheaperRegion.region

--- a/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
+++ b/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
@@ -69,7 +69,7 @@ end
 datasource "ds_google_regions_reference" do
   request do
     host "raw.githubusercontent.com"
-    path "/flexera-public/policy_templates/FOPTS-3939/data/azure/regions.json"
+    path "/flexera-public/policy_templates/FOPTS-3939/data/google/regions.json"
     header "User-Agent", "RS Policies"
   end
 end

--- a/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
+++ b/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
@@ -61,7 +61,7 @@ end
 datasource "ds_azure_regions_reference" do
   request do
     host "raw.githubusercontent.com"
-    path "/flexera-public/policy_templates/FOPTS-3939/data/azure/regions.json"
+    path "/flexera-public/policy_templates/master/data/azure/regions.json"
     header "User-Agent", "RS Policies"
   end
 end
@@ -69,7 +69,7 @@ end
 datasource "ds_google_regions_reference" do
   request do
     host "raw.githubusercontent.com"
-    path "/flexera-public/policy_templates/FOPTS-3939/data/google/regions.json"
+    path "/flexera-public/policy_templates/master/data/google/regions.json"
     header "User-Agent", "RS Policies"
   end
 end

--- a/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
+++ b/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
@@ -32,7 +32,6 @@ parameter "param_billing_centers" do
   label "Billing Center Name"
   description "List of billing centers to be filtered."
   min_length 1
-  # No default value, user input required
 end
 
 ###############################################################################

--- a/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
+++ b/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
@@ -32,6 +32,7 @@ parameter "param_billing_centers" do
   label "Billing Center Name"
   description "List of billing centers to be filtered."
   min_length 1
+  default []
 end
 
 ###############################################################################

--- a/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
+++ b/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
@@ -275,13 +275,9 @@ script "js_new_bc_cost_name", type: "javascript" do
     var azure_cheaper_regions = { "regions": {} }
     
     _.each(azure_supported_regions, function (supportedRegion) {
-        const region = _.find(ds_azure_regions_reference, function (item) {
-            return item.region == supportedRegion.region
-        })
+        var region = _.findWhere(ds_azure_regions_reference, { region: supportedRegion.region })
     
-        const cheaperRegion = _.find(ds_azure_regions_reference, function (item) {
-            return item.region == supportedRegion.cheaper
-        })
+        var cheaperRegion = _.findWhere(ds_azure_regions_reference, { region: supportedRegion.cheaper })
     
         if (region != undefined && cheaperRegion != undefined) {
             azure_cheaper_regions["regions"][region.name] = cheaperRegion.name
@@ -300,13 +296,9 @@ script "js_new_bc_cost_name", type: "javascript" do
     var ec2_cheaper_regions = { "regions": {} }
     
     _.each(ec2_supported_regions, function (supportedRegion) {
-        const region = _.find(ds_aws_regions_reference, function (item) {
-            return item.region == supportedRegion.region
-        })
+        var region = _.findWhere(ds_aws_regions_reference, { region: supportedRegion.region })
     
-        const cheaperRegion = _.find(ds_aws_regions_reference, function (item) {
-            return item.region == supportedRegion.cheaper
-        })
+        var cheaperRegion = _.findWhere(ds_aws_regions_reference, { region: supportedRegion.cheaper })
     
         if (region != undefined && cheaperRegion != undefined) {
             ec2_cheaper_regions["regions"][region.name] = cheaperRegion.name
@@ -322,19 +314,15 @@ script "js_new_bc_cost_name", type: "javascript" do
     var google_cheaper_regions = { "regions": {} }
     
     _.each(google_supported_regions, function (supportedRegion) {
-        const region = _.find(ds_google_regions_reference, function (item) {
-            return item.region == supportedRegion.region
-        })
+        var region = _.findWhere(ds_google_regions_reference, { region: supportedRegion.region })
     
-        const cheaperRegion = _.find(ds_google_regions_reference, function (item) {
-            return item.region == supportedRegion.cheaper
-        })
+        var cheaperRegion = _.findWhere(ds_google_regions_reference, { region: supportedRegion.cheaper })
     
         if (region != undefined && cheaperRegion != undefined) {
             google_cheaper_regions["regions"][region.region] = cheaperRegion.region
         }
     })
-    
+
     for (var i = 0; i < new_bc_costs.length; i++) {
       var arr_bc_name = _.reject(billing_centers, function(bc){ return bc.id != new_bc_costs[i].billing_center_id });
       var bc_name = arr_bc_name[0].name

--- a/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
+++ b/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
@@ -24,12 +24,16 @@ info(
 
 parameter "param_email" do
   type "list"
+  category "Policy Settings"
   label "Email addresses of the recipients you wish to notify"
+  description "A list of email addresses to notify."
 end
 
 parameter "param_billing_centers" do
   type "list"
+  category "Filters"
   label "Billing Center Name"
+  description "List of billing centers to be filtered."
   min_length 1
 end
 
@@ -45,22 +49,8 @@ credentials "auth_flexera" do
 end
 
 ###############################################################################
-# Resources
+# Datasources & Scripts
 ###############################################################################
-
-###############################################################################
-# Datasources
-###############################################################################
-
-datasource "ds_dimensions" do
-  request do
-    auth $auth_flexera
-    host rs_optima_host
-    path join(["/bill-analysis/orgs/",rs_org_id,"/costs/dimensions"])
-    header "Api-Version", "1.0"
-    header "User-Agent", "RS Policies"
-  end
-end
 
 datasource "ds_billing_centers" do
   request do
@@ -105,7 +95,7 @@ end
 
 datasource "ds_new_bc_costs" do
   request do
-    run_script $js_new_costs_request,rs_optima_host,rs_org_id,$ds_billing_centers,$param_billing_centers
+    run_script $js_new_costs_request,$ds_billing_centers,$param_billing_centers,rs_optima_host,rs_org_id
   end
   result do
     encoding "json"
@@ -129,7 +119,7 @@ end
 # Scripts
 ###############################################################################
 script "js_new_costs_request", type: "javascript" do
-  parameters "rs_optima_host", "org_id","ds_billing_centers","param_billing_centers"
+  parameters "ds_billing_centers","param_billing_centers","rs_optima_host", "org_id"
   result "request"
   code <<-EOS
     var start_at = "";
@@ -334,7 +324,7 @@ end
 # Policy
 ###############################################################################
 
-policy "policy_cheaper_regions" do
+policy "pol_cheaper_regions" do
   validate_each $ds_new_bc_cost_name do
     summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} rows with cheaper data"
     check eq(0,1)

--- a/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
+++ b/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
@@ -8,7 +8,7 @@ category "Cost"
 tenancy "single"
 default_frequency "daily"
 info(
-  version: "2.3",
+  version: "2.4",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization"
@@ -259,7 +259,16 @@ script "js_merge_bc_name", type: "javascript" do
         "EU West":    "UK South",
         "EU North":   "UK West",
         "JA East":    "KR South",
-        "JA West":    "KR South"
+        "JA West":    "KR South",
+        "West US":        "West US 2",
+        "East US":        "East US 2",
+        "Korea Central":  "Korea South",
+        "Central US":     "West US 2",
+        "Canada Central": "Canada East",
+        "West Europe":    "UK South",
+        "North Europe":   "UK West",
+        "Japan East":     "Korea South",
+        "Japan West":     "Korea South",
         }
     }
     var ec2_cheaper_regions = {
@@ -269,7 +278,9 @@ script "js_merge_bc_name", type: "javascript" do
         "EU (London)":              "EU (Ireland)",
         "EU (Frankfurt)":           "EU (Ireland)",
         "Asia Pacific (Tokyo)":     "Asia Pacific (Seoul)",
-        "Asia Pacific (Singapore)": "Asia Pacific (Mumbai)"
+        "Asia Pacific (Singapore)": "Asia Pacific (Mumbai)",
+        "Europe (London)":          "Europe (Ireland)",
+        "Europe (Frankfurt)":       "Europe (Ireland)",
       }
     }
     var google_cheaper_regions = {
@@ -280,8 +291,6 @@ script "js_merge_bc_name", type: "javascript" do
       }
     }
     for (var i = 0; i < new_bc_costs.length; i++) {
-      console.log(new_bc_costs[i])
-      console.log(new_bc_costs[i].billing_center_id)
       var arr_bc_name = _.reject(billing_centers, function(bc){ return bc.id != new_bc_costs[i].billing_center_id });
       var bc_name = arr_bc_name[0].name
       var vendor = new_bc_costs[i].vendor
@@ -293,7 +302,6 @@ script "js_merge_bc_name", type: "javascript" do
         if ( account && account.length ){
           var vendor_account_name = account[0].name
         } else {
-          console.log("aws account name is empty")
           var vendor_account_name = ""
         }
       } else if ( vendor == "AzureCSP" || vendor == "Azure" || vendor =="AzureMCA-CSP" ) {
@@ -303,8 +311,6 @@ script "js_merge_bc_name", type: "javascript" do
         var new_region = google_cheaper_regions["regions"][new_bc_costs[i].region]
         var vendor_account_name = new_bc_costs[i].vendor_account_name
       }
-      console.log(new_region)
-      console.log(bc_name)
       if (new_region != null && new_region !== undefined ) {
         results.push({
           billing_center_name: bc_name,

--- a/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
+++ b/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
@@ -8,7 +8,7 @@ category "Cost"
 tenancy "single"
 default_frequency "daily"
 info(
-  version: "2.4",
+  version: "2.4.0",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization"

--- a/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
+++ b/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
@@ -56,20 +56,20 @@ datasource "ds_billing_centers" do
   request do
     auth $auth_flexera
     host rs_optima_host
-    path join(["/analytics/orgs/",rs_org_id,"/billing_centers"])
+    path join(["/analytics/orgs/", rs_org_id, "/billing_centers"])
     query "view", "allocation_table"
     header "Api-Version", "1.0"
     header "User-Agent", "RS Policies"
   end
   result do
     encoding "json"
-    collect jmes_path(response,"[*]") do
-      field "href", jmes_path(col_item,"href")
-      field "id", jmes_path(col_item,"id")
-      field "name", jmes_path(col_item,"name")
-      field "parent_id", jmes_path(col_item,"parent_id")
-      field "ancestor_ids", jmes_path(col_item,"ancestor_ids")
-      field "allocation_table", jmes_path(col_item,"allocation_table")
+    collect jmes_path(response, "[*]") do
+      field "href", jmes_path(col_item, "href")
+      field "id", jmes_path(col_item, "id")
+      field "name", jmes_path(col_item, "name")
+      field "parent_id", jmes_path(col_item, "parent_id")
+      field "ancestor_ids", jmes_path(col_item, "ancestor_ids")
+      field "allocation_table", jmes_path(col_item, "allocation_table")
     end
   end
 end
@@ -78,28 +78,28 @@ datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
     host rs_optima_host
-    path join(["/bill-analysis/orgs/",rs_org_id,"/cloud_vendor_accounts"])
+    path join(["/bill-analysis/orgs/", rs_org_id, "/cloud_vendor_accounts"])
     query "cloud_vendor", "aws"
     header "Api-Version", "0.1"
     header "User-Agent", "RS Policies"
   end
   result do
     encoding "json"
-    collect jmes_path(response,"[*]") do
-      field "id", jmes_path(col_item,"id")
-      field "name", jmes_path(col_item,"name")
-      field "vendor_name", jmes_path(col_item,"vendor_name")
+    collect jmes_path(response, "[*]") do
+      field "id", jmes_path(col_item, "id")
+      field "name", jmes_path(col_item, "name")
+      field "vendor_name", jmes_path(col_item, "vendor_name")
     end
   end
 end
 
 datasource "ds_new_bc_costs" do
   request do
-    run_script $js_new_costs_request,$ds_billing_centers,$param_billing_centers,rs_optima_host,rs_org_id
+    run_script $js_new_costs_request, $ds_billing_centers, $param_billing_centers, rs_optima_host, rs_org_id
   end
   result do
     encoding "json"
-    collect jmes_path(response,"rows[*]") do
+    collect jmes_path(response, "rows[*]") do
       field "billing_center_id", jmes_path(col_item, "dimensions.billing_center_id")
       field "region", jmes_path(col_item, "dimensions.region")
       field "service", jmes_path(col_item, "dimensions.service")
@@ -119,7 +119,7 @@ end
 # Scripts
 ###############################################################################
 script "js_new_costs_request", type: "javascript" do
-  parameters "ds_billing_centers","param_billing_centers","rs_optima_host", "org_id"
+  parameters "ds_billing_centers", "param_billing_centers", "rs_optima_host", "org_id"
   result "request"
   code <<-EOS
     var start_at = "";
@@ -193,34 +193,34 @@ script "js_new_costs_request", type: "javascript" do
         {"type": "or",
           "expressions": [
             {"type" : "and", "expressions" : [
-              {"dimension":"vendor","type":"equal","value":"Azure"},
-              {"dimension":"resource_type","type":"substring","substring":"Virtual Machines"}
+              {"dimension":"vendor", "type":"equal", "value":"Azure"},
+              {"dimension":"resource_type", "type":"substring", "substring":"Virtual Machines"}
             ]},
             {"type" : "and", "expressions" : [
-              {"dimension":"category","type":"equal","value":"Compute"},
-              {"dimension":"vendor","type":"equal","value":"AzureCSP"},
-              {"dimension":"resource_type","type":"substring","substring":"Virtual Machines"}
+              {"dimension":"category", "type":"equal", "value":"Compute"},
+              {"dimension":"vendor", "type":"equal", "value":"AzureCSP"},
+              {"dimension":"resource_type", "type":"substring", "substring":"Virtual Machines"}
             ]},
             {"type" : "and", "expressions" : [
-              {"dimension":"category","type":"equal","value":"Compute"},
-              {"dimension":"vendor","type":"equal","value":"AWS"}
+              {"dimension":"category", "type":"equal", "value":"Compute"},
+              {"dimension":"vendor", "type":"equal", "value":"AWS"}
             ]},
             {"type" : "and", "expressions" : [
-             {"dimension":"category","type":"equal","value":"Compute"},
-             {"dimension":"vendor","type":"equal","value":"AzureMCA-Enterprise"},
+             {"dimension":"category", "type":"equal", "value":"Compute"},
+             {"dimension":"vendor", "type":"equal", "value":"AzureMCA-Enterprise"},
              {"dimension":"service", "type":"equal", value:"Microsoft.Compute"},
-             {"dimension":"resource_type","type":"substring","substring":"Virtual Machines"}
+             {"dimension":"resource_type", "type":"substring", "substring":"Virtual Machines"}
             ]},
             {"type" : "and", "expressions" : [
-             {"dimension":"category","type":"equal","value":"Compute"},
-             {"dimension":"vendor","type":"equal","value":"AzureMCA-CSP"},
+             {"dimension":"category", "type":"equal", "value":"Compute"},
+             {"dimension":"vendor", "type":"equal", "value":"AzureMCA-CSP"},
              {"dimension":"service", "type":"equal", value:"Microsoft.Compute"},
-             {"dimension":"resource_type","type":"substring","substring":"Virtual Machines"}
+             {"dimension":"resource_type", "type":"substring", "substring":"Virtual Machines"}
             ]},
             {"type" : "and", "expressions" : [
-             {"dimension":"vendor","type":"equal","value":"GCP"},
+             {"dimension":"vendor", "type":"equal", "value":"GCP"},
              {"dimension":"service", "type":"equal", value:"Compute Engine"},
-             {"dimension":"resource_type","type":"substring","substring":"*running*"}
+             {"dimension":"resource_type", "type":"substring", "substring":"*running*"}
             ]}
           ]
         }
@@ -327,7 +327,7 @@ end
 policy "pol_cheaper_regions" do
   validate_each $ds_new_bc_cost_name do
     summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} rows with cheaper data"
-    check eq(0,1)
+    check eq(0, 1)
     escalate $esc_email
     export do
       resource_level true

--- a/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
+++ b/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
@@ -61,7 +61,15 @@ end
 datasource "ds_azure_regions_reference" do
   request do
     host "raw.githubusercontent.com"
-    path "/flexera-public/policy_templates/master/data/azure/regions.json"
+    path "/flexera-public/policy_templates/FOPTS-3939/data/azure/regions.json"
+    header "User-Agent", "RS Policies"
+  end
+end
+
+datasource "ds_google_regions_reference" do
+  request do
+    host "raw.githubusercontent.com"
+    path "/flexera-public/policy_templates/FOPTS-3939/data/azure/regions.json"
     header "User-Agent", "RS Policies"
   end
 end

--- a/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
+++ b/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
@@ -5,7 +5,6 @@ short_description "Specify which regions have cheaper alternatives by specifying
 long_description ""
 severity "medium"
 category "Cost"
-tenancy "single"
 default_frequency "daily"
 info(
   version: "2.4.0",
@@ -21,7 +20,7 @@ info(
 parameter "param_email" do
   type "list"
   category "Policy Settings"
-  label "Email addresses of the recipients you wish to notify"
+  label "Email Addresses"
   description "A list of email addresses to notify."
   default []
 end
@@ -265,63 +264,48 @@ script "js_new_bc_cost_name", type: "javascript" do
   result "results"
   code <<-EOS
     var results = []
-    var azure_supported_regions = [
-      { region: "westus", cheaper: "westus2" },
-      { region: "eastus", cheaper: "eastus2" },
-      { region: "koreacentral", cheaper: "koreasouth" },
-      { region: "centralus", cheaper: "westus2" },
-      { region: "canadacentral", cheaper: "canadaeast" },
-      { region: "westeurope", cheaper: "uksouth" },
-      { region: "northeurope", cheaper: "ukwest" },
-      { region: "japaneast", cheaper: "koreasouth" },
-      { region: "japanwest", cheaper: "koreasouth" },
-    ];
+    var azure_supported_regions = _.filter(ds_azure_regions_reference, function (item) {
+      return item.cheaper != null && item.cheaper != undefined;
+    });
     
     var azure_cheaper_regions = { "regions": {} }
     
     _.each(azure_supported_regions, function (supportedRegion) {
-        var region = _.findWhere(ds_azure_regions_reference, { region: supportedRegion.region })
+        const region = _.findWhere(ds_azure_regions_reference, { region: supportedRegion.region })
     
-        var cheaperRegion = _.findWhere(ds_azure_regions_reference, { region: supportedRegion.cheaper })
+        const cheaperRegion = _.findWhere(ds_azure_regions_reference, { region: supportedRegion.cheaper })
     
         if (region != undefined && cheaperRegion != undefined) {
             azure_cheaper_regions["regions"][region.name] = cheaperRegion.name
         }
     })
     
-    var ec2_supported_regions = [
-        { region: "us-west-1", cheaper: "us-west-2" },
-        { region: "ca-central-1", cheaper: "us-east-2" },
-        { region: "eu-west-2", cheaper: "eu-west-1" },
-        { region: "eu-central-1", cheaper: "eu-west-1" },
-        { region: "ap-northeast-1", cheaper: "ap-northeast-2" },
-        { region: "ap-southeast-1", cheaper: "ap-south-1" },
-    ]
+    var ec2_supported_regions = _.filter(ds_aws_regions_reference, function (item) {
+        return item.cheaper != null && item.cheaper != undefined;
+    })
     
     var ec2_cheaper_regions = { "regions": {} }
     
     _.each(ec2_supported_regions, function (supportedRegion) {
-        var region = _.findWhere(ds_aws_regions_reference, { region: supportedRegion.region })
+        const region = _.findWhere(ds_aws_regions_reference, { region: supportedRegion.region })
     
-        var cheaperRegion = _.findWhere(ds_aws_regions_reference, { region: supportedRegion.cheaper })
+        const cheaperRegion = _.findWhere(ds_aws_regions_reference, { region: supportedRegion.cheaper })
     
         if (region != undefined && cheaperRegion != undefined) {
             ec2_cheaper_regions["regions"][region.name] = cheaperRegion.name
         }
     })
     
-    var google_supported_regions = [
-        { region: "us-east4", cheaper: "us-east1" },
-        { region: "europe-west2", cheaper: "europe-west1" },
-        { region: "europe-west3", cheaper: "europe-west1" }
-    ]
+    var google_supported_regions = _.filter(ds_google_regions_reference, function(item) {
+        return item.cheaper != null && item.cheaper != undefined;
+    });
     
     var google_cheaper_regions = { "regions": {} }
     
     _.each(google_supported_regions, function (supportedRegion) {
-        var region = _.findWhere(ds_google_regions_reference, { region: supportedRegion.region })
+        const region = _.findWhere(ds_google_regions_reference, { region: supportedRegion.region })
     
-        var cheaperRegion = _.findWhere(ds_google_regions_reference, { region: supportedRegion.cheaper })
+        const cheaperRegion = _.findWhere(ds_google_regions_reference, { region: supportedRegion.cheaper })
     
         if (region != undefined && cheaperRegion != undefined) {
             google_cheaper_regions["regions"][region.region] = cheaperRegion.region
@@ -379,7 +363,7 @@ end
 
 policy "pol_cheaper_regions" do
   validate $ds_new_bc_cost_name do
-    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Cheaper Regions Found"
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Instances With Cheaper Regions Found"
     check eq(size(data), 0)
     escalate $esc_email
     export do

--- a/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
+++ b/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
@@ -31,7 +31,6 @@ parameter "param_billing_centers" do
   category "Filters"
   label "Billing Center Name"
   description "List of billing centers to be filtered."
-  min_length 1
   default []
 end
 

--- a/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
+++ b/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
@@ -134,7 +134,7 @@ datasource "ds_new_bc_costs" do
 end
 
 datasource "ds_new_bc_cost_name" do
-  run_script $js_new_bc_cost_name, $ds_new_bc_costs, $ds_billing_centers, $ds_cloud_vendor_accounts
+  run_script $js_new_bc_cost_name, $ds_new_bc_costs, $ds_billing_centers, $ds_cloud_vendor_accounts, $ds_aws_regions_reference, $ds_azure_regions_reference, $ds_google_regions_reference
 end
 
 ###############################################################################
@@ -256,51 +256,85 @@ script "js_new_bc_costs", type: "javascript" do
 end
 
 script "js_new_bc_cost_name", type: "javascript" do
-  parameters "new_bc_costs", "billing_centers", "ds_cloud_vendor_accounts"
+  parameters "new_bc_costs", "billing_centers", "ds_cloud_vendor_accounts", "ds_aws_regions_reference", "ds_azure_regions_reference", "ds_google_regions_reference"
   result "results"
   code <<-EOS
     var results = []
-    var azure_cheaper_regions = {
-      "regions": {
-        "US West":    "US West 2",
-        "US East":    "US East 2",
-        "KR Central": "KR South",
-        "US Central": "US West 2",
-        "CA Central": "CA East",
-        "EU West":    "UK South",
-        "EU North":   "UK West",
-        "JA East":    "KR South",
-        "JA West":    "KR South",
-        "West US":        "West US 2",
-        "East US":        "East US 2",
-        "Korea Central":  "Korea South",
-        "Central US":     "West US 2",
-        "Canada Central": "Canada East",
-        "West Europe":    "UK South",
-        "North Europe":   "UK West",
-        "Japan East":     "Korea South",
-        "Japan West":     "Korea South",
+    var azure_supported_regions = [
+      { region: "westus", cheaper: "westus2" },
+      { region: "eastus", cheaper: "eastus2" },
+      { region: "koreacentral", cheaper: "koreasouth" },
+      { region: "centralus", cheaper: "westus2" },
+      { region: "canadacentral", cheaper: "canadaeast" },
+      { region: "westeurope", cheaper: "uksouth" },
+      { region: "northeurope", cheaper: "ukwest" },
+      { region: "japaneast", cheaper: "koreasouth" },
+      { region: "japanwest", cheaper: "koreasouth" },
+    ];
+    
+    var azure_cheaper_regions = { "regions": {} }
+    
+    _.each(azure_supported_regions, function (supportedRegion) {
+        const region = _.find(ds_azure_regions_reference, function (item) {
+            return item.region == supportedRegion.region
+        })
+    
+        const cheaperRegion = _.find(ds_azure_regions_reference, function (item) {
+            return item.region == supportedRegion.cheaper
+        })
+    
+        if (region != undefined && cheaperRegion != undefined) {
+            azure_cheaper_regions["regions"][region.name] = cheaperRegion.name
         }
-    }
-    var ec2_cheaper_regions = {
-      "regions": {
-        "US West (N. California)":  "US West (Oregon)",
-        "Canada (Central)":         "US East (Ohio)",
-        "EU (London)":              "EU (Ireland)",
-        "EU (Frankfurt)":           "EU (Ireland)",
-        "Asia Pacific (Tokyo)":     "Asia Pacific (Seoul)",
-        "Asia Pacific (Singapore)": "Asia Pacific (Mumbai)",
-        "Europe (London)":          "Europe (Ireland)",
-        "Europe (Frankfurt)":       "Europe (Ireland)",
-      }
-    }
-    var google_cheaper_regions = {
-      "regions" : {
-        "us-east4":     "us-east1",
-        "europe-west2": "europe-west1",
-        "europe-west3": "europe-west1"
-      }
-    }
+    })
+    
+    var ec2_supported_regions = [
+        { region: "us-west-1", cheaper: "us-west-2" },
+        { region: "ca-central-1", cheaper: "us-east-2" },
+        { region: "eu-west-2", cheaper: "eu-west-1" },
+        { region: "eu-central-1", cheaper: "eu-west-1" },
+        { region: "ap-northeast-1", cheaper: "ap-northeast-2" },
+        { region: "ap-southeast-1", cheaper: "ap-south-1" },
+    ]
+    
+    var ec2_cheaper_regions = { "regions": {} }
+    
+    _.each(ec2_supported_regions, function (supportedRegion) {
+        const region = _.find(ds_aws_regions_reference, function (item) {
+            return item.region == supportedRegion.region
+        })
+    
+        const cheaperRegion = _.find(ds_aws_regions_reference, function (item) {
+            return item.region == supportedRegion.cheaper
+        })
+    
+        if (region != undefined && cheaperRegion != undefined) {
+            ec2_cheaper_regions["regions"][region.name] = cheaperRegion.name
+        }
+    })
+    
+    var google_supported_regions = [
+        { region: "us-east4", cheaper: "us-east1" },
+        { region: "europe-west2", cheaper: "europe-west1" },
+        { region: "europe-west3", cheaper: "europe-west1" }
+    ]
+    
+    var google_cheaper_regions = { "regions": {} }
+    
+    _.each(google_supported_regions, function (supportedRegion) {
+        const region = _.find(ds_google_regions_reference, function (item) {
+            return item.region == supportedRegion.region
+        })
+    
+        const cheaperRegion = _.find(ds_google_regions_reference, function (item) {
+            return item.region == supportedRegion.cheaper
+        })
+    
+        if (region != undefined && cheaperRegion != undefined) {
+            google_cheaper_regions["regions"][region.region] = cheaperRegion.region
+        }
+    })
+    
     for (var i = 0; i < new_bc_costs.length; i++) {
       var arr_bc_name = _.reject(billing_centers, function(bc){ return bc.id != new_bc_costs[i].billing_center_id });
       var bc_name = arr_bc_name[0].name

--- a/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
+++ b/cost/flexera/cco/cheaper_regions/cheaper_regions.pt
@@ -18,21 +18,21 @@ info(
 # Parameters
 ###############################################################################
 
-# No default value, user input required
 parameter "param_email" do
   type "list"
   category "Policy Settings"
   label "Email addresses of the recipients you wish to notify"
   description "A list of email addresses to notify."
+  # No default value, user input required
 end
 
-# No default value, user input required
 parameter "param_billing_centers" do
   type "list"
   category "Filters"
   label "Billing Center Name"
   description "List of billing centers to be filtered."
   min_length 1
+  # No default value, user input required
 end
 
 ###############################################################################
@@ -49,6 +49,22 @@ end
 ###############################################################################
 # Datasources & Scripts
 ###############################################################################
+
+datasource "ds_aws_regions_reference" do
+  request do
+    host "raw.githubusercontent.com"
+    path "/flexera-public/policy_templates/master/data/aws/regions.json"
+    header "User-Agent", "RS Policies"
+  end
+end
+
+datasource "ds_azure_regions_reference" do
+  request do
+    host "raw.githubusercontent.com"
+    path "/flexera-public/policy_templates/master/data/azure/regions.json"
+    header "User-Agent", "RS Policies"
+  end
+end
 
 datasource "ds_billing_centers" do
   request do

--- a/data/aws/regions.json
+++ b/data/aws/regions.json
@@ -9,7 +9,8 @@
   },
   {
     "name": "US West (N. California)",
-    "region": "us-west-1"
+    "region": "us-west-1",
+    "cheaper": "us-west-2"
   },
   {
     "name": "US West (Oregon)",
@@ -49,7 +50,8 @@
   },
   {
     "name": "Asia Pacific (Singapore)",
-    "region": "ap-southeast-1"
+    "region": "ap-southeast-1",
+    "cheaper": "ap-south-1"
   },
   {
     "name": "Asia Pacific (Sydney)",
@@ -57,11 +59,13 @@
   },
   {
     "name": "Asia Pacific (Tokyo)",
-    "region": "ap-northeast-1"
+    "region": "ap-northeast-1",
+    "cheaper": "ap-northeast-2"
   },
   {
     "name": "Canada (Central)",
-    "region": "ca-central-1"
+    "region": "ca-central-1",
+    "cheaper": "us-east-2"
   },
   {
     "name": "Canada West (Calgary)",
@@ -69,7 +73,8 @@
   },
   {
     "name": "Europe (Frankfurt)",
-    "region": "eu-central-1"
+    "region": "eu-central-1",
+    "cheaper": "eu-west-1"
   },
   {
     "name": "Europe (Ireland)",
@@ -77,7 +82,8 @@
   },
   {
     "name": "Europe (London)",
-    "region": "eu-west-2"
+    "region": "eu-west-2",
+    "cheaper": "eu-west-1"
   },
   {
     "name": "Europe (Milan)",
@@ -112,7 +118,7 @@
     "region": "me-central-1"
   },
   {
-    "name": "South America (São Paulo)",
+    "name": "South America (Sï¿½o Paulo)",
     "region": "sa-east-1"
   },
   {

--- a/data/aws/regions.json
+++ b/data/aws/regions.json
@@ -1,11 +1,13 @@
 [
   {
     "name": "US East (Ohio)",
-    "region": "us-east-2"
+    "region": "us-east-2",
+    "cheaper": null
   },
   {
     "name": "US East (N. Virginia)",
-    "region": "us-east-1"
+    "region": "us-east-1",
+    "cheaper": null
   },
   {
     "name": "US West (N. California)",
@@ -14,39 +16,48 @@
   },
   {
     "name": "US West (Oregon)",
-    "region": "us-west-2"
+    "region": "us-west-2",
+    "cheaper": null
   },
   {
     "name": "Africa (Cape Town)",
-    "region": "af-south-1"
+    "region": "af-south-1",
+    "cheaper": null
   },
   {
     "name": "Asia Pacific (Hong Kong)",
-    "region": "ap-east-1"
+    "region": "ap-east-1",
+    "cheaper": null
   },
   {
     "name": "Asia Pacific (Hyderabad)",
-    "region": "ap-south-2"
+    "region": "ap-south-2",
+    "cheaper": null
   },
   {
     "name": "Asia Pacific (Jakarta)",
-    "region": "ap-southeast-3"
+    "region": "ap-southeast-3",
+    "cheaper": null
   },
   {
     "name": "Asia Pacific (Melbourne)",
-    "region": "ap-southeast-4"
+    "region": "ap-southeast-4",
+    "cheaper": null
   },
   {
     "name": "Asia Pacific (Mumbai)",
-    "region": "ap-south-1"
+    "region": "ap-south-1",
+    "cheaper": null
   },
   {
     "name": "Asia Pacific (Osaka)",
-    "region": "ap-northeast-3"
+    "region": "ap-northeast-3",
+    "cheaper": null
   },
   {
     "name": "Asia Pacific (Seoul)",
-    "region": "ap-northeast-2"
+    "region": "ap-northeast-2",
+    "cheaper": null
   },
   {
     "name": "Asia Pacific (Singapore)",
@@ -55,7 +66,8 @@
   },
   {
     "name": "Asia Pacific (Sydney)",
-    "region": "ap-southeast-2"
+    "region": "ap-southeast-2",
+    "cheaper": null
   },
   {
     "name": "Asia Pacific (Tokyo)",
@@ -69,7 +81,8 @@
   },
   {
     "name": "Canada West (Calgary)",
-    "region": "ca-west-1"
+    "region": "ca-west-1",
+    "cheaper": null
   },
   {
     "name": "Europe (Frankfurt)",
@@ -78,7 +91,8 @@
   },
   {
     "name": "Europe (Ireland)",
-    "region": "eu-west-1"
+    "region": "eu-west-1",
+    "cheaper": null
   },
   {
     "name": "Europe (London)",
@@ -87,46 +101,57 @@
   },
   {
     "name": "Europe (Milan)",
-    "region": "eu-south-1"
+    "region": "eu-south-1",
+    "cheaper": null
   },
   {
     "name": "Europe (Paris)",
-    "region": "eu-west-3"
+    "region": "eu-west-3",
+    "cheaper": null
   },
   {
     "name": "Europe (Spain)",
-    "region": "eu-south-2"
+    "region": "eu-south-2",
+    "cheaper": null
   },
   {
     "name": "Europe (Stockholm)",
-    "region": "eu-north-1"
+    "region": "eu-north-1",
+    "cheaper": null
   },
   {
     "name": "Europe (Zurich)",
-    "region": "eu-central-2"
+    "region": "eu-central-2",
+    "cheaper": null
   },
   {
     "name": "Israel (Tel Aviv)",
-    "region": "il-central-1"
+    "region": "il-central-1",
+    "cheaper": null
   },
   {
     "name": "Middle East (Bahrain)",
-    "region": "me-south-1"
+    "region": "me-south-1",
+    "cheaper": null
   },
   {
     "name": "Middle East (UAE)",
-    "region": "me-central-1"
+    "region": "me-central-1",
+    "cheaper": null
   },
   {
     "name": "South America (S�o Paulo)",
-    "region": "sa-east-1"
+    "region": "sa-east-1",
+    "cheaper": null
   },
   {
     "name": "AWS GovCloud (US-East)",
-    "region": "us-gov-east-1"
+    "region": "us-gov-east-1",
+    "cheaper": null
   },
   {
     "name": "AWS GovCloud (US-West)",
-    "region": "us-gov-west-1"
+    "region": "us-gov-west-1",
+    "cheaper": null
   }
 ]

--- a/data/azure/regions.json
+++ b/data/azure/regions.json
@@ -1,0 +1,326 @@
+[
+  {
+    "name": "East US",
+    "region": "eastus"
+  },
+  {
+    "name": "East US 2",
+    "region": "eastus2"
+  },
+  {
+    "name": "South Central US",
+    "region": "southcentralus"
+  },
+  {
+    "name": "West US 2",
+    "region": "westus2"
+  },
+  {
+    "name": "West US 3",
+    "region": "westus3"
+  },
+  {
+    "name": "Australia East",
+    "region": "australiaeast"
+  },
+  {
+    "name": "Southeast Asia",
+    "region": "southeastasia"
+  },
+  {
+    "name": "North Europe",
+    "region": "northeurope"
+  },
+  {
+    "name": "Sweden Central",
+    "region": "swedencentral"
+  },
+  {
+    "name": "UK South",
+    "region": "uksouth"
+  },
+  {
+    "name": "West Europe",
+    "region": "westeurope"
+  },
+  {
+    "name": "Central US",
+    "region": "centralus"
+  },
+  {
+    "name": "South Africa North",
+    "region": "southafricanorth"
+  },
+  {
+    "name": "Central India",
+    "region": "centralindia"
+  },
+  {
+    "name": "East Asia",
+    "region": "eastasia"
+  },
+  {
+    "name": "Japan East",
+    "region": "japaneast"
+  },
+  {
+    "name": "Korea Central",
+    "region": "koreacentral"
+  },
+  {
+    "name": "Canada Central",
+    "region": "canadacentral"
+  },
+  {
+    "name": "France Central",
+    "region": "francecentral"
+  },
+  {
+    "name": "Germany West Central",
+    "region": "germanywestcentral"
+  },
+  {
+    "name": "Norway East",
+    "region": "norwayeast"
+  },
+  {
+    "name": "Poland Central",
+    "region": "polandcentral"
+  },
+  {
+    "name": "Switzerland North",
+    "region": "switzerlandnorth"
+  },
+  {
+    "name": "UAE North",
+    "region": "uaenorth"
+  },
+  {
+    "name": "Brazil South",
+    "region": "brazilsouth"
+  },
+  {
+    "name": "Central US EUAP",
+    "region": "centraluseuap"
+  },
+  {
+    "name": "Qatar Central",
+    "region": "qatarcentral"
+  },
+  {
+    "name": "Central US (Stage)",
+    "region": "centralusstage"
+  },
+  {
+    "name": "East US (Stage)",
+    "region": "eastusstage"
+  },
+  {
+    "name": "East US 2 (Stage)",
+    "region": "eastus2stage"
+  },
+  {
+    "name": "North Central US (Stage)",
+    "region": "northcentralusstage"
+  },
+  {
+    "name": "South Central US (Stage)",
+    "region": "southcentralusstage"
+  },
+  {
+    "name": "West US (Stage)",
+    "region": "westusstage"
+  },
+  {
+    "name": "West US 2 (Stage)",
+    "region": "westus2stage"
+  },
+  {
+    "name": "Asia",
+    "region": "asia"
+  },
+  {
+    "name": "Asia Pacific",
+    "region": "asiapacific"
+  },
+  {
+    "name": "Australia",
+    "region": "australia"
+  },
+  {
+    "name": "Brazil",
+    "region": "brazil"
+  },
+  {
+    "name": "Canada",
+    "region": "canada"
+  },
+  {
+    "name": "Europe",
+    "region": "europe"
+  },
+  {
+    "name": "France",
+    "region": "france"
+  },
+  {
+    "name": "Germany",
+    "region": "germany"
+  },
+  {
+    "name": "Global",
+    "region": "global"
+  },
+  {
+    "name": "India",
+    "region": "india"
+  },
+  {
+    "name": "Japan",
+    "region": "japan"
+  },
+  {
+    "name": "Korea",
+    "region": "korea"
+  },
+  {
+    "name": "Norway",
+    "region": "norway"
+  },
+  {
+    "name": "Singapore",
+    "region": "singapore"
+  },
+  {
+    "name": "South Africa",
+    "region": "southafrica"
+  },
+  {
+    "name": "Switzerland",
+    "region": "switzerland"
+  },
+  {
+    "name": "United Arab Emirates",
+    "region": "uae"
+  },
+  {
+    "name": "United Kingdom",
+    "region": "uk"
+  },
+  {
+    "name": "United States",
+    "region": "unitedstates"
+  },
+  {
+    "name": "United States EUAP",
+    "region": "unitedstateseuap"
+  },
+  {
+    "name": "East Asia (Stage)",
+    "region": "eastasiastage"
+  },
+  {
+    "name": "Southeast Asia (Stage)",
+    "region": "southeastasiastage"
+  },
+  {
+    "name": "Brazil US",
+    "region": "brazilus"
+  },
+  {
+    "name": "East US STG",
+    "region": "eastusstg"
+  },
+  {
+    "name": "North Central US",
+    "region": "northcentralus"
+  },
+  {
+    "name": "West US",
+    "region": "westus"
+  },
+  {
+    "name": "Jio India West",
+    "region": "jioindiawest"
+  },
+  {
+    "name": "East US 2 EUAP",
+    "region": "eastus2euap"
+  },
+  {
+    "name": "South Central US STG",
+    "region": "southcentralusstg"
+  },
+  {
+    "name": "West Central US",
+    "region": "westcentralus"
+  },
+  {
+    "name": "South Africa West",
+    "region": "southafricawest"
+  },
+  {
+    "name": "Australia Central",
+    "region": "australiacentral"
+  },
+  {
+    "name": "Australia Central 2",
+    "region": "australiacentral2"
+  },
+  {
+    "name": "Australia Southeast",
+    "region": "australiasoutheast"
+  },
+  {
+    "name": "Japan West",
+    "region": "japanwest"
+  },
+  {
+    "name": "Jio India Central",
+    "region": "jioindiacentral"
+  },
+  {
+    "name": "Korea South",
+    "region": "koreasouth"
+  },
+  {
+    "name": "South India",
+    "region": "southindia"
+  },
+  {
+    "name": "West India",
+    "region": "westindia"
+  },
+  {
+    "name": "Canada East",
+    "region": "canadaeast"
+  },
+  {
+    "name": "France South",
+    "region": "francesouth"
+  },
+  {
+    "name": "Germany North",
+    "region": "germanynorth"
+  },
+  {
+    "name": "Norway West",
+    "region": "norwaywest"
+  },
+  {
+    "name": "Switzerland West",
+    "region": "switzerlandwest"
+  },
+  {
+    "name": "UK West",
+    "region": "ukwest"
+  },
+  {
+    "name": "UAE Central",
+    "region": "uaecentral"
+  },
+  {
+    "name": "Brazil Southeast",
+    "region": "brazilsoutheast"
+  }
+]

--- a/data/azure/regions.json
+++ b/data/azure/regions.json
@@ -1,7 +1,8 @@
 [
   {
     "name": "East US",
-    "region": "eastus"
+    "region": "eastus",
+    "cheaper": "eastus2"
   },
   {
     "name": "East US 2",
@@ -29,7 +30,8 @@
   },
   {
     "name": "North Europe",
-    "region": "northeurope"
+    "region": "northeurope",
+    "cheaper": "ukwest"
   },
   {
     "name": "Sweden Central",
@@ -41,11 +43,13 @@
   },
   {
     "name": "West Europe",
-    "region": "westeurope"
+    "region": "westeurope",
+    "cheaper": "uksouth"
   },
   {
     "name": "Central US",
-    "region": "centralus"
+    "region": "centralus",
+    "cheaper": "westus2"
   },
   {
     "name": "South Africa North",
@@ -61,15 +65,18 @@
   },
   {
     "name": "Japan East",
-    "region": "japaneast"
+    "region": "japaneast",
+    "cheaper": "koreasouth"
   },
   {
     "name": "Korea Central",
-    "region": "koreacentral"
+    "region": "koreacentral",
+    "cheaper": "koreasouth"
   },
   {
     "name": "Canada Central",
-    "region": "canadacentral"
+    "region": "canadacentral",
+    "cheaper": "canadaeast"
   },
   {
     "name": "France Central",
@@ -237,7 +244,8 @@
   },
   {
     "name": "West US",
-    "region": "westus"
+    "region": "westus",
+    "cheaper": "westus2"
   },
   {
     "name": "Jio India West",
@@ -273,7 +281,8 @@
   },
   {
     "name": "Japan West",
-    "region": "japanwest"
+    "region": "japanwest",
+    "cheaper": "koreasouth"
   },
   {
     "name": "Jio India Central",

--- a/data/azure/regions.json
+++ b/data/azure/regions.json
@@ -6,27 +6,33 @@
   },
   {
     "name": "East US 2",
-    "region": "eastus2"
+    "region": "eastus2",
+    "cheaper": null
   },
   {
     "name": "South Central US",
-    "region": "southcentralus"
+    "region": "southcentralus",
+    "cheaper": null
   },
   {
     "name": "West US 2",
-    "region": "westus2"
+    "region": "westus2",
+    "cheaper": null
   },
   {
     "name": "West US 3",
-    "region": "westus3"
+    "region": "westus3",
+    "cheaper": null
   },
   {
     "name": "Australia East",
-    "region": "australiaeast"
+    "region": "australiaeast",
+    "cheaper": null
   },
   {
     "name": "Southeast Asia",
-    "region": "southeastasia"
+    "region": "southeastasia",
+    "cheaper": null
   },
   {
     "name": "North Europe",
@@ -35,11 +41,13 @@
   },
   {
     "name": "Sweden Central",
-    "region": "swedencentral"
+    "region": "swedencentral",
+    "cheaper": null
   },
   {
     "name": "UK South",
-    "region": "uksouth"
+    "region": "uksouth",
+    "cheaper": null
   },
   {
     "name": "West Europe",
@@ -53,15 +61,18 @@
   },
   {
     "name": "South Africa North",
-    "region": "southafricanorth"
+    "region": "southafricanorth",
+    "cheaper": null
   },
   {
     "name": "Central India",
-    "region": "centralindia"
+    "region": "centralindia",
+    "cheaper": null
   },
   {
     "name": "East Asia",
-    "region": "eastasia"
+    "region": "eastasia",
+    "cheaper": null
   },
   {
     "name": "Japan East",
@@ -80,167 +91,208 @@
   },
   {
     "name": "France Central",
-    "region": "francecentral"
+    "region": "francecentral",
+    "cheaper": null
   },
   {
     "name": "Germany West Central",
-    "region": "germanywestcentral"
+    "region": "germanywestcentral",
+    "cheaper": null
   },
   {
     "name": "Norway East",
-    "region": "norwayeast"
+    "region": "norwayeast",
+    "cheaper": null
   },
   {
     "name": "Poland Central",
-    "region": "polandcentral"
+    "region": "polandcentral",
+    "cheaper": null
   },
   {
     "name": "Switzerland North",
-    "region": "switzerlandnorth"
+    "region": "switzerlandnorth",
+    "cheaper": null
   },
   {
     "name": "UAE North",
-    "region": "uaenorth"
+    "region": "uaenorth",
+    "cheaper": null
   },
   {
     "name": "Brazil South",
-    "region": "brazilsouth"
+    "region": "brazilsouth",
+    "cheaper": null
   },
   {
     "name": "Central US EUAP",
-    "region": "centraluseuap"
+    "region": "centraluseuap",
+    "cheaper": null
   },
   {
     "name": "Qatar Central",
-    "region": "qatarcentral"
+    "region": "qatarcentral",
+    "cheaper": null
   },
   {
     "name": "Central US (Stage)",
-    "region": "centralusstage"
+    "region": "centralusstage",
+    "cheaper": null
   },
   {
     "name": "East US (Stage)",
-    "region": "eastusstage"
+    "region": "eastusstage",
+    "cheaper": null
   },
   {
     "name": "East US 2 (Stage)",
-    "region": "eastus2stage"
+    "region": "eastus2stage",
+    "cheaper": null
   },
   {
     "name": "North Central US (Stage)",
-    "region": "northcentralusstage"
+    "region": "northcentralusstage",
+    "cheaper": null
   },
   {
     "name": "South Central US (Stage)",
-    "region": "southcentralusstage"
+    "region": "southcentralusstage",
+    "cheaper": null
   },
   {
     "name": "West US (Stage)",
-    "region": "westusstage"
+    "region": "westusstage",
+    "cheaper": null
   },
   {
     "name": "West US 2 (Stage)",
-    "region": "westus2stage"
+    "region": "westus2stage",
+    "cheaper": null
   },
   {
     "name": "Asia",
-    "region": "asia"
+    "region": "asia",
+    "cheaper": null
   },
   {
     "name": "Asia Pacific",
-    "region": "asiapacific"
+    "region": "asiapacific",
+    "cheaper": null
   },
   {
     "name": "Australia",
-    "region": "australia"
+    "region": "australia",
+    "cheaper": null
   },
   {
     "name": "Brazil",
-    "region": "brazil"
+    "region": "brazil",
+    "cheaper": null
   },
   {
     "name": "Canada",
-    "region": "canada"
+    "region": "canada",
+    "cheaper": null
   },
   {
     "name": "Europe",
-    "region": "europe"
+    "region": "europe",
+    "cheaper": null
   },
   {
     "name": "France",
-    "region": "france"
+    "region": "france",
+    "cheaper": null
   },
   {
     "name": "Germany",
-    "region": "germany"
+    "region": "germany",
+    "cheaper": null
   },
   {
     "name": "Global",
-    "region": "global"
+    "region": "global",
+    "cheaper": null
   },
   {
     "name": "India",
-    "region": "india"
+    "region": "india",
+    "cheaper": null
   },
   {
     "name": "Japan",
-    "region": "japan"
+    "region": "japan",
+    "cheaper": null
   },
   {
     "name": "Korea",
-    "region": "korea"
+    "region": "korea",
+    "cheaper": null
   },
   {
     "name": "Norway",
-    "region": "norway"
+    "region": "norway",
+    "cheaper": null
   },
   {
     "name": "Singapore",
-    "region": "singapore"
+    "region": "singapore",
+    "cheaper": null
   },
   {
     "name": "South Africa",
-    "region": "southafrica"
+    "region": "southafrica",
+    "cheaper": null
   },
   {
     "name": "Switzerland",
-    "region": "switzerland"
+    "region": "switzerland",
+    "cheaper": null
   },
   {
     "name": "United Arab Emirates",
-    "region": "uae"
+    "region": "uae",
+    "cheaper": null
   },
   {
     "name": "United Kingdom",
-    "region": "uk"
+    "region": "uk",
+    "cheaper": null
   },
   {
     "name": "United States",
-    "region": "unitedstates"
+    "region": "unitedstates",
+    "cheaper": null
   },
   {
     "name": "United States EUAP",
-    "region": "unitedstateseuap"
+    "region": "unitedstateseuap",
+    "cheaper": null
   },
   {
     "name": "East Asia (Stage)",
-    "region": "eastasiastage"
+    "region": "eastasiastage",
+    "cheaper": null
   },
   {
     "name": "Southeast Asia (Stage)",
-    "region": "southeastasiastage"
+    "region": "southeastasiastage",
+    "cheaper": null
   },
   {
     "name": "Brazil US",
-    "region": "brazilus"
+    "region": "brazilus",
+    "cheaper": null
   },
   {
     "name": "East US STG",
-    "region": "eastusstg"
+    "region": "eastusstg",
+    "cheaper": null
   },
   {
     "name": "North Central US",
-    "region": "northcentralus"
+    "region": "northcentralus",
+    "cheaper": null
   },
   {
     "name": "West US",
@@ -249,35 +301,43 @@
   },
   {
     "name": "Jio India West",
-    "region": "jioindiawest"
+    "region": "jioindiawest",
+    "cheaper": null
   },
   {
     "name": "East US 2 EUAP",
-    "region": "eastus2euap"
+    "region": "eastus2euap",
+    "cheaper": null
   },
   {
     "name": "South Central US STG",
-    "region": "southcentralusstg"
+    "region": "southcentralusstg",
+    "cheaper": null
   },
   {
     "name": "West Central US",
-    "region": "westcentralus"
+    "region": "westcentralus",
+    "cheaper": null
   },
   {
     "name": "South Africa West",
-    "region": "southafricawest"
+    "region": "southafricawest",
+    "cheaper": null
   },
   {
     "name": "Australia Central",
-    "region": "australiacentral"
+    "region": "australiacentral",
+    "cheaper": null
   },
   {
     "name": "Australia Central 2",
-    "region": "australiacentral2"
+    "region": "australiacentral2",
+    "cheaper": null
   },
   {
     "name": "Australia Southeast",
-    "region": "australiasoutheast"
+    "region": "australiasoutheast",
+    "cheaper": null
   },
   {
     "name": "Japan West",
@@ -286,50 +346,62 @@
   },
   {
     "name": "Jio India Central",
-    "region": "jioindiacentral"
+    "region": "jioindiacentral",
+    "cheaper": null
   },
   {
     "name": "Korea South",
-    "region": "koreasouth"
+    "region": "koreasouth",
+    "cheaper": null
   },
   {
     "name": "South India",
-    "region": "southindia"
+    "region": "southindia",
+    "cheaper": null
   },
   {
     "name": "West India",
-    "region": "westindia"
+    "region": "westindia",
+    "cheaper": null
   },
   {
     "name": "Canada East",
-    "region": "canadaeast"
+    "region": "canadaeast",
+    "cheaper": null
   },
   {
     "name": "France South",
-    "region": "francesouth"
+    "region": "francesouth",
+    "cheaper": null
   },
   {
     "name": "Germany North",
-    "region": "germanynorth"
+    "region": "germanynorth",
+    "cheaper": null
   },
   {
     "name": "Norway West",
-    "region": "norwaywest"
+    "region": "norwaywest",
+    "cheaper": null
   },
   {
     "name": "Switzerland West",
-    "region": "switzerlandwest"
+    "region": "switzerlandwest",
+    "cheaper": null
   },
   {
     "name": "UK West",
-    "region": "ukwest"
+    "region": "ukwest",
+    "cheaper": null
   },
   {
     "name": "UAE Central",
-    "region": "uaecentral"
+    "region": "uaecentral",
+    "cheaper": null
   },
   {
     "name": "Brazil Southeast",
-    "region": "brazilsoutheast"
+    "region": "brazilsoutheast",
+    "cheaper": null
   }
 ]

--- a/data/google/regions.json
+++ b/data/google/regions.json
@@ -1,63 +1,78 @@
 [
   {
     "name": "Asia Pacific Changhua County, Taiwan",
-    "region": "asia-east1"
+    "region": "asia-east1",
+    "cheaper": null
   },
   {
     "name": "Asia Pacific Hong Kong",
-    "region": "asia-east2"
+    "region": "asia-east2",
+    "cheaper": null
   },
   {
     "name": "Asia Pacific Tokyo, Japan",
-    "region": "asia-northeast1"
+    "region": "asia-northeast1",
+    "cheaper": null
   },
   {
     "name": "Asia Pacific Osaka, Japan",
-    "region": "asia-northeast2"
+    "region": "asia-northeast2",
+    "cheaper": null
   },
   {
     "name": "Asia Pacific Seoul, South Korea",
-    "region": "asia-northeast3"
+    "region": "asia-northeast3",
+    "cheaper": null
   },
   {
     "name": "Asia Pacific Mumbai, India",
-    "region": "asia-south1"
+    "region": "asia-south1",
+    "cheaper": null
   },
   {
     "name": "Asia Pacific Delhi, India",
-    "region": "asia-south2"
+    "region": "asia-south2",
+    "cheaper": null
   },
   {
     "name": "Asia Pacific Jurong West, Singapore:",
-    "region": "asia-southeast1"
+    "region": "asia-southeast1",
+    "cheaper": null
   },
   {
     "name": "Asia Pacific Jakarta, Indonesia:",
-    "region": "asia-southeast2"
+    "region": "asia-southeast2",
+    "cheaper": null
   },
   {
     "name": "Asia Pacific Sydney, Australia:",
-    "region": "australia-southeast1"
+    "region": "australia-southeast1",
+    "cheaper": null
   },
   {
     "name": "Asia Pacific Melbourne, Australia:",
-    "region": "australia-southeast2"
+    "region": "australia-southeast2",
+    "cheaper": null
   },
   {
     "name": "EU Central Warsaw, Poland:",
-    "region": "europe-central2"
+    "region": "europe-central2",
+    "cheaper": null
   },
   {
     "name": "EU Hamina, Finland:",
-    "region": "europe-north1"
+    "region": "europe-north1",
+    "cheaper": null
   },
   {
     "name": "EU Madrid, Spain:",
-    "region": "europe-southwest1"
+    "region": "europe-southwest1",
+    "cheaper": null
   },
   {
     "name": "EU West St. Ghislain, Belgium:",
-    "region": "europe-west1"
+    "region": "europe-west1",
+    "cheaper": null
   },
   {
     "name": "EU West London, England, UK",
@@ -71,55 +86,68 @@
   },
   {
     "name": "EU West Eemshaven, Netherlands",
-    "region": "europe-west4"
+    "region": "europe-west4",
+    "cheaper": null
   },
   {
     "name": "EU West Zurish, Switzerland",
-    "region": "europe-west6"
+    "region": "europe-west6",
+    "cheaper": null
   },
   {
     "name": "EU West Milan, Italy",
-    "region": "europe-west8"
+    "region": "europe-west8",
+    "cheaper": null
   },
   {
     "name": "EU West Paris, France",
-    "region": "europe-west9"
+    "region": "europe-west9",
+    "cheaper": null
   },
   {
     "name": "EU West Turin, Italy",
-    "region": "europe-west1"
+    "region": "europe-west1",
+    "cheaper": null
   },
   {
     "name": "Middle East Doha, Qatar",
-    "region": "me-central1"
+    "region": "me-central1",
+    "cheaper": null
   },
   {
     "name": "Middle East Tel Aviv, Israel",
-    "region": "me-west1"
+    "region": "me-west1",
+    "cheaper": null
   },
   {
     "name": "North America Montréal, Québec, Canada",
-    "region": "northamerica-northeast1"
+    "region": "northamerica-northeast1",
+    "cheaper": null
   },
   {
     "name": "North America Toronto, Ontario, Canada",
-    "region": "northamerica-northeast2"
+    "region": "northamerica-northeast2",
+    "cheaper": null
   },
   {
     "name": "South America São Paulo, Brazil",
-    "region": "southamerica-east1"
+    "region": "southamerica-east1",
+    "cheaper": null
   },
   {
     "name": "South America Santiago, Chile",
-    "region": "southamerica-east2"
+    "region": "southamerica-east2",
+    "cheaper": null
   },
   {
     "name": "US Central Council Bluffs, Iowa, USA",
-    "region": "us-central1"
+    "region": "us-central1",
+    "cheaper": null
   },
   {
     "name": "US East Moncks Corner, South Carolina, USA",
-    "region": "us-east1"
+    "region": "us-east1",
+    "cheaper": null
   },
   {
     "name": "US East Ashburn, Northern Virginia, USA",
@@ -128,26 +156,32 @@
   },
   {
     "name": "US East Columbus, Ohio, North America, USA",
-    "region": "us-east5"
+    "region": "us-east5",
+    "cheaper": null
   },
   {
     "name": "US South Dallas, Texas, USA",
-    "region": "us-south1"
+    "region": "us-south1",
+    "cheaper": null
   },
   {
     "name": "US West The Dalles, Oregon, USA",
-    "region": "us-west1"
+    "region": "us-west1",
+    "cheaper": null
   },
   {
     "name": "US West Los Angeles, California, USA",
-    "region": "us-west2"
+    "region": "us-west2",
+    "cheaper": null
   },
   {
     "name": "US West Salt Lake City, Utah, USA",
-    "region": "us-west3"
+    "region": "us-west3",
+    "cheaper": null
   },
   {
     "name": "US West Las Vegas, Nevada, USA",
-    "region": "us-west4"
+    "region": "us-west4",
+    "cheaper": null
   }
 ]

--- a/data/google/regions.json
+++ b/data/google/regions.json
@@ -61,11 +61,13 @@
   },
   {
     "name": "EU West London, England, UK",
-    "region": "europe-west2"
+    "region": "europe-west2",
+    "cheaper": "europe-west1"
   },
   {
     "name": "EU West Frankfurt, Germany",
-    "region": "europe-west3"
+    "region": "europe-west3",
+    "cheaper": "europe-west1"
   },
   {
     "name": "EU West Eemshaven, Netherlands",
@@ -121,7 +123,8 @@
   },
   {
     "name": "US East Ashburn, Northern Virginia, USA",
-    "region": "us-east4"
+    "region": "us-east4",
+    "cheaper": "us-east1"
   },
   {
     "name": "US East Columbus, Ohio, North America, USA",

--- a/data/google/regions.json
+++ b/data/google/regions.json
@@ -1,0 +1,486 @@
+[
+  {
+    "region": "africa-south1-a",
+    "name": "Johannesburg, South Africa"
+  },
+  {
+    "region": "africa-south1-b",
+    "name": "Johannesburg, South Africa"
+  },
+  {
+    "region": "africa-south1-c",
+    "name": "Johannesburg, South Africa"
+  },
+  {
+    "region": "asia-east1-a",
+    "name": "Changhua County, Taiwan, APAC"
+  },
+  {
+    "region": "asia-east1-b",
+    "name": "Changhua County, Taiwan, APAC"
+  },
+  {
+    "region": "asia-east1-c",
+    "name": "Changhua County, Taiwan, APAC"
+  },
+  {
+    "region": "asia-east2-a",
+    "name": "Hong Kong, APAC"
+  },
+  {
+    "region": "asia-east2-b",
+    "name": "Hong Kong, APAC"
+  },
+  {
+    "region": "asia-east2-c",
+    "name": "Hong Kong, APAC"
+  },
+  {
+    "region": "asia-northeast1-a",
+    "name": "Tokyo, Japan, APAC"
+  },
+  {
+    "region": "asia-northeast1-b",
+    "name": "Tokyo, Japan, APAC"
+  },
+  {
+    "region": "asia-northeast1-c",
+    "name": "Tokyo, Japan, APAC"
+  },
+  {
+    "region": "asia-northeast2-a",
+    "name": "Osaka, Japan, APAC"
+  },
+  {
+    "region": "asia-northeast2-b",
+    "name": "Osaka, Japan, APAC"
+  },
+  {
+    "region": "asia-northeast2-c",
+    "name": "Osaka, Japan, APAC"
+  },
+  {
+    "region": "asia-northeast3-a",
+    "name": "Seoul, South Korea, APAC"
+  },
+  {
+    "region": "asia-northeast3-b",
+    "name": "Seoul, South Korea, APAC"
+  },
+  {
+    "region": "asia-northeast3-c",
+    "name": "Seoul, South Korea, APAC"
+  },
+  {
+    "region": "asia-south1-a",
+    "name": "Mumbai, India, APAC"
+  },
+  {
+    "region": "asia-south1-b",
+    "name": "Mumbai, India, APAC"
+  },
+  {
+    "region": "asia-south1-c",
+    "name": "Mumbai, India, APAC"
+  },
+  {
+    "region": "asia-south2-a",
+    "name": "Delhi, India, APAC"
+  },
+  {
+    "region": "asia-south2-b",
+    "name": "Delhi, India, APAC"
+  },
+  {
+    "region": "asia-south2-c",
+    "name": "Delhi, India, APAC"
+  },
+  {
+    "region": "asia-southeast1-a",
+    "name": "Jurong West, Singapore, APAC"
+  },
+  {
+    "region": "asia-southeast1-b",
+    "name": "Jurong West, Singapore, APAC"
+  },
+  {
+    "region": "asia-southeast1-c",
+    "name": "Jurong West, Singapore, APAC"
+  },
+  {
+    "region": "asia-southeast2-a",
+    "name": "Jakarta, Indonesia, APAC"
+  },
+  {
+    "region": "asia-southeast2-b",
+    "name": "Jakarta, Indonesia, APAC"
+  },
+  {
+    "region": "asia-southeast2-c",
+    "name": "Jakarta, Indonesia, APAC"
+  },
+  {
+    "region": "australia-southeast1-a",
+    "name": "Sydney, Australia, APAC"
+  },
+  {
+    "region": "australia-southeast1-b",
+    "name": "Sydney, Australia, APAC"
+  },
+  {
+    "region": "australia-southeast1-c",
+    "name": "Sydney, Australia, APAC"
+  },
+  {
+    "region": "australia-southeast2-a",
+    "name": "Melbourne, Australia, APAC"
+  },
+  {
+    "region": "australia-southeast2-b",
+    "name": "Melbourne, Australia, APAC"
+  },
+  {
+    "region": "australia-southeast2-c",
+    "name": "Melbourne, Australia, APAC"
+  },
+  {
+    "region": "europe-central2-a",
+    "name": "Warsaw, Poland, Europe"
+  },
+  {
+    "region": "europe-central2-b",
+    "name": "Warsaw, Poland, Europe"
+  },
+  {
+    "region": "europe-central2-c",
+    "name": "Warsaw, Poland, Europe"
+  },
+  {
+    "region": "europe-north1-a",
+    "name": "Hamina, Finland, Europe"
+  },
+  {
+    "region": "europe-north1-b",
+    "name": "Hamina, Finland, Europe"
+  },
+  {
+    "region": "europe-north1-c",
+    "name": "Hamina, Finland, Europe"
+  },
+  {
+    "region": "europe-southwest1-a",
+    "name": "Madrid, Spain, Europe"
+  },
+  {
+    "region": "europe-southwest1-b",
+    "name": "Madrid, Spain, Europe"
+  },
+  {
+    "region": "europe-southwest1-c",
+    "name": "Madrid, Spain, Europe"
+  },
+  {
+    "region": "europe-west1-b",
+    "name": "St. Ghislain, Belgium, Europe"
+  },
+  {
+    "region": "europe-west1-c",
+    "name": "St. Ghislain, Belgium, Europe"
+  },
+  {
+    "region": "europe-west1-d",
+    "name": "St. Ghislain, Belgium, Europe"
+  },
+  {
+    "region": "europe-west10-a",
+    "name": "Berlin, Germany, Europe"
+  },
+  {
+    "region": "europe-west10-b",
+    "name": "Berlin, Germany, Europe"
+  },
+  {
+    "region": "europe-west10-c",
+    "name": "Berlin, Germany, Europe"
+  },
+  {
+    "region": "europe-west12-a",
+    "name": "Turin, Italy, Europe"
+  },
+  {
+    "region": "europe-west12-b",
+    "name": "Turin, Italy, Europe"
+  },
+  {
+    "region": "europe-west12-c",
+    "name": "Turin, Italy, Europe"
+  },
+  {
+    "region": "europe-west2-a",
+    "name": "London, England, Europe"
+  },
+  {
+    "region": "europe-west2-b",
+    "name": "London, England, Europe"
+  },
+  {
+    "region": "europe-west2-c",
+    "name": "London, England, Europe"
+  },
+  {
+    "region": "europe-west3-a",
+    "name": "Frankfurt, Germany, Europe"
+  },
+  {
+    "region": "europe-west3-b",
+    "name": "Frankfurt, Germany, Europe"
+  },
+  {
+    "region": "europe-west3-c",
+    "name": "Frankfurt, Germany, Europe"
+  },
+  {
+    "region": "europe-west4-a",
+    "name": "Eemshaven, Netherlands, Europe"
+  },
+  {
+    "region": "europe-west4-b",
+    "name": "Eemshaven, Netherlands, Europe"
+  },
+  {
+    "region": "europe-west4-c",
+    "name": "Eemshaven, Netherlands, Europe"
+  },
+  {
+    "region": "europe-west6-a",
+    "name": "Zurich, Switzerland, Europe"
+  },
+  {
+    "region": "europe-west6-b",
+    "name": "Zurich, Switzerland, Europe"
+  },
+  {
+    "region": "europe-west6-c",
+    "name": "Zurich, Switzerland, Europe"
+  },
+  {
+    "region": "europe-west8-a",
+    "name": "Milan, Italy, Europe"
+  },
+  {
+    "region": "europe-west8-b",
+    "name": "Milan, Italy, Europe"
+  },
+  {
+    "region": "europe-west8-c",
+    "name": "Milan, Italy, Europe"
+  },
+  {
+    "region": "europe-west9-a",
+    "name": "Paris, France, Europe"
+  },
+  {
+    "region": "europe-west9-b",
+    "name": "Paris, France, Europe"
+  },
+  {
+    "region": "europe-west9-c",
+    "name": "Paris, France, Europe"
+  },
+  {
+    "region": "me-central1-a",
+    "name": "Doha, Qatar, Middle East"
+  },
+  {
+    "region": "me-central1-b",
+    "name": "Doha, Qatar, Middle East"
+  },
+  {
+    "region": "me-central1-c",
+    "name": "Doha, Qatar, Middle East"
+  },
+  {
+    "region": "me-central2-a",
+    "name": "Dammam, Saudi Arabia, Middle East"
+  },
+  {
+    "region": "me-central2-b",
+    "name": "Dammam, Saudi Arabia, Middle East"
+  },
+  {
+    "region": "me-central2-c",
+    "name": "Dammam, Saudi Arabia, Middle East"
+  },
+  {
+    "region": "me-west1-a",
+    "name": "Tel Aviv, Israel, Middle East"
+  },
+  {
+    "region": "me-west1-b",
+    "name": "Tel Aviv, Israel, Middle East"
+  },
+  {
+    "region": "me-west1-c",
+    "name": "Tel Aviv, Israel, Middle East"
+  },
+  {
+    "region": "northamerica-northeast1-a",
+    "name": "Montréal, Québec, North America"
+  },
+  {
+    "region": "northamerica-northeast1-b",
+    "name": "Montréal, Québec, North America"
+  },
+  {
+    "region": "northamerica-northeast1-c",
+    "name": "Montréal, Québec, North America"
+  },
+  {
+    "region": "northamerica-northeast2-a",
+    "name": "Toronto, Ontario, North America"
+  },
+  {
+    "region": "northamerica-northeast2-b",
+    "name": "Toronto, Ontario, North America"
+  },
+  {
+    "region": "northamerica-northeast2-c",
+    "name": "Toronto, Ontario, North America"
+  },
+  {
+    "region": "southamerica-east1-a",
+    "name": "Osasco, São Paulo, Brazil, South America"
+  },
+  {
+    "region": "southamerica-east1-b",
+    "name": "Osasco, São Paulo, Brazil, South America"
+  },
+  {
+    "region": "southamerica-east1-c",
+    "name": "Osasco, São Paulo, Brazil, South America"
+  },
+  {
+    "region": "southamerica-west1-a",
+    "name": "Santiago, Chile, South America"
+  },
+  {
+    "region": "southamerica-west1-b",
+    "name": "Santiago, Chile, South America"
+  },
+  {
+    "region": "southamerica-west1-c",
+    "name": "Santiago, Chile, South America"
+  },
+  {
+    "region": "us-central1-a",
+    "name": "Council Bluffs, Iowa, North America"
+  },
+  {
+    "region": "us-central1-b",
+    "name": "Council Bluffs, Iowa, North America"
+  },
+  {
+    "region": "us-central1-c",
+    "name": "Council Bluffs, Iowa, North America"
+  },
+  {
+    "region": "us-central1-f",
+    "name": "Council Bluffs, Iowa, North America"
+  },
+  {
+    "region": "us-east1-b",
+    "name": "Moncks Corner, South Carolina, North America"
+  },
+  {
+    "region": "us-east1-c",
+    "name": "Moncks Corner, South Carolina, North America"
+  },
+  {
+    "region": "us-east1-d",
+    "name": "Moncks Corner, South Carolina, North America"
+  },
+  {
+    "region": "us-east4-a",
+    "name": "Ashburn, Virginia, North America"
+  },
+  {
+    "region": "us-east4-b",
+    "name": "Ashburn, Virginia, North America"
+  },
+  {
+    "region": "us-east4-c",
+    "name": "Ashburn, Virginia, North America"
+  },
+  {
+    "region": "us-east5-a",
+    "name": "Columbus, Ohio, North America"
+  },
+  {
+    "region": "us-east5-b",
+    "name": "Columbus, Ohio, North America"
+  },
+  {
+    "region": "us-east5-c",
+    "name": "Columbus, Ohio, North America"
+  },
+  {
+    "region": "us-south1-a",
+    "name": "Dallas, Texas, North America"
+  },
+  {
+    "region": "us-south1-b",
+    "name": "Dallas, Texas, North America"
+  },
+  {
+    "region": "us-south1-c",
+    "name": "Dallas, Texas, North America"
+  },
+  {
+    "region": "us-west1-a",
+    "name": "The Dalles, Oregon, North America"
+  },
+  {
+    "region": "us-west1-b",
+    "name": "The Dalles, Oregon, North America"
+  },
+  {
+    "region": "us-west1-c",
+    "name": "The Dalles, Oregon, North America"
+  },
+  {
+    "region": "us-west2-a",
+    "name": "Los Angeles, California, North America"
+  },
+  {
+    "region": "us-west2-b",
+    "name": "Los Angeles, California, North America"
+  },
+  {
+    "region": "us-west2-c",
+    "name": "Los Angeles, California, North America"
+  },
+  {
+    "region": "us-west3-a",
+    "name": "Salt Lake City, Utah, North America"
+  },
+  {
+    "region": "us-west3-b",
+    "name": "Salt Lake City, Utah, North America"
+  },
+  {
+    "region": "us-west3-c",
+    "name": "Salt Lake City, Utah, North America"
+  },
+  {
+    "region": "us-west4-a",
+    "name": "Las Vegas, Nevada, North America"
+  },
+  {
+    "region": "us-west4-b",
+    "name": "Las Vegas, Nevada, North America"
+  },
+  {
+    "region": "us-west4-c",
+    "name": "Las Vegas, Nevada, North America"
+  }
+]

--- a/data/google/regions.json
+++ b/data/google/regions.json
@@ -1,486 +1,150 @@
 [
   {
-    "region": "africa-south1-a",
-    "name": "Johannesburg, South Africa"
+    "name": "Asia Pacific Changhua County, Taiwan",
+    "region": "asia-east1"
   },
   {
-    "region": "africa-south1-b",
-    "name": "Johannesburg, South Africa"
+    "name": "Asia Pacific Hong Kong",
+    "region": "asia-east2"
   },
   {
-    "region": "africa-south1-c",
-    "name": "Johannesburg, South Africa"
+    "name": "Asia Pacific Tokyo, Japan",
+    "region": "asia-northeast1"
   },
   {
-    "region": "asia-east1-a",
-    "name": "Changhua County, Taiwan, APAC"
+    "name": "Asia Pacific Osaka, Japan",
+    "region": "asia-northeast2"
   },
   {
-    "region": "asia-east1-b",
-    "name": "Changhua County, Taiwan, APAC"
+    "name": "Asia Pacific Seoul, South Korea",
+    "region": "asia-northeast3"
   },
   {
-    "region": "asia-east1-c",
-    "name": "Changhua County, Taiwan, APAC"
+    "name": "Asia Pacific Mumbai, India",
+    "region": "asia-south1"
   },
   {
-    "region": "asia-east2-a",
-    "name": "Hong Kong, APAC"
+    "name": "Asia Pacific Delhi, India",
+    "region": "asia-south2"
   },
   {
-    "region": "asia-east2-b",
-    "name": "Hong Kong, APAC"
+    "name": "Asia Pacific Jurong West, Singapore:",
+    "region": "asia-southeast1"
   },
   {
-    "region": "asia-east2-c",
-    "name": "Hong Kong, APAC"
+    "name": "Asia Pacific Jakarta, Indonesia:",
+    "region": "asia-southeast2"
   },
   {
-    "region": "asia-northeast1-a",
-    "name": "Tokyo, Japan, APAC"
+    "name": "Asia Pacific Sydney, Australia:",
+    "region": "australia-southeast1"
   },
   {
-    "region": "asia-northeast1-b",
-    "name": "Tokyo, Japan, APAC"
+    "name": "Asia Pacific Melbourne, Australia:",
+    "region": "australia-southeast2"
   },
   {
-    "region": "asia-northeast1-c",
-    "name": "Tokyo, Japan, APAC"
+    "name": "EU Central Warsaw, Poland:",
+    "region": "europe-central2"
   },
   {
-    "region": "asia-northeast2-a",
-    "name": "Osaka, Japan, APAC"
+    "name": "EU Hamina, Finland:",
+    "region": "europe-north1"
   },
   {
-    "region": "asia-northeast2-b",
-    "name": "Osaka, Japan, APAC"
+    "name": "EU Madrid, Spain:",
+    "region": "europe-southwest1"
   },
   {
-    "region": "asia-northeast2-c",
-    "name": "Osaka, Japan, APAC"
+    "name": "EU West St. Ghislain, Belgium:",
+    "region": "europe-west1"
   },
   {
-    "region": "asia-northeast3-a",
-    "name": "Seoul, South Korea, APAC"
+    "name": "EU West London, England, UK",
+    "region": "europe-west2"
   },
   {
-    "region": "asia-northeast3-b",
-    "name": "Seoul, South Korea, APAC"
+    "name": "EU West Frankfurt, Germany",
+    "region": "europe-west3"
   },
   {
-    "region": "asia-northeast3-c",
-    "name": "Seoul, South Korea, APAC"
+    "name": "EU West Eemshaven, Netherlands",
+    "region": "europe-west4"
   },
   {
-    "region": "asia-south1-a",
-    "name": "Mumbai, India, APAC"
+    "name": "EU West Zurish, Switzerland",
+    "region": "europe-west6"
   },
   {
-    "region": "asia-south1-b",
-    "name": "Mumbai, India, APAC"
+    "name": "EU West Milan, Italy",
+    "region": "europe-west8"
   },
   {
-    "region": "asia-south1-c",
-    "name": "Mumbai, India, APAC"
+    "name": "EU West Paris, France",
+    "region": "europe-west9"
   },
   {
-    "region": "asia-south2-a",
-    "name": "Delhi, India, APAC"
+    "name": "EU West Turin, Italy",
+    "region": "europe-west1"
   },
   {
-    "region": "asia-south2-b",
-    "name": "Delhi, India, APAC"
+    "name": "Middle East Doha, Qatar",
+    "region": "me-central1"
   },
   {
-    "region": "asia-south2-c",
-    "name": "Delhi, India, APAC"
+    "name": "Middle East Tel Aviv, Israel",
+    "region": "me-west1"
   },
   {
-    "region": "asia-southeast1-a",
-    "name": "Jurong West, Singapore, APAC"
+    "name": "North America Montréal, Québec, Canada",
+    "region": "northamerica-northeast1"
   },
   {
-    "region": "asia-southeast1-b",
-    "name": "Jurong West, Singapore, APAC"
+    "name": "North America Toronto, Ontario, Canada",
+    "region": "northamerica-northeast2"
   },
   {
-    "region": "asia-southeast1-c",
-    "name": "Jurong West, Singapore, APAC"
+    "name": "South America São Paulo, Brazil",
+    "region": "southamerica-east1"
   },
   {
-    "region": "asia-southeast2-a",
-    "name": "Jakarta, Indonesia, APAC"
+    "name": "South America Santiago, Chile",
+    "region": "southamerica-east2"
   },
   {
-    "region": "asia-southeast2-b",
-    "name": "Jakarta, Indonesia, APAC"
+    "name": "US Central Council Bluffs, Iowa, USA",
+    "region": "us-central1"
   },
   {
-    "region": "asia-southeast2-c",
-    "name": "Jakarta, Indonesia, APAC"
+    "name": "US East Moncks Corner, South Carolina, USA",
+    "region": "us-east1"
   },
   {
-    "region": "australia-southeast1-a",
-    "name": "Sydney, Australia, APAC"
+    "name": "US East Ashburn, Northern Virginia, USA",
+    "region": "us-east4"
   },
   {
-    "region": "australia-southeast1-b",
-    "name": "Sydney, Australia, APAC"
+    "name": "US East Columbus, Ohio, North America, USA",
+    "region": "us-east5"
   },
   {
-    "region": "australia-southeast1-c",
-    "name": "Sydney, Australia, APAC"
+    "name": "US South Dallas, Texas, USA",
+    "region": "us-south1"
   },
   {
-    "region": "australia-southeast2-a",
-    "name": "Melbourne, Australia, APAC"
+    "name": "US West The Dalles, Oregon, USA",
+    "region": "us-west1"
   },
   {
-    "region": "australia-southeast2-b",
-    "name": "Melbourne, Australia, APAC"
+    "name": "US West Los Angeles, California, USA",
+    "region": "us-west2"
   },
   {
-    "region": "australia-southeast2-c",
-    "name": "Melbourne, Australia, APAC"
+    "name": "US West Salt Lake City, Utah, USA",
+    "region": "us-west3"
   },
   {
-    "region": "europe-central2-a",
-    "name": "Warsaw, Poland, Europe"
-  },
-  {
-    "region": "europe-central2-b",
-    "name": "Warsaw, Poland, Europe"
-  },
-  {
-    "region": "europe-central2-c",
-    "name": "Warsaw, Poland, Europe"
-  },
-  {
-    "region": "europe-north1-a",
-    "name": "Hamina, Finland, Europe"
-  },
-  {
-    "region": "europe-north1-b",
-    "name": "Hamina, Finland, Europe"
-  },
-  {
-    "region": "europe-north1-c",
-    "name": "Hamina, Finland, Europe"
-  },
-  {
-    "region": "europe-southwest1-a",
-    "name": "Madrid, Spain, Europe"
-  },
-  {
-    "region": "europe-southwest1-b",
-    "name": "Madrid, Spain, Europe"
-  },
-  {
-    "region": "europe-southwest1-c",
-    "name": "Madrid, Spain, Europe"
-  },
-  {
-    "region": "europe-west1-b",
-    "name": "St. Ghislain, Belgium, Europe"
-  },
-  {
-    "region": "europe-west1-c",
-    "name": "St. Ghislain, Belgium, Europe"
-  },
-  {
-    "region": "europe-west1-d",
-    "name": "St. Ghislain, Belgium, Europe"
-  },
-  {
-    "region": "europe-west10-a",
-    "name": "Berlin, Germany, Europe"
-  },
-  {
-    "region": "europe-west10-b",
-    "name": "Berlin, Germany, Europe"
-  },
-  {
-    "region": "europe-west10-c",
-    "name": "Berlin, Germany, Europe"
-  },
-  {
-    "region": "europe-west12-a",
-    "name": "Turin, Italy, Europe"
-  },
-  {
-    "region": "europe-west12-b",
-    "name": "Turin, Italy, Europe"
-  },
-  {
-    "region": "europe-west12-c",
-    "name": "Turin, Italy, Europe"
-  },
-  {
-    "region": "europe-west2-a",
-    "name": "London, England, Europe"
-  },
-  {
-    "region": "europe-west2-b",
-    "name": "London, England, Europe"
-  },
-  {
-    "region": "europe-west2-c",
-    "name": "London, England, Europe"
-  },
-  {
-    "region": "europe-west3-a",
-    "name": "Frankfurt, Germany, Europe"
-  },
-  {
-    "region": "europe-west3-b",
-    "name": "Frankfurt, Germany, Europe"
-  },
-  {
-    "region": "europe-west3-c",
-    "name": "Frankfurt, Germany, Europe"
-  },
-  {
-    "region": "europe-west4-a",
-    "name": "Eemshaven, Netherlands, Europe"
-  },
-  {
-    "region": "europe-west4-b",
-    "name": "Eemshaven, Netherlands, Europe"
-  },
-  {
-    "region": "europe-west4-c",
-    "name": "Eemshaven, Netherlands, Europe"
-  },
-  {
-    "region": "europe-west6-a",
-    "name": "Zurich, Switzerland, Europe"
-  },
-  {
-    "region": "europe-west6-b",
-    "name": "Zurich, Switzerland, Europe"
-  },
-  {
-    "region": "europe-west6-c",
-    "name": "Zurich, Switzerland, Europe"
-  },
-  {
-    "region": "europe-west8-a",
-    "name": "Milan, Italy, Europe"
-  },
-  {
-    "region": "europe-west8-b",
-    "name": "Milan, Italy, Europe"
-  },
-  {
-    "region": "europe-west8-c",
-    "name": "Milan, Italy, Europe"
-  },
-  {
-    "region": "europe-west9-a",
-    "name": "Paris, France, Europe"
-  },
-  {
-    "region": "europe-west9-b",
-    "name": "Paris, France, Europe"
-  },
-  {
-    "region": "europe-west9-c",
-    "name": "Paris, France, Europe"
-  },
-  {
-    "region": "me-central1-a",
-    "name": "Doha, Qatar, Middle East"
-  },
-  {
-    "region": "me-central1-b",
-    "name": "Doha, Qatar, Middle East"
-  },
-  {
-    "region": "me-central1-c",
-    "name": "Doha, Qatar, Middle East"
-  },
-  {
-    "region": "me-central2-a",
-    "name": "Dammam, Saudi Arabia, Middle East"
-  },
-  {
-    "region": "me-central2-b",
-    "name": "Dammam, Saudi Arabia, Middle East"
-  },
-  {
-    "region": "me-central2-c",
-    "name": "Dammam, Saudi Arabia, Middle East"
-  },
-  {
-    "region": "me-west1-a",
-    "name": "Tel Aviv, Israel, Middle East"
-  },
-  {
-    "region": "me-west1-b",
-    "name": "Tel Aviv, Israel, Middle East"
-  },
-  {
-    "region": "me-west1-c",
-    "name": "Tel Aviv, Israel, Middle East"
-  },
-  {
-    "region": "northamerica-northeast1-a",
-    "name": "Montréal, Québec, North America"
-  },
-  {
-    "region": "northamerica-northeast1-b",
-    "name": "Montréal, Québec, North America"
-  },
-  {
-    "region": "northamerica-northeast1-c",
-    "name": "Montréal, Québec, North America"
-  },
-  {
-    "region": "northamerica-northeast2-a",
-    "name": "Toronto, Ontario, North America"
-  },
-  {
-    "region": "northamerica-northeast2-b",
-    "name": "Toronto, Ontario, North America"
-  },
-  {
-    "region": "northamerica-northeast2-c",
-    "name": "Toronto, Ontario, North America"
-  },
-  {
-    "region": "southamerica-east1-a",
-    "name": "Osasco, São Paulo, Brazil, South America"
-  },
-  {
-    "region": "southamerica-east1-b",
-    "name": "Osasco, São Paulo, Brazil, South America"
-  },
-  {
-    "region": "southamerica-east1-c",
-    "name": "Osasco, São Paulo, Brazil, South America"
-  },
-  {
-    "region": "southamerica-west1-a",
-    "name": "Santiago, Chile, South America"
-  },
-  {
-    "region": "southamerica-west1-b",
-    "name": "Santiago, Chile, South America"
-  },
-  {
-    "region": "southamerica-west1-c",
-    "name": "Santiago, Chile, South America"
-  },
-  {
-    "region": "us-central1-a",
-    "name": "Council Bluffs, Iowa, North America"
-  },
-  {
-    "region": "us-central1-b",
-    "name": "Council Bluffs, Iowa, North America"
-  },
-  {
-    "region": "us-central1-c",
-    "name": "Council Bluffs, Iowa, North America"
-  },
-  {
-    "region": "us-central1-f",
-    "name": "Council Bluffs, Iowa, North America"
-  },
-  {
-    "region": "us-east1-b",
-    "name": "Moncks Corner, South Carolina, North America"
-  },
-  {
-    "region": "us-east1-c",
-    "name": "Moncks Corner, South Carolina, North America"
-  },
-  {
-    "region": "us-east1-d",
-    "name": "Moncks Corner, South Carolina, North America"
-  },
-  {
-    "region": "us-east4-a",
-    "name": "Ashburn, Virginia, North America"
-  },
-  {
-    "region": "us-east4-b",
-    "name": "Ashburn, Virginia, North America"
-  },
-  {
-    "region": "us-east4-c",
-    "name": "Ashburn, Virginia, North America"
-  },
-  {
-    "region": "us-east5-a",
-    "name": "Columbus, Ohio, North America"
-  },
-  {
-    "region": "us-east5-b",
-    "name": "Columbus, Ohio, North America"
-  },
-  {
-    "region": "us-east5-c",
-    "name": "Columbus, Ohio, North America"
-  },
-  {
-    "region": "us-south1-a",
-    "name": "Dallas, Texas, North America"
-  },
-  {
-    "region": "us-south1-b",
-    "name": "Dallas, Texas, North America"
-  },
-  {
-    "region": "us-south1-c",
-    "name": "Dallas, Texas, North America"
-  },
-  {
-    "region": "us-west1-a",
-    "name": "The Dalles, Oregon, North America"
-  },
-  {
-    "region": "us-west1-b",
-    "name": "The Dalles, Oregon, North America"
-  },
-  {
-    "region": "us-west1-c",
-    "name": "The Dalles, Oregon, North America"
-  },
-  {
-    "region": "us-west2-a",
-    "name": "Los Angeles, California, North America"
-  },
-  {
-    "region": "us-west2-b",
-    "name": "Los Angeles, California, North America"
-  },
-  {
-    "region": "us-west2-c",
-    "name": "Los Angeles, California, North America"
-  },
-  {
-    "region": "us-west3-a",
-    "name": "Salt Lake City, Utah, North America"
-  },
-  {
-    "region": "us-west3-b",
-    "name": "Salt Lake City, Utah, North America"
-  },
-  {
-    "region": "us-west3-c",
-    "name": "Salt Lake City, Utah, North America"
-  },
-  {
-    "region": "us-west4-a",
-    "name": "Las Vegas, Nevada, North America"
-  },
-  {
-    "region": "us-west4-b",
-    "name": "Las Vegas, Nevada, North America"
-  },
-  {
-    "region": "us-west4-c",
-    "name": "Las Vegas, Nevada, North America"
+    "name": "US West Las Vegas, Nevada, USA",
+    "region": "us-west4"
   }
 ]

--- a/data/policy_permissions_list/master_policy_permissions_list.json
+++ b/data/policy_permissions_list/master_policy_permissions_list.json
@@ -2895,6 +2895,38 @@
       ]
     },
     {
+      "id": "./cost/flexera/cco/cheaper_regions/cheaper_regions.pt",
+      "name": "Cheaper Regions",
+      "version": "2.4.0",
+      "providers": [
+        {
+          "name": "flexera",
+          "permissions": [
+            {
+              "name": "billing_center_viewer",
+              "read_only": true,
+              "required": true
+            },
+            {
+              "name": "policy_designer",
+              "read_only": true,
+              "required": true
+            },
+            {
+              "name": "policy_manager",
+              "read_only": true,
+              "required": true
+            },
+            {
+              "name": "policy_publisher",
+              "read_only": true,
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "./cost/flexera/cco/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt",
       "name": "Cloud Cost Anomaly Alerts",
       "version": "3.6",

--- a/data/policy_permissions_list/master_policy_permissions_list.yaml
+++ b/data/policy_permissions_list/master_policy_permissions_list.yaml
@@ -1707,6 +1707,24 @@
     - name: optima:billing_center:show
       read_only: true
       required: true
+- id: "./cost/flexera/cco/cheaper_regions/cheaper_regions.pt"
+  name: Cheaper Regions
+  version: 2.4.0
+  :providers:
+  - :name: flexera
+    :permissions:
+    - name: billing_center_viewer
+      read_only: true
+      required: true
+    - name: policy_designer
+      read_only: true
+      required: true
+    - name: policy_manager
+      read_only: true
+      required: true
+    - name: policy_publisher
+      read_only: true
+      required: true
 - id: "./cost/flexera/cco/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt"
   name: Cloud Cost Anomaly Alerts
   version: '3.6'

--- a/tools/policy_master_permission_generation/validated_policy_templates.yaml
+++ b/tools/policy_master_permission_generation/validated_policy_templates.yaml
@@ -113,6 +113,7 @@ validated_policy_templates:
 -  "./cost/flexera/cco/email_recommendations/email_recommendations.pt"
 -  "./cost/flexera/cco/focus_report/focus_report.pt"
 -  "./cost/flexera/cco/scheduled_reports/scheduled_report.pt"
+-  "./cost/flexera/cco/cheaper_regions/cheaper_regions.pt"
 -  "./cost/flexera/msp/master_org_cost_policy/master_org_cost_policy.pt"
 -  "./cost/flexera/msp/master_org_cost_policy_currency/master_org_cost_policy_currency.pt"
 -  "./cost/scheduled_report_unallocated/scheduled_report_unallocated.pt"


### PR DESCRIPTION
### Description

Issue reported in this support question: https://flexera.atlassian.net/browse/SQ-7976 by Albertsons.
Policy is returning empty results, checking the code it's because some regions for Azure and AWS are outdated, previously we had for example: `US West`, `US West 2`, etc. But now those are named `West US`, `West US 2`, etc. Also few `console.log` statements were removed.

### Issues Resolved

Policy is returning empty results because of outdated regions for Azure and AWS vendors.

### Link to Example Applied Policy

https://app.flexera.com/orgs/1105/automation/applied-policies/projects/60073?policyId=663e4547ba767e47966578c9

### Contribution Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
