### PR TITLE
FOPTS-6034 Make Azure New Marketplace Products Policy Support MSP Configurations

### DIFF
--- a/operational/azure/marketplace_new_products/CHANGELOG.md
+++ b/operational/azure/marketplace_new_products/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.5.0
+
+- Added support for organizations with Microsoft MCA accounts.
+- Refactored for supporting MSP clients.
+
 ## v0.4.3
 
 - Added `hide_skip_approvals` field to the info section. It dynamically controls "Skip Action Approvals" visibility.

--- a/operational/azure/marketplace_new_products/azure_marketplace_new_products.pt
+++ b/operational/azure/marketplace_new_products/azure_marketplace_new_products.pt
@@ -69,34 +69,6 @@ datasource "ds_applied_policy" do
   end
 end
 
-# Get region-specific Flexera API endpoints
-datasource "ds_flexera_api_hosts" do
-  run_script $js_flexera_api_hosts, rs_optima_host
-end
-
-script "js_flexera_api_hosts", type: "javascript" do
-  parameters "rs_optima_host"
-  result "result"
-  code <<-EOS
-  host_table = {
-    "api.optima.flexeraeng.com": {
-      flexera: "api.flexera.com",
-      fsm: "api.fsm.flexeraeng.com"
-    },
-    "api.optima-eu.flexeraeng.com": {
-      flexera: "api.flexera.eu",
-      fsm: "api.fsm-eu.flexeraeng.com"
-    },
-    "api.optima-apac.flexeraeng.com": {
-      flexera: "api.flexera.au",
-      fsm: "api.fsm-apac.flexeraeng.com"
-    }
-  }
-
-  result = host_table[rs_optima_host]
-EOS
-end
-
 datasource "ds_billing_centers" do
   request do
     auth $auth_flexera
@@ -306,11 +278,11 @@ datasource "ds_previous_products_oldconnection" do
 end
 
 script "js_get_products_oldconnection", type: "javascript" do
-  parameters "ds_bill_connections_old", "ds_top_level_bcs", "lookback", "rs_org_id", "rs_optima_host"
+  parameters "ds_bill_connections_old", "ds_top_level_bcs", "param_lookback", "rs_org_id", "rs_optima_host"
   result "request"
   code <<-EOS
   end_date = new Date()
-  end_date.setDate(end_date.getDate() - (lookback - 1))
+  end_date.setDate(end_date.getDate() - (param_lookback - 1))
   end_date.setMilliseconds(999)
   end_date.setSeconds(59)
   end_date.setMinutes(59)
@@ -318,7 +290,7 @@ script "js_get_products_oldconnection", type: "javascript" do
   end_date = end_date.toISOString().split('T')[0]
 
   start_date = new Date()
-  start_date.setDate(start_date.getDate() - lookback)
+  start_date.setDate(start_date.getDate() - param_lookback)
   start_date.setMilliseconds(0)
   start_date.setSeconds(0)
   start_date.setMinutes(0)
@@ -412,11 +384,11 @@ datasource "ds_previous_products_newconnection" do
 end
 
 script "js_get_products_newconnection", type: "javascript" do
-  parameters "ds_bill_connections_new", "ds_top_level_bcs", "lookback", "rs_org_id", "rs_optima_host"
+  parameters "ds_bill_connections_new", "ds_top_level_bcs", "param_lookback", "rs_org_id", "rs_optima_host"
   result "request"
   code <<-EOS
   end_date = new Date()
-  end_date.setDate(end_date.getDate() - (lookback - 1))
+  end_date.setDate(end_date.getDate() - (param_lookback - 1))
   end_date.setMilliseconds(999)
   end_date.setSeconds(59)
   end_date.setMinutes(59)
@@ -424,7 +396,7 @@ script "js_get_products_newconnection", type: "javascript" do
   end_date = end_date.toISOString().split('T')[0]
 
   start_date = new Date()
-  start_date.setDate(start_date.getDate() - lookback)
+  start_date.setDate(start_date.getDate() - param_lookback)
   start_date.setMilliseconds(0)
   start_date.setSeconds(0)
   start_date.setMinutes(0)
