### PR TITLE
POL-1370 Update AWS Instance Types JSON to include superseded instances for r, db.m, db.r families

### DIFF
--- a/data/aws/instance_types.json
+++ b/data/aws/instance_types.json
@@ -5893,6 +5893,12 @@
     "vcpu": "2",
     "up": "db.m4.xlarge",
     "down": null,
+    "superseded": {
+      "regular": "db.m5.large",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "nfu": "4",
     "memory": "8"
   },
@@ -5900,6 +5906,12 @@
     "vcpu": "4",
     "up": "db.m4.2xlarge",
     "down": "db.m4.large",
+    "superseded": {
+      "regular": "db.m5.xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "nfu": "8",
     "memory": "16"
   },
@@ -5907,6 +5919,12 @@
     "vcpu": "8",
     "up": "db.m4.4xlarge",
     "down": "db.m4.xlarge",
+    "superseded": {
+      "regular": "db.m5.2xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "nfu": "16",
     "memory": "32"
   },
@@ -5914,6 +5932,12 @@
     "vcpu": "16",
     "up": "db.m4.10xlarge",
     "down": "db.m4.2xlarge",
+    "superseded": {
+      "regular": "db.m5.4xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "nfu": "32",
     "memory": "64"
   },
@@ -5921,6 +5945,12 @@
     "vcpu": "40",
     "up": "db.m4.16xlarge",
     "down": "db.m4.4xlarge",
+    "superseded": {
+      "regular": "db.m5.12xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "nfu": "80",
     "memory": "160"
   },
@@ -5928,6 +5958,12 @@
     "vcpu": "64",
     "up": null,
     "down": "db.m4.10xlarge",
+    "superseded": {
+      "regular": "db.m5.16xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "nfu": "128",
     "memory": "256"
   },

--- a/data/aws/instance_types.json
+++ b/data/aws/instance_types.json
@@ -3700,7 +3700,12 @@
   "r4.large": {
     "up": "r4.xlarge",
     "down": null,
-    "superseded": null,
+    "superseded": {
+      "regular": "r5.large",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "2",
@@ -3710,7 +3715,12 @@
   "r4.xlarge": {
     "up": "r4.2xlarge",
     "down": "r4.large",
-    "superseded": null,
+    "superseded": {
+      "regular": "r5.xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "4",
@@ -3720,7 +3730,12 @@
   "r4.2xlarge": {
     "up": "r4.4xlarge",
     "down": "r4.xlarge",
-    "superseded": null,
+    "superseded": {
+      "regular": "r5.2xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "8",
@@ -3730,7 +3745,12 @@
   "r4.4xlarge": {
     "up": "r4.8xlarge",
     "down": "r4.2xlarge",
-    "superseded": null,
+    "superseded": {
+      "regular": "r5.4xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "16",
@@ -3740,7 +3760,12 @@
   "r4.8xlarge": {
     "up": "r4.16xlarge",
     "down": "r4.4xlarge",
-    "superseded": null,
+    "superseded": {
+      "regular": "r5.8xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "32",
@@ -3750,7 +3775,12 @@
   "r4.16xlarge": {
     "up": null,
     "down": "r4.8xlarge",
-    "superseded": null,
+    "superseded": {
+      "regular": "r5.16xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "ec2_classic": false,
     "enhanced_networking": true,
     "vcpu": "64",

--- a/data/aws/instance_types.json
+++ b/data/aws/instance_types.json
@@ -6211,6 +6211,12 @@
     "vcpu": "2",
     "up": "db.r4.xlarge",
     "down": null,
+    "superseded": {
+      "regular": "db.r5.large",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "nfu": "4",
     "memory": "15.25"
   },
@@ -6218,6 +6224,12 @@
     "vcpu": "4",
     "up": "db.r4.2xlarge",
     "down": "db.r4.large",
+    "superseded": {
+      "regular": "db.r5.xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "nfu": "8",
     "memory": "30.5"
   },
@@ -6225,6 +6237,12 @@
     "vcpu": "8",
     "up": "db.r4.4xlarge",
     "down": "db.r4.xlarge",
+    "superseded": {
+      "regular": "db.r5.2xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "nfu": "16",
     "memory": "61"
   },
@@ -6232,6 +6250,12 @@
     "vcpu": "16",
     "up": "db.r4.8xlarge",
     "down": "db.r4.2xlarge",
+    "superseded": {
+      "regular": "db.r5.4xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "nfu": "32",
     "memory": "122"
   },
@@ -6239,6 +6263,12 @@
     "vcpu": "32",
     "up": "db.r4.16xlarge",
     "down": "db.r4.4xlarge",
+    "superseded": {
+      "regular": "db.r5.8xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "nfu": "64",
     "memory": "244"
   },
@@ -6246,6 +6276,12 @@
     "vcpu": "64",
     "up": null,
     "down": "db.r4.8xlarge",
+    "superseded": {
+      "regular": "db.r5.16xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "nfu": "128",
     "memory": "488"
   },
@@ -6286,15 +6322,22 @@
   },
   "db.r5.12xlarge": {
     "vcpu": "48",
-    "up": "db.r5.24xlarge",
-    "down": "db.r5.4xlarge",
+    "up": "db.r5.16xlarge",
+    "down": "db.r5.8xlarge",
     "nfu": "96",
     "memory": "384"
   },
-  "db.r5.24xlarge": {
+  "db.r5.16xlarge": {
     "vcpu": "64",
-    "up": null,
+    "up": "db.r5.24xlarge",
     "down": "db.r5.12xlarge",
+    "nfu": "128",
+    "memory": "512"
+  },
+  "db.r5.24xlarge": {
+    "vcpu": "96",
+    "up": null,
+    "down": "db.r5.16xlarge",
     "nfu": "192",
     "memory": "768"
   },


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves below -->

- ~~C family (e.g., c4 → c5)~~ (already in file)
- ~~M family (e.g., m4 → m5)~~ (already in file)
- R family (e.g., r4 → r5)
- DB instances:
  - M family (e.g., db.m4 → db.m5)
  - R family (e.g., db.r4 → db.r5)

### Issues Resolved

<!-- List any existing issues this PR resolves below -->
Resolves issue where AWS Superseded EC2 Instances policy does not report on the above instance types despite them being superseded.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List
