### PR TITLE
FOPTS-7572 Changed the way to calculate used memory | Policy: Azure Rightsize Compute Instances

### DIFF
--- a/cost/azure/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.0.4
+
+- Fix for v6.0.3, changed the approach for handling memory statics for rightsized instances. Functionality unchanged.
+
 ## v6.0.3
 
 - Fixed error that caused showing negative values at the incident fields for memory statistics for recently rightsized instances. Functionality unchanged.

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.0.3",
+  version: "6.0.4",
   provider: "Azure",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -687,30 +687,6 @@ datasource "ds_azure_skus" do
   end
 end
 
-datasource "ds_azure_sku_memory" do
-  run_script $js_azure_sku_memory, $ds_azure_skus
-end
-
-script "js_azure_sku_memory", type: "javascript" do
-  parameters "ds_azure_skus"
-  result "result"
-  code <<-EOS
-  result = {}
-
-  _.each(ds_azure_skus, function(sku) {
-    name = sku['name'].toLowerCase()
-
-    if (result[name] == undefined && sku["resourceType"] == "virtualMachines") {
-      memory = _.find(sku['capabilities'], function(item) {
-        return item["name"] == "MemoryGB"
-      })
-
-      result[name] = memory["value"] * 1024 * 1024 * 1024
-    }
-  })
-EOS
-end
-
 datasource "ds_azure_instances_metrics" do
   iterate $ds_azure_instances_status_filtered
   request do
@@ -764,7 +740,7 @@ script "js_azure_instances_metrics", type: "javascript" do
       "api-version": "2018-01-01",
       "timespan": timespan,
       "interval": ds_stats_interval["api"],
-      "metricnames": "Percentage CPU,Available Memory Bytes",
+      "metricnames": "Percentage CPU,Available Memory Percentage",
       "aggregation": "average,maximum,minimum"
     },
     headers: {
@@ -777,11 +753,11 @@ EOS
 end
 
 datasource "ds_azure_instances_metrics_organized" do
-  run_script $js_azure_instances_metrics_organized, $ds_azure_instances_metrics, $ds_azure_sku_memory
+  run_script $js_azure_instances_metrics_organized, $ds_azure_instances_metrics
 end
 
 script "js_azure_instances_metrics_organized", type: "javascript" do
-  parameters "ds_azure_instances_metrics", "ds_azure_sku_memory"
+  parameters "ds_azure_instances_metrics"
   result "result"
   code <<-EOS
   // Function to calculate percentiles from metrics
@@ -808,7 +784,7 @@ script "js_azure_instances_metrics_organized", type: "javascript" do
           cpu_stats = stat["timeseries"][0]["data"]
         }
 
-        if (stat['name']['value'] == "Available Memory Bytes") {
+        if (stat['name']['value'] == "Available Memory Percentage") {
           mem_stats = stat["timeseries"][0]["data"]
         }
       }
@@ -865,35 +841,26 @@ script "js_azure_instances_metrics_organized", type: "javascript" do
     mem_avg_count = 0
     mem_all_stats = []
 
-    total_memory = ds_azure_sku_memory[vm['resourceType'].toLowerCase()]
-
     if (mem_stats != null && mem_stats != undefined) {
       _.each(mem_stats, function(item) {
-        // Convert available memory in bytes to used memory in percentage
         // Note: The switch between min and max is intentional because
-        // the maximum available memory is equivalent to the minumum
+        // the maximum available memory is equivalent to the minimum
         // memory used.
-        // Note 2: Sometimes the amount of memory provided by Azure metrics is greater by far than the
-        // total memory of the instance size, for these cases we skip making recommendations based on
-        // memory since not knowing the total memory makes all the derived calculations wrong.
-        // This behavior happens because the instances are recently rightsized and stats data from their
-        // previous size and stats data from the current size is mixed. This caused showing negative values
-        // for memory statistics.
-        if (item["average"] != undefined && item["average"] != null && item["average"] <= total_memory) {
-          average = (total_memory - item["average"]) / total_memory
+        if (item["average"] != undefined && item["average"] != null) {
+          average = (100 - item["average"]) / 100
           mem_all_stats.push(average)
           mem_avg += average
           mem_avg_count += 1
         }
 
-        if (item["minimum"] != undefined && item["minimum"] != null && item["minimum"] <= total_memory) {
-          maximum = (total_memory - item["minimum"]) / total_memory
+        if (item["minimum"] != undefined && item["minimum"] != null) {
+          maximum = (100 - item["minimum"]) / 100
           mem_all_stats.push(maximum)
           if (maximum > mem_max) { mem_max = maximum }
         }
 
-        if (item["maximum"] != undefined && item["maximum"] != null && item["maximum"] <= total_memory) {
-          minimum = (total_memory - item["maximum"]) / total_memory
+        if (item["maximum"] != undefined && item["maximum"] != null) {
+          minimum = (100 - item["maximum"]) / 100
           mem_all_stats.push(minimum)
           if (minimum < mem_min || mem_min == null) { mem_min = minimum }
         }

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -663,30 +663,6 @@ script "js_azure_instances_status_filtered", type: "javascript" do
 EOS
 end
 
-datasource "ds_azure_skus" do
-  iterate $ds_azure_subscriptions_filtered
-  request do
-    auth $auth_azure
-    pagination $pagination_azure
-    host $param_azure_endpoint
-    path join(["/subscriptions/", val(iter_item, "id"), "/providers/Microsoft.Compute/skus"])
-    query "api-version", "2017-09-01"
-    header "User-Agent", "RS Policies"
-    # Ignore status 400, 403, and 404 which can be returned in certain (legacy) types of Azure Subscriptions
-    ignore_status [400, 403, 404]
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "value") do
-      field "resourceType", jmes_path(col_item, "resourceType")
-      field "name", jmes_path(col_item, "name")
-      field "locations", jmes_path(col_item, "locations")
-      field "capabilities", jmes_path(col_item, "capabilities")
-      field "restrictions", jmes_path(col_item, "restrictions")
-    end
-  end
-end
-
 datasource "ds_azure_instances_metrics" do
   iterate $ds_azure_instances_status_filtered
   request do


### PR DESCRIPTION
### Description

This PR changed the way to calculate "used memory" for Azure instances.
Previously the policy is trying to compute "used memory" by substracting "available memory" from "total memory".
This PR has changed to directly retrieving "available memory" from Azure metrics.

The previous method had flawed if the "total memory" is changed due to instance resizing.

### Issues Resolved

- https://flexera.atlassian.net/browse/SQ-12222

### Link to Example Applied Policy

https://app.flexeratest.com/orgs/1105/automation/projects/60073/policy-templates/67c1fc4249c80a0e0d6140d9
**BEFORE**
![image](https://github.com/user-attachments/assets/bccc0e88-651f-4490-92e9-429ea8db0f3c)

**NOW**
![image](https://github.com/user-attachments/assets/c6555746-2146-4ba7-9cf1-7e99d57464ca)

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