@@ -511,11 +483,11 @@ datasource "ds_previous_products_mcacbiconnection" do
 end
 
 script "js_get_products_mcacbiconnection", type: "javascript" do
-  parameters "ds_bill_connections_mcacbi", "ds_top_level_bcs", "lookback", "rs_org_id", "rs_optima_host"
+  parameters "ds_bill_connections_mcacbi", "ds_top_level_bcs", "param_lookback", "rs_org_id", "rs_optima_host"
   result "request"
   code <<-EOS
   end_date = new Date()
-  end_date.setDate(end_date.getDate() - (lookback - 1))
+  end_date.setDate(end_date.getDate() - (param_lookback - 1))
   end_date.setMilliseconds(999)
   end_date.setSeconds(59)
   end_date.setMinutes(59)
@@ -523,7 +495,7 @@ script "js_get_products_mcacbiconnection", type: "javascript" do
   end_date = end_date.toISOString().split('T')[0]
 
   start_date = new Date()
-  start_date.setDate(start_date.getDate() - lookback)
+  start_date.setDate(start_date.getDate() - param_lookback)
   start_date.setMilliseconds(0)
   start_date.setSeconds(0)
   start_date.setMinutes(0)

--- a/operational/azure/marketplace_new_products/azure_marketplace_new_products.pt
+++ b/operational/azure/marketplace_new_products/azure_marketplace_new_products.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "0.4.3",
+  version: "0.5.0",
   provider: "Azure",
   service: "Marketplace",
   policy_set: "New Marketplace Products",
@@ -191,43 +191,97 @@ end
 
 datasource "ds_bill_connections" do
   request do
-    auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
-    path join(["/finops-onboarding/v1/orgs/", rs_org_id, "/bill-connects"])
-    header "Api-Version", "1.0"
-    header "User-Agent", "RS Policies"
+    run_script $js_bill_connections, $ds_top_level_bcs, $param_lookback, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
-    collect jmes_path(response, "values[*]") do
-      field "id", jmes_path(col_item, "id")
-      field "kind", jmes_path(col_item, "kind")
+    collect jmes_path(response, "rows") do
+      field "bill_source", jmes_path(col_item, "dimensions.bill_source")
     end
   end
 end
 
+script "js_bill_connections", type: "javascript" do
+  parameters "ds_top_level_bcs", "param_lookback", "org_id", "optima_host"
+  result "request"
+  code <<-EOS
+  end_date = new Date()
+  end_date.setMilliseconds(999)
+  end_date.setSeconds(59)
+  end_date.setMinutes(59)
+  end_date.setHours(23)
+  end_date = end_date.toISOString().split('T')[0]
+
+  start_date = new Date()
+  start_date.setDate(start_date.getDate() - param_lookback)
+  start_date.setMilliseconds(0)
+  start_date.setSeconds(0)
+  start_date.setMinutes(0)
+  start_date = start_date.toISOString().split('T')[0]
+
+  payload = {
+    "billing_center_ids": ds_top_level_bcs,
+    "dimensions": [ "bill_source" ],
+    "granularity": "day",
+    "metrics": [ "cost_amortized_unblended_adj" ],
+    "end_at": end_date,
+    "start_at": start_date
+  }
+
+  var request = {
+    auth: "auth_flexera",
+    host: optima_host,
+    path: "/bill-analysis/orgs/" + org_id + "/costs/aggregated",
+    verb: "POST",
+    body_fields: payload,
+    headers: {
+      "User-Agent": "RS Policies"
+    }
+  }
+EOS
+end
+
+# Filter out old Azure EA connections and new Azure EA connections
 datasource "ds_bill_connections_old" do
-  run_script $js_bill_connections_filter, $ds_bill_connections, "finops:bill-connect-azure-ea"
+  run_script $js_bill_connections_filter, $ds_bill_connections, "ea_old"
 end
 
 datasource "ds_bill_connections_new" do
