### PR TITLE
POL-1169 P90, P95 and P99 for Azure Rightsize Managed Disks

### DIFF
--- a/cost/azure/rightsize_managed_disks/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_disks/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.4.0
+
+- Added more options for parameters *IOPS Threshold Statistic* and *Throughput Threshold Statistic*: P90, P95 and P99.
+- Fixed a bug that caused the incident fields "New Disk IOPS" and "New Disk Throughput (MB/s)" to be miscalculated when "Premium SSD v2" was the recommended disk type.
+
 ## v2.3.0
 
 - Implemented automatic currency detection and conversion, ensuring recommendations are displayed in the currency configured in the user's settings.

--- a/cost/azure/rightsize_managed_disks/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_disks/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## v2.4.0
 
-- Added more options for parameters *IOPS Threshold Statistic* and *Throughput Threshold Statistic*: P90, P95 and P99.
+- Added a parameter to select the interval to use when gathering Azure metrics data.
+- Added more options for parameters *IOPS Threshold Statistic* and *Throughput Threshold Statistic*: p90, p95 and p99.
 - Fixed a bug that caused the incident fields "New Disk IOPS" and "New Disk Throughput (MB/s)" to be miscalculated when "Premium SSD v2" was the recommended disk type.
 
 ## v2.3.0

--- a/cost/azure/rightsize_managed_disks/README.md
+++ b/cost/azure/rightsize_managed_disks/README.md
@@ -36,6 +36,7 @@ The policy includes the estimated monthly savings. The estimated monthly savings
 - *IOPS Threshold Statistic* - Statistic to use for IOPS when determining if a managed disk is underutilized.
 - *Throughput Threshold (%)* - The throughput threshold at which to consider a managed disk to be underutilized.
 - *Throughput Threshold Statistic* - Statistic to use for throughput when determining if a managed disk is underutilized.
+- *Statistic Interval* - The interval to use when gathering Azure metrics data.
 - *Lookback Period* - How many days back to look at disk IOPS and throughput data. This value cannot be set higher than 90 because Azure does not retain metrics for longer than 90 days.
 - *Recommend HDD tier* - Sometimes the user does not want the policy to recommend changing a disk tier to HDD, with this parameter user can decide if he wants HDD tier recommendations.
 

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
@@ -533,7 +533,7 @@ script "js_azure_virtual_machines_with_metrics", type: "javascript" do
       "metricnames": "OS Disk IOPS Consumed Percentage,OS Disk Bandwidth Consumed Percentage,Data Disk IOPS Consumed Percentage,Data Disk Bandwidth Consumed Percentage",
       "timespan": timespan,
       "$filter": "LUN eq '*'",
-      "aggregation": "Average, Maximum",
+      "aggregation": "Average, Maximum, Minimum",
       "interval": "PT1H",
     },
     headers: {
@@ -577,6 +577,12 @@ script "js_azure_disks_with_metrics", type: "javascript" do
     return result
   }
 
+  function getMinValues(data) {
+    var minValues = _.filter(data, function(data) { return data.minimum != undefined && data.minimum != null })
+    minValues = _.map(minValues, function(v) { return v.minimum })
+    return minValues
+  }
+
   function getMaxValues(data) {
     var maxValues = _.filter(data, function(data) { return data.maximum != undefined && data.maximum != null })
     maxValues = _.map(maxValues, function(v) { return v.maximum })
@@ -616,20 +622,17 @@ script "js_azure_disks_with_metrics", type: "javascript" do
           p99: -1
         }
       } else {
+        var minValues = getMinValues(correspondingTs.data)
         var maxValues = getMaxValues(correspondingTs.data)
         var avgValues = getAvgValues(correspondingTs.data)
+        var allValues = sortArray(minValues.concat(maxValues).concat(avgValues))
         var r = {
           average: getAverage(avgValues),
           maximum: _.last(maxValues),
-          p90: percentile(maxValues, 90),
-          p95: percentile(maxValues, 95),
-          p99: percentile(maxValues, 99),
+          p90: percentile(allValues, 90),
+          p95: percentile(allValues, 95),
+          p99: percentile(allValues, 99),
         }
-        console.log("maxValues")
-        console.log(maxValues)
-        console.log("avgValues")
-        console.log(avgValues)
-        console.log("average: " + r.average + " maximum: " + r.maximum + " p90: " + r.p90 + " p95: " + r.p95 + " p99: " + r.p99)
         return r
       }
     }
