### PR TITLE
FOPTS-4819 Added `hide_skip_approvals` to AWS Right Size policies

### DIFF
--- a/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3.2
 
-- Added `hide_skip_approvals` field to the info section. It dynamically controls "Skip Action Approvals" visibility.
+- Added `hide_skip_approvals` field to the info section, enabling the UI to dynamically show or hide the "Skip Approval" option. Functionality unchanged.
 
 ## v0.3.1
 

--- a/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.2
+
+- Added `hide_skip_approvals` field to the info section. It dynamically controls "Skip Action Approvals" visibility.
+
 ## v0.3.1
 
 - Minor code improvements to conform with current standards. Functionality unchanged.

--- a/cost/aws/rightsize_ebs_volumes/aws_rightsize_ebs_volumes.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_rightsize_ebs_volumes.pt
@@ -7,11 +7,12 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.1",
+  version: "0.3.2",
   provider: "AWS",
   service: "EBS",
   policy_set: "Unused Volumes",
-  recommendation_type: "Usage Reduction"
+  recommendation_type: "Usage Reduction",
+  hide_skip_approvals: "true"
 )
 
 ###############################################################################

--- a/cost/aws/rightsize_ebs_volumes/aws_rightsize_ebs_volumes_meta_parent.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_rightsize_ebs_volumes_meta_parent.pt
@@ -7,9 +7,10 @@ category "Meta"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "0.3.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.3.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
-  deprecated: "false"
+  deprecated: "false",
+  hide_skip_approvals: "true"
 )
 
 ##############################################################################

--- a/cost/aws/rightsize_ec2_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_ec2_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.3.1
+
+- Added `hide_skip_approvals` field to the info section. It dynamically controls "Skip Action Approvals" visibility.
+
 ## v5.3.0
 
 - Added support for downsizing multiple sizes where appropriate

--- a/cost/aws/rightsize_ec2_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_ec2_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v5.3.1
 
-- Added `hide_skip_approvals` field to the info section. It dynamically controls "Skip Action Approvals" visibility.
+- Added `hide_skip_approvals` field to the info section, enabling the UI to dynamically show or hide the "Skip Approval" option. Functionality unchanged.
 
 ## v5.3.0
 

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances.pt
@@ -7,11 +7,12 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "5.3.0",
+  version: "5.3.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
-  recommendation_type: "Usage Reduction"
+  recommendation_type: "Usage Reduction",
+  hide_skip_approvals: "true"
 )
 
 ###############################################################################

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
@@ -7,9 +7,10 @@ category "Meta"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "5.3.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.3.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
-  deprecated: "false"
+  deprecated: "false",
+  hide_skip_approvals: "true"
 )
 
 ##############################################################################

--- a/cost/aws/rightsize_elasticache/CHANGELOG.md
+++ b/cost/aws/rightsize_elasticache/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.1
+
+- Added `hide_skip_approvals` field to the info section. It dynamically controls "Skip Action Approvals" visibility.
+
 ## v0.2.0
 
 - Added support for downsizing multiple sizes where appropriate

--- a/cost/aws/rightsize_elasticache/CHANGELOG.md
+++ b/cost/aws/rightsize_elasticache/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.1
 
-- Added `hide_skip_approvals` field to the info section. It dynamically controls "Skip Action Approvals" visibility.
+- Added `hide_skip_approvals` field to the info section, enabling the UI to dynamically show or hide the "Skip Approval" option. Functionality unchanged.
 
 ## v0.2.0
 

--- a/cost/aws/rightsize_elasticache/aws_rightsize_elasticache.pt
+++ b/cost/aws/rightsize_elasticache/aws_rightsize_elasticache.pt
@@ -7,11 +7,12 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.0",
+  version: "0.2.1",
   provider: "AWS",
   service: "Database",
   policy_set: "Rightsize Database Instances",
-  recommendation_type: "Usage Reduction"
+  recommendation_type: "Usage Reduction",
+  hide_skip_approvals: "true"
 )
 
 ###############################################################################

