### PR TITLE
POL-1231 New Policy: Azure Usage Report - Instance Time Used

### DIFF
--- a/data/policy_permissions_list/master_policy_permissions_list.json
+++ b/data/policy_permissions_list/master_policy_permissions_list.json
@@ -4375,6 +4375,23 @@
       ]
     },
     {
+      "id": "./operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt",
+      "name": "Azure Usage Report - Instance Time Used",
+      "version": "1.0.0",
+      "providers": [
+        {
+          "name": "flexera",
+          "permissions": [
+            {
+              "name": "billing_center_viewer",
+              "read_only": true,
+              "required": true
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "./operational/azure/total_instance_vcpus/azure_usage_instance_vcpus_used.pt",
       "name": "Azure Usage Report - Number of Instance vCPUs Used",
       "version": "2.1.1",

--- a/data/policy_permissions_list/master_policy_permissions_list.yaml
+++ b/data/policy_permissions_list/master_policy_permissions_list.yaml
@@ -2575,6 +2575,15 @@
     - name: billing_center_viewer
       read_only: true
       required: true
+- id: "./operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt"
+  name: Azure Usage Report - Instance Time Used
+  version: 1.0.0
+  :providers:
+  - :name: flexera
+    :permissions:
+    - name: billing_center_viewer
+      read_only: true
+      required: true
 - id: "./operational/azure/total_instance_vcpus/azure_usage_instance_vcpus_used.pt"
   name: Azure Usage Report - Number of Instance vCPUs Used
   version: 2.1.1

--- a/operational/azure/total_instance_hours/CHANGELOG.md
+++ b/operational/azure/total_instance_hours/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1.2
+
+- Deprecated: This policy is no longer being updated. Please see policy README for more information.
+
 ## v2.1.1
 
 - Fixed issue where only top-level billing centers could be filtered on. Policy now additionally supports filtering on child billing centers.

--- a/operational/azure/total_instance_hours/README.md
+++ b/operational/azure/total_instance_hours/README.md
@@ -1,5 +1,9 @@
 # Azure Usage Report - Number of Instance Hours Used
 
+## Deprecated
+
+This policy is no longer being updated. The [Azure Usage Report - Instance Time Used](https://github.com/flexera-public/policy_templates/tree/master/operational/azure/total_instance_usage_report/) policy now includes this functionality and should be used instead.
+
 ## What It Does
 
 This Policy Template leverages Flexera CCO APIs to produce a stacked bar chart showing Total Instance Hours for Azure Virtual Machine Families used per month for the last 12 months.

--- a/operational/azure/total_instance_hours/azure_usage_instance_hours_used.pt
+++ b/operational/azure/total_instance_hours/azure_usage_instance_hours_used.pt
@@ -1,13 +1,13 @@
 name "Azure Usage Report - Number of Instance Hours Used"
 rs_pt_ver 20180301
 type "policy"
-short_description "This policy produces a usage report showing the number of Hours used for each Azure Instance Family. See the [README](https://github.com/flexera-public/policy_templates/tree/master/operational/azure/total_instance_hours) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "**Deprecated: This policy is no longer being updated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/operational/azure/total_instance_hours/) for more details.**  This policy produces a usage report showing the number of Hours used for each Azure Instance Family. See the [README](https://github.com/flexera-public/policy_templates/tree/master/operational/azure/total_instance_hours) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "2.1.1",
+  version: "2.1.2",
   provider: "Azure",
   service: "Compute",
   policy_set: "Usage Report"
@@ -134,7 +134,7 @@ script "js_filtered_billing_centers", type: "javascript" do
     //If there are conflicting child/parent BCs then ignore the child BC and take the parent BC
     if (conflicting_child_bcs != undefined) {
       var conflicting_child_bc_ids = _.pluck(conflicting_child_bcs, "id")
-      
+ 
       var filtered_bc_list = _.reject(billing_center_list, function(bc) {
         return _.contains(conflicting_child_bc_ids, bc.id)
       })
@@ -142,7 +142,7 @@ script "js_filtered_billing_centers", type: "javascript" do
     } else {
       result = _.compact(_.pluck(billing_center_list, 'id'))
     }
-    
+
   } else {
     var billing_center_list = _.filter(ds_billing_centers, function(bc) {
       return bc['parent_id'] == null || bc['parent_id'] == undefined
@@ -184,7 +184,7 @@ script "js_usage_data", type: "javascript" do
   var billing_center_ids = ds_filtered_billing_centers
   var allow_deny_test = { "Allow": true, "Deny": false }
 
-  //Define Expressions for API Filter 
+  //Define Expressions for API Filter
   var expressions = [
     { "dimension": "category", "type": "equal", "value": "Compute" },
     { "dimension": "resource_type", "type": "substring", "substring": "Virtual Machines" },
@@ -197,7 +197,7 @@ script "js_usage_data", type: "javascript" do
 
   //Get Regions list if applicable
   if (param_regions_list.length > 0) {
-    
+
     var regions_filter_list = []
     _.each(param_regions_list, function(reg) {
         var region_dimension = { "dimension": "region", "type": "equal", "value": reg }
@@ -206,7 +206,7 @@ script "js_usage_data", type: "javascript" do
 
     var region_filter_json = {}
     if (param_regions_allow_or_deny == "Deny") {
-      
+
       region_filter_json = {
         "type": "not",
         "expression": {
@@ -217,7 +217,7 @@ script "js_usage_data", type: "javascript" do
       expressions.push(region_filter_json)
 
     } else {
-      
+
       region_filter_json = {
         "type": "or",
         "expressions": regions_filter_list
@@ -226,7 +226,7 @@ script "js_usage_data", type: "javascript" do
 
     }
   }
-  
+
   //POST JSON payload
   payload = {
     "billing_center_ids": billing_center_ids,

--- a/operational/azure/total_instance_memory/CHANGELOG.md
+++ b/operational/azure/total_instance_memory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1.2
+
+- Deprecated: This policy is no longer being updated. Please see policy README for more information.
+
 ## v2.1.1
 
 - Fixed issue where only top-level billing centers could be filtered on. Policy now additionally supports filtering on child billing centers.

--- a/operational/azure/total_instance_memory/README.md
+++ b/operational/azure/total_instance_memory/README.md
@@ -1,5 +1,9 @@
 # Azure Usage Report - Amount of Instance Memory Used
 
+## Deprecated
+
+This policy is no longer being updated. The [Azure Usage Report - Instance Time Used](https://github.com/flexera-public/policy_templates/tree/master/operational/azure/total_instance_usage_report/) policy now includes this functionality and should be used instead.
+
 ## What It Does
 
 This Policy Template leverages Flexera CCO APIs to produce a stacked bar chart showing Total Instance Memory (in Gigabytes (GiB)) for Azure Virtual Machine Families used per month for the last 12 months.

--- a/operational/azure/total_instance_memory/azure_usage_instance_memory_used.pt
+++ b/operational/azure/total_instance_memory/azure_usage_instance_memory_used.pt
@@ -1,13 +1,13 @@
 name "Azure Usage Report - Amount of Instance Memory Used"
 rs_pt_ver 20180301
 type "policy"
-short_description "This policy produces a usage report showing the amount of memory (in Gigabytes (GiB)) used for each Azure Instance Family. See the [README](https://github.com/flexera-public/policy_templates/tree/master/operational/azure/total_instance_memory) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "**Deprecated: This policy is no longer being updated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/operational/azure/total_instance_memory/) for more details.**  This policy produces a usage report showing the amount of memory (in Gigabytes (GiB)) used for each Azure Instance Family. See the [README](https://github.com/flexera-public/policy_templates/tree/master/operational/azure/total_instance_memory) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "2.1.1",
+  version: "2.1.2",
   provider: "Azure",
   service: "Compute",
   policy_set: "Usage Report"
@@ -134,7 +134,7 @@ script "js_filtered_billing_centers", type: "javascript" do
     //If there are conflicting child/parent BCs then ignore the child BC and take the parent BC
     if (conflicting_child_bcs != undefined) {
       var conflicting_child_bc_ids = _.pluck(conflicting_child_bcs, "id")
-      
+
       var filtered_bc_list = _.reject(billing_center_list, function(bc) {
         return _.contains(conflicting_child_bc_ids, bc.id)
       })
@@ -142,7 +142,7 @@ script "js_filtered_billing_centers", type: "javascript" do
     } else {
       result = _.compact(_.pluck(billing_center_list, 'id'))
     }
-    
+
   } else {
     var billing_center_list = _.filter(ds_billing_centers, function(bc) {
       return bc['parent_id'] == null || bc['parent_id'] == undefined
@@ -184,7 +184,7 @@ script "js_usage_data", type: "javascript" do
   var billing_center_ids = ds_filtered_billing_centers
   var allow_deny_test = { "Allow": true, "Deny": false }
 
-  //Define Expressions for API Filter 
+  //Define Expressions for API Filter
   var expressions = [
     { "dimension": "category", "type": "equal", "value": "Compute" },
     { "dimension": "resource_type", "type": "substring", "substring": "Virtual Machines" },
@@ -197,7 +197,7 @@ script "js_usage_data", type: "javascript" do
 
   //Get Regions list if applicable
   if (param_regions_list.length > 0) {
-    
+
     var regions_filter_list = []
     _.each(param_regions_list, function(reg) {
         var region_dimension = { "dimension": "region", "type": "equal", "value": reg }
@@ -206,7 +206,7 @@ script "js_usage_data", type: "javascript" do
 
     var region_filter_json = {}
     if (param_regions_allow_or_deny == "Deny") {
-      
+
       region_filter_json = {
         "type": "not",
         "expression": {
@@ -217,7 +217,7 @@ script "js_usage_data", type: "javascript" do
       expressions.push(region_filter_json)
 
     } else {
-      
+  
       region_filter_json = {
         "type": "or",
         "expressions": regions_filter_list
@@ -226,7 +226,7 @@ script "js_usage_data", type: "javascript" do
 
     }
   }
-  
+
   //POST JSON payload
   payload = {
     "billing_center_ids": billing_center_ids,

--- a/operational/azure/total_instance_usage_report/CHANGELOG.md
+++ b/operational/azure/total_instance_usage_report/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v1.0.0
+
+- Initial release

--- a/operational/azure/total_instance_usage_report/README.md
+++ b/operational/azure/total_instance_usage_report/README.md
@@ -16,7 +16,7 @@ This Policy Template leverages Flexera CCO APIs to produce a stacked bar chart s
 - *Email Addresses* - A list of email addresses to notify.
 - *Months Back* - How many months to go back in the chart/incident.
 - *Instance Unit* - Instance (Virtual Machine) unit to normalize usage against. Supported units:
-  - `Normalized Units (NFUs)` - Normalize the data against each [Instance Size Flexibility (ISF) Ratio](https://learn.microsoft.com/en-us/azure/virtual-machines/reserved-vm-instance-size-flexibility) of each Virtual Machine instance.
+  - `Normalized Instance Count` - Normalize the data against each [Instance Size Flexibility (ISF) Ratio](https://learn.microsoft.com/en-us/azure/virtual-machines/reserved-vm-instance-size-flexibility) of each Virtual Machine instance.
   - `vCPUs` - Normalize the data against each vCPU of each Virtual Machine instance.
   - `Memory (GiB)` - Normalize the data against each GiB of total memory of each Virtual Machine instance.
 - *Time Unit* - Unit of time to use for results. The `Instance Unit` will be normalized to this time unit. Units are calculated as follows:

--- a/operational/azure/total_instance_usage_report/README.md
+++ b/operational/azure/total_instance_usage_report/README.md
@@ -1,0 +1,54 @@
+# Azure Usage Report - Instance Time Used
+
+## What It Does
+
+This Policy Template leverages Flexera CCO APIs to produce a stacked bar chart showing Total Instance Time for Azure Virtaul Machine Families used per month for the last 12 months. The user can specify which unit of time and which instance spec to use to normalize time against; for example, a chart can be produced for total instance vCPU hours. The data feeding this chart can be filtered by Azure region or Flexera Billing Center if desired. Optionally, the result can be emailed.
+
+## How It Works
+
+- This policy supports a single Azure region or the entire Organization.
+- This policy produces a stacked-bar chart showing Total Instance Units by Virtual Machine Family for the top 8 most used Virtual Machine Families. All other Virtual Machine Families will be aggregated and displayed as "Other". Values shown in the graph are for the past 12 months.
+- The unit used for normalizing instance usage depends on the value of the `Instance Unit` parameter.
+- The unit used for time depends on the value of the `Time Unit` parameter.
+
+## Input Parameters
+
+- *Email Addresses* - A list of email addresses to notify.
+- *Months Back* - How many months to go back in the chart/incident.
+- *Instance Unit* - Instance (Virtual Machine) unit to normalize usage against. Supported units:
+  - `Normalized Units (NFUs)` - Normalize the data against each [Instance Size Flexibility (ISF) Ratio](https://learn.microsoft.com/en-us/azure/virtual-machines/reserved-vm-instance-size-flexibility) of each Virtual Machine instance.
+  - `vCPUs` - Normalize the data against each vCPU of each Virtual Machine instance.
+  - `Memory (GiB)` - Normalize the data against each GiB of total memory of each Virtual Machine instance.
+- *Time Unit* - Unit of time to use for results. The `Instance Unit` will be normalized to this time unit. Units are calculated as follows:
+  - `Hours` - 1 hour.
+  - `Days` - 24 hours.
+  - `Weeks` - 168 hours e.g. 7 days * 24 hours.
+  - `Months` - 730 hours e.g. 365 days / 12 months * 24 hours.
+  - `Years` - 8760 hours e.g. 365 days * 24 hours.
+- *Allow/Deny Regions* - Whether to treat `Allow/Deny Regions List` parameter as allow or deny list. Has no effect if `Allow/Deny Regions List` is left empty.
+- *Allow/Deny Regions List* - A list of allowed or denied regions. Example: `US East`. Leave blank to check all regions.
+- *Allow/Deny Billing Centers* - Whether to treat `Allow/Deny Billing Center List` parameter as allow or deny list. Has no effect if `Allow/Deny Billing Center List` is left empty.
+- *Allow/Deny Billing Center List* - A list of allowed or denied Billing Center names/IDs. Leave blank to check all Billing Centers.
+
+## Policy Actions
+
+- Sends an email notification
+
+## Prerequisites
+
+This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).
+
+### Credential configuration
+
+- [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
+  - `billing_center_viewer`
+
+The [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) page in the docs has detailed instructions for setting up Credentials for the most common providers.
+
+## Supported Clouds
+
+- Azure
+
+## Cost
+
+This Policy Template does not incur any cloud costs.

--- a/operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt
+++ b/operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt
@@ -163,5 +163,221 @@ script "js_billing_centers_filtered", type: "javascript" do
   }
 
   result = _.compact(_.pluck(final_list, 'id'))
-EOS
+  EOS
 end
+
+datasource "ds_usage_data" do
+  request do
+    run_script $js_usage_data, $ds_billing_centers_filtered, $param_regions_allow_or_deny, $param_regions_list, $param_months_back, rs_org_id, rs_optima_host
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "rows") do
+      field "billing_center_id", jmes_path(col_item, "dimensions.billing_center_id")
+      field "instance_type", jmes_path(col_item, "dimensions.instance_type")
+      field "usage_unit", jmes_path(col_item, "dimensions.usage_unit")
+      field "cost", jmes_path(col_item, "metrics.cost_nonamortized_unblended_adj")
+      field "usage_amount", jmes_path(col_item, "metrics.usage_amount")
+      field "month", jmes_path(col_item, "timestamp")
+    end
+  end
+end
+
+script "js_usage_data", type: "javascript" do
+  parameters "ds_billing_centers_filtered", "param_regions_allow_or_deny", "param_regions_list", "param_months_back", "rs_org_id", "rs_optima_host"
+  result "request"
+  code <<-EOS
+  // Get Start and End dates
+  start_date = new Date()
+  start_date.setMonth(start_date.getMonth() - param_months_back)
+  start_date = start_date.toISOString().split('-')[0] + '-' + start_date.toISOString().split('-')[1]
+
+  end_date = new Date()
+  end_date = end_date.toISOString().split('-')[0] + '-' + end_date.toISOString().split('-')[1]
+
+  // Generate region filters if applicable
+  region_filters = []
+
+  if (param_regions_list.length > 0) {
+    subfilters = _.map(param_regions_list, function(region) {
+      return { dimension: "region", type: "equal", value: region }
+    })
+
+    // Create a collection of 'not' filters if deny list
+    if (param_regions_allow_or_deny == "Deny") {
+      region_filters = _.map(subfilters, function(subfilter) {
+        return { type: "not", expression: subfilter }
+      })
+    } else {
+      // Otherwise, create a single or filter if allow list
+      region_filters = [{ type: "or", expressions: subfilters }]
+    }
+  }
+
+  // Create full list of expressions for API Filter
+  expressions = region_filters.concat([
+    { "dimension": "category", "type": "equal", "value": "Compute" },
+    { "dimension": "resource_type", "type": "substring", "substring": "Virtual Machines" },
+    { "dimension": "vendor", "type": "substring", substring: "Azure" }, // Use a substring type to include both "Azure" (Azure EA) and "AzureMCA-Enterprise" (Azure MCA) subscriptions
+    {
+      "type": "not",
+      "expression": { "dimension": "instance_type", "type": "equal", "value": "None" }
+    }
+  ])
+
+  // Payload to send to API
+  payload = {
+    dimensions: [ "billing_center_id", "instance_type", "usage_unit" ],
+    billing_center_ids: ds_billing_centers_filtered,
+    filter: { type: "and", expressions: expressions },
+    metrics: [ "cost_nonamortized_unblended_adj", "usage_amount" ],
+    granularity: "month",
+    end_at: end_date,
+    start_at: start_date
+  }
+
+  // Request
+  var request = {
+    auth: "auth_flexera",
+    verb: "POST",
+    host: rs_optima_host,
+    path: "/bill-analysis/orgs/" + rs_org_id + "/costs/aggregated",
+    headers: {
+      "User-Agent": "RS Policies",
+    },
+    body_fields: payload
+  }
+  EOS
+end
+
+datasource "ds_azure_instance_size_map" do
+  request do
+    verb "GET"
+    host "raw.githubusercontent.com"
+    path "/flexera-public/policy_templates/master/data/azure/instance_types.json"
+    header "User-Agent", "RS Policies"
+  end
+end
+
+datasource "ds_isf_ratio_csv" do
+  request do
+    host "aka.ms"
+    path "/isf"
+  end
+  result do
+    encoding "text"
+  end
+end
+
+datasource "ds_instance_units_per_family" do
+  run_script $js_instance_units_per_family, $ds_azure_instance_size_map, $ds_isf_ratio_csv, $ds_usage_data, $param_unit_time, $param_unit_instance
+end
+
+script "js_instance_units_per_family", type: "javascript" do
+  parameters "ds_azure_instance_size_map", "ds_isf_ratio_csv", "ds_usage_data", "param_unit_time", "param_unit_instance"
+  result "result"
+  code <<-'EOS'
+
+  // Convert Instance Family csv to json
+  var isf_ratio_array = azure_inst_fam.toString().split("\r\n")
+  var inst_families = []
+  _.each(isf_ratio_array, function(ratio) {
+    inst_families.push({
+      "instance_family": ratio.split(",")[0],
+      "instance_type": ratio.split(",")[1]
+    })
+  })
+
+  // Tables to convert parameters to units
+  time_unit = { "Hours": 1, "Days": 24, "Weeks": 168, "Months": 730, "Years": 8760 }
+  instance_unit = { "Normalized Units (NFUs)": "nfu", "vCPUs": "vcpu", "Memory (GiB)": "memory" }
+  result = []
+
+  // Get Normalization Factor units from Instance Data json
+  cpu_ratios = {}
+
+  _.each(_.keys(ds_azure_instance_size_map), function(instance_type) {
+    cpu = ds_azure_instance_size_map[instance_type][instance_unit[param_unit_instance]]
+    if (typeof(cpu) != 'number' && typeof(cpu) != 'string') { cpu = 1 }
+    cpu_ratios[instance_type] = Number(cpu)
+  })
+
+  // Enrich current data with Instance Family, and then calculate Normalized Instance Hours using NFU
+  enriched_usage_data = _.map(ds_usage_data, function(data) {
+    matched_inst_fam = _.find(inst_families, function(fam) {
+      return data.instance_type == fam.instance_type
+    })
+
+    instance_family = ""
+    if (matched_inst_fam != undefined) {
+      instance_family = matched_inst_fam.instance_family
+    } else {
+      instance_family = data.instance_family
+    }
+
+    normalized_instance_units = 0
+
+    if (typeof(cpu_ratios[data['instance_type']]) == 'number') {
+      normalized_instance_units = (data['usage_amount'] / time_unit[param_unit_time]) * cpu_ratios[data['instance_type']]
+    }
+
+    return {
+      billing_center_id: data['billing_center_id'],
+      instance_type: data['instance_type'],
+      usage_unit: data['usage_unit'],
+      cost: data['cost'],
+      usage_amount: data['usage_amount'],
+      month: data['month'],
+      instance_family: instance_family,
+      normalized_instance_units: normalized_instance_units
+    }
+  })
+
+  // Sort data into two lists
+  full_list = []    // Data sorted by month, instance family, and total instance units
+  family_list = []  // Data sorted by instance family and total instance units
+  months = _.uniq(_.pluck(enriched_usage_data, 'month'))
+  families = _.uniq(_.pluck(enriched_usage_data, 'instance_family'))
+
+  _.each(families, function(family) {
+    // Store family data separately so we can find the top 8 families
+    family_data = _.filter(enriched_usage_data, function(data) { return data['instance_family'] == family })
+    family_units = _.pluck(family_data, 'normalized_instance_units')
+    family_instance_units = _.reduce(family_units, function(memo, num) { return memo + num }, 0)
+    family_list.push({ family: family, units: family_instance_units })
+
+    _.each(months, function(month) {
+      matched_data = _.filter(enriched_usage_data, function(data) {
+        return data['month'] == month && data['instance_family'] == family
+      })
+
+      normalized_units = _.pluck(matched_data, 'normalized_instance_units')
+      total_instance_units = _.reduce(normalized_units, function(memo, num) { return memo + num }, 0)
+      full_list.push({ month: month, instance_family: family, total_instance_units: total_instance_units })
+    })
+  })
+
+  // Find top 8 families and store their data in the result
+  family_list = _.sortBy(family_list, 'units').reverse()
+  top_eight_families = _.pluck(family_list.slice(0, 8), 'family')
+
+  result = _.filter(full_list, function(item) {
+    return _.contains(top_eight_families, item['instance_family'])
+  })
+
+  // Combine the data for the remaining families into "Other"
+  remaining_list = _.reject(full_list, function(item) {
+    return _.contains(top_eight_families, item['instance_family'])
+  })
+
+  if (remaining_list.length > 0) {
+    _.each(months, function(month) {
+      monthly_remaining = _.filter(remaining_list, function(item) { return item['month'] == month })
+      units = _.pluck(monthly_remaining, 'total_instance_units')
+      total_instance_units = _.reduce(units, function(memo, num) { return memo + num }, 0)
+      result.push({ month: month, instance_family: "Other", total_instance_units: total_instance_units })
+    })
+  }
+  EOS
+end
+

--- a/operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt
+++ b/operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt
@@ -381,3 +381,73 @@ script "js_instance_units_per_family", type: "javascript" do
   EOS
 end
 
+datasource "ds_chart_creation" do
+  run_script $js_chart_creation, $ds_instance_units_per_family, $ds_applied_policy, $param_regions_allow_or_deny, $param_regions_list, $param_unit_time, $param_unit_instance, $param_months_back
+end
+
+script "js_chart_creation", type: "javascript" do
+  parameters "ds_instance_units_per_family", "ds_applied_policy", "param_regions_allow_or_deny", "param_regions_list", "param_unit_time", "param_unit_instance", "param_months_back"
+  result "result"
+  code <<-EOS
+  instance_unit = { "Normalized Units (NFUs)": "NFU", "vCPUs": "vCPU", "Memory (GiB)": "Memory (GiB)" }
+
+  // Get list of months from data and create chart X axis labels
+  months = _.uniq(_.pluck(ds_instance_units_per_family, 'month'))
+  chart_axis_labels = "chxl=1:|" + _.map(months, function(name) { return name.substring(0, 7) }).join('|')
+
+  // Get list of families and create chart legend from it
+  group_by_family = _.groupBy(ds_instance_units_per_family, function(data) {
+    return data['instance_family']
+  })
+
+  chart_legend = "chdl=" + _.keys(group_by_family).join('|')
+
+  // Get data for each family and create chart data from it
+  data_parts = _.map(group_by_family, function(family_list) {
+    return _.pluck(family_list, 'total_instance_units').join(',')
+  })
+
+  chart_data = "chd=t:" + data_parts.join('|')
+
+  // Create chart axis format
+  chart_axis_format = "chxs=0N*f" + "0sz* " + param_unit_time + "|1,min40"
+
+  // Create chart title
+  policy_title = "Total Instance " + instance_unit[param_unit_instance] + " " + param_unit_time + " Used Per Instance Family"
+  chart_title = "chtt=" + policy_title
+
+  // Assemble chart
+  chart = {
+    chart_type: encodeURI("cht=bvs"),
+    chart_size: encodeURI("chs=900x500"),
+    chart_data: encodeURI(chart_data),
+    chart_title: encodeURI(chart_title),
+    chart_image: encodeURI("chof=.png"),
+    chart_label_position: encodeURI("chdlp=b"),
+    chart_axis: encodeURI("chxt=y,x"),
+    chart_axis_label: encodeURI(chart_axis_labels),
+    chart_axis_format: encodeURI(chart_axis_format),
+    chart_line_style: encodeURI("chls=3|3|3|3|3|3|3|3|3|3|3"),
+    chart_line_color: encodeURI("chco=6929c4,9f1853,198038,b28600,1192e8,009d9a,005d5d,007d79"),
+    chart_data_scale: encodeURI("chds=a"),
+    chart_legend: encodeURI(chart_legend),
+    chart_legend_size: encodeURI("chdls=000000,10"),
+    policy_title: policy_title
+  }
+
+  // Create final incident table and store chart in first entry
+  result = _.map(ds_instance_units_per_family, function(item) {
+    return {
+      month: item['month'].split('-')[0] + '-' + item['month'].split('-')[1],
+      instance_family: item['instance_family'],
+      total_instance_units: Math.round(item['total_instance_units'] * 100) / 100,
+      time_unit: param_unit_time,
+      instance_unit: instance_unit[param_unit_instance],
+      months_back: param_months_back
+    }
+  })
+
+  result[0]['chart_dimensions'] = chart
+  result[0]['policy_name'] = ds_applied_policy['name']
+  EOS
+end

--- a/operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt
+++ b/operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt
@@ -1,0 +1,88 @@
+name "Azure Usage Report - Instance Time Used"
+rs_pt_ver 20180301
+type "policy"
+short_description "This policy produces a usage report showing the amount of time used for each Azure Virtual Machine/Instance Family. See the [README](https://github.com/flexera-public/policy_templates/tree/master/operational/azure/total_instance_usage_report) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+long_description ""
+severity "low"
+category "Operational"
+default_frequency "monthly"
+info(
+  version: "1.0.0",
+  provider: "Azure",
+  service: "Compute",
+  policy_set: "Usage Report"
+)
+
+###############################################################################
+# Parameters
+###############################################################################
+
+parameter "param_email" do
+  type "list"
+  category "Policy Settings"
+  label "Email Addresses"
+  description "Email addresses of the recipients you wish to notify."
+  default []
+end
+
+parameter "param_months_back" do
+  type "number"
+  category "Policy Settings"
+  label "Months Back"
+  description "How many months to go back in the chart/incident."
+  min_value 1
+  max_value 12
+  default 12
+end
+
+parameter "param_unit_instance" do
+  type "string"
+  category "Policy Settings"
+  label "Instance Unit"
+  description "Instance unit to normalize usage against. See README for more details."
+  allowed_values "Normalized Units (NFUs)", "vCPUs", "Memory (GiB)"
+  default "Normalized Units (NFUs)"
+end
+
+parameter "param_unit_time" do
+  type "string"
+  category "Policy Settings"
+  label "Time Unit"
+  description "Unit of time to use for results. See README for more details."
+  allowed_values "Hours", "Days", "Weeks", "Months", "Years"
+  default "Hours"
+end
+
+parameter "param_regions_allow_or_deny" do
+  type "string"
+  category "Filters"
+  label "Allow/Deny Regions"
+  description "Allow or Deny entered regions."
+  allowed_values "Allow", "Deny"
+  default "Allow"
+end
+
+parameter "param_regions_list" do
+  type "list"
+  category "Filters"
+  label "Allow/Deny Regions List"
+  description "A list of allowed or denied regions. Example: 'US West (Oregon)'. Leave blank to check all regions."
+  default []
+end
+
+parameter "param_bc_allow_or_deny" do
+  type "string"
+  category "Filters"
+  label "Allow/Deny Billing Centers"
+  description "Allow or Deny entered Billing Centers."
+  allowed_values "Allow", "Deny"
+  default "Allow"
+end
+
+parameter "param_bc_list" do
+  type "list"
+  category "Filters"
+  label "Allow/Deny Billing Center List"
+  description "A list of allowed or denied Billing Center names/IDs. Leave blank to check all Billing Centers."
+  default []
+end

--- a/operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt
+++ b/operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt
@@ -40,8 +40,8 @@ parameter "param_unit_instance" do
   category "Policy Settings"
   label "Instance Unit"
   description "Instance unit to normalize usage against. See README for more details."
-  allowed_values "Normalized Units (NFUs)", "vCPUs", "Memory (GiB)"
-  default "Normalized Units (NFUs)"
+  allowed_values "Normalized Instance Count", "vCPUs", "Memory (GiB)"
+  default "Normalized Instance Count"
 end
 
 parameter "param_unit_time" do
@@ -290,10 +290,10 @@ script "js_instance_units_per_family", type: "javascript" do
 
   // Tables to convert parameters to units
   time_unit = { "Hours": 1, "Days": 24, "Weeks": 168, "Months": 730, "Years": 8760 }
-  instance_unit = { "Normalized Units (NFUs)": "nfu", "vCPUs": "vcpu", "Memory (GiB)": "memory" }
+  instance_unit = { "Normalized Instance Count": "nfu", "vCPUs": "vcpu", "Memory (GiB)": "memory" }
   result = []
 
-  // Get Normalization Factor units from Instance Data json
+  // Get Normalization Factor Units from Instance Data json
   cpu_ratios = {}
 
   _.each(_.keys(ds_azure_instance_size_map), function(instance_type) {
@@ -302,7 +302,7 @@ script "js_instance_units_per_family", type: "javascript" do
     cpu_ratios[instance_type] = Number(cpu)
   })
 
-  // Enrich current data with Instance Family, and then calculate Normalized Instance Hours using NFU
+  // Enrich current data with Instance Family, and then calculate Normalized Instance Count/Units using ISF
   enriched_usage_data = _.map(ds_usage_data, function(data) {
     matched_inst_fam = _.find(inst_families, function(fam) {
       return data.instance_type == fam.instance_type
@@ -389,7 +389,7 @@ script "js_chart_creation", type: "javascript" do
   parameters "ds_instance_units_per_family", "ds_applied_policy", "param_regions_allow_or_deny", "param_regions_list", "param_unit_time", "param_unit_instance", "param_months_back"
   result "result"
   code <<-EOS
-  instance_unit = { "Normalized Units (NFUs)": "NFU", "vCPUs": "vCPU", "Memory (GiB)": "Memory (GiB)" }
+  instance_unit = { "Normalized Instance Count": "Count", "vCPUs": "vCPU", "Memory (GiB)": "Memory (GiB)" }
 
   // Get list of months from data and create chart X axis labels
   months = _.uniq(_.pluck(ds_instance_units_per_family, 'month'))

--- a/operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt
+++ b/operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt
@@ -279,7 +279,7 @@ script "js_instance_units_per_family", type: "javascript" do
   code <<-'EOS'
 
   // Convert Instance Family csv to json
-  var isf_ratio_array = azure_inst_fam.toString().split("\r\n")
+  var isf_ratio_array = ds_isf_ratio_csv.toString().split("\r\n")
   var inst_families = []
   _.each(isf_ratio_array, function(ratio) {
     inst_families.push({

--- a/operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt
+++ b/operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt
@@ -86,3 +86,16 @@ parameter "param_bc_list" do
   description "A list of allowed or denied Billing Center names/IDs. Leave blank to check all Billing Centers."
   default []
 end
+
+###############################################################################
+# Authentication
+###############################################################################
+
+credentials "auth_flexera" do
+  schemes "oauth2"
+  label "Flexera"
+  description "Select Flexera One OAuth2 credentials"
+  tags "provider=flexera"
+end
+
+

--- a/operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt
+++ b/operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt
@@ -98,4 +98,70 @@ credentials "auth_flexera" do
   tags "provider=flexera"
 end
 
+###############################################################################
+# Datasources & Scripts
+###############################################################################
 
+# Get applied policy metadata for use later
+datasource "ds_applied_policy" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    header "Api-Version", "1.0"
+  end
+end
+
+datasource "ds_billing_centers" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/analytics/orgs/", rs_org_id, "/billing_centers"])
+    header "Api-Version", "1.0"
+    header "User-Agent", "RS Policies"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "href", jmes_path(col_item, "href")
+      field "id", jmes_path(col_item, "id")
+      field "name", jmes_path(col_item, "name")
+      field "parent_id", jmes_path(col_item, "parent_id")
+    end
+  end
+end
+
+datasource "ds_billing_centers_filtered" do
+  run_script $js_billing_centers_filtered, $ds_billing_centers, $param_bc_allow_or_deny, $param_bc_list
+end
+
+script "js_billing_centers_filtered", type: "javascript" do
+  parameters "ds_billing_centers", "param_bc_allow_or_deny", "param_bc_list"
+  result "result"
+  code <<-EOS
+  allow_deny_test = { "Allow": true, "Deny": false }
+
+  if (param_bc_list.length > 0) {
+    billing_centers = _.filter(ds_billing_centers, function(item) {
+      id_found = _.contains(param_bc_list, item['id']) == allow_deny_test[param_regions_allow_or_deny]
+      name_found = _.contains(param_bc_list, item['name']) == allow_deny_test[param_regions_allow_or_deny]
+      return id_found || name_found
+    })
+
+    // Check for conflicting parents/children and remove children if present
+    bc_ids = _.compact(_.pluck(billing_centers, 'id'))
+    bad_children = _.filter(ds_billing_centers, function(bc) { return _.contains(bc_ids, bc['parent_id']) })
+    bad_children_ids = _.pluck(bad_children, 'id')
+
+    // Create final result with the bad children removed
+    final_list = _.reject(billing_centers, function(bc) { return _.contains(bad_children_ids, bc['id']) })
+  } else {
+    // If we're not filtering at all, just grab all of the top level billing centers
+    final_list = _.filter(ds_billing_centers, function(bc) {
+      return bc['parent_id'] == null || bc['parent_id'] == undefined
+    })
+  }
+
+  result = _.compact(_.pluck(final_list, 'id'))
+EOS
+end

--- a/operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt
+++ b/operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt
@@ -451,3 +451,48 @@ script "js_chart_creation", type: "javascript" do
   result[0]['policy_name'] = ds_applied_policy['name']
   EOS
 end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "pol_usage_report" do
+  validate_each $ds_chart_creation do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: (Normalized - Past {{ with index data 0 }}{{ .months_back }}{{ end }} Months)"
+    detail_template <<-EOS
+# Azure - {{ with index data 0 }}{{ .chart_dimensions.policy_title }}{{ end }} Report
+![Instance {{ with index data 0 }}{{ .instance_unit }}{{ end }} {{ with index data 0 }}{{ .time_unit }}{{ end }} Used Per Instance Family Chart](https://api.image-charts-auth.flexeraeng.com/ic-function?rs_org_id={{ rs_org_id }}&rs_project_id={{ rs_project_id }}&{{ with index data 0 }}{{ .chart_dimensions.chart_data }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_size }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_type }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_image }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_title }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_label_position }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_axis }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_axis_label }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_line_style }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_line_color }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_data_scale }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_legend_size }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_legend }}{{ end }}&{{ with index data 0 }}{{ .chart_dimensions.chart_axis_format }}{{ end }})
+EOS
+    check eq(0, 1)
+    escalate $esc_email
+    export do
+      resource_level false
+      field "month" do
+        label "Month"
+      end
+      field "instance_family" do
+        label "Instance Family"
+      end
+      field "total_instance_units" do
+        label "Instance Units Used"
+      end
+      field "instance_unit" do
+        label "Instance Unit"
+      end
+      field "time_unit" do
+        label "Time Unit"
+      end
+    end
+  end
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end

--- a/operational/azure/total_instance_vcpus/CHANGELOG.md
+++ b/operational/azure/total_instance_vcpus/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1.2
+
+- Deprecated: This policy is no longer being updated. Please see policy README for more information.
+
 ## v2.1.1
 
 - Fixed issue where only top-level billing centers could be filtered on. Policy now additionally supports filtering on child billing centers.

--- a/operational/azure/total_instance_vcpus/README.md
+++ b/operational/azure/total_instance_vcpus/README.md
@@ -1,5 +1,9 @@
 # Azure Usage Report - Number of Instance vCPUs Used
 
+## Deprecated
+
+This policy is no longer being updated. The [Azure Usage Report - Instance Time Used](https://github.com/flexera-public/policy_templates/tree/master/operational/azure/total_instance_usage_report/) policy now includes this functionality and should be used instead.
+
 ## What It Does
 
 This Policy Template leverages Flexera CCO APIs to produce a stacked bar chart showing Total Instance vCPUs for Azure Virtual Machine Families used per month for the last 12 months.

--- a/operational/azure/total_instance_vcpus/azure_usage_instance_vcpus_used.pt
+++ b/operational/azure/total_instance_vcpus/azure_usage_instance_vcpus_used.pt
@@ -1,13 +1,13 @@
 name "Azure Usage Report - Number of Instance vCPUs Used"
 rs_pt_ver 20180301
 type "policy"
-short_description "This policy produces a usage report showing the number of vCPUs used for each Azure Instance Family. See the [README](https://github.com/flexera-public/policy_templates/tree/master/operational/azure/total_instance_vcpus) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "**Deprecated: This policy is no longer being updated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/operational/azure/total_instance_vcpus/) for more details.**  This policy produces a usage report showing the number of vCPUs used for each Azure Instance Family. See the [README](https://github.com/flexera-public/policy_templates/tree/master/operational/azure/total_instance_vcpus) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "2.1.1",
+  version: "2.1.2",
   provider: "Azure",
   service: "Compute",
   policy_set: "Usage Report"
@@ -134,7 +134,7 @@ script "js_filtered_billing_centers", type: "javascript" do
     //If there are conflicting child/parent BCs then ignore the child BC and take the parent BC
     if (conflicting_child_bcs != undefined) {
       var conflicting_child_bc_ids = _.pluck(conflicting_child_bcs, "id")
-      
+
       var filtered_bc_list = _.reject(billing_center_list, function(bc) {
         return _.contains(conflicting_child_bc_ids, bc.id)
       })
@@ -142,7 +142,7 @@ script "js_filtered_billing_centers", type: "javascript" do
     } else {
       result = _.compact(_.pluck(billing_center_list, 'id'))
     }
-    
+
   } else {
     var billing_center_list = _.filter(ds_billing_centers, function(bc) {
       return bc['parent_id'] == null || bc['parent_id'] == undefined
@@ -184,7 +184,7 @@ script "js_usage_data", type: "javascript" do
   var billing_center_ids = ds_filtered_billing_centers
   var allow_deny_test = { "Allow": true, "Deny": false }
 
-  //Define Expressions for API Filter 
+  //Define Expressions for API Filter
   var expressions = [
     { "dimension": "category", "type": "equal", "value": "Compute" },
     { "dimension": "resource_type", "type": "substring", "substring": "Virtual Machines" },
@@ -197,7 +197,7 @@ script "js_usage_data", type: "javascript" do
 
   //Get Regions list if applicable
   if (param_regions_list.length > 0) {
-    
+
     var regions_filter_list = []
     _.each(param_regions_list, function(reg) {
         var region_dimension = { "dimension": "region", "type": "equal", "value": reg }
@@ -206,7 +206,7 @@ script "js_usage_data", type: "javascript" do
 
     var region_filter_json = {}
     if (param_regions_allow_or_deny == "Deny") {
-      
+
       region_filter_json = {
         "type": "not",
         "expression": {
@@ -217,7 +217,7 @@ script "js_usage_data", type: "javascript" do
       expressions.push(region_filter_json)
 
     } else {
-      
+
       region_filter_json = {
         "type": "or",
         "expressions": regions_filter_list
@@ -226,7 +226,7 @@ script "js_usage_data", type: "javascript" do
 
     }
   }
-  
+
   //POST JSON payload
   payload = {
     "billing_center_ids": billing_center_ids,

--- a/tools/policy_master_permission_generation/validated_policy_templates.yaml
+++ b/tools/policy_master_permission_generation/validated_policy_templates.yaml
@@ -88,6 +88,7 @@ validated_policy_templates:
 -  "./operational/azure/tag_cardinality/azure_tag_cardinality.pt"
 -  "./operational/azure/total_instance_hours/azure_usage_instance_hours_used.pt"
 -  "./operational/azure/total_instance_memory/azure_usage_instance_memory_used.pt"
+-  "./operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt"
 -  "./operational/azure/total_instance_vcpus/azure_usage_instance_vcpus_used.pt"
 -  "./operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks.pt"
 # Google


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves below -->
This is a new policy, `Azure Usage Report - Instance Time Used`, that replaces the following policies that are being deprecated as part of this same change:

- `Azure Usage Report - Number of Instance Hours Used`
- `Azure Usage Report - Number of Instance vCPUs Used`
- `Azure Usage Report - Amount of Instance Memory Used`

This was done because these policies were almost identical; as a consequence, it really didn't make sense to maintain 3 separate policies for something that could be a simple user parameter. The READMEs of these policies have been updated to direct users to this policy.

The new policy contains all of the functionality of the above, allowing the user to simply select which unit they want to report against. Additionally, the following improvements have been made:

The user can choose which unit of time to normalize the unit against. Default is Hours. Ambiguous units, such as Months, are defined explicitly in the README.
The user can decide how many months back to generate the report for. Still limited to 12 but can be less than 12 if desired.
The incident output has been cleaned up. Months no longer have unnecessary hours/minutes/seconds attached to them, and the normalized numbers are rounded to the 100th.
Code in general has been rewritten and optimized to be more readable, more efficient, and have good comments explaining what is happening within the policy.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behaviour. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->
Tested the policy using various inputs, for example:
- Testing policy to ensure existing functionality still works:
  - Test policy with default parameters (no filters).
  - Test filter on two BCs, Deny
  - Test filter on one region, Allow
- Testing policy to ensure new functionality works:
  - Test `Months Back` parameter
  - Test `Instance Unit` parameter for:
    - NFU metric
    - vCPU metric
    - Memory metric
  - Test `Time Unit` parameter e.g., Memory by Month

Example below:
![image](https://github.com/flexera-public/policy_templates/assets/92175447/bb602d48-9643-45f7-a01f-dc7371941c87)


### Contribution Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
