### PR TITLE
FLEX-5397 - Modify Meta Parent Compiler to Conditionally Include `hide_skip_approvals`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -69,7 +69,8 @@ task :generate_policy_list do
       puts "Skipping #{pp.parsed_name} because publish flag set to a value other than 'true'"
     else
       # Get datetime for last time file was modified
-      updated_at = `git log -1 --format="%cI" -- #{file}`.strip
+      commits = github_client.commits(repo_name, branch, path: file)
+      updated_at = commits.first.commit.author.date.utc.iso8601 if !commits.empty?
       generally_recommended = generally_recommended_template_names.include?(pp.parsed_name) && !deprecated
 
       puts "Adding #{pp.parsed_name}"

--- a/Rakefile
+++ b/Rakefile
@@ -48,12 +48,15 @@ task :generate_policy_list do
       recommendation_type = pp.parsed_info[:recommendation_type]
       publish = pp.parsed_info[:publish]
       deprecated = pp.parsed_info[:deprecated]
+      hide_skip_approvals = pp.parsed_info[:hide_skip_approvals]
+
 
       # 'publish' defaults to true unless explicitly set to false
       # 'deprecated' defaults to false unless explicitly set to true
       publish = !(publish == 'false' || publish == false)
       deprecated = deprecated == 'true' || deprecated == true
-      hide_skip_approvals = pp.parsed_info[:hide_skip_approvals]
+      # 'hide_skip_approvals' defaults to false unless explicitly set to true
+      hide_skip_approvals = hide_skip_approvals == 'true' || hide_skip_approvals == true
     end
 
     # Get version from long description
@@ -66,8 +69,7 @@ task :generate_policy_list do
       puts "Skipping #{pp.parsed_name} because publish flag set to a value other than 'true'"
     else
       # Get datetime for last time file was modified
-      commits = github_client.commits(repo_name, branch, path: file)
-      updated_at = commits.first.commit.author.date.utc.iso8601 if !commits.empty?
+      updated_at = `git log -1 --format="%cI" -- #{file}`.strip
       generally_recommended = generally_recommended_template_names.include?(pp.parsed_name) && !deprecated
 
       puts "Adding #{pp.parsed_name}"

--- a/Rakefile
+++ b/Rakefile
@@ -53,6 +53,7 @@ task :generate_policy_list do
       # 'deprecated' defaults to false unless explicitly set to true
       publish = !(publish == 'false' || publish == false)
       deprecated = deprecated == 'true' || deprecated == true
+      hide_skip_approvals = pp.parsed_info[:hide_skip_approvals]
     end
 
     # Get version from long description
@@ -86,7 +87,8 @@ task :generate_policy_list do
         "recommendation_type": recommendation_type,
         "updated_at": updated_at,
         "generally_recommended": generally_recommended,
-        "deprecated": deprecated
+        "deprecated": deprecated,
+        "hide_skip_approvals": hide_skip_approvals
       }
     end
   end

--- a/cost/aws/rightsize_ebs_volumes/aws_rightsize_ebs_volumes_meta_parent.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_rightsize_ebs_volumes_meta_parent.pt
@@ -9,8 +9,7 @@ info(
   provider: "AWS",
   version: "0.3.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
-  deprecated: "false",
-  hide_skip_approvals: "true"
+  deprecated: "false"
 )
 
 ##############################################################################

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
@@ -9,8 +9,7 @@ info(
   provider: "AWS",
   version: "5.3.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
-  deprecated: "false",
-  hide_skip_approvals: "true"
+  deprecated: "false"
 )
 
 ##############################################################################

--- a/cost/aws/rightsize_elasticache/aws_rightsize_elasticache_meta_parent.pt
+++ b/cost/aws/rightsize_elasticache/aws_rightsize_elasticache_meta_parent.pt
@@ -9,8 +9,7 @@ info(
   provider: "AWS",
   version: "0.2.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
-  deprecated: "false",
-  hide_skip_approvals: "true"
+  deprecated: "false"
 )
 
 ##############################################################################

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
@@ -9,8 +9,7 @@ info(
   provider: "AWS",
   version: "5.5.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
-  deprecated: "false",
-  hide_skip_approvals: "true"
+  deprecated: "false"
 )
 
 ##############################################################################

--- a/cost/aws/rightsize_redshift/aws_rightsize_redshift_meta_parent.pt
+++ b/cost/aws/rightsize_redshift/aws_rightsize_redshift_meta_parent.pt
@@ -9,8 +9,7 @@ info(
   provider: "AWS",
   version: "0.1.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
-  deprecated: "false",
-  hide_skip_approvals: "true"
+  deprecated: "false"
 )
 
 ##############################################################################

--- a/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
@@ -9,7 +9,8 @@ info(
   provider: "AWS",
   version: "__PLACEHOLDER_FOR_CHILD_POLICY_VERSION__", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "__PLACEHOLDER_FOR_CHILD_POLICY_PUBLISH__",
-  deprecated: "__PLACEHOLDER_FOR_CHILD_POLICY_DEPRECATED__"
+  deprecated: "__PLACEHOLDER_FOR_CHILD_POLICY_DEPRECATED__",
+  hide_skip_approvals: "__PLACEHOLDER_FOR_CHILD_POLICY_HIDE_SKIP_APPROVALS__"
 )
 
 ##############################################################################

