### PR TITLE
POL-1249 fix: AWS/Azure Usage Reports - fix chart not rendering in email for Memory Used

### DIFF
--- a/operational/aws/total_instance_usage_forecast/CHANGELOG.md
+++ b/operational/aws/total_instance_usage_forecast/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.1
+
+- Fixed issue with URL encoding causing the chart to not render in emails in some instances.
+- Fixed issue with Billing Center filter so users can now successfully allow/deny Billing Centers from the Usage Report.
+
 ## v1.0.0
 
 - Initial release

--- a/operational/aws/total_instance_usage_forecast/aws_total_instance_usage_forecast.pt
+++ b/operational/aws/total_instance_usage_forecast/aws_total_instance_usage_forecast.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "1.0.0",
+  version: "1.0.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Usage Report"

--- a/operational/aws/total_instance_usage_forecast/aws_total_instance_usage_forecast.pt
+++ b/operational/aws/total_instance_usage_forecast/aws_total_instance_usage_forecast.pt
@@ -153,8 +153,8 @@ script "js_billing_centers_filtered", type: "javascript" do
 
   if (param_bc_list.length > 0) {
     billing_centers = _.filter(ds_billing_centers, function(item) {
-      id_found = _.contains(param_bc_list, item['id']) == allow_deny_test[param_regions_allow_or_deny]
-      name_found = _.contains(param_bc_list, item['name']) == allow_deny_test[param_regions_allow_or_deny]
+      id_found = _.contains(param_bc_list, item['id']) == allow_deny_test[param_bc_allow_or_deny]
+      name_found = _.contains(param_bc_list, item['name']) == allow_deny_test[param_bc_allow_or_deny]
       return id_found || name_found
     })
 
@@ -505,7 +505,7 @@ end
 script "js_chart_creation", type: "javascript" do
   parameters "ds_forecast_data", "ds_applied_policy", "param_unit_time", "param_unit_instance", "param_lookback_months", "param_forecasted_months"
   result "result"
-  code <<-EOS
+  code <<-'EOS'
   instance_unit = { "Normalized Units (NFUs)": "NFU", "vCPUs": "vCPU", "Memory (GiB)": "Memory (GiB)" }
 
   // Group data by Instance Family
@@ -555,7 +555,7 @@ script "js_chart_creation", type: "javascript" do
     chart_type: encodeURI("cht=bvs"),
     chart_size: encodeURI("chs=999x450"),
     chart_data: encodeURI(chart_data),
-    chart_title: encodeURI(chart_title),
+    chart_title: encodeURI(chart_title).replace(/\(/g, "%28").replace(/\)/g, "%29"),
     chart_image: encodeURI("chof=.png"),
     chart_label_position: encodeURI("chdlp=b"),
     chart_axis: encodeURI("chxt=y,x"),

--- a/operational/aws/total_instance_usage_report/CHANGELOG.md
+++ b/operational/aws/total_instance_usage_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.2
+
+- Fixed issue with URL encoding causing the chart to not render in emails in some instances.
+
 ## v1.0.1
 
 - Fixed issue with Billing Center filter so users can now successfully allow/deny Billing Centers from the Usage Report.

--- a/operational/aws/total_instance_usage_report/aws_total_instance_usage_report.pt
+++ b/operational/aws/total_instance_usage_report/aws_total_instance_usage_report.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "1.0.1",
+  version: "1.0.2",
   provider: "AWS",
   service: "Compute",
   policy_set: "Usage Report"
@@ -356,7 +356,7 @@ end
 script "js_chart_creation", type: "javascript" do
   parameters "ds_instance_units_per_family", "ds_applied_policy", "param_regions_allow_or_deny", "param_regions_list", "param_unit_time", "param_unit_instance", "param_months_back"
   result "result"
-  code <<-EOS
+  code <<-'EOS'
   instance_unit = { "Normalized Units (NFUs)": "NFU", "vCPUs": "vCPU", "Memory (GiB)": "Memory (GiB)" }
 
   // Get list of months from data and create chart X axis labels
@@ -389,7 +389,7 @@ script "js_chart_creation", type: "javascript" do
     chart_type: encodeURI("cht=bvs"),
     chart_size: encodeURI("chs=900x500"),
     chart_data: encodeURI(chart_data),
-    chart_title: encodeURI(chart_title),
+    chart_title: encodeURI(chart_title).replace(/\(/g, "%28").replace(/\)/g, "%29"),
     chart_image: encodeURI("chof=.png"),
     chart_label_position: encodeURI("chdlp=b"),
     chart_axis: encodeURI("chxt=y,x"),

--- a/operational/azure/total_instance_usage_report/CHANGELOG.md
+++ b/operational/azure/total_instance_usage_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.2
+
+- Fixed issue with URL encoding causing the chart to not render in emails in some instances.
+
 ## v1.0.1
 
 - Fixed issue with Billing Center filter so users can now successfully allow/deny Billing Centers from the Usage Report.

--- a/operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt
+++ b/operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "1.0.1",
+  version: "1.0.2",
   provider: "Azure",
   service: "Compute",
   policy_set: "Usage Report"
@@ -388,7 +388,7 @@ end
 script "js_chart_creation", type: "javascript" do
   parameters "ds_instance_units_per_family", "ds_applied_policy", "param_regions_allow_or_deny", "param_regions_list", "param_unit_time", "param_unit_instance", "param_months_back"
   result "result"
-  code <<-EOS
+  code <<-'EOS'
   instance_unit = { "Normalized Instance Count": "Count", "vCPUs": "vCPU", "Memory (GiB)": "Memory (GiB)" }
 
   // Get list of months from data and create chart X axis labels
@@ -421,7 +421,7 @@ script "js_chart_creation", type: "javascript" do
     chart_type: encodeURI("cht=bvs"),
     chart_size: encodeURI("chs=900x500"),
     chart_data: encodeURI(chart_data),
-    chart_title: encodeURI(chart_title),
+    chart_title: encodeURI(chart_title).replace(/\(/g, "%28").replace(/\)/g, "%29"),
     chart_image: encodeURI("chof=.png"),
     chart_label_position: encodeURI("chdlp=b"),
     chart_axis: encodeURI("chxt=y,x"),


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves below -->
When creating a report for Instance Time Used it should render in emails. It works for Normalized Units/Instances and vCPUs, however it does not render correctly for Memory Used. 

This is likely being caused by the Chart Title, which in the case of Memory Used, contains parentheses. These parentheses are not being URL encoded.

This is a change to implement a fix.

### Issues Resolved

<!-- List any existing issues this PR resolves below -->
- Fixes issue where parentheses are not encoded correctly in the image-charts URL

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