@@ -646,13 +649,15 @@ script "js_azure_disks_with_metrics", type: "javascript" do
       if (vmWithDisk.osDisk === null || vmWithDisk.osDisk === undefined) continue;
       if (metric.name.value === "OS Disk IOPS Consumed Percentage") {
         try {
+          var minValues = getMinValues(metric.timeseries[0].data)
           var maxValues = getMaxValues(metric.timeseries[0].data)
           var avgValues = getAvgValues(metric.timeseries[0].data)
+          var allValues = sortArray(minValues.concat(maxValues).concat(avgValues))
           vmWithDisk.osDisk.iopsConsumedPctAvg = getAverage(avgValues)
           vmWithDisk.osDisk.iopsConsumedPctMax = _.last(maxValues)
-          vmWithDisk.osDisk.iopsConsumedPctP90 = percentile(maxValues, 90)
-          vmWithDisk.osDisk.iopsConsumedPctP95 = percentile(maxValues, 95)
-          vmWithDisk.osDisk.iopsConsumedPctP99 = percentile(maxValues, 99)
+          vmWithDisk.osDisk.iopsConsumedPctP90 = percentile(allValues, 90)
+          vmWithDisk.osDisk.iopsConsumedPctP95 = percentile(allValues, 95)
+          vmWithDisk.osDisk.iopsConsumedPctP99 = percentile(allValues, 99)
         } catch (err) {
           vmWithDisk.osDisk.iopsConsumedPctAvg = -1
           vmWithDisk.osDisk.iopsConsumedPctMax = -1
@@ -663,13 +668,15 @@ script "js_azure_disks_with_metrics", type: "javascript" do
       }
       if (metric.name.value === "OS Disk Bandwidth Consumed Percentage") {
         try {
+          var minValues = getMinValues(metric.timeseries[0].data)
           var maxValues = getMaxValues(metric.timeseries[0].data)
           var avgValues = getAvgValues(metric.timeseries[0].data)
+          var allValues = sortArray(minValues.concat(maxValues).concat(avgValues))
           vmWithDisk.osDisk.bandwithConsumedPctAvg = getAverage(avgValues)
           vmWithDisk.osDisk.bandwithConsumedPctMax = _.last(maxValues)
-          vmWithDisk.osDisk.bandwithConsumedPctP90 = percentile(maxValues, 90)
-          vmWithDisk.osDisk.bandwithConsumedPctP95 = percentile(maxValues, 95)
-          vmWithDisk.osDisk.bandwithConsumedPctP99 = percentile(maxValues, 99)
+          vmWithDisk.osDisk.bandwithConsumedPctP90 = percentile(allValues, 90)
+          vmWithDisk.osDisk.bandwithConsumedPctP95 = percentile(allValues, 95)
+          vmWithDisk.osDisk.bandwithConsumedPctP99 = percentile(allValues, 99)
         } catch (err) {
           vmWithDisk.osDisk.bandwithConsumedPctAvg = -1
           vmWithDisk.osDisk.bandwithConsumedPctMax = -1

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
@@ -41,7 +41,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 1
+  default 0
 end
 
 parameter "param_exclusion_tags" do
@@ -75,7 +75,7 @@ parameter "param_subscriptions_list" do
   category "Filters"
   label "Allow/Deny Subscriptions List"
   description "A list of allowed or denied ubscription IDs/names. See the README for more details."
-  default ["05c47f84-4712-48ad-96a2-431f95c3c06c"]
+  default []
 end
 
 parameter "param_regions_allow_or_deny" do
@@ -92,7 +92,7 @@ parameter "param_regions_list" do
   category "Filters"
   label "Allow/Deny Regions List"
   description "A list of allowed or denied regions. See the README for more details."
-  default ["westus", "westus2", "westus3", "eastus", "eastus2", "southcentraluseastus2", "southcentralus"]
+  default []
 end
 
 parameter "param_sku_ignore_list" do
@@ -110,7 +110,7 @@ parameter "param_min_used_disk_iops_pct" do
   description "The IOPs threshold at which to consider a managed disk to be underutilized. Set to -1 to turn off this filter."
   min_value -1
   max_value 100
-  default 50
+  default -1
 end
 
 parameter "param_stats_aggregation_for_disk_iops" do
@@ -119,7 +119,7 @@ parameter "param_stats_aggregation_for_disk_iops" do
   label "IOPS Threshold Statistic"
   description "Statistic to use for IOPS when determining if a managed disk is underutilized."
   allowed_values "Average", "Maximum", "P90", "P95", "P99"
-  default "P90"
+  default "Maximum"
 end
 
 parameter "param_min_used_disk_throughput_pct" do
@@ -129,7 +129,7 @@ parameter "param_min_used_disk_throughput_pct" do
   description "The throughput threshold at which to consider a managed disk to be underutilized. Set to -1 to turn off this filter."
   min_value -1
   max_value 100
-  default 50
+  default -1
 end
 
 parameter "param_stats_aggregation_for_disk_throughput" do
@@ -138,7 +138,7 @@ parameter "param_stats_aggregation_for_disk_throughput" do
   label "Throughput Threshold Statistic"
   description "Statistic to use for throughput when determining if a managed disk is underutilized."
   allowed_values "Average", "Maximum", "P90", "P95", "P99"
-  default "P95"
+  default "Maximum"
 end
 
 parameter "param_stats_lookback" do
@@ -157,7 +157,7 @@ parameter "param_recommend_hdd_tier" do
   label "Recommend HDD tier"
   description "When this value is set to Yes, the policy will consider the Standard HDD tier for making recommendations."
   allowed_values "Yes", "No"
-  default "No"
+  default "Yes"
 end
 
 ###############################################################################

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
@@ -118,7 +118,7 @@ parameter "param_stats_aggregation_for_disk_iops" do
   category "Statistics"
   label "IOPS Threshold Statistic"
   description "Statistic to use for IOPS when determining if a managed disk is underutilized."
-  allowed_values "Average", "Maximum", "P90", "P95", "P99"
+  allowed_values "Average", "Maximum", "p99", "p95", "p90"
   default "Maximum"
 end
 
@@ -137,8 +137,17 @@ parameter "param_stats_aggregation_for_disk_throughput" do
   category "Statistics"
   label "Throughput Threshold Statistic"
   description "Statistic to use for throughput when determining if a managed disk is underutilized."
-  allowed_values "Average", "Maximum", "P90", "P95", "P99"
+  allowed_values "Average", "Maximum", "p99", "p95", "p90"
   default "Maximum"
+end
+
+parameter "param_stats_interval" do
+  type "string"
+  category "Statistics"
+  label "Statistic Interval"
+  description "The interval to use when gathering Azure metrics data. Smaller intervals produce more accurate results at the expense of policy memory usage and completion time due to larger data sets."
+  allowed_values "1 Minute", "5 Minutes", "15 Minutes", "30 Minutes", "1 Hour", "6 Hours", "12 Hours", "1 Day"
+  default "15 Minutes"
 end
 
 parameter "param_stats_lookback" do
@@ -217,6 +226,33 @@ datasource "ds_azure_subscriptions" do
       field "state", jmes_path(col_item, "state")
     end
   end
+end
+
+datasource "ds_stats_interval" do
+  run_script $js_stats_interval, $param_stats_interval
+end
+
+script "js_stats_interval", type: "javascript" do
+  parameters "param_stats_interval"
+  result "result"
+  code <<-EOS
+  // Tables to convert human-readable parameter values to their API equivalents
+  interval_table = {
+    "1 Minute": "PT1M",
+    "5 Minutes": "PT5M",
+    "15 Minutes": "PT15M",
+    "30 Minutes": "PT30M",
+    "1 Hour": "PT1H",
+    "6 Hours": "PT6H",
+    "12 Hours": "PT12H",
+    "1 Day": "P1D"
+  }
+
+  result = {
+    pretty: param_stats_interval,
+    api: interval_table[param_stats_interval]
+  }
+EOS
 end
 
 datasource "ds_applied_policy" do
@@ -496,7 +532,7 @@ end
 datasource "ds_azure_virtual_machines_with_metrics" do
   iterate $ds_azure_virtual_machines_with_disks
   request do
-    run_script $js_azure_virtual_machines_with_metrics, val(iter_item, "vmId"), $param_azure_endpoint, $param_stats_lookback
+    run_script $js_azure_virtual_machines_with_metrics, val(iter_item, "vmId"), $ds_stats_interval, $param_azure_endpoint, $param_stats_lookback
   end
   result do
     encoding "json"
@@ -506,7 +542,7 @@ datasource "ds_azure_virtual_machines_with_metrics" do
 end
 
 script "js_azure_virtual_machines_with_metrics", type: "javascript" do
-  parameters "vmId", "param_azure_endpoint", "param_stats_lookback"
+  parameters "vmId", "ds_stats_interval", "param_azure_endpoint", "param_stats_lookback"
   result "request"
   code <<-EOS
   var end_date = new Date()
@@ -534,7 +570,7 @@ script "js_azure_virtual_machines_with_metrics", type: "javascript" do
       "timespan": timespan,
       "$filter": "LUN eq '*'",
       "aggregation": "Average, Maximum, Minimum",
-      "interval": "PT1H",
+      "interval": ds_stats_interval.api,
     },
     headers: {
       "User-Agent": "RS Policies",
@@ -789,13 +825,13 @@ script "js_azure_disks_with_metrics_thresholds_filtered", type: "javascript" do
         case "Maximum":
           usedMetricPct = disk.iopsConsumedPctMax
           break;
-        case "P90":
+        case "p90":
           usedMetricPct = disk.iopsConsumedPctP90
           break;
-        case "P95":
+        case "p95":
           usedMetricPct = disk.iopsConsumedPctP95
           break;
-        case "P99":
+        case "p99":
           usedMetricPct = disk.iopsConsumedPctP99
           break;
       }
@@ -812,13 +848,13 @@ script "js_azure_disks_with_metrics_thresholds_filtered", type: "javascript" do
         case "Maximum":
           usedMetricPct = disk.bandwithConsumedPctMax
           break;
-        case "P90":
+        case "p90":
           usedMetricPct = disk.bandwithConsumedPctP90
           break;
-        case "P95":
+        case "p95":
           usedMetricPct = disk.bandwithConsumedPctP95
           break;
-        case "P99":
+        case "p99":
           usedMetricPct = disk.bandwithConsumedPctP99
           break;
       }
@@ -1372,13 +1408,13 @@ EOS
         path "iopsPctAverage"
       end
       field "iopsPctP90" do
-        label "IOPS P90 %"
+        label "IOPS p90"
       end
       field "iopsPctP95" do
-        label "IOPS P95 %"
+        label "IOPS p95"
       end
       field "iopsPctP99" do
-        label "IOPS P99 %"
+        label "IOPS p99"
       end
       field "iopsThreshold" do
         label "IOPS Threshold %"
@@ -1390,13 +1426,13 @@ EOS
         label "Throughput Average %"
       end
       field "throughputPctP90" do
-        label "Throughput P90 %"
+        label "Throughput p90"
       end
       field "throughputPctP95" do
-        label "Throughput P95 %"
+        label "Throughput p95"
       end
       field "throughputPctP99" do
-        label "Throughput P99 %"
+        label "Throughput p99"
       end
       field "throughputThreshold" do
         label "Throughput Threshold %"

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "monthly"
 info(
-  version: "2.3.0",
+  version: "2.4.0",
   provider: "Azure",
   service: "Managed Disks",
   policy_set: "Rightsize Storage",
@@ -41,7 +41,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do
@@ -75,7 +75,7 @@ parameter "param_subscriptions_list" do
   category "Filters"
   label "Allow/Deny Subscriptions List"
   description "A list of allowed or denied ubscription IDs/names. See the README for more details."
-  default []
+  default ["05c47f84-4712-48ad-96a2-431f95c3c06c"]
 end
 
 parameter "param_regions_allow_or_deny" do
@@ -92,7 +92,7 @@ parameter "param_regions_list" do
   category "Filters"
   label "Allow/Deny Regions List"
   description "A list of allowed or denied regions. See the README for more details."
-  default []
+  default ["westus", "westus2", "westus3", "eastus", "eastus2", "southcentraluseastus2", "southcentralus"]
 end
 
 parameter "param_sku_ignore_list" do
@@ -110,7 +110,7 @@ parameter "param_min_used_disk_iops_pct" do
   description "The IOPs threshold at which to consider a managed disk to be underutilized. Set to -1 to turn off this filter."
   min_value -1
   max_value 100
-  default -1
+  default 50
 end
 
 parameter "param_stats_aggregation_for_disk_iops" do
@@ -118,8 +118,8 @@ parameter "param_stats_aggregation_for_disk_iops" do
   category "Statistics"
   label "IOPS Threshold Statistic"
   description "Statistic to use for IOPS when determining if a managed disk is underutilized."
-  allowed_values "Average", "Maximum"
-  default "Maximum"
+  allowed_values "Average", "Maximum", "P90", "P95", "P99"
+  default "P90"
 end
 
 parameter "param_min_used_disk_throughput_pct" do
@@ -129,7 +129,7 @@ parameter "param_min_used_disk_throughput_pct" do
   description "The throughput threshold at which to consider a managed disk to be underutilized. Set to -1 to turn off this filter."
   min_value -1
   max_value 100
-  default -1
+  default 50
 end
 
 parameter "param_stats_aggregation_for_disk_throughput" do
@@ -137,8 +137,8 @@ parameter "param_stats_aggregation_for_disk_throughput" do
   category "Statistics"
   label "Throughput Threshold Statistic"
   description "Statistic to use for throughput when determining if a managed disk is underutilized."
-  allowed_values "Average", "Maximum"
-  default "Maximum"
+  allowed_values "Average", "Maximum", "P90", "P95", "P99"
+  default "P95"
 end
 
 parameter "param_stats_lookback" do
@@ -157,7 +157,7 @@ parameter "param_recommend_hdd_tier" do
   label "Recommend HDD tier"
   description "When this value is set to Yes, the policy will consider the Standard HDD tier for making recommendations."
   allowed_values "Yes", "No"
-  default "Yes"
+  default "No"
 end
 
 ###############################################################################
@@ -534,7 +534,7 @@ script "js_azure_virtual_machines_with_metrics", type: "javascript" do
       "timespan": timespan,
       "$filter": "LUN eq '*'",
       "aggregation": "Average, Maximum",
-      "interval": "FULL",
+      "interval": "PT1H",
     },
     headers: {
       "User-Agent": "RS Policies",
@@ -563,6 +563,40 @@ script "js_azure_disks_with_metrics", type: "javascript" do
   parameters "ds_azure_virtual_machines_with_metrics", "ds_azure_virtual_machines_with_disks", "ds_azure_virtual_machines_with_disk_space"
   result "result"
   code <<-EOS
+  // Returns an array of single values sorted.
+  function sortArray(array) {
+    return array.sort(function (a, b) {
+      return a - b;
+    });
+  }
+
+  function percentile(sortedArray, p) {
+    if (sortedArray.length === 0) return 0
+    var index = (p / 100) * sortedArray.length
+    var result = sortedArray[Math.ceil(index) - 1]
+    return result
+  }
+
+  function getMaxValues(data) {
+    var maxValues = _.filter(data, function(data) { return data.maximum != undefined && data.maximum != null })
+    maxValues = _.map(maxValues, function(v) { return v.maximum })
+    return sortArray(maxValues)
+  }
+
+  function getAvgValues(data) {
+    var avgValues = _.filter(data, function(data) { return data.average != undefined && data.average != null })
+    avgValues = _.map(avgValues, function(v) { return v.average })
+    return avgValues
+  }
+
+  function getAverage(data) {
+    var sum = 0.0
+    for (var i = 0; i < data.length; i++) {
+      sum += data[i]
+    }
+    return sum / data.length
+  }
+
   function findMetricsForDataDisk(metrics, metricName, lun) {
     for (var i in metrics) {
       var metric = metrics[i]
@@ -574,9 +608,29 @@ script "js_azure_disks_with_metrics", type: "javascript" do
         )
       })
       if (correspondingTs === undefined) {
-        return { average: -1, maximum: -1 }
+        return {
+          average: -1,
+          maximum: -1,
+          p90: -1,
+          p95: -1,
+          p99: -1
+        }
       } else {
-        return { average: correspondingTs.data[0].average, maximum: correspondingTs.data[0].maximum }
+        var maxValues = getMaxValues(correspondingTs.data)
+        var avgValues = getAvgValues(correspondingTs.data)
+        var r = {
+          average: getAverage(avgValues),
+          maximum: _.last(maxValues),
+          p90: percentile(maxValues, 90),
+          p95: percentile(maxValues, 95),
+          p99: percentile(maxValues, 99),
+        }
+        console.log("maxValues")
+        console.log(maxValues)
+        console.log("avgValues")
+        console.log(avgValues)
+        console.log("average: " + r.average + " maximum: " + r.maximum + " p90: " + r.p90 + " p95: " + r.p95 + " p99: " + r.p99)
+        return r
       }
     }
   }