--- a/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
@@ -9,7 +9,8 @@ info(
   provider: "Azure",
   version: "__PLACEHOLDER_FOR_CHILD_POLICY_VERSION__", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "__PLACEHOLDER_FOR_CHILD_POLICY_PUBLISH__",
-  deprecated: "__PLACEHOLDER_FOR_CHILD_POLICY_DEPRECATED__"
+  deprecated: "__PLACEHOLDER_FOR_CHILD_POLICY_DEPRECATED__",
+  hide_skip_approvals: "__PLACEHOLDER_FOR_CHILD_POLICY_HIDE_SKIP_APPROVALS__"
 )
 
 ##############################################################################

--- a/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
@@ -10,6 +10,7 @@ info(
   version: "__PLACEHOLDER_FOR_CHILD_POLICY_VERSION__", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "__PLACEHOLDER_FOR_CHILD_POLICY_PUBLISH__",
   deprecated: "__PLACEHOLDER_FOR_CHILD_POLICY_DEPRECATED__"
+  hide_skip_approvals: "__PLACEHOLDER_FOR_CHILD_POLICY_HIDE_SKIP_APPROVALS__"
 )
 
 ##############################################################################

--- a/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
+++ b/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
@@ -430,12 +430,10 @@ end
   output_pt = output_pt.gsub("__PLACEHOLDER_FOR_CHILD_POLICY_PUBLISH__", publish)
   output_pt = output_pt.gsub("__PLACEHOLDER_FOR_CHILD_POLICY_DEPRECATED__", deprecated)
   if !hide_skip_approvals.empty?
-    # Replace the placeholder with the actual value
     output_pt = output_pt.gsub("__PLACEHOLDER_FOR_CHILD_POLICY_HIDE_SKIP_APPROVALS__", hide_skip_approvals)
   else
-    # Remove the entire line containing hide_skip_approvals, including any preceding whitespace and commas
+    # Remove the entire line containing hide_skip_approvals
     output_pt = output_pt.gsub(/^\s*,?\s*hide_skip_approvals: "__PLACEHOLDER_FOR_CHILD_POLICY_HIDE_SKIP_APPROVALS__",?\s*\n/, "")
-    # Remove any trailing commas before the closing parenthesis
     output_pt = output_pt.gsub(/,\s*\)/, "\n)")
   end
   # Attempt to identify the URL to the child policy template file on github using the file_path provided

--- a/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
+++ b/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
@@ -186,6 +186,10 @@ def compile_meta_parent_policy(file_path)
   deprecated_scan = pt.scan(/deprecated: "(.*?)"/)
   deprecated = "false"
   deprecated = deprecated_scan[0][0] if !deprecated_scan.empty?
+  # get the hide_skip_approvals string if it exists, defaulting to false if not present
+  hide_skip_approvals_scan = pt.scan(/hide_skip_approvals: "(.*?)"/)
+  hide_skip_approvals = ""
+  hide_skip_approvals = hide_skip_approvals_scan[0][0] if !hide_skip_approvals_scan.empty?
   # print("Name: #{name}\n")
   # print("Description: #{description}\n")
   # print("\n###########################\n")
@@ -425,6 +429,15 @@ end
   output_pt = output_pt.gsub("__PLACEHOLDER_FOR_CHILD_POLICY_VERSION__", version)
   output_pt = output_pt.gsub("__PLACEHOLDER_FOR_CHILD_POLICY_PUBLISH__", publish)
   output_pt = output_pt.gsub("__PLACEHOLDER_FOR_CHILD_POLICY_DEPRECATED__", deprecated)
+  if !hide_skip_approvals.empty?
+    # Replace the placeholder with the actual value
+    output_pt = output_pt.gsub("__PLACEHOLDER_FOR_CHILD_POLICY_HIDE_SKIP_APPROVALS__", hide_skip_approvals)
+  else
+    # Remove the entire line containing hide_skip_approvals, including any preceding whitespace and commas
+    output_pt = output_pt.gsub(/^\s*,?\s*hide_skip_approvals: "__PLACEHOLDER_FOR_CHILD_POLICY_HIDE_SKIP_APPROVALS__",?\s*\n/, "")
+    # Remove any trailing commas before the closing parenthesis
+    output_pt = output_pt.gsub(/,\s*\)/, "\n)")
+  end
   # Attempt to identify the URL to the child policy template file on github using the file_path provided
   # This would only work if the pt file is located under the `policy_templates` repo directory
   # If it is not, then the URL will be incorrect


### PR DESCRIPTION
### Description

This pull request enhances the Meta Parent Policy Template Compiler to conditionally include the hide_skip_approvals field in the generated meta parent policy templates when it exists in the child policy templates.
It also removes prior manual modifications to meta parent policies : https://github.com/flexera-public/policy_templates/pull/2799

More context:[ Seeking Your Input: Proposed Solution for Conditional "Skip Approvals" Visibility](https://teams.microsoft.com/l/message/19:833373548e104af2a20b0216eda1ba7b@thread.skype/1728495063426?tenantId=91034d23-0b63-4943-b138-367d4dfac252&groupId=fb250818-e040-4a26-b207-61c3cd99fd6e&parentMessageId=1728495063426&teamName=Team%20Flexera%20One&channelName=Policy%20Support%20and%20Questions&createdTime=1728495063426)

### Issues Resolved

<!-- List any existing issues this PR resolves below -->

[FLEX-5397](https://flexera.atlassian.net/browse/FLEX-5397)


<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
