### PR TITLE
POL-1246 AWS/Azure Usage Reports - fix BC Allow/Deny Filter

### DIFF
--- a/operational/aws/total_instance_usage_report/CHANGELOG.md
+++ b/operational/aws/total_instance_usage_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.1
+
+- Fixed issue with Billing Center filter so users can now successfully allow/deny Billing Centers from the Usage Report.
+
 ## v1.0.0
 
 - Initial release

--- a/operational/aws/total_instance_usage_report/aws_total_instance_usage_report.pt
+++ b/operational/aws/total_instance_usage_report/aws_total_instance_usage_report.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "1.0.0",
+  version: "1.0.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Usage Report"
@@ -143,8 +143,8 @@ script "js_billing_centers_filtered", type: "javascript" do
 
   if (param_bc_list.length > 0) {
     billing_centers = _.filter(ds_billing_centers, function(item) {
-      id_found = _.contains(param_bc_list, item['id']) == allow_deny_test[param_regions_allow_or_deny]
-      name_found = _.contains(param_bc_list, item['name']) == allow_deny_test[param_regions_allow_or_deny]
+      id_found = _.contains(param_bc_list, item['id']) == allow_deny_test[param_bc_allow_or_deny]
+      name_found = _.contains(param_bc_list, item['name']) == allow_deny_test[param_bc_allow_or_deny]
       return id_found || name_found
     })
 

--- a/operational/azure/total_instance_usage_report/CHANGELOG.md
+++ b/operational/azure/total_instance_usage_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.1
+
+- Fixed issue with Billing Center filter so users can now successfully allow/deny Billing Centers from the Usage Report.
+
 ## v1.0.0
 
 - Initial release

--- a/operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt
+++ b/operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "1.0.0",
+  version: "1.0.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Usage Report"
@@ -143,8 +143,8 @@ script "js_billing_centers_filtered", type: "javascript" do
 
   if (param_bc_list.length > 0) {
     billing_centers = _.filter(ds_billing_centers, function(item) {
-      id_found = _.contains(param_bc_list, item['id']) == allow_deny_test[param_regions_allow_or_deny]
-      name_found = _.contains(param_bc_list, item['name']) == allow_deny_test[param_regions_allow_or_deny]
+      id_found = _.contains(param_bc_list, item['id']) == allow_deny_test[param_bc_allow_or_deny]
+      name_found = _.contains(param_bc_list, item['name']) == allow_deny_test[param_bc_allow_or_deny]
       return id_found || name_found
     })
 


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves below -->
Current AWS and Azure Usage Report - Instance Time Used policies will fail when a user specifies a list of Billing Centers to Allow or Deny. This is a change to fix this issue.

### Issues Resolved

<!-- List any existing issues this PR resolves below -->
- Fixed issue with Billing Center filter so users can now successfully allow/deny Billing Centers from the Usage Report.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->
Tested in customer tenant where the original policy error was found.

### Contribution Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