-  run_script $js_bill_connections_filter, $ds_bill_connections, "finops:bill-connect-cbi-oi-azure-ea"
+  run_script $js_bill_connections_filter, $ds_bill_connections, "ea_new"
+end
+
+datasource "ds_bill_connections_mcacbi" do
+  run_script $js_bill_connections_filter, $ds_bill_connections, "mca_cbi"
 end
 
 script "js_bill_connections_filter", type:"javascript" do
-  parameters "ds_bill_connections", "filter_value"
+  parameters "bill_connections", "type"
   result "result"
   code <<-EOS
-  result = _.filter(ds_bill_connections, function(connection) {
-    return connection['kind'] == filter_value
-  })
+  switch (type) {
+    case "ea_old":
+      bill_sources = _.filter(bill_connections, function(connection) {
+        return connection["bill_source"].indexOf("azure-ea") == 0
+      })
+      break;
+    case "ea_new":
+      bill_sources = _.filter(bill_connections, function(connection) {
+        return connection["bill_source"].indexOf("azure-ea") == 7
+      })
+      break;
+    case "mca_cbi":
+      bill_sources = _.filter(bill_connections, function(connection) {
+        return connection["bill_source"].indexOf("cbi-oi-azure-mca") >= 0
+      })
+      break;
+  }
+  result = _.uniq(_.compact(_.pluck(bill_sources, 'bill_source')))
 EOS
 end
 
 datasource "ds_current_products_oldconnection" do
-  iterate $ds_bill_connections_old
   request do
-    run_script $js_get_products_oldconnection, val(iter_item, 'id'), $ds_top_level_bcs, 3, rs_org_id, rs_optima_host
+    run_script $js_get_products_oldconnection, $ds_bill_connections_old, $ds_top_level_bcs, 3, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -239,9 +293,8 @@ datasource "ds_current_products_oldconnection" do
 end
 
 datasource "ds_previous_products_oldconnection" do
-  iterate $ds_bill_connections_old
   request do
-    run_script $js_get_products_oldconnection, val(iter_item, 'id'), $ds_top_level_bcs, $param_lookback, rs_org_id, rs_optima_host
+    run_script $js_get_products_oldconnection, $ds_bill_connections_old, $ds_top_level_bcs, $param_lookback, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -253,16 +306,60 @@ datasource "ds_previous_products_oldconnection" do
 end
 
 script "js_get_products_oldconnection", type: "javascript" do
-  parameters "bill_source", "ds_top_level_bcs", "lookback", "rs_org_id", "rs_optima_host"
+  parameters "ds_bill_connections_old", "ds_top_level_bcs", "lookback", "rs_org_id", "rs_optima_host"
   result "request"
   code <<-EOS
   end_date = new Date()
   end_date.setDate(end_date.getDate() - (lookback - 1))
+  end_date.setMilliseconds(999)
+  end_date.setSeconds(59)
+  end_date.setMinutes(59)
+  end_date.setHours(23)
   end_date = end_date.toISOString().split('T')[0]
 
   start_date = new Date()
   start_date.setDate(start_date.getDate() - lookback)
+  start_date.setMilliseconds(0)
+  start_date.setSeconds(0)
+  start_date.setMinutes(0)
   start_date = start_date.toISOString().split('T')[0]
