### PR TITLE
FOPTS-5666 Handle properly null values in Google Rightsize VM Recommender Policy

### DIFF
--- a/cost/google/rightsize_vm_recommendations/CHANGELOG.md
+++ b/cost/google/rightsize_vm_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.4
+
+- Added validation to properly handle null values for cpuAverage, cpuMaximum, and cpuMinimum when sorting recommendations
+
 ## v3.1.3
 
 - Added `hide_skip_approvals` field to the info section. It dynamically controls "Skip Action Approvals" visibility.

--- a/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations.pt
+++ b/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "3.1.3",
+  version: "3.1.4",
   provider: "Google",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -827,6 +827,10 @@ script "js_sorted_recommendations", type:"javascript" do
             resourceType = instance['machineType'].split('/')[10]
           }
 
+          cpuAverage = instance['cpuAverage'];
+          cpuMaximum = instance['cpuMaximum'];
+          cpuMinimum = instance['cpuMinimum'];
+
           idle_result.push({
             resourceID: instance['id'],
             resourceName: instance['name'],
@@ -841,9 +845,9 @@ script "js_sorted_recommendations", type:"javascript" do
             accountID: instance['projectId'],
             accountName: instance['projectName'],
             projectNumber: instance['projectNumber'],
-            cpuAverage: Number(instance['cpuAverage'].toFixed(2)),
-            cpuMaximum: Number(instance['cpuMaximum'].toFixed(2)),
-            cpuMinimum: Number(instance['cpuMinimum'].toFixed(2)),
+            cpuAverage: cpuAverage? Number(cpuAverage.toFixed(2)): cpuAverage,
+            cpuMaximum: cpuMaximum? Number(cpuMaximum.toFixed(2)): cpuMaximum,
+            cpuMinimum: cpuMinimum? Number(cpuMinimum.toFixed(2)): cpuMinimum,
             priority: recommendation['priority'],
             primaryImpact: recommendation['primaryImpact'],
             primaryImpactCategory: recommendation['primaryImpact']['category'],
@@ -915,6 +919,10 @@ script "js_sorted_recommendations", type:"javascript" do
             newResourceType = recommendation['recommendedMachineType']['name']
           }
 
+          cpuAverage = instance['cpuAverage'];
+          cpuMaximum = instance['cpuMaximum'];
+          cpuMinimum = instance['cpuMinimum'];
+
           underutil_result.push({
             resourceID: instance['id'],
             resourceName: instance['name'],
@@ -929,9 +937,9 @@ script "js_sorted_recommendations", type:"javascript" do
             accountID: instance['projectId'],
             accountName: instance['projectName'],
             projectNumber: instance['projectNumber'],
-            cpuAverage: Number(instance['cpuAverage'].toFixed(2)),
-            cpuMaximum: Number(instance['cpuMaximum'].toFixed(2)),
-            cpuMinimum: Number(instance['cpuMinimum'].toFixed(2)),
+            cpuAverage: cpuAverage? Number(cpuAverage.toFixed(2)): cpuAverage,
+            cpuMaximum: cpuMaximum? Number(cpuMaximum.toFixed(2)): cpuMaximum,
+            cpuMinimum: cpuMinimum? Number(cpuMinimum.toFixed(2)): cpuMinimum,
             priority: recommendation['priority'],
             primaryImpact: recommendation['primaryImpact'],
             primaryImpactCategory: recommendation['primaryImpact']['category'],

--- a/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
+++ b/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
@@ -7,7 +7,7 @@ category "Meta"
 default_frequency "15 minutes"
 info(
   provider: "Google",
-  version: "3.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.1.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"


### PR DESCRIPTION
### Description

We had an issue sorting recommendations when cpuAvergae. cpuMinimum or cpuMaximum are nulls. 

### Issues Resolved

[FOPTS-5666](https://flexera.atlassian.net/browse/FOPTS-5666)
[SQ-10199](https://flexera.atlassian.net/browse/SQ-10199)

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
