### PR TITLE
POL-1247 fix: Add default value for `IAM Role Names/IDs/ARNs` param

### DIFF
--- a/compliance/aws/iam_role_audit/CHANGELOG.md
+++ b/compliance/aws/iam_role_audit/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.0.1
+
+- Add default value for `IAM Role Names/IDs/ARNs` param
+
 ## v3.0.0
 
 - Several parameters altered to be more descriptive and human-readable

--- a/compliance/aws/iam_role_audit/aws_iam_role_audit.pt
+++ b/compliance/aws/iam_role_audit/aws_iam_role_audit.pt
@@ -7,7 +7,7 @@ severity "medium"
 category "Compliance"
 default_frequency "daily"
 info(
-  version: "3.0.0",
+  version: "3.0.1",
   provider:"AWS",
   service: "IAM",
   policy_set: "Identity & Access Management"
@@ -38,7 +38,7 @@ parameter "param_role_names" do
   category "Policy Settings"
   label "IAM Role Names/IDs/ARNs"
   description "List of IAM role names/IDs/ARNs to check."
-  # No default value, user input required
+  default ["FlexeraAutomationAccessRole"]
 end
 
 ###############################################################################


### PR DESCRIPTION
### Description

Add default value for `IAM Role Names/IDs/ARNs` param

This is helpful so we can deploy using the Meta Parent Policy Template and no required user input parameters.

Value is the name of the role created by the recommended Cloud Formation Template

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