--- a/cost/aws/rightsize_elasticache/aws_rightsize_elasticache_meta_parent.pt
+++ b/cost/aws/rightsize_elasticache/aws_rightsize_elasticache_meta_parent.pt
@@ -7,9 +7,10 @@ category "Meta"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "0.2.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
-  deprecated: "false"
+  deprecated: "false",
+  hide_skip_approvals: "true"
 )
 
 ##############################################################################

--- a/cost/aws/rightsize_rds_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_rds_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.5.2
+
+- Added `hide_skip_approvals` field to the info section. It dynamically controls "Skip Action Approvals" visibility.
+
 ## v5.5.1
 
 - Fixed issue where policy template would fail if "db.serverless" instances were found

--- a/cost/aws/rightsize_rds_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_rds_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v5.5.2
 
-- Added `hide_skip_approvals` field to the info section. It dynamically controls "Skip Action Approvals" visibility.
+- Added `hide_skip_approvals` field to the info section, enabling the UI to dynamically show or hide the "Skip Approval" option. Functionality unchanged.
 
 ## v5.5.1
 

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
@@ -7,11 +7,12 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "5.5.1",
+  version: "5.5.2",
   provider: "AWS",
   service: "RDS",
   policy_set: "Rightsize Database Instances",
-  recommendation_type: "Usage Reduction"
+  recommendation_type: "Usage Reduction",
+  hide_skip_approvals: "true"
 )
 
 ###############################################################################

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
@@ -7,9 +7,10 @@ category "Meta"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "5.5.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.5.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
-  deprecated: "false"
+  deprecated: "false",
+  hide_skip_approvals: "true"
 )
 
 ##############################################################################

--- a/cost/aws/rightsize_redshift/CHANGELOG.md
+++ b/cost/aws/rightsize_redshift/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.1.2
 
-- Added `hide_skip_approvals` field to the info section. It dynamically controls "Skip Action Approvals" visibility.
+- Added `hide_skip_approvals` field to the info section, enabling the UI to dynamically show or hide the "Skip Approval" option. Functionality unchanged.
 
 ## v0.1.1
 

--- a/cost/aws/rightsize_redshift/CHANGELOG.md
+++ b/cost/aws/rightsize_redshift/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.2
+
+- Added `hide_skip_approvals` field to the info section. It dynamically controls "Skip Action Approvals" visibility.
+
 ## v0.1.1
 
 - Minor code improvements to conform with current standards. Functionality unchanged.

--- a/cost/aws/rightsize_redshift/aws_rightsize_redshift.pt
+++ b/cost/aws/rightsize_redshift/aws_rightsize_redshift.pt
@@ -7,11 +7,12 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.1.1",
+  version: "0.1.2",
   provider: "AWS",
   service: "Database",
   policy_set: "Rightsize Database Instances",
-  recommendation_type: "Usage Reduction"
+  recommendation_type: "Usage Reduction",
+  hide_skip_approvals: "true"
 )
 
 ###############################################################################

--- a/cost/aws/rightsize_redshift/aws_rightsize_redshift_meta_parent.pt
+++ b/cost/aws/rightsize_redshift/aws_rightsize_redshift_meta_parent.pt
@@ -7,9 +7,10 @@ category "Meta"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "0.1.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.1.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
-  deprecated: "false"
+  deprecated: "false",
+  hide_skip_approvals: "true"
 )
 
 ##############################################################################


### PR DESCRIPTION
### Description

Adding a new hide_skip_approvals field to the info section of policy templates that do not utilize the request approval option in any escalation. This field enables the UI to dynamically show or hide the "Skip Approval" option based on the policy configuration. Initially, these changes are applied to AWS Right Size policies, with plans to update additional policies in subsequent steps.

More context:[ Seeking Your Input: Proposed Solution for Conditional "Skip Approvals" Visibility](https://teams.microsoft.com/l/message/19:833373548e104af2a20b0216eda1ba7b@thread.skype/1728495063426?tenantId=91034d23-0b63-4943-b138-367d4dfac252&groupId=fb250818-e040-4a26-b207-61c3cd99fd6e&parentMessageId=1728495063426&teamName=Team%20Flexera%20One&channelName=Policy%20Support%20and%20Questions&createdTime=1728495063426)

### Issues Resolved

[FLEX-5397](https://flexera.atlassian.net/browse/FLEX-5397)
<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
