### PR TITLE
FOPTS-8007 Fixed OAuth authentication for `Common Bill Ingestion from Azure Blob Storage` policy

### DIFF
--- a/cost/flexera/cco/cbi_ingestion_azure_blob/CHANGELOG.md
+++ b/cost/flexera/cco/cbi_ingestion_azure_blob/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.1
+
+- Fixes a bug where the policy is unable to use Microsoft Entra OAuth token for authentication.
+
 ## v0.1.0
 
 - Initial release

--- a/cost/flexera/cco/cbi_ingestion_azure_blob/cbi_ingestion_azure_blob.pt
+++ b/cost/flexera/cco/cbi_ingestion_azure_blob/cbi_ingestion_azure_blob.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "0.1.0",
+  version: "0.1.1",
   provider: "Flexera",
   service: "Common Bill Ingestion",
   policy_set: "Common Bill Ingestion",
@@ -393,6 +393,7 @@ datasource "ds_cost_file" do
     host $param_blob_hostname
     path join([$param_blob_prefix, val($ds_dates, "period"), ".csv"])
     header "User-Agent", "RS Policies"
+    header "x-ms-version", "2025-05-05"
   end
   result do
     encoding "text"


### PR DESCRIPTION
### Description

Fixed OAuth2 authentication for `Common Bill Ingestion from Azure Blob Storage` policy.

This is caused by the request missing `x-ms-version` header.
(See section "**Requests that use an OAuth 2.0 token from Microsoft Entra**" in Microsoft documentation [Versioning for Azure Storage](https://learn.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services#specify-service-versions-in-requests))

### Issues Resolved

https://flexera.atlassian.net/browse/FOPTS-8007
https://flexera.atlassian.net/browse/SQ-13259

### Link to Example Applied Policy

**Policy log prior to this change:**
https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/60073?policyId=67d34fec81c5ea9238715455
![image](https://github.com/user-attachments/assets/1bccdd00-f1d0-4f02-aecf-b4a4d4594cf5)

**Policy log after this change:**
https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/60073?policyId=67d454d9c669b1c27d4ce916

> Evaluation completed without errors
> Total validations: 1
> Total checks: 1
> Total data items: 1
> Total items failing checks: 1

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
