### PR TITLE
POL-1381 Update AWS Instance Types JSON to include superseded instances for db.t family

### DIFF
--- a/data/aws/instance_types.json
+++ b/data/aws/instance_types.json
@@ -5790,6 +5790,12 @@
     "vcpu": "1",
     "up": null,
     "down": null,
+    "superseded": {
+      "regular": "db.t3.micro",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "nfu": "0.5",
     "memory": "0.613"
   },
@@ -5797,6 +5803,12 @@
     "vcpu": "1",
     "up": "db.t2.small",
     "down": null,
+    "superseded": {
+      "regular": "db.t3.micro",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "nfu": "0.5",
     "memory": "1"
   },
@@ -5804,6 +5816,12 @@
     "vcpu": "1",
     "up": "db.t2.medium",
     "down": "db.t2.micro",
+    "superseded": {
+      "regular": "db.t3.small",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "nfu": "1",
     "memory": "2"
   },
@@ -5811,6 +5829,12 @@
     "vcpu": "2",
     "up": "db.t2.large",
     "down": "db.t2.small",
+    "superseded": {
+      "regular": "db.t3.medium",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "nfu": "2",
     "memory": "4"
   },
@@ -5818,6 +5842,12 @@
     "vcpu": "2",
     "up": "db.t2.xlarge",
     "down": "db.t2.medium",
+    "superseded": {
+      "regular": "db.t3.large",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "nfu": "4",
     "memory": "8"
   },
@@ -5825,6 +5855,12 @@
     "vcpu": "4",
     "up": "db.t2.2xlarge",
     "down": "db.t2.large",
+    "superseded": {
+      "regular": "db.t3.xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "nfu": "8",
     "memory": "16"
   },
@@ -5832,6 +5868,12 @@
     "vcpu": "8",
     "up": null,
     "down": "db.t2.xlarge",
+    "superseded": {
+      "regular": "db.t3.2xlarge",
+      "next_gen": "",
+      "burstable": "",
+      "amd": ""
+    },
     "nfu": "16",
     "memory": "32"
   },


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves below -->
- DB instances:
  - M family (e.g., db.t2 → db.t3)

### Issues Resolved

<!-- List any existing issues this PR resolves below -->
Potentially allows for testing the new AWS Superseded RDS Instances policy using RDS resources in existing Flexera One tenants.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List
