### PR TITLE
FOPTS-4009 add cumulative report option

### DIFF
--- a/cost/flexera/cco/budget_v_actual_spend_report/CHANGELOG.md
+++ b/cost/flexera/cco/budget_v_actual_spend_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.5.2
+
+- Enhanced policy functionality to display data cumulatively or monthly (in both chart and table format) based on a new "report type" parameter.
+
 ## v2.5.1
 
 - Updated policy to use internal Flexera API for generating charts. Policy functionality is unchanged.

--- a/cost/flexera/cco/budget_v_actual_spend_report/README.md
+++ b/cost/flexera/cco/budget_v_actual_spend_report/README.md
@@ -22,6 +22,8 @@ Refer to the [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN
 
 ## Input Parameters
 
+
+- _Report Type_: Allows selection between cumulative and monthly reporting options.
 - _Budget Name or ID_: The name or ID of the target Budget.
 - _Filter Group By Dimensions_: Filter by dimension=value pairs (e.g., 'Cloud Vendor=AWS'). Multiple values for the same dimension can be supplied as coma-separated list.
 - _Unbudgeted Spend_: Parameter to include or exclude unbudgeted funds in the calculation.

--- a/cost/flexera/cco/budget_v_actual_spend_report/README.md
+++ b/cost/flexera/cco/budget_v_actual_spend_report/README.md
@@ -6,7 +6,6 @@ This policy generates an email report comparing actual spending to budgeted valu
 
 ## Input Parameters
 
-
 - _Report Type_: Allows selection between cumulative and monthly reporting options.
 - _Budget Name or ID_: The name or ID of the target Budget.
 - _Filter Group By Dimensions_: Filter by dimension=value pairs (e.g., 'Cloud Vendor=AWS'). Multiple values for the same dimension can be supplied as coma-separated list.

--- a/cost/flexera/cco/budget_v_actual_spend_report/README.md
+++ b/cost/flexera/cco/budget_v_actual_spend_report/README.md
@@ -21,7 +21,6 @@ This policy generates an email report comparing actual spending to budgeted valu
 This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).
 
 - [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
-  - `policy_manager`
   - `billing_center_viewer`
 
 The [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) page in the docs has detailed instructions for setting up Credentials for the most common providers.

--- a/cost/flexera/cco/budget_v_actual_spend_report/README.md
+++ b/cost/flexera/cco/budget_v_actual_spend_report/README.md
@@ -1,24 +1,8 @@
 # Budget vs Actual Spend Report
 
-## What it does
+## What It Does
 
 This policy generates an email report comparing actual spending to budgeted values. It utilizes the Flexera Budget API to gather details and sends the report via email, eliminating the need for stakeholders to log in to Flexera One for report access.
-
-## Prerequisites
-
-This policy requires appropriate [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authentication. Ensure a Flexera Credential is registered, compatible with this policy.
-
-- [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (_provider=flexera_) which has the following roles:
-  - `optima:budget:index`
-  - `optima:budget:report`
-  - `optima:billing_center:show`
-
-Refer to the [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) page for detailed instructions on setting up Credentials.
-
-## Functional Details
-
-- Chart templates are updated for improved configuration adaptability.
-- Various minor enhancements and bug fixes contribute to improved stability and performance.
 
 ## Input Parameters
 
@@ -28,6 +12,29 @@ Refer to the [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN
 - _Filter Group By Dimensions_: Filter by dimension=value pairs (e.g., 'Cloud Vendor=AWS'). Multiple values for the same dimension can be supplied as coma-separated list.
 - _Unbudgeted Spend_: Parameter to include or exclude unbudgeted funds in the calculation.
 - _Email Addresses_: A list of email addresses to notify.
+
+## Policy Actions
+
+- Send an email report
+
+## Prerequisites
+
+This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).
+
+- [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
+  - `policy_manager`
+  - `billing_center_viewer`
+
+The [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) page in the docs has detailed instructions for setting up Credentials for the most common providers.
+
+## Supported Clouds
+
+- Flexera
+
+## Functional Details
+
+- Chart templates are updated for improved configuration adaptability.
+- Various minor enhancements and bug fixes contribute to improved stability and performance.
 
 ## Cost
 

--- a/cost/flexera/cco/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
+++ b/cost/flexera/cco/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
@@ -280,11 +280,11 @@ script "js_reports", type: "javascript" do
 end
 
 datasource "ds_aggregated_report" do
-  run_script $js_aggregated_report, $ds_reports, $ds_currency_code, $ds_currency_reference, $ds_dimensions, $ds_filters, $param_budget_name_id, f1_app_host, $param_report_type
+  run_script $js_aggregated_report, $ds_reports, $ds_currency_code, $ds_currency_reference, $ds_dimensions, $ds_filters, $param_budget_name_id, $param_report_type, f1_app_host
 end
 
 script "js_aggregated_report", type: "javascript" do
-  parameters "reports", "currency_code", "currency_reference", "ds_dimensions", "filters", "budget_name_id", "f1_app_host" , "report_type"
+  parameters "reports", "currency_code", "currency_reference", "ds_dimensions", "filters", "budget_name_id", "f1_app_host", "report_type"
   result "results"
   code <<-EOS
   var invalid = [];
@@ -416,7 +416,6 @@ script "js_aggregated_report", type: "javascript" do
       item.is_budgeted = !item.dimensions.is_budgeted || item.dimensions.is_budgeted === "Budgeted";
     }
     item.metric = cost_metric[item.metric || ''] || item.metric;
-
 
     item.host = f1_app_host;
     item.dimm = get_dimm_names(item.dimensionsIDs);

--- a/cost/flexera/cco/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
+++ b/cost/flexera/cco/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
@@ -36,6 +36,15 @@ parameter "param_filter" do
   default []
 end
 
+parameter "param_report_type" do
+  type "string"
+  category "Policy Settings"
+  label "Report type (cumulative or monthly)"
+  description "Select the type of report to generate: Cumulative or Monthly(non-cumulative)."
+  allowed_values "Monthly", "Cumulative"
+  default "Monthly"
+end
+
 parameter "param_unbudgeted" do
   type "string"
   category "Policy Settings"
@@ -447,15 +456,20 @@ EOS
   end
 
   validate $ds_aggregated_report do
-    summary_template "{{with index data.reportData 0}}{{ .name }}{{end}}: Monthly Budget vs Actual Spend Report"
+    summary_template "{{with index data.reportData 0}}{{ .name }}{{end}}: {{parameters.param_report_type}} Budget vs Actual Spend Report"
     detail_template <<-EOS
-  # {{with index data.reportData 0}}{{ .name }}{{end}}: Monthly Budget vs Actual Spend Report
+  # {{with index data.reportData 0}}{{ .name }}{{end}}: {{parameters.param_report_type}} Budget vs Actual Spend Report
 
   Currency: **{{with index data.reportData 0}}{{ .currency }}{{end}}**
 
   Cost Metric: **{{with index data.reportData 0}}{{ .metric }}{{end}}**
 
   Dimensions: **{{with index data.reportData 0}}{{ .dimm }}{{end}}**
+
+  {{ if eq parameters.param_report_type  "Cumulative"  }}
+  Target Groups: \n
+    Note : Budget, Actual Spend, and Overspend columns throughout this report reflect cumulative totals.
+  {{end}}
 
   {{ if parameters.param_filter }}
   Target Groups: \n

--- a/cost/flexera/cco/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
+++ b/cost/flexera/cco/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
@@ -8,7 +8,7 @@ category "Cost"
 tenancy "single"
 default_frequency "daily"
 info(
-  version: "2.5.1",
+  version: "2.5.2",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization"
@@ -280,11 +280,11 @@ script "js_reports", type: "javascript" do
 end
 
 datasource "ds_aggregated_report" do
-  run_script $js_aggregated_report, $ds_reports, $ds_currency_code, $ds_currency_reference, $ds_dimensions, $ds_filters, $param_budget_name_id, f1_app_host
+  run_script $js_aggregated_report, $ds_reports, $ds_currency_code, $ds_currency_reference, $ds_dimensions, $ds_filters, $param_budget_name_id, f1_app_host, $param_report_type
 end
 
 script "js_aggregated_report", type: "javascript" do
-  parameters "reports", "currency_code", "currency_reference", "ds_dimensions", "filters", "budget_name_id", "f1_app_host"
+  parameters "reports", "currency_code", "currency_reference", "ds_dimensions", "filters", "budget_name_id", "f1_app_host" , "report_type"
   result "results"
   code <<-EOS
   var invalid = [];
@@ -354,8 +354,9 @@ script "js_aggregated_report", type: "javascript" do
   var yearMonthsArr = [];
   var chartMap = {};
   var currentYearMonth = fmtDate(currentDate);
+  var cumulativeAmount = {};
 
-  _.each(reports, function (item, idx) {
+  _.each(_.sortBy(_.sortBy(reports, function (item) {return item.group;}), function (item) {return item.monthYear;}), function (item, idx) {
     item.currency = currency_code.value;
     if (idx == 0) {
       yearMonthsArr = item.yearMonths.filter(function (ym) {
@@ -368,6 +369,12 @@ script "js_aggregated_report", type: "javascript" do
         };
       });
     }
+    if (!cumulativeAmount[item.group]) {
+      cumulativeAmount[item.group] = { 
+        budget: 0,
+        spend: 0,
+        };
+    }
 
     item.budgetAmount = item.budgetAmount || 0;
     item.spendAmount = item.spendAmount || 0;
@@ -378,11 +385,22 @@ script "js_aggregated_report", type: "javascript" do
 
     item.budgetAmount = Math.round(item.budgetAmount * 100) / 100;
     item.spendAmount = Math.round(item.spendAmount * 100) / 100;
-    item.overBudgetAmount = Math.max(0, Math.round((item.spendAmount - item.budgetAmount) * 100) / 100);
+
+    if (report_type == "Cumulative") {
+      cumulativeAmount[item.group].budget += item.budgetAmount;
+      cumulativeAmount[item.group].spend += item.spendAmount;
+      item.reportSpecificBudget =  cumulativeAmount[item.group].budget;
+      item.reportSpecificSpend = cumulativeAmount[item.group].spend;
+    }else{
+      item.reportSpecificBudget =  item.budgetAmount;
+      item.reportSpecificSpend = item.spendAmount;
+    }
+
+    item.overBudgetAmount = Math.max(0, Math.round((item.reportSpecificSpend - item.reportSpecificBudget) * 100) / 100);
 
     // values for export
-    item.budget = item.budgetAmount;
-    item.spend = item.spendAmount;
+    item.budget = item.reportSpecificBudget;
+    item.spend = item.reportSpecificSpend;
     item.overBudget = item.overBudgetAmount;
     item.group = "";
     item.is_budgeted = true;
@@ -410,14 +428,23 @@ script "js_aggregated_report", type: "javascript" do
 
   var chartBudget = [];
   var chartSpend = [];
+  cumulativeBudget = 0;
+  cumulativeSpend = 0;
   _.each(yearMonthsArr, function (ym) {
-    chartBudget.push(Math.round(chartMap[ym].budget));
-    chartSpend.push(Math.round(chartMap[ym].spend));
+    if (report_type == "Cumulative") {
+      cumulativeBudget += chartMap[ym].budget
+      cumulativeSpend += chartMap[ym].spend
+      chartBudget.push(Math.round(cumulativeBudget));
+      chartSpend.push(Math.round(cumulativeSpend));
+    }else{
+      chartBudget.push(Math.round(chartMap[ym].budget));
+      chartSpend.push(Math.round(chartMap[ym].spend));
+    }
   });
 
   var results = {
     invalid: invalid,
-    reportData: _.sortBy(reportData, function (item) {return item.group;}),
+    reportData: reportData,
     chartType: encodeURI('cht=lc'),
     chartScaling: encodeURI('chds=a'),
     chartFormat: encodeURI('chxs=1N*c'+ currency_code.value +'0zsx*'),
@@ -488,10 +515,10 @@ EOS
       field "group" do
         label "Group"
       end
-      field "budgetAmount" do
+      field "budget" do
         label "Budget"
       end
-      field "spendAmount" do
+      field "spend" do
         label "Actual Spend"
       end
       field "overBudget" do

--- a/cost/flexera/cco/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
+++ b/cost/flexera/cco/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
@@ -399,15 +399,6 @@ script "js_aggregated_report", type: "javascript" do
     }
     item.metric = cost_metric[item.metric || ''] || item.metric;
 
-    if (item.budget > 0) {
-      item.budget = currency + item.budget;
-    }
-    if (item.spend > 0) {
-      item.spend = currency + item.spend;
-    }
-    if (item.overBudget <= 0) {
-      item.overBudget = 0;
-    }
 
     item.host = f1_app_host;
     item.dimm = get_dimm_names(item.dimensionsIDs);
@@ -429,7 +420,7 @@ script "js_aggregated_report", type: "javascript" do
     reportData: _.sortBy(reportData, function (item) {return item.group;}),
     chartType: encodeURI('cht=lc'),
     chartScaling: encodeURI('chds=a'),
-    chartFormat: encodeURI('chxs=1N*cUSD0zsx*'),
+    chartFormat: encodeURI('chxs=1N*c'+ currency_code.value +'0zsx*'),
     chartTitle: encodeURI('chtt=Spending+Overview'),
     chartAxVis: encodeURI('chxt=x,y'),
     chartSize: encodeURI('chs=700x250'),

--- a/cost/flexera/cco/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
+++ b/cost/flexera/cco/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
@@ -284,7 +284,7 @@ datasource "ds_aggregated_report" do
 end
 
 script "js_aggregated_report", type: "javascript" do
-  parameters "reports", "currency_code", "currency_reference", "ds_dimensions", "filters", "budget_name_id", "f1_app_host", "report_type"
+  parameters "reports", "currency_code", "currency_reference", "ds_dimensions", "filters", "budget_name_id", "report_type", "f1_app_host"
   result "results"
   code <<-EOS
   var invalid = [];

--- a/cost/flexera/cco/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
+++ b/cost/flexera/cco/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
@@ -289,6 +289,7 @@ script "js_aggregated_report", type: "javascript" do
   code <<-EOS
   var invalid = [];
   var reportData = [];
+  var currentDate = new Date();
 
   if (!reports || !reports.length) {
     invalid.push(budget_name_id);
@@ -352,11 +353,14 @@ script "js_aggregated_report", type: "javascript" do
 
   var yearMonthsArr = [];
   var chartMap = {};
+  var currentYearMonth = fmtDate(currentDate);
 
   _.each(reports, function (item, idx) {
     item.currency = currency_code.value;
     if (idx == 0) {
-      yearMonthsArr = item.yearMonths;
+      yearMonthsArr = item.yearMonths.filter(function (ym) {
+        return ym <= currentYearMonth;
+      });
       _.each(item.yearMonths, function (ym) {
         chartMap[ym] = {
           budget: 0,


### PR DESCRIPTION
### Description

This change address the request at [SQ-8125](https://flexera.atlassian.net/browse/SQ-8125)

### Issues Resolved

- Added Cumulative report option 
- Cumulative chart should show cumulative monthly data
- Cumulative table should show cumulative based on groups
- For cumulative report shows a note to indicate that budget, Spend, OverSpend columns shows cumulative data
- Exclude future data in charts
- Not include currency sign in the table
- Chart axis shows accurate currency sign

The history of request changes and also proof of test could be found in the task : [FOPTS-4009](https://flexera.atlassian.net/jira/software/c/projects/FOPTS/boards/398?assignee=712020%3A90605881-06e4-4701-9150-efda16878a29&selectedIssue=FOPTS-4009)

### Link to Example Applied Policy
1- [Cumulative report example](https://app.flexera.com/orgs/1105/automation/applied-policies/projects/60073?policyId=6654bcc91a93010aee5b4dca)
2- [Monthly report example ](https://app.flexera.com/orgs/1105/automation/applied-policies/projects/60073?policyId=6654bc961a93010aee5b4dc9)
3- [Previous version Monthly report for regression test](https://app.flexera.com/orgs/1105/automation/applied-policies/projects/60073?policyId=6650f788ba767e479665a61a)

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