+
+  filter = {
+    "type": "and",
+    "expressions": [
+      {
+        "type": "or",
+        "expressions": [
+          {
+            "dimension": "service",
+            "type": "equal",
+            "value": "Microsoft.Marketplace"
+          },
+          {
+            "dimension": "service",
+            "type": "equal",
+            "value": "microsoft.marketplace"
+          }
+        ]
+      },
+      {
+        "type": "not",
+        "expression": {
+          "dimension": "usage_type",
+          "type": "substring",
+          "substring": "Shared"
+        }
+      }
+    ]
+  }
+
+  bill_source_expressions = _.map(ds_bill_connections_old, function(bc) {
+    return { "dimension": "bill_source", "type": "equal", "value": bc }
+  })
+
+  if (bill_source_expressions.length > 0) {
+    filter["expressions"].push({ "type": "or", "expressions": bill_source_expressions })
+  }
 
   var request = {
     auth: "auth_flexera",
@@ -277,39 +374,7 @@ script "js_get_products_oldconnection", type: "javascript" do
       metrics: ["cost_amortized_unblended_adj"],
       billing_center_ids: ds_top_level_bcs,
       limit: 100000,
-      filter: {
-        "type": "and",
-        "expressions": [
-          {
-            "type": "or",
-            "expressions": [
-              {
-                "dimension": "service",
-                "type": "equal",
-                "value": "Microsoft.Marketplace"
-              },
-              {
-                "dimension": "service",
-                "type": "equal",
-                "value": "microsoft.marketplace"
-              }
-            ]
-          },
-          {
-            "dimension": "bill_source",
-            "type": "equal",
-            "value": bill_source
-          },
-          {
-            "type": "not",
-            "expression": {
-              "dimension": "usage_type",
-              "type": "substring",
-              "substring": "Shared"
-            }
-          }
-        ]
-      }
+      filter: filter
     },
     headers: {
       'User-Agent': "RS Policies",
@@ -321,9 +386,8 @@ EOS
 end
 
 datasource "ds_current_products_newconnection" do
-  iterate $ds_bill_connections_new
   request do
-    run_script $js_get_products_newconnection, val(iter_item, 'id'), $ds_top_level_bcs, 3, rs_org_id, rs_optima_host
+    run_script $js_get_products_newconnection, $ds_bill_connections_new, $ds_top_level_bcs, 3, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -335,9 +399,8 @@ datasource "ds_current_products_newconnection" do
 end
 
 datasource "ds_previous_products_newconnection" do
-  iterate $ds_bill_connections_new
   request do
-    run_script $js_get_products_newconnection, val(iter_item, 'id'), $ds_top_level_bcs, $param_lookback, rs_org_id, rs_optima_host
+    run_script $js_get_products_newconnection, $ds_bill_connections_new, $ds_top_level_bcs, $param_lookback, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -349,16 +412,53 @@ datasource "ds_previous_products_newconnection" do
 end
 
 script "js_get_products_newconnection", type: "javascript" do
-  parameters "bill_source", "ds_top_level_bcs", "lookback", "rs_org_id", "rs_optima_host"
+  parameters "ds_bill_connections_new", "ds_top_level_bcs", "lookback", "rs_org_id", "rs_optima_host"
   result "request"
   code <<-EOS
   end_date = new Date()
   end_date.setDate(end_date.getDate() - (lookback - 1))
+  end_date.setMilliseconds(999)
+  end_date.setSeconds(59)
+  end_date.setMinutes(59)
+  end_date.setHours(23)
   end_date = end_date.toISOString().split('T')[0]
 
   start_date = new Date()
   start_date.setDate(start_date.getDate() - lookback)
+  start_date.setMilliseconds(0)
+  start_date.setSeconds(0)
+  start_date.setMinutes(0)
   start_date = start_date.toISOString().split('T')[0]
+
+  filter = {
+    "type": "and",
+    "expressions": [
+      {
+        "type": "not",
+        "expression": {
+          "dimension": "manufacturer_name",
+          "type": "substring",
+          "substring": "Microsoft"
+        }
+      },
+      {
+        "type": "not",
+        "expression": {
+          "dimension": "usage_type",
+          "type": "substring",
+          "substring": "Shared"
+        }
+      }
+    ]
+  }
+
+  bill_source_expressions = _.map(ds_bill_connections_new, function(bc) {
+    return { "dimension": "bill_source", "type": "equal", "value": bc }
+  })
+
+  if (bill_source_expressions.length > 0) {
+    filter["expressions"].push({ "type": "or", "expressions": bill_source_expressions })
+  }
 
   var request = {
     auth: "auth_flexera",
@@ -373,32 +473,106 @@ script "js_get_products_newconnection", type: "javascript" do
       metrics: ["cost_amortized_unblended_adj"],
       billing_center_ids: ds_top_level_bcs,
       limit: 100000,
-      filter: {
-        "type": "and",
-        "expressions": [
-          {
-            "dimension": "bill_source",
-            "type": "equal",
-            "value": bill_source
-          },
-          {
-            "type": "not",
-            "expression": {
-              "dimension": "manufacturer_name",
-              "type": "substring",
-              "substring": "Microsoft"
-            }
-          },
-          {
-            "type": "not",
-            "expression": {
-              "dimension": "usage_type",
-              "type": "substring",
-              "substring": "Shared"
-            }
-          }
-        ]
+      filter: filter
+    },
+    headers: {
+      'User-Agent': "RS Policies",
+      'Api-Version': "1.0"
+    },
+    ignore_status: [400]
+  }
+EOS
+end
+
+datasource "ds_current_products_mcacbiconnection" do
+  request do
+    run_script $js_get_products_mcacbiconnection, $ds_bill_connections_mcacbi, $ds_top_level_bcs, 3, rs_org_id, rs_optima_host
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "rows[*]") do
+      field "product", jmes_path(col_item, "dimensions.resource_type")
+      field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
+    end
+  end
+end
+
+datasource "ds_previous_products_mcacbiconnection" do
+  request do
+    run_script $js_get_products_mcacbiconnection, $ds_bill_connections_mcacbi, $ds_top_level_bcs, $param_lookback, rs_org_id, rs_optima_host
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "rows[*]") do
+      field "product", jmes_path(col_item, "dimensions.resource_type")
+      field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
+    end
+  end
+end
+
+script "js_get_products_mcacbiconnection", type: "javascript" do
+  parameters "ds_bill_connections_mcacbi", "ds_top_level_bcs", "lookback", "rs_org_id", "rs_optima_host"
+  result "request"
+  code <<-EOS
+  end_date = new Date()
+  end_date.setDate(end_date.getDate() - (lookback - 1))
+  end_date.setMilliseconds(999)
+  end_date.setSeconds(59)
+  end_date.setMinutes(59)
+  end_date.setHours(23)
+  end_date = end_date.toISOString().split('T')[0]
+
+  start_date = new Date()
+  start_date.setDate(start_date.getDate() - lookback)
+  start_date.setMilliseconds(0)
+  start_date.setSeconds(0)
+  start_date.setMinutes(0)
+  start_date = start_date.toISOString().split('T')[0]
+
+  filter = {
+    "type": "and",
+    "expressions": [
+      {
+        "type": "not",
+        "expression": {
+          "dimension": "manufacturer_name",
+          "type": "substring",
+          "substring": "Microsoft"
+        }
+      },
+      {
+        "type": "not",
+        "expression": {
+          "dimension": "usage_type",
+          "type": "substring",
+          "substring": "Shared"
+        }
       }
+    ]
+  }
+
+  bill_source_expressions = _.map(ds_bill_connections_mcacbi, function(bc) {
+    return { "dimension": "bill_source", "type": "equal", "value": bc }
+  })
+
+  if (bill_source_expressions.length > 0) {
+    filter["expressions"].push({ "type": "or", "expressions": bill_source_expressions })
+  }
+
+  var request = {
+    auth: "auth_flexera",
+    host: rs_optima_host,
+    verb: "POST",
+    path: "/bill-analysis/orgs/" + rs_org_id + "/costs/aggregated",
+    body_fields: {
+      dimensions: ["resource_type"],
+      granularity: "day",
+      start_at: start_date,
+      end_at: end_date,
+      metrics: ["cost_amortized_unblended_adj"],
+      billing_center_ids: ds_top_level_bcs,
+      limit: 100000,
+      filter: filter
     },
     headers: {
       'User-Agent': "RS Policies",
@@ -410,18 +584,18 @@ EOS
 end
 
 datasource "ds_current_products" do
-  run_script $js_products_combiner, $ds_current_products_oldconnection, $ds_current_products_newconnection
+  run_script $js_products_combiner, $ds_current_products_oldconnection, $ds_current_products_newconnection, $ds_current_products_mcacbiconnection
 end
 
 datasource "ds_previous_products" do
-  run_script $js_products_combiner, $ds_previous_products_oldconnection, $ds_previous_products_newconnection
+  run_script $js_products_combiner, $ds_previous_products_oldconnection, $ds_previous_products_newconnection, $ds_previous_products_mcacbiconnection
 end
 
 script "js_products_combiner", type:"javascript" do
-  parameters "oldconnection", "newconnection"
+  parameters "oldconnection", "newconnection", "mcacbiconnection"
   result "result"
   code <<-EOS
-  result = oldconnection.concat(newconnection)
+  result = oldconnection.concat(newconnection).concat(mcacbiconnection)
 EOS
 end
 

--- a/operational/azure/marketplace_new_products/azure_marketplace_new_products.pt
+++ b/operational/azure/marketplace_new_products/azure_marketplace_new_products.pt
@@ -283,17 +283,10 @@ script "js_get_products_oldconnection", type: "javascript" do
   code <<-EOS
   end_date = new Date()
   end_date.setDate(end_date.getDate() - (param_lookback - 1))
-  end_date.setMilliseconds(999)
-  end_date.setSeconds(59)
-  end_date.setMinutes(59)
-  end_date.setHours(23)
   end_date = end_date.toISOString().split('T')[0]
 
   start_date = new Date()
   start_date.setDate(start_date.getDate() - param_lookback)
-  start_date.setMilliseconds(0)
-  start_date.setSeconds(0)
-  start_date.setMinutes(0)
   start_date = start_date.toISOString().split('T')[0]
 
   filter = {
@@ -389,17 +382,10 @@ script "js_get_products_newconnection", type: "javascript" do
   code <<-EOS
   end_date = new Date()
   end_date.setDate(end_date.getDate() - (param_lookback - 1))
-  end_date.setMilliseconds(999)
-  end_date.setSeconds(59)
-  end_date.setMinutes(59)
-  end_date.setHours(23)
   end_date = end_date.toISOString().split('T')[0]
 
   start_date = new Date()
   start_date.setDate(start_date.getDate() - param_lookback)
-  start_date.setMilliseconds(0)
-  start_date.setSeconds(0)
-  start_date.setMinutes(0)
   start_date = start_date.toISOString().split('T')[0]
 
   filter = {
@@ -488,17 +474,10 @@ script "js_get_products_mcacbiconnection", type: "javascript" do
   code <<-EOS
   end_date = new Date()
   end_date.setDate(end_date.getDate() - (param_lookback - 1))
-  end_date.setMilliseconds(999)
-  end_date.setSeconds(59)
-  end_date.setMinutes(59)
-  end_date.setHours(23)
   end_date = end_date.toISOString().split('T')[0]
 
   start_date = new Date()
   start_date.setDate(start_date.getDate() - param_lookback)
-  start_date.setMilliseconds(0)
-  start_date.setSeconds(0)
-  start_date.setMinutes(0)
   start_date = start_date.toISOString().split('T')[0]
 
   filter = {


### PR DESCRIPTION
### Description

We changed the method used to obtain the bill connections, now instead of calling the bill-connects API we fetch cost data and get the bill connections from there, this change is required since MSP customers have a different way of configuring their bill connects, and that method would make the policy fail.

This also adds support for MCA connections.

Code change used here is based on already tested code for policy template **Azure Savings Realized from Reservations**.

### Issues Resolved

- https://flexera.atlassian.net/browse/FOPTS-6315 (Refactor  Azure New Marketplace Products policy)

### Link to Example Applied Policy

- https://app.flexera.com/orgs/1105/automation/applied-policies/projects/60073?policyId=6786e49cc605973ecfa7a53f

![image](https://github.com/user-attachments/assets/02ecb2aa-b743-48ea-80d3-00cab5aa580d)

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD

### IMPORTANT ❗❗❗

Please ignore the following message:

![image](https://github.com/user-attachments/assets/f50d2b84-a6f9-4458-be25-5599f5f69815)

The linter is not able to tell that the script that this datasource uses puts the parameters according to the rule we have:

![image](https://github.com/user-attachments/assets/20f1eba0-c58f-43c7-a060-a194d241fd8e)