### PR TITLE
POL-1323 - fix: AWS Rightsize EC2 get memory metrics for Autoscaling groups

### DIFF
--- a/cost/aws/rightsize_ec2_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_ec2_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.1.2
+
+- Fix bug preventing Memory metrics from being included in result for some EC2 Instances created by Autoscaling Group
+
 ## v5.1.1
 
 - Idle EC2 Instances incident now includes a `Recommended Instance Size` field with a value of `Terminate EC2 Instance` for ease of analyzing recommendations from the Flexera Optimization dashboard

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances.pt
@@ -640,11 +640,8 @@ script "js_cloudwatch_queries", type: "javascript" do
       }
 
       // If instance.tags contains object with key value == aws:autoscaling:groupName
-      var asg_name = _.find(instance['tags'], function(tag) {
-        return tag['key'] == 'aws:autoscaling:groupName'
-      })
-      if (asg_name != undefined) {
-          dimensions.push({ "Name": "AutoScalingGroupName", "Value": asg_name['value'] })
+      if (typeof(instance['tags']) == 'object' && instance['tags']['aws:autoscaling:groupName']) {
+        dimensions.push({ "Name": "AutoScalingGroupName", "Value": asg_name['value'] })
       }
 
       _.each(stats, function(stat) {

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "5.1.1",
+  version: "5.1.2",
   provider: "AWS",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -172,6 +172,19 @@ credentials "auth_flexera" do
   label "Flexera"
   description "Select Flexera One OAuth2 credentials"
   tags "provider=flexera"
+end
+
+###############################################################################
+# Pagination
+###############################################################################
+
+pagination "pagination_aws_getmetricdata" do
+  get_page_marker do
+    body_path "NextToken"
+  end
+  set_page_marker do
+    body_field "NextToken"
+  end
 end
 
 ###############################################################################
@@ -626,6 +639,14 @@ script "js_cloudwatch_queries", type: "javascript" do
         ]
       }
 
+      // If instance.tags contains object with key value == aws:autoscaling:groupName
+      var asg_name = _.find(instance['tags'], function(tag) {
+        return tag['key'] == 'aws:autoscaling:groupName'
+      })
+      if (asg_name != undefined) {
+          dimensions.push({ "Name": "AutoScalingGroupName", "Value": asg_name['value'] })
+      }
+
       _.each(stats, function(stat) {
         query = {
           "Id": instance['instanceId'].replace('-', '_') + "_mem" + stat,
@@ -718,6 +739,7 @@ script "js_cloudwatch_data", type: "javascript" do
   var request = {
     auth: "auth_aws",
     host: 'monitoring.' + region + '.amazonaws.com',
+    pagination: "pagination_aws_getmetricdata",
     verb: "POST",
     path: "/",
     headers: {


### PR DESCRIPTION
### Description

Fix bug preventing Memory metrics from being included in result for some EC2 Instances created by Autoscaling Group

### Issues Resolved

https://flexera.atlassian.net/browse/POL-1323

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=66c37967a79b5457a2816c0d

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
