### PR TITLE
POL-1398 Azure Expiring Credentials - fix Days Until Expiration bug

### DIFF
--- a/data/policy_permissions_list/master_policy_permissions_list.json
+++ b/data/policy_permissions_list/master_policy_permissions_list.json
@@ -6516,7 +6516,7 @@
     {
       "id": "./operational/azure/azure_certificates/azure_certificates.pt",
       "name": "Azure Expiring Certificates",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "providers": [
         {
           "name": "azure_rm",

--- a/data/policy_permissions_list/master_policy_permissions_list.yaml
+++ b/data/policy_permissions_list/master_policy_permissions_list.yaml
@@ -3780,7 +3780,7 @@
       required: true
 - id: "./operational/azure/azure_certificates/azure_certificates.pt"
   name: Azure Expiring Certificates
-  version: 4.0.0
+  version: 4.0.1
   :providers:
   - :name: azure_rm
     :permissions:

--- a/operational/azure/azure_certificates/CHANGELOG.md
+++ b/operational/azure/azure_certificates/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.0.1
+
+- Fixed issue where policy incident would show incorrect `Days Until Expiration` for several resources
+
 ## v4.0.0
 
 - Added ability to delete Azure certificates automatically or manually

--- a/operational/azure/azure_certificates/azure_certificates.pt
+++ b/operational/azure/azure_certificates/azure_certificates.pt
@@ -7,7 +7,7 @@ category "Operational"
 severity "low"
 default_frequency "daily"
 info(
-  version: "4.0.0",
+  version: "4.0.1",
   provider: "Azure",
   service: "PaaS",
   policy_set: "Expiring Certificates"
@@ -348,7 +348,7 @@ script "js_azure_certificates_expiring", type: "javascript" do
     if (today >= expiration_date) {
       status = "Expired"
     } else {
-      days_until_expiration = Math.round((today - expiration_date) / 86400000)
+      days_until_expiration = Math.round((expiration_date - today) / 86400000)
     }
 
     if (status == "Expired" || days_until_expiration <= param_expiration_days) {

--- a/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
+++ b/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
@@ -7,7 +7,7 @@ category "Meta"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "4.0.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.0.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false"
 )


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves below -->
Regardless of the threshold set, the Azure Expiring Certificates policy returns (in the incident) certificate resources that will expire months and years from now. The reason for this is an incorrect calculation which makes the 'Days Until Expiration' a negative number. This is a change to fix this.

### Issues Resolved

<!-- List any existing issues this PR resolves below -->
- 'Days Until Expiration' no longer produces a negative value in the policy incident.
- Certificate resources outside of the threshold set are no longer returned in the policy incident.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in CHANGELOG.MD
