### PR TITLE
POL-1373 Update AWS Superseded EBS Volumes - fix incorrect "New Monthly List Price" value

### DIFF
--- a/cost/aws/superseded_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/superseded_ebs_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.3.1
+
+- Fixed issue where `New Monthly List Price` and `Estimated Monthly Savings` were being incorrectly reported in the policy incident.
+
 ## v6.3.0
 
 - Added `Resource ARN` to incident table.

--- a/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
+++ b/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
@@ -580,7 +580,7 @@ end
 datasource "ds_gp2_prices" do
   iterate $ds_volume_regions_list
   request do
-    run_script $js_volume_prices, $ds_aws_api_hosts, iter_item, "gp2"
+    run_script $js_volume_prices, $ds_aws_api_hosts, "gp2", iter_item
   end
   result do
     encoding "json"
@@ -593,7 +593,7 @@ end
 datasource "ds_gp3_prices" do
   iterate $ds_volume_regions_list
   request do
-    run_script $js_volume_prices, $ds_aws_api_hosts, iter_item, "gp3"
+    run_script $js_volume_prices, $ds_aws_api_hosts, "gp3", iter_item
   end
   result do
     encoding "json"
@@ -604,7 +604,7 @@ datasource "ds_gp3_prices" do
 end
 
 script "js_volume_prices", type: "javascript" do
-  parameters "ds_aws_api_hosts", "volume_region", "volumeApiName"
+  parameters "ds_aws_api_hosts", "volumeApiName", "volume_region"
   result "request"
   code <<-EOS
   var request = {

--- a/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
+++ b/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
@@ -667,7 +667,7 @@ script "js_volumes_with_prices", type: "javascript" do
 
       convertedPriceList[region].push(entry)
     })
-    
+
     return convertedPriceList
   }
 

--- a/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
+++ b/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
@@ -1,5 +1,4 @@
-
-name "AWS Superseded EBS Volumes"
+name "AWS Superseded EBS Volumes - TEST Pricing API Fix"
 rs_pt_ver 20180301
 type "policy"
 short_description "This policy finds AWS GP2 volume types and recommends them for an upgrade to GP3 if this would result in savings. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/superseded_ebs_volumes/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
@@ -565,20 +564,47 @@ script "js_volumes_tag_filtered", type: "javascript" do
 EOS
 end
 
+# Get list of Volume regions for Pricing API requests
+datasource "ds_volume_regions_list" do
+  run_script $js_volume_regions_list, $ds_volumes_tag_filtered
+end
+
+script "js_volume_regions_list", type: "javascript" do
+  parameters "ds_volumes_tag_filtered"
+  result "result"
+  code <<-EOS
+  result = _.uniq(_.pluck(ds_volumes_tag_filtered, "region"))
+  EOS
+end
+
 datasource "ds_gp2_prices" do
+  iterate $ds_volume_regions_list
   request do
-    run_script $js_volume_prices, $ds_aws_api_hosts, "gp2"
+    run_script $js_volume_prices, $ds_aws_api_hosts, iter_item, "gp2"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "PriceList") do
+      field "priceList", jmes_path(col_item, "@")
+    end
   end
 end
 
 datasource "ds_gp3_prices" do
+  iterate $ds_volume_regions_list
   request do
-    run_script $js_volume_prices, $ds_aws_api_hosts, "gp3"
+    run_script $js_volume_prices, $ds_aws_api_hosts, iter_item, "gp3"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "PriceList") do
+      field "priceList", jmes_path(col_item, "@")
+    end
   end
 end
 
 script "js_volume_prices", type: "javascript" do
-  parameters "ds_aws_api_hosts", "volumeApiName"
+  parameters "ds_aws_api_hosts", "volume_region", "volumeApiName"
   result "request"
   code <<-EOS
   var request = {
@@ -603,6 +629,11 @@ script "js_volume_prices", type: "javascript" do
           "Type": "TERM_MATCH",
           "Field": "volumeApiName",
           "Value": volumeApiName
+        },
+        {
+          "Type": "TERM_MATCH",
+          "Field": "regionCode",
+          "Value": volume_region
         }
       ],
       "FormatVersion": "aws_v1",
@@ -623,11 +654,11 @@ script "js_volumes_with_prices", type: "javascript" do
   result "result"
   code <<-EOS
   // Function to convert price lists to proper JSON
