### PR TITLE
POL-1364 Update Azure Savings Plan Expiration - Fix Policy Set value

### DIFF
--- a/cost/azure/savings_plan/expiration/CHANGELOG.md
+++ b/cost/azure/savings_plan/expiration/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.1
+
+- Updated `policy_set` value in metadata to `Savings Plans`. This does not affect the functionality of the policy.
+
 ## v0.1.0
 
 - Initial Release

--- a/cost/azure/savings_plan/expiration/azure_savings_plan_expiration.pt
+++ b/cost/azure/savings_plan/expiration/azure_savings_plan_expiration.pt
@@ -7,10 +7,10 @@ category "Cost"
 severity "medium"
 default_frequency "daily"
 info(
-  version: "0.1.0",
+  version: "0.1.1",
   provider: "Azure",
   service: "Compute",
-  policy_set: "Savings Plan"
+  policy_set: "Savings Plans"
 )
 
 ###############################################################################


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves below -->
The policy_set field in the policy template metadata has been changed from its current value of "Savings Plan" to "Savings Plans" . 
### Issues Resolved

<!-- List any existing issues this PR resolves below -->
This does not change the functionality of the policy but it does help us internally with reporting on templates in our repository.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [x] New functionality has been documented in CHANGELOG.MD
