### PR TITLE
POL-1368 AWS Superseded EBS Volumes - Update Name in Readme

### DIFF
--- a/cost/aws/superseded_ebs_volumes/README.md
+++ b/cost/aws/superseded_ebs_volumes/README.md
@@ -1,4 +1,4 @@
-# AWS Rightsize EBS Volumes
+# AWS Superseded EBS Volumes
 
 ## What It Does
 


### PR DESCRIPTION
Updated policy template name in readme from `AWS Rightsize EBS Volumes` to `AWS Superseded EBS Volumes`

### Description

<!-- Describe what this change achieves below -->
Updates the Policy Template Name in the README doc from `AWS Rightsize EBS Volumes` to `AWS Superseded EBS Volumes`

### Issues Resolved

<!-- List any existing issues this PR resolves below -->
Fixes the name in readme doc to be correct.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->
N/A

### Contribution Check List

- [x] New functionality has been documented in the README if applicable
