### PR TITLE
POL-1404 AWS Superseded EBS Volumes - Fix Currency Conversion Message in Policy Incident

### DIFF
--- a/cost/aws/superseded_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/superseded_ebs_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.3.3
+
+- Fixed issue where Currency Conversion messaging in policy incident would show incorrectly. Functionality unchanged.
+
 ## v6.3.2
 
 - Minor code improvements to conform with current standards. Functionality unchanged.

--- a/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
+++ b/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "6.3.2",
+  version: "6.3.3",
   provider: "AWS",
   service: "Compute",
   policy_set: "Inefficient Disk Usage",
@@ -1011,7 +1011,7 @@ script "js_underutil_volumes", type: "javascript" do
 
   api_disclaimer = ""
 
-  if (ds_currency_conversion['to'] == undefined && ds_currency['code'] != 'USD') {
+  if (ds_currency_conversion[0]['to'] == undefined && ds_currency['code'] != 'USD') {
     api_disclaimer = "\n\nPrice and savings values are in USD due to a malfunction with Flexera's internal currency conversion API. Please contact Flexera support to report this issue."
   }
 

--- a/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes_meta_parent.pt
+++ b/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes_meta_parent.pt
@@ -7,7 +7,7 @@ category "Meta"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "6.3.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.3.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false"
 )

--- a/data/policy_permissions_list/master_policy_permissions_list.json
+++ b/data/policy_permissions_list/master_policy_permissions_list.json
@@ -2784,7 +2784,7 @@
     {
       "id": "./cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt",
       "name": "AWS Superseded EBS Volumes",
-      "version": "6.3.2",
+      "version": "6.3.3",
       "providers": [
         {
           "name": "aws",

--- a/data/policy_permissions_list/master_policy_permissions_list.yaml
+++ b/data/policy_permissions_list/master_policy_permissions_list.yaml
@@ -1597,7 +1597,7 @@
       required: true
 - id: "./cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt"
   name: AWS Superseded EBS Volumes
-  version: 6.3.2
+  version: 6.3.3
   :providers:
   - :name: aws
     :permissions:


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves below -->
This change fixes a bug in the policy incident of the AWS Superseded EBS Volumes policy in a customer's tenant.

This bug occurs when the customer’s native currency in the platform is not USD: 

> “Price and savings values are in USD due to a malfunction with Flexera's internal currency conversion API. Please contact Flexera support to report this issue.”

This message is incorrectly showing even though currency conversion was successful.

This change fixes this bug.

### Issues Resolved

<!-- List any existing issues this PR resolves below -->
Fixes a bug where the Currency Conversion messaging in the policy incident is incorrectly showing.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->
Tested in customer tenant.

### Contribution Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in CHANGELOG.MD
