### PR TITLE
feat/disable_concurrency_update_active_policy_list_workflow

### DIFF
--- a/.github/workflows/update-active-policy-list.yaml
+++ b/.github/workflows/update-active-policy-list.yaml
@@ -15,6 +15,13 @@ on:
     branches:
       - master
 
+# Enable only running 1 workflow at a time, cancelling previous in progress
+# This prevents race-condition between multiple workflows being triggered
+# We only need one to run at a time, and it should be from the most recent trigger/commit
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   policy_list:
     name: "Update Active Policy List"


### PR DESCRIPTION
### Description

Enable only running 1 workflow at a time, cancelling previous in progress

This prevents race-condition between multiple workflows being triggered

We only need one to run at a time, and it should be from the most recent trigger/commit