### PR TITLE
fix: Meta Parent template `$action_options` check type is array

### DIFF
--- a/automation/aws/aws_missing_regions/aws_missing_regions_meta_parent.pt
+++ b/automation/aws/aws_missing_regions/aws_missing_regions_meta_parent.pt
@@ -974,7 +974,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/compliance/aws/disallowed_regions/aws_disallowed_regions_meta_parent.pt
+++ b/compliance/aws/disallowed_regions/aws_disallowed_regions_meta_parent.pt
@@ -1060,7 +1060,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/compliance/aws/ecs_unused/aws_unused_ecs_clusters_meta_parent.pt
+++ b/compliance/aws/ecs_unused/aws_unused_ecs_clusters_meta_parent.pt
@@ -1041,7 +1041,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/compliance/aws/iam_role_audit/aws_iam_role_audit_meta_parent.pt
+++ b/compliance/aws/iam_role_audit/aws_iam_role_audit_meta_parent.pt
@@ -998,7 +998,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent_meta_parent.pt
+++ b/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent_meta_parent.pt
@@ -1015,7 +1015,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/compliance/aws/long_stopped_instances/aws_long_stopped_instances_meta_parent.pt
+++ b/compliance/aws/long_stopped_instances/aws_long_stopped_instances_meta_parent.pt
@@ -1066,7 +1066,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/compliance/aws/untagged_resources/aws_untagged_resources_meta_parent.pt
+++ b/compliance/aws/untagged_resources/aws_untagged_resources_meta_parent.pt
@@ -1066,7 +1066,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry_meta_parent.pt
+++ b/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry_meta_parent.pt
@@ -1066,7 +1066,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent.pt
+++ b/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent.pt
@@ -1086,7 +1086,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/compliance/azure/azure_long_stopped_instances/long_stopped_instances_azure_meta_parent.pt
+++ b/compliance/azure/azure_long_stopped_instances/long_stopped_instances_azure_meta_parent.pt
@@ -1086,7 +1086,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/compliance/azure/azure_policy_audit/azure_policy_audit_meta_parent.pt
+++ b/compliance/azure/azure_policy_audit/azure_policy_audit_meta_parent.pt
@@ -1022,7 +1022,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent.pt
+++ b/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent.pt
@@ -1081,7 +1081,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/compliance/azure/azure_untagged_vms/untagged_vms_meta_parent.pt
+++ b/compliance/azure/azure_untagged_vms/untagged_vms_meta_parent.pt
@@ -1118,7 +1118,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/compliance/azure/compliance_score/azure_regulatory_compliance_report_meta_parent.pt
+++ b/compliance/azure/compliance_score/azure_regulatory_compliance_report_meta_parent.pt
@@ -1002,7 +1002,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
+++ b/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
@@ -1016,7 +1016,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/compliance/google/long_stopped_instances/google_long_stopped_instances_meta_parent.pt
+++ b/compliance/google/long_stopped_instances/google_long_stopped_instances_meta_parent.pt
@@ -1074,7 +1074,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/compliance/google/unlabeled_resources/unlabeled_resources_meta_parent.pt
+++ b/compliance/google/unlabeled_resources/unlabeled_resources_meta_parent.pt
@@ -1054,7 +1054,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/aws/burstable_ec2_instances/aws_burstable_ec2_instances_meta_parent.pt
+++ b/cost/aws/burstable_ec2_instances/aws_burstable_ec2_instances_meta_parent.pt
@@ -1092,7 +1092,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/aws/eks_without_spot/aws_eks_without_spot_meta_parent.pt
+++ b/cost/aws/eks_without_spot/aws_eks_without_spot_meta_parent.pt
@@ -1028,7 +1028,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume_meta_parent.pt
+++ b/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume_meta_parent.pt
@@ -1038,7 +1038,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
+++ b/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
@@ -1147,7 +1147,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
@@ -1092,7 +1092,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
@@ -1133,7 +1133,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/aws/rds_instance_license_info/rds_instance_license_info_meta_parent.pt
+++ b/cost/aws/rds_instance_license_info/rds_instance_license_info_meta_parent.pt
@@ -1002,7 +1002,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_volumes_rightsizing_meta_parent.pt
@@ -1092,7 +1092,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
@@ -1348,7 +1348,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
@@ -1276,7 +1276,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/aws/s3_bucket_size/aws_bucket_size_meta_parent.pt
+++ b/cost/aws/s3_bucket_size/aws_bucket_size_meta_parent.pt
@@ -1031,7 +1031,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check_meta_parent.pt
+++ b/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check_meta_parent.pt
@@ -1016,7 +1016,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/aws/schedule_instance/aws_schedule_instance_meta_parent.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance_meta_parent.pt
@@ -1160,7 +1160,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
@@ -1095,7 +1095,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/aws/unused_clbs/aws_unused_clbs_meta_parent.pt
+++ b/cost/aws/unused_clbs/aws_unused_clbs_meta_parent.pt
@@ -1079,7 +1079,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
@@ -1075,7 +1075,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/aws/unused_rds/unused_rds_meta_parent.pt
+++ b/cost/aws/unused_rds/unused_rds_meta_parent.pt
@@ -1078,7 +1078,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
@@ -1098,7 +1098,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/azure/blob_storage_optimization/azure_blob_storage_optimization_meta_parent.pt
+++ b/cost/azure/blob_storage_optimization/azure_blob_storage_optimization_meta_parent.pt
@@ -1130,7 +1130,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/azure/databricks/rightsize_compute/azure_databricks_rightsize_compute_meta_parent.pt
+++ b/cost/azure/databricks/rightsize_compute/azure_databricks_rightsize_compute_meta_parent.pt
@@ -1358,7 +1358,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
@@ -1097,7 +1097,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
@@ -1085,7 +1085,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
@@ -1088,7 +1088,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
@@ -1065,7 +1065,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
@@ -1097,7 +1097,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/azure/reserved_instances/recommendations/azure_reserved_instance_recommendations_meta_parent.pt
+++ b/cost/azure/reserved_instances/recommendations/azure_reserved_instance_recommendations_meta_parent.pt
@@ -1094,7 +1094,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
@@ -1380,7 +1380,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks_meta_parent.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks_meta_parent.pt
@@ -1165,7 +1165,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/azure/rightsize_netapp_files/azure_rightsize_netapp_files_meta_parent.pt
+++ b/cost/azure/rightsize_netapp_files/azure_rightsize_netapp_files_meta_parent.pt
@@ -1229,7 +1229,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
@@ -1272,7 +1272,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
@@ -1192,7 +1192,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/azure/sql_servers_without_elastic_pool/azure_sql_servers_without_elastic_pool_meta_parent.pt
+++ b/cost/azure/sql_servers_without_elastic_pool/azure_sql_servers_without_elastic_pool_meta_parent.pt
@@ -1048,7 +1048,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent.pt
+++ b/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent.pt
@@ -1033,7 +1033,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
@@ -1097,7 +1097,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/azure/unoptimized_web_app_scaling/azure_unoptimized_web_app_scaling_meta_parent.pt
+++ b/cost/azure/unoptimized_web_app_scaling/azure_unoptimized_web_app_scaling_meta_parent.pt
@@ -1043,7 +1043,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/azure/unused_firewalls/azure_unused_firewalls_meta_parent.pt
+++ b/cost/azure/unused_firewalls/azure_unused_firewalls_meta_parent.pt
@@ -1092,7 +1092,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
@@ -1110,7 +1110,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
+++ b/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
@@ -1068,7 +1068,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
@@ -1134,7 +1134,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations_meta_parent.pt
+++ b/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations_meta_parent.pt
@@ -1124,7 +1124,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/google/cud_expiration/google_cud_expiration_report_meta_parent.pt
+++ b/cost/google/cud_expiration/google_cud_expiration_report_meta_parent.pt
@@ -1025,7 +1025,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/google/cud_recommendations/google_committed_use_discount_recommendations_meta_parent.pt
+++ b/cost/google/cud_recommendations/google_committed_use_discount_recommendations_meta_parent.pt
@@ -1061,7 +1061,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/google/cud_report/google_committed_use_discount_report_meta_parent.pt
+++ b/cost/google/cud_report/google_committed_use_discount_report_meta_parent.pt
@@ -1022,7 +1022,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
@@ -1091,7 +1091,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
@@ -1121,7 +1121,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/google/object_storage_optimization/google_object_storage_optimization_meta_parent.pt
+++ b/cost/google/object_storage_optimization/google_object_storage_optimization_meta_parent.pt
@@ -1097,7 +1097,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
@@ -1080,7 +1080,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/google/recommender/recommender_meta_parent.pt
+++ b/cost/google/recommender/recommender_meta_parent.pt
@@ -1043,7 +1043,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
+++ b/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
@@ -1261,7 +1261,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/cost/google/schedule_instance/google_schedule_instance_meta_parent.pt
+++ b/cost/google/schedule_instance/google_schedule_instance_meta_parent.pt
@@ -1180,7 +1180,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/operational/aws/ec2_stopped_report/aws_ec2_stopped_report_meta_parent.pt
+++ b/operational/aws/ec2_stopped_report/aws_ec2_stopped_report_meta_parent.pt
@@ -1113,7 +1113,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate_meta_parent.pt
+++ b/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate_meta_parent.pt
@@ -1053,7 +1053,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
+++ b/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
@@ -1101,7 +1101,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/operational/aws/scheduled_ec2_events/aws_scheduled_ec2_events_meta_parent.pt
+++ b/operational/aws/scheduled_ec2_events/aws_scheduled_ec2_events_meta_parent.pt
@@ -1058,7 +1058,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/operational/aws/tag_cardinality/aws_tag_cardinality_meta_parent.pt
+++ b/operational/aws/tag_cardinality/aws_tag_cardinality_meta_parent.pt
@@ -987,7 +987,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/operational/azure/aks_nodepools_without_autoscaling/aks_nodepools_without_autoscaling_meta_parent.pt
+++ b/operational/azure/aks_nodepools_without_autoscaling/aks_nodepools_without_autoscaling_meta_parent.pt
@@ -1045,7 +1045,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/operational/azure/aks_nodepools_without_zero_autoscaling/aks_nodepools_without_zero_autoscaling_meta_parent.pt
+++ b/operational/azure/aks_nodepools_without_zero_autoscaling/aks_nodepools_without_zero_autoscaling_meta_parent.pt
@@ -1051,7 +1051,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
+++ b/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
@@ -1106,7 +1106,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
@@ -1118,7 +1118,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
+++ b/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
@@ -1004,7 +1004,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent.pt
+++ b/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent.pt
@@ -1048,7 +1048,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes_meta_parent.pt
+++ b/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes_meta_parent.pt
@@ -1010,7 +1010,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/security/aws/public_buckets/aws_public_buckets_meta_parent.pt
+++ b/security/aws/public_buckets/aws_public_buckets_meta_parent.pt
@@ -999,7 +999,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances_meta_parent.pt
+++ b/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances_meta_parent.pt
@@ -1050,7 +1050,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/security/google/public_buckets/google_public_buckets_meta_parent.pt
+++ b/security/google/public_buckets/google_public_buckets_meta_parent.pt
@@ -1036,7 +1036,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
@@ -912,7 +912,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
@@ -922,7 +922,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)

--- a/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
@@ -922,7 +922,7 @@ define runActions($incidents, $action_label, $governance_host, $rs_project_id, $
         body: { "options":[{ "name": "ids",  "value": $incident["resource_ids"] }] }
       }
       # If the action has parameters, add them to the request body
-      if size($action_options) > 0
+      if type($action_options) == "array" && size($action_options) > 0
         $request["body"]["options"] = $request["body"]["options"] + $action_options
       end
       $response = http_request($request)


### PR DESCRIPTION
### Description

Fixes issue where $action_options is null instead of a list, which results in an error