@@ -592,20 +646,36 @@ script "js_azure_disks_with_metrics", type: "javascript" do
       if (vmWithDisk.osDisk === null || vmWithDisk.osDisk === undefined) continue;
       if (metric.name.value === "OS Disk IOPS Consumed Percentage") {
         try {
-          vmWithDisk.osDisk.iopsConsumedPctAvg = metric.timeseries[0].data[0].average
-          vmWithDisk.osDisk.iopsConsumedPctMax = metric.timeseries[0].data[0].maximum
+          var maxValues = getMaxValues(metric.timeseries[0].data)
+          var avgValues = getAvgValues(metric.timeseries[0].data)
+          vmWithDisk.osDisk.iopsConsumedPctAvg = getAverage(avgValues)
+          vmWithDisk.osDisk.iopsConsumedPctMax = _.last(maxValues)
+          vmWithDisk.osDisk.iopsConsumedPctP90 = percentile(maxValues, 90)
+          vmWithDisk.osDisk.iopsConsumedPctP95 = percentile(maxValues, 95)
+          vmWithDisk.osDisk.iopsConsumedPctP99 = percentile(maxValues, 99)
         } catch (err) {
           vmWithDisk.osDisk.iopsConsumedPctAvg = -1
           vmWithDisk.osDisk.iopsConsumedPctMax = -1
+          vmWithDisk.osDisk.iopsConsumedPctP90 = -1
+          vmWithDisk.osDisk.iopsConsumedPctP95 = -1
+          vmWithDisk.osDisk.iopsConsumedPctP99 = -1
         }
       }
       if (metric.name.value === "OS Disk Bandwidth Consumed Percentage") {
         try {
-          vmWithDisk.osDisk.bandwithConsumedPctAvg = metric.timeseries[0].data[0].average
-          vmWithDisk.osDisk.bandwithConsumedPctMax = metric.timeseries[0].data[0].maximum
+          var maxValues = getMaxValues(metric.timeseries[0].data)
+          var avgValues = getAvgValues(metric.timeseries[0].data)
+          vmWithDisk.osDisk.bandwithConsumedPctAvg = getAverage(avgValues)
+          vmWithDisk.osDisk.bandwithConsumedPctMax = _.last(maxValues)
+          vmWithDisk.osDisk.bandwithConsumedPctP90 = percentile(maxValues, 90)
+          vmWithDisk.osDisk.bandwithConsumedPctP95 = percentile(maxValues, 95)
+          vmWithDisk.osDisk.bandwithConsumedPctP99 = percentile(maxValues, 99)
         } catch (err) {
           vmWithDisk.osDisk.bandwithConsumedPctAvg = -1
           vmWithDisk.osDisk.bandwithConsumedPctMax = -1
+          vmWithDisk.osDisk.bandwithConsumedPctP90 = -1
+          vmWithDisk.osDisk.bandwithConsumedPctP95 = -1
+          vmWithDisk.osDisk.bandwithConsumedPctP99 = -1
         }
       }
     }
