### PR TITLE
POL-1300 - fix: use `PaginationToken` for paginating tagging API

### DIFF
--- a/compliance/aws/untagged_resources/CHANGELOG.md
+++ b/compliance/aws/untagged_resources/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.2.1
+
+- Fixed bug related to pagination on the AWS Tagging API
+
 ## v5.2.0
 
 - Added parameter `Include Savings` to optionally allow the user to not report savings

--- a/compliance/aws/untagged_resources/aws_untagged_resources.pt
+++ b/compliance/aws/untagged_resources/aws_untagged_resources.pt
@@ -7,7 +7,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.2.0",
+  version: "5.2.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Untagged Resources"
@@ -109,12 +109,12 @@ end
 # Pagination
 ###############################################################################
 
-pagination "pagination_aws" do
+pagination "pagination_aws_tagging" do
   get_page_marker do
-    body_path jmes_path(response, "NextToken")
+    body_path jmes_path(response,"PaginationToken")
   end
   set_page_marker do
-    body_field "NextToken"
+    body_field "PaginationToken"
   end
 end
 
@@ -412,7 +412,7 @@ datasource "ds_aws_resources" do
   iterate $ds_regions
   request do
     auth $auth_aws
-    pagination $pagination_aws
+    pagination $pagination_aws_tagging
     verb "POST"
     host join(["tagging.", val(iter_item, "region"), ".amazonaws.com"])
     path "/"

--- a/compliance/aws/untagged_resources/aws_untagged_resources.pt
+++ b/compliance/aws/untagged_resources/aws_untagged_resources.pt
@@ -111,7 +111,7 @@ end
 
 pagination "pagination_aws_tagging" do
   get_page_marker do
-    body_path jmes_path(response,"PaginationToken")
+    body_path jmes_path(response, "PaginationToken")
   end
   set_page_marker do
     body_field "PaginationToken"

--- a/operational/aws/tag_cardinality/CHANGELOG.md
+++ b/operational/aws/tag_cardinality/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.1
+
+- Fixed bug related to pagination on the AWS Tagging API
+
 ## v3.1
 
 - Added parameter to enable region filtering

--- a/operational/aws/tag_cardinality/aws_tag_cardinality.pt
+++ b/operational/aws/tag_cardinality/aws_tag_cardinality.pt
@@ -85,7 +85,7 @@ end
 
 pagination "pagination_aws_tagging" do
   get_page_marker do
-    body_path jmes_path(response,"PaginationToken")
+    body_path jmes_path(response, "PaginationToken")
   end
   set_page_marker do
     body_field "PaginationToken"

--- a/operational/aws/tag_cardinality/aws_tag_cardinality.pt
+++ b/operational/aws/tag_cardinality/aws_tag_cardinality.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "3.1",
+  version: "3.1.1",
   provider: "AWS",
   service: "Tags",
   policy_set: "Tag Cardinality"
@@ -80,6 +80,15 @@ pagination "pagination_aws" do
   end
   set_page_marker do
     body_field "NextToken"
+  end
+end
+
+pagination "pagination_aws_tagging" do
+  get_page_marker do
+    body_path jmes_path(response,"PaginationToken")
+  end
+  set_page_marker do
+    body_field "PaginationToken"
   end
 end
 
@@ -185,7 +194,7 @@ datasource "ds_aws_resources" do
   iterate $ds_regions
   request do
     auth $auth_aws
-    pagination $pagination_aws
+    pagination $pagination_aws_tagging
     verb "POST"
     host join(["tagging.", val(iter_item, "region"), ".amazonaws.com"])
     path "/"


### PR DESCRIPTION
### Description

Fixes an issue discovered when troubleshooting the `AWS Untagged Resources` Policy Template

 - Use [`PaginationToken`](https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/API_GetResources.html#API_GetResources_RequestSyntax) for paginating tagging API

### Link to Example Applied Policy

<img width="582" alt="image" src="https://github.com/user-attachments/assets/9cfb3e84-0c12-4f23-a518-ac06309518d7">

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
