### PR TITLE
FOPTS-6730 Fix negative memory statistics for recently rightsized resources | Policy: Azure Rightsize Compute Instances

### DIFF
--- a/cost/azure/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.0.3
+
+- Fixed error that caused showing negative values at the incident fields for memory statistics for recently rightsized instances. Functionality unchanged.
+
 ## v6.0.2
 
 - Added `hide_skip_approvals` field to the info section. It dynamically controls "Skip Action Approvals" visibility.

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.0.2",
+  version: "6.0.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -873,20 +873,27 @@ script "js_azure_instances_metrics_organized", type: "javascript" do
         // Note: The switch between min and max is intentional because
         // the maximum available memory is equivalent to the minumum
         // memory used.
-        if (item["average"] != undefined && item["average"] != null) {
+        // Note 2: Sometimes the amount of memory provided by Azure metrics is greater by far than the
+        // total memory of the instance size, for these cases we skip making recommendations based on
+        // memory since not knowing the total memory makes all the derived calculations wrong.
+        // This behavior happens because the instances are recently rightsized and stats data from their
+        // previous size and stats data from the current size is mixed. This caused showing negative values
+        // for memory statistics.
+
+        if (item["average"] != undefined && item["average"] != null && item["average"] <= total_memory) {
           average = (total_memory - item["average"]) / total_memory
           mem_all_stats.push(average)
           mem_avg += average
           mem_avg_count += 1
         }
 
-        if (item["minimum"] != undefined && item["minimum"] != null) {
+        if (item["minimum"] != undefined && item["minimum"] != null && item["minimum"] <= total_memory) {
           maximum = (total_memory - item["minimum"]) / total_memory
           mem_all_stats.push(maximum)
           if (maximum > mem_max) { mem_max = maximum }
         }
 
-        if (item["maximum"] != undefined && item["maximum"] != null) {
+        if (item["maximum"] != undefined && item["maximum"] != null && item["maximum"] <= total_memory) {
           minimum = (total_memory - item["maximum"]) / total_memory
           mem_all_stats.push(minimum)
           if (minimum < mem_min || mem_min == null) { mem_min = minimum }

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -879,7 +879,6 @@ script "js_azure_instances_metrics_organized", type: "javascript" do
         // This behavior happens because the instances are recently rightsized and stats data from their
         // previous size and stats data from the current size is mixed. This caused showing negative values
         // for memory statistics.
-
         if (item["average"] != undefined && item["average"] != null && item["average"] <= total_memory) {
           average = (total_memory - item["average"]) / total_memory
           mem_all_stats.push(average)


### PR DESCRIPTION
### Description

This change skips memory recommendations when data from recently rightsized instances gets mixed with current data making negative values for memory usage.

Here's a much more detailed explanation of the problem: https://flexera.atlassian.net/browse/SQ-12222?focusedCommentId=2672680

### Issues Resolved

- https://flexera.atlassian.net/browse/SQ-12222

### Link to Example Applied Policy

Policy compiles well: https://app.flexeratest.com/orgs/1105/automation/projects/60073/policy-templates/648b803cfa3d220001edf8cf

BEFORE
![image](https://github.com/user-attachments/assets/bccc0e88-651f-4490-92e9-429ea8db0f3c)

NOW
![image](https://github.com/user-attachments/assets/3c961383-bef9-4db2-8563-fcaa4475e6df)

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
