### PR TITLE
FOPTS-6693 Fix conversion issue that stops policy execution

### DIFF
--- a/cost/aws/superseded_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/superseded_ebs_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.3.6
+
+- Fixed issue where Currency Conversion messaging in policy incident would stop policy execution because of an error. Functionality unchanged.
+
 ## v6.3.5
 
 - Added `hide_skip_approvals` field to the info section. It dynamically controls "Skip Action Approvals" visibility.

--- a/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
+++ b/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "6.3.5",
+  version: "6.3.6",
   provider: "AWS",
   service: "Compute",
   policy_set: "Inefficient Disk Usage",
@@ -1019,7 +1019,7 @@ script "js_underutil_volumes", type: "javascript" do
 
   api_disclaimer = ""
 
-  if (ds_currency_conversion[0]['to'] == undefined && ds_currency['code'] != 'USD') {
+  if (ds_currency_conversion.length == 0 || (ds_currency_conversion[0]['to'] == undefined && ds_currency['code'] != 'USD')) {
     api_disclaimer = "\n\nPrice and savings values are in USD due to a malfunction with Flexera's internal currency conversion API. Please contact Flexera support to report this issue."
   }
 


### PR DESCRIPTION
### Description

This fixes a problem when the ds_currency_conversion is an empty list, causing the policy to terminate.

### Issues Resolved

- https://flexera.atlassian.net/browse/SQ-12110 (Support Case 02978642 - Issue with Meta Policy - AWS Superseded volumes)

### Link to Example Applied Policy

Policy compiles well:
https://app.flexeratest.com/orgs/1105/automation/projects/60073/policy-templates/67817652b5f49a4905e46a1a

Also the change was tested:

BEFORE
![image](https://github.com/user-attachments/assets/db369c35-86bc-4264-aa68-67bce6bafa53)

NOW
![image](https://github.com/user-attachments/assets/f4de6ff1-8eb6-4a6f-be38-0b733eb0eb02)

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