@@ -620,6 +690,9 @@ script "js_azure_disks_with_metrics", type: "javascript" do
       )
       dataDisk.iopsConsumedPctAvg = correspondingIopsMetrics.average
       dataDisk.iopsConsumedPctMax = correspondingIopsMetrics.maximum
+      dataDisk.iopsConsumedPctP90 = correspondingIopsMetrics.p90
+      dataDisk.iopsConsumedPctP95 = correspondingIopsMetrics.p95
+      dataDisk.iopsConsumedPctP99 = correspondingIopsMetrics.p99
       // Bandwith
       var correspondingBandwidthMetrics = findMetricsForDataDisk(
         correspondingVmWithMetrics.metrics,
@@ -628,6 +701,9 @@ script "js_azure_disks_with_metrics", type: "javascript" do
       )
       dataDisk.bandwithConsumedPctAvg = correspondingBandwidthMetrics.average
       dataDisk.bandwithConsumedPctMax = correspondingBandwidthMetrics.maximum
+      dataDisk.bandwithConsumedPctP90 = correspondingBandwidthMetrics.p90
+      dataDisk.bandwithConsumedPctP95 = correspondingBandwidthMetrics.p95
+      dataDisk.bandwithConsumedPctP99 = correspondingBandwidthMetrics.p99
     }
   }
 
