### PR TITLE
POL-1347 - fix: meta_parent_policy_compiler.rb no export block

### DIFF
--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -1229,7 +1229,7 @@ def policy_bad_comma_spacing?(file, file_lines)
     line_number = index + 1
     line = line.strip
     if line.include?(",") && !line.include?("allowed_pattern") && !line.include?('= ","') && !line.include?("(',')") && !line.include?('(",")') && !line.include?("jq(") && !line.include?("/,/")
-      if line.match(/,\s{2,}/) || line.match(/\s,/) || line.match(/,[^\s]/) && !(line.match(/\',\'/) || line.match(/\",\"/))
+      if line.match(/,\s{2,}/) || line.match(/\s,/) || line.match(/,[^\s]/) && !(line.match(/\',\'/) || line.match(/\",\"/) || line.match(/\`,\`/))
         if fail_message.empty?
           fail_message += "\n\n"
         end

--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -1229,16 +1229,16 @@ def policy_bad_comma_spacing?(file, file_lines)
     line_number = index + 1
     line = line.strip
     if line.include?(",") && !line.include?("allowed_pattern") && !line.include?('= ","') && !line.include?("(',')") && !line.include?('(",")') && !line.include?("jq(") && !line.include?("/,/")
-      if line.match(/,\s{2,}/) || line.match(/\s,/) || line.match(/,[^\s]/) && !line.match(/\',\'/)
+      if line.match(/,\s{2,}/) || line.match(/\s,/) || line.match(/,[^\s]/) && !(line.match(/\',\'/) || line.match(/\",\"/))
         if fail_message.empty?
-          fail_message += "Possible invalid spacing between comma-separated items found.\n\n"
+          fail_message += "\n\n"
         end
         fail_message += "Line #{line_number.to_s}: `"+line+"`\n\n"
       end
     end
   end
 
-  fail_message = "Issues with comma-separation found:\n\n" + fail_message + "\n\nComma separated items should be organized as follows, with a single space following each comma: apple, banana, pear" if !fail_message.empty?
+  fail_message = "Possible invalid spacing between comma-separated items found:\n\n" + fail_message + "\n\nComma separated items should be organized as follows, with a single space following each comma: apple, banana, pear" if !fail_message.empty?
 
   return fail_message.strip if !fail_message.empty?
   return false

--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -1225,18 +1225,20 @@ def policy_bad_comma_spacing?(file, file_lines)
   puts Time.now.strftime("%H:%M:%S.%L") + " *** Testing whether Policy Template file has improper comma spacing..."
 
   fail_message = ""
-
   file_lines.each_with_index do |line, index|
     line_number = index + 1
-
+    line = line.strip
     if line.include?(",") && !line.include?("allowed_pattern") && !line.include?('= ","') && !line.include?("(',')") && !line.include?('(",")') && !line.include?("jq(") && !line.include?("/,/")
-      if line.strip.match(/,\s{2,}/) || line.strip.match(/\s,/) || line.strip.match(/,[^\s]/)
-        fail_message += "Line #{line_number.to_s}: Possible invalid spacing between comma-separated items found.\nComma separated items should be organized as follows, with a single space following each comma: apple, banana, pear\n\n"
+      if line.match(/,\s{2,}/) || line.match(/\s,/) || line.match(/,[^\s]/) && !line.match(/\',\'/)
+        if fail_message.empty?
+          fail_message += "Possible invalid spacing between comma-separated items found.\n\n"
+        end
+        fail_message += "Line #{line_number.to_s}: `"+line+"`\n\n"
       end
     end
   end
 
-  fail_message = "Issues with comma-separation found:\n\n" + fail_message if !fail_message.empty?
+  fail_message = "Issues with comma-separation found:\n\n" + fail_message + "\n\nComma separated items should be organized as follows, with a single space following each comma: apple, banana, pear" if !fail_message.empty?
 
   return fail_message.strip if !fail_message.empty?
   return false

--- a/cost/aws/schedule_instance/CHANGELOG.md
+++ b/cost/aws/schedule_instance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## V7.0.1
+
+- Minor changes to policy template to pass lint tests. No functional changes.
+
 ## v7.0.0
 
 - Remove `next_stop`, `next_start` label requirements

--- a/cost/aws/schedule_instance/CHANGELOG.md
+++ b/cost/aws/schedule_instance/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## V7.0.1
+## v7.0.1
 
 - Minor changes to policy template to pass lint tests. No functional changes.
 

--- a/cost/aws/schedule_instance/aws_schedule_instance.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance.pt
@@ -279,7 +279,7 @@ datasource "ds_instance_sets" do
     encoding "xml"
     collect xpath(response, "//DescribeInstancesResponse/reservationSet/item", "array") do
       field "instances_set" do
-        collect xpath(col_item,"instancesSet/item", "array") do
+        collect xpath(col_item, "instancesSet/item", "array") do
           field "region", val(iter_item, "region")
           field "instanceId", xpath(col_item, "instanceId")
           field "imageId", xpath(col_item, "imageId")
@@ -287,9 +287,9 @@ datasource "ds_instance_sets" do
           field "platform", xpath(col_item, "platformDetails")
           field "privateDnsName", xpath(col_item, "privateDnsName")
           field "launchTime", xpath(col_item, "launchTime")
-          field "state", xpath(col_item,"instanceState/name")
+          field "state", xpath(col_item, "instanceState/name")
           field "tags" do
-            collect xpath(col_item,"tagSet/item", "array") do
+            collect xpath(col_item, "tagSet/item", "array") do
               field "key", xpath(col_item, "key")
               field "value", xpath(col_item, "value")
             end
@@ -436,7 +436,7 @@ script "js_instances_with_schedule", type: "javascript" do
       // Parse Days - second part of schedule
       var days = schedule_split[1]
       // replace all '-' with ','
-      // this is not needed as README calls out comma `,`, but may be helpful for some users that are also using GCP which uses dash separator `-`
+      // this is not needed as README calls out comma, but may be helpful for some users that are also using GCP which uses dash separator `-`
       days = days.replace(/-/g, ',')
 
       var start_rule = 'FREQ=WEEKLY;BYDAY=' + days.toUpperCase()
@@ -671,7 +671,7 @@ define execute_schedules($data, $param_tag_schedule) return $all_responses do
   end
 
   if inspect($$errors) != "null"
-    raise join($$errors,"\n")
+    raise join($$errors, "\n")
   end
 end
 
@@ -685,7 +685,7 @@ define update_schedules($data, $param_schedule, $param_tag_schedule) return $all
   end
 
   if inspect($$errors) != "null"
-    raise join($$errors,"\n")
+    raise join($$errors, "\n")
   end
 end
 
@@ -699,7 +699,7 @@ define delete_schedules($data, $param_tag_schedule) return $all_responses do
   end
 
   if inspect($$errors) != "null"
-    raise join($$errors,"\n")
+    raise join($$errors, "\n")
   end
 end
 
@@ -713,7 +713,7 @@ define start_instances($data) return $all_responses do
   end
 
   if inspect($$errors) != "null"
-    raise join($$errors,"\n")
+    raise join($$errors, "\n")
   end
 end
 
@@ -727,7 +727,7 @@ define stop_instances($data) return $all_responses do
   end
 
   if inspect($$errors) != "null"
-    raise join($$errors,"\n")
+    raise join($$errors, "\n")
   end
 end
 
@@ -747,7 +747,7 @@ define terminate_instances($data) return $all_responses do
   end
 
   if inspect($$errors) != "null"
-    raise join($$errors,"\n")
+    raise join($$errors, "\n")
   end
 end
 
@@ -1146,7 +1146,7 @@ datasource "ds_get_policy" do
     auth $auth_flexera
     host rs_governance_host
     ignore_status [404]
-    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", switch(ne(meta_parent_policy_id,""), meta_parent_policy_id, policy_id) ])
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", switch(ne(meta_parent_policy_id, ""), meta_parent_policy_id, policy_id) ])
     header "Api-Version", "1.0"
   end
   result do

--- a/cost/aws/schedule_instance/aws_schedule_instance.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance.pt
@@ -416,7 +416,6 @@ script "js_instances_with_schedule", type: "javascript" do
     }
 
     if (schedule != null) {
-      // schedule="8:00-17:30;MO,TU,WE,TH,FR;America/Los_Angeles"
       var schedule_split = schedule.split(';')
 
       // Parse Time - first part of schedule

--- a/cost/aws/schedule_instance/aws_schedule_instance.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance.pt
@@ -623,6 +623,7 @@ escalation "esc_update_schedules" do
     category "Policy Actions"
     label "New Schedule"
     description "Enter a new value for the schedule tag. See README for more details"
+    # No default value, user input required
   end
   run "update_schedules", data, $param_schedule, $param_tag_schedule
 end

--- a/cost/aws/schedule_instance/aws_schedule_instance.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "15 minutes"
 info(
-  version: "7.0.0",
+  version: "7.0.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Schedule Instance"

--- a/cost/aws/schedule_instance/aws_schedule_instance_meta_parent.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance_meta_parent.pt
@@ -7,7 +7,7 @@ category "Meta"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "6.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "7.0.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false"
 )
@@ -76,22 +76,6 @@ parameter "param_tag_schedule" do
   default "schedule"
 end
 
-parameter "param_tag_next_start" do
-  type "string"
-  category "Tag Keys"
-  label "Next Start Tag Key"
-  description "Tag key to use for scheduling instance to start. Default is recommended for most use cases."
-  default "next_start"
-end
-
-parameter "param_tag_next_stop" do
-  type "string"
-  category "Tag Keys"
-  label "Next Stop Tag Key"
-  description "Tag key to use for scheduling instance to stop. Default is recommended for most use cases."
-  default "next_stop"
-end
-
 parameter "param_exclusion_tags" do
   type "list"
   category "Filters"
@@ -122,8 +106,8 @@ parameter "param_regions_list" do
   type "list"
   category "Filters"
   label "Allow/Deny Regions List"
-  allowed_pattern /^([a-zA-Z-_]+-[a-zA-Z0-9-_]+-[0-9-_]+,*|)+$/
   description "A list of allowed or denied regions. See the README for more details"
+  allowed_pattern /^([a-zA-Z-_]+-[a-zA-Z0-9-_]+-[0-9-_]+,*|)+$/
   default []
 end
 
@@ -133,7 +117,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action(s)"
   allowed_values ["Execute Schedules"]
-  default []
+  default ["Execute Schedules"]
 end
 
 ###############################################################################
@@ -863,11 +847,11 @@ datasource "ds_child_incident_details" do
   end
 end
 
-datasource "ds_instances_to_schedule_combined_incidents" do
-  run_script $js_ds_instances_to_schedule_combined_incidents, $ds_child_incident_details
+datasource "ds_instances_schedule_result_combined_incidents" do
+  run_script $js_ds_instances_schedule_result_combined_incidents, $ds_child_incident_details
 end
 
-script "js_ds_instances_to_schedule_combined_incidents", type: "javascript" do
+script "js_ds_instances_schedule_result_combined_incidents", type: "javascript" do
   parameters "ds_child_incident_details"
   result "result"
   code <<-EOS
@@ -983,7 +967,7 @@ end
 policy "policy_scheduled_report" do
   # Consolidated Incident Check(s)
     # Consolidated incident for AWS Scheduled EC2 Instances
-  validate $ds_instances_to_schedule_combined_incidents do
+  validate $ds_instances_schedule_result_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} AWS Scheduled EC2 Instances"
     escalate $esc_email
     escalate $esc_execute_schedules
@@ -1036,6 +1020,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "ID"
+      end
+      field "event_active" do
+        label "Event Active"
       end
       field "incident_id" do
         label "Child Incident ID"

--- a/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
@@ -7,7 +7,7 @@ category "Meta"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.0.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false"
 )
@@ -85,22 +85,6 @@ parameter "param_tag_schedule" do
   default "schedule"
 end
 
-parameter "param_tag_next_start" do
-  type "string"
-  category "Tag Keys"
-  label "Next Start Tag Key"
-  description "Tag key to use for scheduling instance to start. Default is recommended for most use cases."
-  default "next_start"
-end
-
-parameter "param_tag_next_stop" do
-  type "string"
-  category "Tag Keys"
-  label "Next Stop Tag Key"
-  description "Tag key to use for scheduling instance to stop. Default is recommended for most use cases."
-  default "next_stop"
-end
-
 parameter "param_exclusion_tags" do
   type "list"
   category "Filters"
@@ -150,7 +134,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action."
   allowed_values ["Execute Schedules"]
-  default []
+  default ["Execute Schedules"]
 end
 
 ###############################################################################
@@ -890,11 +874,11 @@ datasource "ds_child_incident_details" do
   end
 end
 
-datasource "ds_instances_to_schedule_combined_incidents" do
-  run_script $js_ds_instances_to_schedule_combined_incidents, $ds_child_incident_details
+datasource "ds_instances_schedule_result_combined_incidents" do
+  run_script $js_ds_instances_schedule_result_combined_incidents, $ds_child_incident_details
 end
 
-script "js_ds_instances_to_schedule_combined_incidents", type: "javascript" do
+script "js_ds_instances_schedule_result_combined_incidents", type: "javascript" do
   parameters "ds_child_incident_details"
   result "result"
   code <<-EOS
@@ -937,6 +921,7 @@ escalation "esc_update_schedules" do
     category "Policy Actions"
     label "New Schedule"
     description "Enter a new value for the schedule tag. See README for more details"
+    # No default value, user input required
   end
   # Run declaration should go at end, after any parameters that may exist
   run "esc_update_schedules", data, rs_governance_host, rs_project_id, $param_schedule
@@ -961,29 +946,29 @@ define esc_delete_schedules($data, $governance_host, $rs_project_id) do
 end
 
 # Escalation for Power On Instances
-escalation "esc_poweron_instances" do
+escalation "esc_start_instances" do
   automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
   label "Power On Instances"
   description "Approval to power on all selected instances"
 
   # Run declaration should go at end, after any parameters that may exist
-  run "esc_poweron_instances", data, rs_governance_host, rs_project_id
+  run "esc_start_instances", data, rs_governance_host, rs_project_id
 end
-define esc_poweron_instances($data, $governance_host, $rs_project_id) do
+define esc_start_instances($data, $governance_host, $rs_project_id) do
   $actions_options = []
   call child_run_action($data, $governance_host, $rs_project_id, "Power On Instances", $action_options)
 end
 
 # Escalation for Power Off Instances
-escalation "esc_poweroff_instances" do
+escalation "esc_stop_instances" do
   automatic false # Do not automatically action from meta parent. the child will handle automatic escalations if param is set
   label "Power Off Instances"
   description "Approval to power off all selected instances"
 
   # Run declaration should go at end, after any parameters that may exist
-  run "esc_poweroff_instances", data, rs_governance_host, rs_project_id
+  run "esc_stop_instances", data, rs_governance_host, rs_project_id
 end
-define esc_poweroff_instances($data, $governance_host, $rs_project_id) do
+define esc_stop_instances($data, $governance_host, $rs_project_id) do
   $actions_options = []
   call child_run_action($data, $governance_host, $rs_project_id, "Power Off Instances", $action_options)
 end
@@ -1010,14 +995,14 @@ end
 policy "policy_scheduled_report" do
   # Consolidated Incident Check(s)
     # Consolidated incident for Azure Scheduled Instances
-  validate $ds_instances_to_schedule_combined_incidents do
+  validate $ds_instances_schedule_result_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Azure Scheduled Instances"
     escalate $esc_email
     escalate $esc_execute_schedules
     escalate $esc_update_schedules
     escalate $esc_delete_schedules
-    escalate $esc_poweron_instances
-    escalate $esc_poweroff_instances
+    escalate $esc_start_instances
+    escalate $esc_stop_instances
     escalate $esc_delete_instances
     check eq(size(data), 0)
     export do
@@ -1069,6 +1054,9 @@ policy "policy_scheduled_report" do
       end
       field "tags_object" do
         label "Tags (Object)"
+      end
+      field "event_active" do
+        label "Event Active"
       end
       field "incident_id" do
         label "Child Incident ID"

--- a/cost/google/schedule_instance/CHANGELOG.md
+++ b/cost/google/schedule_instance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.0.1
+
+- Removed datasource that was not necessary for results
+
 ## v5.0.0
 
 - Remove `next_stop`, `next_start` label requirements

--- a/cost/google/schedule_instance/google_schedule_instance.pt
+++ b/cost/google/schedule_instance/google_schedule_instance.pt
@@ -381,8 +381,8 @@ script "js_instances_with_schedule", type: "javascript" do
 
       // stop time is second part of time string split by '-'
       var stop_time = time.split('-')[1]
-      var stop_hour = stop_time.slice(0,2) // first 2 characters is HH
-      var stop_minute = stop_time.slice(2,4) // last 2 characters is MM
+      var stop_hour = stop_time.slice(0, 2) // first 2 characters is HH
+      var stop_minute = stop_time.slice(2, 4) // last 2 characters is MM
       if (stop_minute == null) { stop_minute = '00' }
 
       // Parse Days - second part of schedule
@@ -654,7 +654,7 @@ define execute_schedules($data, $param_label_schedule) return $all_responses do
   end
 
   if inspect($$errors) != "null"
-    raise join($$errors,"\n")
+    raise join($$errors, "\n")
   end
 end
 
@@ -668,7 +668,7 @@ define update_schedules($data, $param_schedule, $param_label_schedule) return $a
   end
 
   if inspect($$errors) != "null"
-    raise join($$errors,"\n")
+    raise join($$errors, "\n")
   end
 end
 
@@ -682,7 +682,7 @@ define delete_schedules($data, $param_label_schedule) return $all_responses do
   end
 
   if inspect($$errors) != "null"
-    raise join($$errors,"\n")
+    raise join($$errors, "\n")
   end
 end
 
@@ -696,7 +696,7 @@ define start_instances($data) return $all_responses do
   end
 
   if inspect($$errors) != "null"
-    raise join($$errors,"\n")
+    raise join($$errors, "\n")
   end
 end
 
@@ -710,7 +710,7 @@ define stop_instances($data) return $all_responses do
   end
 
   if inspect($$errors) != "null"
-    raise join($$errors,"\n")
+    raise join($$errors, "\n")
   end
 end
 
@@ -724,7 +724,7 @@ define delete_instances($data) return $all_responses do
   end
 
   if inspect($$errors) != "null"
-    raise join($$errors,"\n")
+    raise join($$errors, "\n")
   end
 end
 
@@ -1108,7 +1108,7 @@ datasource "ds_get_policy" do
     auth $auth_flexera
     host rs_governance_host
     ignore_status [404]
-    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", switch(ne(meta_parent_policy_id,""), meta_parent_policy_id, policy_id) ])
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", switch(ne(meta_parent_policy_id, ""), meta_parent_policy_id, policy_id) ])
     header "Api-Version", "1.0"
   end
   result do

--- a/cost/google/schedule_instance/google_schedule_instance.pt
+++ b/cost/google/schedule_instance/google_schedule_instance.pt
@@ -607,6 +607,7 @@ escalation "esc_update_schedules" do
     category "Policy Actions"
     label "New Schedule"
     description "Enter a new value for the schedule label. See README for more details"
+    # No default value, user input required
   end
   run "update_schedules", data, $param_schedule, $param_label_schedule
 end

--- a/cost/google/schedule_instance/google_schedule_instance.pt
+++ b/cost/google/schedule_instance/google_schedule_instance.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "15 minutes"
 info(
-  version: "5.0.0",
+  version: "5.0.1",
   provider: "Google",
   service: "Compute",
   policy_set: "Schedule Instance"
@@ -136,73 +136,6 @@ datasource "ds_applied_policy" do
     path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
     header "Api-Version", "1.0"
   end
-end
-
-# Get Child policies incidents
-datasource "ds_applied_policy_action_status" do
-  request do
-    auth $auth_flexera
-    host rs_governance_host
-    path join(["/api/governance/projects/", rs_project_id, "/action_status"])
-    query "applied_policy_id", policy_id
-    query "view", "extended"
-    header "Api-Version", "1.0"
-  end
-  result do
-    encoding "json"
-    collect jq(response, 'select(.count > 0) | .items[] | select(.name == "esc_execute_schedules") | .action_items[]') do
-      # // field "id", jq(col_item, ".id")
-      # // field "status", jq(col_item, ".status")
-      # // field "name", jq(col_item, ".name")
-      # // field "label", jq(col_item, ".label")
-      # // field "action_items", jq(col_item, ".action_items", "array")
-      # // field "automatic", jq(col_item, ".automatic")
-      # // field "type", jq(col_item, ".type")
-      # // field "started_at", jq(col_item, ".started_at")
-      # // field "finished_at", jq(col_item, ".finished_at")
-      # // field "run_by_email", jq(col_item, ".run_by.email")
-      # // field "run_by_name", jq(col_item, ".run_by.name")
-      # // field "run_by_id", jq(col_item, ".run_by.id")
-      field "process_href", jq(col_item, ".process_href")
-    end
-  end
-end
-
-# Get Child policies incidents
-datasource "ds_action_details" do
-  iterate $ds_applied_policy_action_status
-  request do
-    run_script $js_action_details, iter_item
-  end
-end
-
-# curl 'https://cloud-workflow3.rightscale.com/cwf/v1/accounts/136976/processes/66f1021128c42f0f470bee26?view=expanded' -H 'X-Api-Version: 1.0' ...
-# curl 'https://cloud-workflow3.rightscale.com/cwf/v1/accounts/136976/processes/66f1021128c42f0f470bee26/profile' -H 'X-Api-Version: 1.0'
-script "js_action_details", type: "javascript" do
-  parameters "iter_item"
-  result "request"
-  code <<-EOS
-  var process_href = iter_item['process_href']
-  // Protocol is everything before the first ://
-  var protocol = process_href.split('://')[0]
-  // Host is everything between the first :// and the first / (so 3rd element)
-  var host = process_href.split('/')[2]
-  // Path is everything after the host
-  var path = '/' + process_href.split('/').slice(3).join('/')
-  // Construct the request object
-  var request = {
-    auth: "auth_flexera",
-    host: host,
-    path: path,
-    headers: {
-      "X-Api-Version": "1.0",
-      "Content-Type":"application/json"
-    },
-    query_params: {
-      view: "expanded"
-    }
-  }
-EOS
 end
 
 datasource "ds_google_projects" do
@@ -571,11 +504,6 @@ end
 ###############################################################################
 
 policy "pol_schedule_instance" do
-  validate $ds_action_details do
-    summary_template "Google Scheduled VM Instances - Action Status"
-    detail_template "{{ data }}"
-    check false # Create incident if there is at least one action status
-  end
   validate_each $ds_instances_schedule_result do
     summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Google Scheduled VM Instances"
     # Policy check fails and incident is created only if data is not empty and the Parent Policy has not been terminated

--- a/cost/google/schedule_instance/google_schedule_instance_meta_parent.pt
+++ b/cost/google/schedule_instance/google_schedule_instance_meta_parent.pt
@@ -7,7 +7,7 @@ category "Meta"
 default_frequency "15 minutes"
 info(
   provider: "Google",
-  version: "4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.0.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false"
 )
@@ -76,22 +76,6 @@ parameter "param_label_schedule" do
   default "schedule"
 end
 
-parameter "param_label_next_start" do
-  type "string"
-  category "Label Keys"
-  label "Next Start Label Key"
-  description "Label key to use for scheduling instance to start. Default is recommended for most use cases."
-  default "next_start"
-end
-
-parameter "param_label_next_stop" do
-  type "string"
-  category "Label Keys"
-  label "Next Stop Label Key"
-  description "Label key to use for scheduling instance to stop. Default is recommended for most use cases."
-  default "next_stop"
-end
-
 parameter "param_regions_allow_or_deny" do
   type "string"
   category "Filters"
@@ -132,7 +116,7 @@ parameter "param_automatic_action" do
   label "Automatic Actions"
   description "When this value is set, this policy will automatically take the selected action."
   allowed_values ["Execute Schedules"]
-  default []
+  default ["Execute Schedules"] # Schedules enabled by default because resource label required to action.  Can be disabled by removing from list which is helpful for debugging / manual triggers.
 end
 
 ###############################################################################
@@ -872,11 +856,33 @@ datasource "ds_child_incident_details" do
   end
 end
 
-datasource "ds_instances_to_schedule_combined_incidents" do
-  run_script $js_ds_instances_to_schedule_combined_incidents, $ds_child_incident_details
+datasource "ds_action_details_combined_incidents" do
+  run_script $js_ds_action_details_combined_incidents, $ds_child_incident_details
 end
 
-script "js_ds_instances_to_schedule_combined_incidents", type: "javascript" do
+script "js_ds_action_details_combined_incidents", type: "javascript" do
+  parameters "ds_child_incident_details"
+  result "result"
+  code <<-EOS
+  result = []
+  _.each(ds_child_incident_details, function(incident) {
+    s = incident["summary"];
+    // If the incident summary contains "Google Scheduled VM Instances" then include it in the filter result
+    if (s.indexOf("Google Scheduled VM Instances") > -1) {
+      _.each(incident["violation_data"], function(violation) {
+        violation["incident_id"] = incident["id"];
+        result.push(violation);
+      });
+    }
+  });
+EOS
+end
+
+datasource "ds_instances_schedule_result_combined_incidents" do
+  run_script $js_ds_instances_schedule_result_combined_incidents, $ds_child_incident_details
+end
+
+script "js_ds_instances_schedule_result_combined_incidents", type: "javascript" do
   parameters "ds_child_incident_details"
   result "result"
   code <<-EOS
@@ -992,7 +998,21 @@ end
 policy "policy_scheduled_report" do
   # Consolidated Incident Check(s)
     # Consolidated incident for Google Scheduled VM Instances
-  validate $ds_instances_to_schedule_combined_incidents do
+  validate $ds_action_details_combined_incidents do
+    summary_template "Consolidated Incident: {{ len data }} Google Scheduled VM Instances"
+    escalate $esc_email
+    
+    check eq(size(data), 0)
+    export do
+      resource_level true
+      field "incident_id" do
+        label "Child Incident ID"
+      end
+    end
+  end
+
+  # Consolidated incident for Google Scheduled VM Instances
+  validate $ds_instances_schedule_result_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Google Scheduled VM Instances"
     escalate $esc_email
     escalate $esc_execute_schedules
@@ -1057,6 +1077,9 @@ policy "policy_scheduled_report" do
       end
       field "id" do
         label "ID"
+      end
+      field "event_active" do
+        label "Event Active"
       end
       field "incident_id" do
         label "Child Incident ID"

--- a/cost/google/schedule_instance/google_schedule_instance_meta_parent.pt
+++ b/cost/google/schedule_instance/google_schedule_instance_meta_parent.pt
@@ -7,7 +7,7 @@ category "Meta"
 default_frequency "15 minutes"
 info(
   provider: "Google",
-  version: "5.0.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.0.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false"
 )
@@ -856,28 +856,6 @@ datasource "ds_child_incident_details" do
   end
 end
 
-datasource "ds_action_details_combined_incidents" do
-  run_script $js_ds_action_details_combined_incidents, $ds_child_incident_details
-end
-
-script "js_ds_action_details_combined_incidents", type: "javascript" do
-  parameters "ds_child_incident_details"
-  result "result"
-  code <<-EOS
-  result = []
-  _.each(ds_child_incident_details, function(incident) {
-    s = incident["summary"];
-    // If the incident summary contains "Google Scheduled VM Instances" then include it in the filter result
-    if (s.indexOf("Google Scheduled VM Instances") > -1) {
-      _.each(incident["violation_data"], function(violation) {
-        violation["incident_id"] = incident["id"];
-        result.push(violation);
-      });
-    }
-  });
-EOS
-end
-
 datasource "ds_instances_schedule_result_combined_incidents" do
   run_script $js_ds_instances_schedule_result_combined_incidents, $ds_child_incident_details
 end
@@ -998,20 +976,6 @@ end
 policy "policy_scheduled_report" do
   # Consolidated Incident Check(s)
     # Consolidated incident for Google Scheduled VM Instances
-  validate $ds_action_details_combined_incidents do
-    summary_template "Consolidated Incident: {{ len data }} Google Scheduled VM Instances"
-    escalate $esc_email
-    
-    check eq(size(data), 0)
-    export do
-      resource_level true
-      field "incident_id" do
-        label "Child Incident ID"
-      end
-    end
-  end
-
-  # Consolidated incident for Google Scheduled VM Instances
   validate $ds_instances_schedule_result_combined_incidents do
     summary_template "Consolidated Incident: {{ len data }} Google Scheduled VM Instances"
     escalate $esc_email

--- a/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
+++ b/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
@@ -334,7 +334,7 @@ end
     fields = [] # Provide a default value, which is no fields declared
     # Check if export_block is length > 0
     if export_block.length > 0
-      fields = export_block[0].scan(/field\s+"[^"]+"/).flatten
+      fields = export_block[0].scan(/(^.*field\s+\".*?\".*?end)/m).flatten
     end
     fields.each do |field|
       # Remove path from the field output in the meta parent

--- a/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
+++ b/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
@@ -331,7 +331,11 @@ end
     # print(export_block)
     # print("\n---\n")
     # From the export block, capture the field blocks
-    fields = export_block[0].scan(/(^.*field\s+\".*?\".*?end)/m).flatten
+    fields = [] # Provide a default value, which is no fields declared
+    # Check if export_block is length > 0
+    if export_block.length > 0
+      fields = export_block[0].scan(/field\s+"[^"]+"/).flatten
+    end
     fields.each do |field|
       # Remove path from the field output in the meta parent
       field.gsub!(/\n.*?path.*?\n/, "\n")


### PR DESCRIPTION
### Description

https://github.com/flexera-public/policy_templates/actions/runs/11059501776
Workflow is currently failing on a PT

```
Writing parent policy template: ../../security/azure/sql_auditing_retention/sql_auditing_retention_meta_parent.pt
meta_parent_policy_compiler.rb:334:in `block in compile_meta_parent_policy': undefined method `scan' for nil (NoMethodError)

    fields = export_block[0].scan(/(^.*field\s+\".*?\".*?end)/m).flatten
                            ^^^^^
	from meta_parent_policy_compiler.rb:314:in `each'
	from meta_parent_policy_compiler.rb:314:in `compile_meta_parent_policy'
	from meta_parent_policy_compiler.rb:467:in `block in <main>'
	from meta_parent_policy_compiler.rb:466:in `each'
	from meta_parent_policy_compiler.rb:466:in `<main>'
```
Modified Workflow Run Succesful: https://github.com/flexera-public/policy_templates/actions/runs/11059612277

Which resulted in these changes: https://github.com/flexera-public/policy_templates/pull/2687

### Contribution Check List

- [X] New functionality includes testing.
