### PR TITLE
POL-1428 Scheduled Report - fix +Inf issue related to incident creation

### DIFF
--- a/cost/flexera/cco/scheduled_reports/CHANGELOG.md
+++ b/cost/flexera/cco/scheduled_reports/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.5.2
+
+- Fixed a bug that prevented the policy incident from being created when `Billing Term` parameter was set to `Week`.
+
 ## v3.5.1
 
 - Added `hide_skip_approvals` field to the info section. It dynamically controls "Skip Action Approvals" visibility.

--- a/cost/flexera/cco/scheduled_reports/scheduled_report.pt
+++ b/cost/flexera/cco/scheduled_reports/scheduled_report.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "monthly"
 info(
-  version: "3.5.1",
+  version: "3.5.2",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -584,6 +584,7 @@ script "js_collated_data", type: "javascript" do
       }
     })
   }
+  
   // Sort pulled_costs by timestamp
   // This ensures that the Percent Change calculations are accurate
   pulled_costs = _.sortBy(pulled_costs, 'timestamp')
@@ -770,8 +771,14 @@ script "js_collated_data", type: "javascript" do
         if (previousTimePeriod[category]["sum"] != undefined) {
           var previousSum = previousTimePeriod[category]["sum"]
           var previousDailyAverageCost = previousTimePeriod[category]["dailyAverageCost"]
-          percentChange = Number( (((sum - previousSum) / previousSum) * 100).toFixed(3)  )
-          percentChangeDailyAverageCost = Number( (((dailyAverageCost - previousDailyAverageCost) / previousDailyAverageCost) * 100).toFixed(3) )
+ 
+          if (previousSum > 0) {
+            percentChange = Number( (((sum - previousSum) / previousSum) * 100).toFixed(3)  )
+          }
+
+          if (previousDailyAverageCost > 0) {
+            percentChangeDailyAverageCost = Number( (((dailyAverageCost - previousDailyAverageCost) / previousDailyAverageCost) * 100).toFixed(3) )
+          }
 
           // See if the percent change is above the threshold
           // Take the absolute value of percentChange so we can compare it to the threshold.  Otherwise, by default and most use-cases any negative percent change would be below the threshold which would trigger a report which is not generally needed for downward change
@@ -820,6 +827,7 @@ script "js_collated_data", type: "javascript" do
       })
     })
   }
+
   if (param_percent_change_consecutive_threshold > 0) {
     // Loop through all rows to determine if last n periods (param_percent_change_consecutive_threshold) for each category is above threshold
     var rowsGroupedByCategory = _.groupBy(result, 'category')

--- a/data/policy_permissions_list/master_policy_permissions_list.json
+++ b/data/policy_permissions_list/master_policy_permissions_list.json
@@ -5184,7 +5184,7 @@
     {
       "id": "./cost/flexera/cco/scheduled_reports/scheduled_report.pt",
       "name": "Scheduled Report",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "providers": [
         {
           "name": "flexera",

--- a/data/policy_permissions_list/master_policy_permissions_list.yaml
+++ b/data/policy_permissions_list/master_policy_permissions_list.yaml
@@ -2990,7 +2990,7 @@
       required: true
 - id: "./cost/flexera/cco/scheduled_reports/scheduled_report.pt"
   name: Scheduled Report
-  version: 3.5.1
+  version: 3.5.2
   :providers:
   - :name: flexera
     :permissions:


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves below -->
This change implements a fix for the Scheduled Report policy incident so that it is successfully created when the `Billing Term` parameter is set to `Week`.

### Issues Resolved

<!-- List any existing issues this PR resolves below -->
This PR resolves an issue where the Scheduled Report policy incident failed to generate due to a `+Inf` error.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->
Tested in customer tenant and can confirm it now works as expected.

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
