### PR TITLE
Update readme_tests.rb to include colon(`:`) in permission regex.

### DIFF
--- a/.dangerfile/readme_tests.rb
+++ b/.dangerfile/readme_tests.rb
@@ -406,7 +406,7 @@ def readme_invalid_credentials?(file)
       fail_message += "```- [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:```\n\n"
     end
 
-    flexera_perm_tester = /^`[a-zA-Z0-9\-_\.]+`(?:\*)?$/
+    flexera_perm_tester = /^`[a-zA-Z0-9\-_\.:]+`(?:\*)?$/
     asterix_found = 0
     permission_list_found = 0
 


### PR DESCRIPTION
### Description

The current validation for Flexera permission list items in README.md flags correctly formatted items like `common:org:own` (which is the suggested one!) as incorrect. This happens because the existing regex does not allow colons (:).

### Issues Resolved

Updated the regex to include colons `:`

Example of PR that shows this error:
https://github.com/flexera-public/policy_templates/pull/2262


