### PR TITLE
FOPTS-7572 Fixed memory stats showing decimal instead of percentage | Policy: Azure Rightsize Compute Instances

### DIFF
--- a/cost/azure/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.0.5
+
+- Fix for memory stats showing decimal (such as 0.5 for half) instead of showing percentage (such as 50 for half).
+
 ## v6.0.4
 
 - Fix for v6.0.3, changed the approach for handling memory statics for rightsized instances. Functionality unchanged.

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.0.5",
+  version: "6.1.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.0.4",
+  version: "6.0.5",
   provider: "Azure",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -823,20 +823,19 @@ script "js_azure_instances_metrics_organized", type: "javascript" do
         // the maximum available memory is equivalent to the minimum
         // memory used.
         if (item["average"] != undefined && item["average"] != null) {
-          average = (100 - item["average"]) / 100
-          mem_all_stats.push(average)
-          mem_avg += average
+          mem_all_stats.push(item["average"])
+          mem_avg += item["average"]
           mem_avg_count += 1
         }
 
         if (item["minimum"] != undefined && item["minimum"] != null) {
-          maximum = (100 - item["minimum"]) / 100
+          var maximum = 100 - item["minimum"]
           mem_all_stats.push(maximum)
           if (maximum > mem_max) { mem_max = maximum }
         }
 
         if (item["maximum"] != undefined && item["maximum"] != null) {
-          minimum = (100 - item["maximum"]) / 100
+          var minimum = 100 - item["maximum"]
           mem_all_stats.push(minimum)
           if (minimum < mem_min || mem_min == null) { mem_min = minimum }
         }
@@ -844,7 +843,7 @@ script "js_azure_instances_metrics_organized", type: "javascript" do
     }
 
     if (mem_min == null) { mem_min = 0 }
-    if (mem_avg_count != 0) { mem_avg = mem_avg / mem_avg_count * 100 }
+    if (mem_avg_count != 0) { mem_avg = mem_avg / mem_avg_count }
 
     if (mem_all_stats.length > 0) {
       mem_p90 = percentile(mem_all_stats, 90)


### PR DESCRIPTION
### Description

Memory stats were showing decimal numbers (such as `0.5` for half), instead of showing percentage (such as `50` for half).
Showing `50` for half and `100` for all is the expected behavior.

### Issues Resolved

- https://flexera.atlassian.net/browse/SQ-12222
- https://flexera.atlassian.net/browse/FOPTS-7572

### Link to Example Applied Policy

Before the change:
![memory_decimals](https://github.com/user-attachments/assets/a844684c-2f73-4ff3-a3ca-f0ee42cc832b)
After the change:
![image](https://github.com/user-attachments/assets/320b8ee8-9d6f-41df-aee0-dd20c6addc16)

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