@@ -676,7 +752,17 @@ script "js_azure_disks_with_metrics_thresholds_filtered", type: "javascript" do
   code <<-EOS
   var result = _.filter(ds_azure_disks_with_metrics, function(disk) {
     // Filter the disk if we do not have IOPS and throughput data for the disk
-    if (disk.iopsConsumedPctAvg === -1 || disk.iopsConsumedPctMax === -1 || disk.bandwithConsumedPctAvg === -1 || disk.bandwithConsumedPctMax === -1) {
+    if ( disk.iopsConsumedPctAvg === -1
+      || disk.iopsConsumedPctMax === -1
+      || disk.iopsConsumedPctP90 === -1
+      || disk.iopsConsumedPctP95 === -1
+      || disk.iopsConsumedPctP99 === -1
+      || disk.bandwithConsumedPctAvg === -1
+      || disk.bandwithConsumedPctMax === -1
+      || disk.bandwithConsumedPctP90 === -1
+      || disk.bandwithConsumedPctP95 === -1
+      || disk.bandwithConsumedPctP99 === -1
+    ) {
       return false
     }
     if (ds_min_used_disk_space_pct != -1) {
@@ -688,13 +774,47 @@ script "js_azure_disks_with_metrics_thresholds_filtered", type: "javascript" do
       }
     }
     if (param_min_used_disk_iops_pct != -1) {
-      var usedMetricPct = param_stats_aggregation_for_disk_iops === "Average" ? disk.iopsConsumedPctAvg : disk.iopsConsumedPctMax
+      var usedMetricPct = null
+      switch (param_stats_aggregation_for_disk_iops) {
+        case "Average":
+          usedMetricPct = disk.iopsConsumedPctAvg
+          break;
+        case "Maximum":
+          usedMetricPct = disk.iopsConsumedPctMax
+          break;
+        case "P90":
+          usedMetricPct = disk.iopsConsumedPctP90
+          break;
+        case "P95":
+          usedMetricPct = disk.iopsConsumedPctP95
+          break;
+        case "P99":
+          usedMetricPct = disk.iopsConsumedPctP99
+          break;
+      }
       if (usedMetricPct > param_min_used_disk_iops_pct) {
         return false
       }
     }
     if (param_min_used_disk_throughput_pct != -1) {
-      var usedMetricPct = param_stats_aggregation_for_disk_throughput === "Average" ? disk.bandwithConsumedPctAvg : disk.bandwithConsumedPctMax
+      var usedMetricPct = null
+      switch (param_stats_aggregation_for_disk_throughput) {
+        case "Average":
+          usedMetricPct = disk.bandwithConsumedPctAvg
+          break;
+        case "Maximum":
+          usedMetricPct = disk.bandwithConsumedPctMax
+          break;
+        case "P90":
+          usedMetricPct = disk.bandwithConsumedPctP90
+          break;
+        case "P95":
+          usedMetricPct = disk.bandwithConsumedPctP95
+          break;
+        case "P99":
+          usedMetricPct = disk.bandwithConsumedPctP99
+          break;
+      }
       if (usedMetricPct > param_min_used_disk_throughput_pct) {
         return false
       }
@@ -905,8 +1025,9 @@ script "js_disk_rightsizing_recommendations", type: "javascript" do
         pricePerUnit: Math.round( premSsdV2Pricing.PREMIUM_LRS_PROVISIONED_CAPACITY.pricePerUnit * 720 * currentUsedGB ),
         currencyCode: premSsdV2Pricing.PREMIUM_LRS_PROVISIONED_CAPACITY.currencyCode,
         sizeGiB: currentUsedGB,
-        IOPS: currentUsedIops,
-        throughput: currentUsedThroughput,
+        // Premium SSD v2 provides a baseline performance of 3,000 IOPS and 125 MB/s for any disk size
+        IOPS: 3000,
+        throughput: 125,
         unitOfMeasure: premSsdV2Pricing.PREMIUM_LRS_PROVISIONED_CAPACITY.unitOfMeasure
       }
     }
@@ -1088,9 +1209,15 @@ script "js_disk_rightsizing_recommendations", type: "javascript" do
       savingsCurrency: ds_currency.code,
       iopsPctMaximum: Math.round(disk.iopsConsumedPctMax),
       iopsPctAverage: Math.round(disk.iopsConsumedPctAvg),
+      iopsPctP90: Math.round(disk.iopsConsumedPctP90),
+      iopsPctP95: Math.round(disk.iopsConsumedPctP95),
+      iopsPctP99: Math.round(disk.iopsConsumedPctP99),
       iopsThreshold: param_min_used_disk_iops_pct,
       throughputPctMaximum: Math.round(disk.bandwithConsumedPctMax),
       throughputPctAverage: Math.round(disk.bandwithConsumedPctAvg),
+      throughputPctP90: Math.round(disk.bandwithConsumedPctP90),
+      throughputPctP95: Math.round(disk.bandwithConsumedPctP95),
+      throughputPctP99: Math.round(disk.bandwithConsumedPctP99),
       throughputThreshold: param_min_used_disk_throughput_pct,
       sizeGB: disk.diskSizeGB,
       usedGBPct: disk.diskUsedGB != undefined ? Math.round(disk.diskUsedGB * 100 / disk.diskSizeGB) : "Unknown",
@@ -1237,6 +1364,15 @@ EOS
         label "IOPS Average %"
         path "iopsPctAverage"
       end
+      field "iopsPctP90" do
+        label "IOPS P90 %"
+      end
+      field "iopsPctP95" do
+        label "IOPS P95 %"
+      end
+      field "iopsPctP99" do
+        label "IOPS P99 %"
+      end
       field "iopsThreshold" do
         label "IOPS Threshold %"
       end
@@ -1245,6 +1381,15 @@ EOS
       end
       field "throughputPctAverage" do
         label "Throughput Average %"
+      end
+      field "throughputPctP90" do
+        label "Throughput P90 %"
+      end
+      field "throughputPctP95" do
+        label "Throughput P95 %"
+      end
+      field "throughputPctP99" do
+        label "Throughput P99 %"
       end
       field "throughputThreshold" do
         label "Throughput Threshold %"


### PR DESCRIPTION
### Description

I implemented the statistics P90, P95 and P99 for the parameters:
- IOPS Threshold Statistic
- Throughput Threshold Statistic

### Issues Resolved

- https://flexera.attlassian.com/browse/POL-1169

### Link to Example Applied Policy

Applied policy link cannot be shared, but here are some screenshots:

*New incident fields*
![image](https://github.com/user-attachments/assets/c4a81f88-32b2-4e16-8a0b-73051eab704c)
![image](https://github.com/user-attachments/assets/10435318-339c-4b2c-8757-60e0a5540a90)

*Data used for validation*
```
EXAMPLE 1
console.log:
    [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,2,2,3.316666666666667,3.316666666666667,3.3333333333333335,3.35,3.35,3.3666666666666667,3.3833333333333333,3.4,3.433333333333333,3.45,3.466666666666667,3.4833333333333334,3.4833333333333334,3.5,3.5,3.5,3.5166666666666666,3.533333333333333,3.533333333333333,3.55,3.566666666666667,3.5833333333333335,3.5833333333333335,3.6,3.6166666666666667,3.6166666666666667,3.6333333333333333,3.65,3.6666666666666665,3.6666666666666665,3.716666666666667,3.7333333333333334,3.7333333333333334,3.7333333333333334,3.75,3.7666666666666666,3.783333333333333,3.783333333333333,3.783333333333333,3.8,3.8,3.8333333333333335,3.85,3.8666666666666667,3.8666666666666667,3.8833333333333333,3.9,3.9166666666666665,3.9166666666666665,3.95,3.95,4,4,4.05,4.1,4.1,4.1,4.116666666666666,4.15,4.183333333333334,4.183333333333334,4.2,4.25,4.366666666666666,4.383333333333334,4.4,4.433333333333334,4.433333333333334,4.45,4.45,4.466666666666667,4.583333333333333,4.65,4.65,4.666666666666667,4.7,4.75,4.783333333333333,4.8,4.8,4.8,5.033333333333333,5.2,5.316666666666666,5.383333333333334,5.466666666666667,5.716666666666667,5.85,5.916666666666667,5.933333333333334,5.95,6,6,6.016666666666667,6.3,6.416666666666667,6.416666666666667,6.483333333333333,6.516666666666667,6.516666666666667,6.566666666666666,6.6,6.666666666666667,6.733333333333333,6.833333333333333,7,7.066666666666666,7.4,7.633333333333334,7.95,8.55,9.266666666666667,10.05,10.066666666666666,10.116666666666667,10.95,11.333333333333334,14,14.233333333333333,15,15,15,15,16,16,16,16,16,16,16,16.916666666666668,17,17,17,17,17,17,17,17,17,17,17,17,17,17,17,17,17,17,17,18,18,18,18,18,18,18,18,18,18,18,19,19,19,19,19,19,19,20,20,20,20,20,20,20,20,20,20,20,21,21,21,22,22,23,23,23,23.083333333333332,24,24,24,24,24.033333333333335,25,25,25,26,26,26,26,26,26,27,28,28,28,30,33,33,37,37,37,39,40,47,50,52,52,54,58,59,62,63,69,71,76,78,82,86,89,98,99,100,100,100,100,100,100,100,100,100,100]
console.log: "average: 5.361570247933884 maximum: 100 p90: 28 p95: 69 p99: 100"

EXAMPLE 2
console.log:
    [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0.38333333333333336,0.38333333333333336,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4166666666666667,0.4166666666666667,0.4166666666666667,0.43333333333333335,0.43333333333333335,0.43333333333333335,0.43333333333333335,0.43333333333333335,0.45,0.45,0.45,0.45,0.45,0.45,0.45,0.45,0.45,0.45,0.45,0.45,0.4666666666666667,0.4666666666666667,0.4666666666666667,0.4666666666666667,0.4666666666666667,0.4666666666666667,0.4666666666666667,0.4666666666666667,0.4666666666666667,0.4666666666666667,0.48333333333333334,0.48333333333333334,0.48333333333333334,0.48333333333333334,0.48333333333333334,0.48333333333333334,0.5,0.5,0.5,0.5,0.5,0.5,0.5166666666666667,0.5166666666666667,0.5166666666666667,0.5166666666666667,0.5166666666666667,0.5166666666666667,0.5333333333333333,0.5333333333333333,0.5333333333333333,0.5333333333333333,0.55,0.55,0.55,0.5666666666666667,0.5666666666666667,0.5666666666666667,0.5666666666666667,0.5833333333333334,0.5833333333333334,0.5833333333333334,0.6,0.6166666666666667,0.6166666666666667,0.6666666666666666,0.6666666666666666,0.6666666666666666,0.6666666666666666,0.6666666666666666,0.6833333333333333,0.7333333333333333,0.75,0.7666666666666667,0.7666666666666667,0.7833333333333333,0.8,0.8166666666666667,0.8333333333333334,0.85,0.8833333333333333,0.9666666666666667,0.9833333333333333,1,1,1.0166666666666666,1.0166666666666666,1.0166666666666666,1.0333333333333334,1.0666666666666667,1.15,1.1666666666666667,1.3,1.3,1.3166666666666667,1.3666666666666667,1.3666666666666667,1.4,1.4166666666666667,1.45,1.5,1.5,1.5333333333333334,1.7166666666666666,2.1333333333333333,2.55,2.6666666666666665,2.716666666666667,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3.433333333333333,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,5,5,5,5,5,5,5,5,6,6,6,6,6,7,7,7,7,8,8,8,9,9,9,9,10,10,10,11,11,11,11,11,11,12,12,13,14,14,14,15,15,15,16,18,18,21,21,22,22,22,23,23,23,24,26,33,35,35,37,39,43,44,52]
console.log: "average: 0.7517906336088154 maximum: 52 p90: 10 p95: 18 p99: 39"
```
![Untitled](https://github.com/user-attachments/assets/3947810e-162f-40eb-ab91-bf47b491ab4f)
![Untitled](https://github.com/user-attachments/assets/5f2d6ec0-2935-4d24-966c-64661db55a6c)

*New options in the parameters*
![image](https://github.com/user-attachments/assets/48b50495-33c2-4323-a2e3-003944835339)
![image](https://github.com/user-attachments/assets/0939462c-3e19-45b0-96bb-142af3a30087)

### Contribution Check List

- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