-  function convertPriceList(priceList) {
+  function convertPriceList(prices) {
     convertedPriceList = {}
 
-    _.each(priceList, function(price) {
-      entry = JSON.parse(price.replace(/\\"/g, '"'))
+    _.each(prices, function(price) {
+      entry = JSON.parse(price.priceList.replace(/\\"/g, '"'))
       region = entry['product']['attributes']['regionCode']
 
       if (convertedPriceList[region] == undefined) {
@@ -636,7 +667,7 @@ script "js_volumes_with_prices", type: "javascript" do
 
       convertedPriceList[region].push(entry)
     })
-
+    
     return convertedPriceList
   }
 
@@ -687,6 +718,8 @@ script "js_volumes_with_prices", type: "javascript" do
       throughput = Number(instance['throughput'])
     }
 
+    console.log(size, "GB", iops, "IOPS", throughput, "Throughput")
+
     foundPrice = 0.0
 
     if (priceList[region] != undefined) {
@@ -704,14 +737,17 @@ script "js_volumes_with_prices", type: "javascript" do
         })
 
         if (item['product']['productFamily'] == "System Operation") {
+          console.log(prePrice, "IOPS Price")
           foundPrice += prePrice * (iops - 3000)
         }
 
         if (item['product']['productFamily'] == "Provisioned Throughput") {
+          console.log(prePrice, "Throughput Price")
           foundPrice += prePrice * (throughput - 125)
         }
 
         if (item['product']['productFamily'] == "Storage") {
+          console.log(prePrice, "Storage Price")
           foundPrice += prePrice * size
         }
       })
@@ -721,8 +757,8 @@ script "js_volumes_with_prices", type: "javascript" do
   }
 
   result = []
-  gp2_pricelist = convertPriceList(ds_gp2_prices['PriceList'])
-  gp3_pricelist = convertPriceList(ds_gp3_prices['PriceList'])
+  gp2_pricelist = convertPriceList(ds_gp2_prices)
+  gp3_pricelist = convertPriceList(ds_gp3_prices)
 
   _.each(ds_volumes_tag_filtered, function(volume) {
     gp2_price = getGP2Price(volume, gp2_pricelist) * ds_currency['exchange_rate']

--- a/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
+++ b/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
@@ -580,7 +580,7 @@ end
 datasource "ds_gp2_prices" do
   iterate $ds_volume_regions_list
   request do
-    run_script $js_volume_prices, $ds_aws_api_hosts, "gp2", iter_item
+    run_script $js_volume_prices, iter_item, $ds_aws_api_hosts, "gp2"
   end
   result do
     encoding "json"
@@ -593,7 +593,7 @@ end
 datasource "ds_gp3_prices" do
   iterate $ds_volume_regions_list
   request do
-    run_script $js_volume_prices, $ds_aws_api_hosts, "gp3", iter_item
+    run_script $js_volume_prices, iter_item, $ds_aws_api_hosts, "gp3"
   end
   result do
     encoding "json"
@@ -604,7 +604,7 @@ datasource "ds_gp3_prices" do
 end
 
 script "js_volume_prices", type: "javascript" do
-  parameters "ds_aws_api_hosts", "volumeApiName", "volume_region"
+  parameters "volume_region", "ds_aws_api_hosts", "volumeApiName"
   result "request"
   code <<-EOS
   var request = {

--- a/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
+++ b/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
@@ -1,4 +1,4 @@
-name "AWS Superseded EBS Volumes - TEST Pricing API Fix"
+name "AWS Superseded EBS Volumes"
 rs_pt_ver 20180301
 type "policy"
 short_description "This policy finds AWS GP2 volume types and recommends them for an upgrade to GP3 if this would result in savings. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/superseded_ebs_volumes/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."

--- a/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
+++ b/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "6.3.0",
+  version: "6.3.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Inefficient Disk Usage",

--- a/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
+++ b/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
@@ -718,8 +718,6 @@ script "js_volumes_with_prices", type: "javascript" do
       throughput = Number(instance['throughput'])
     }
 
-    console.log(size, "GB", iops, "IOPS", throughput, "Throughput")
-
     foundPrice = 0.0
 
     if (priceList[region] != undefined) {
@@ -737,17 +735,14 @@ script "js_volumes_with_prices", type: "javascript" do
         })
 
         if (item['product']['productFamily'] == "System Operation") {
-          console.log(prePrice, "IOPS Price")
           foundPrice += prePrice * (iops - 3000)
         }
 
         if (item['product']['productFamily'] == "Provisioned Throughput") {
-          console.log(prePrice, "Throughput Price")
           foundPrice += prePrice * (throughput - 125)
         }
 
         if (item['product']['productFamily'] == "Storage") {
-          console.log(prePrice, "Storage Price")
           foundPrice += prePrice * size
         }
       })

--- a/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes_meta_parent.pt
+++ b/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes_meta_parent.pt
@@ -7,7 +7,7 @@ category "Meta"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "6.3.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.3.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false"
 )

--- a/data/policy_permissions_list/master_policy_permissions_list.json
+++ b/data/policy_permissions_list/master_policy_permissions_list.json
@@ -2573,7 +2573,7 @@
     {
       "id": "./cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt",
       "name": "AWS Superseded EBS Volumes",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "providers": [
         {
           "name": "aws",

--- a/data/policy_permissions_list/master_policy_permissions_list.yaml
+++ b/data/policy_permissions_list/master_policy_permissions_list.yaml
@@ -1475,7 +1475,7 @@
       required: true
 - id: "./cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt"
   name: AWS Superseded EBS Volumes
-  version: 6.3.0
+  version: 6.3.1
   :providers:
   - :name: aws
     :permissions:


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves below -->
This policy was previously showing incorrect values in the incident for "New Monthly List Price" and "Estimated Monthly Savings". 

This change improves the querying of the AWS Price List API to capture all prices associated with GP3 volumes to provide an accurate value for both these fields in the policy incident.

### Issues Resolved

<!-- List any existing issues this PR resolves below -->
Policy incident now shows accurate values for "New Monthly List Price" and "Estimated Monthly Savings" to the user.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->
Tested in multiple customer tenants.

### Contribution Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in CHANGELOG.MD
