### PR TITLE
SQ-12222 Fixed incorrect calculation for "average used memory"

### DIFF
--- a/cost/azure/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v6.1.2
 
-- Fixed incorrect calculation for "average used memory".
+- Fixed incorrect calculation for memory related fields "memAverage", "memP90", memP95", and "memP99".
 
 ## v6.1.1
 

--- a/cost/azure/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.1.2
+
+- Fix for incorrect calculation for "available average memory".
+
 ## v6.1.1
 
 - Fix for memory stats showing decimal (such as 0.5 for half) instead of showing percentage (such as 50 for half).

--- a/cost/azure/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v6.1.2
 
-- Fix for incorrect calculation for "available average memory".
+- Fixed incorrect calculation for "average used memory".
 
 ## v6.1.1
 

--- a/cost/azure/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v6.1.2
 
-- Fixed incorrect calculation for memory related fields "memAverage", "memP90", memP95", and "memP99".
+- Fixed incorrect calculation for memory related fields "Memory Average %", "Memory p90", Memory p95", and "Memory p99".
 
 ## v6.1.1
 

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.1.1",
+  version: "6.1.2",
   provider: "Azure",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -824,8 +824,9 @@ script "js_azure_instances_metrics_organized", type: "javascript" do
         // the maximum available memory is equivalent to the minimum
         // memory used.
         if (item["average"] != undefined && item["average"] != null) {
-          mem_all_stats.push(item["average"])
-          mem_avg += item["average"]
+          var average = 100 - item["average"];
+          mem_all_stats.push(average)
+          mem_avg += average
           mem_avg_count += 1
         }
 

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
@@ -7,7 +7,7 @@ category "Meta"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "6.1.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.1.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"


### PR DESCRIPTION
### Description

Fixed incorrect calculation for "average used memory".

### Issues Resolved

https://flexera.atlassian.net/browse/SQ-12222

### Link to Example Applied Policy

[applied policy v6.1.1](https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/107982?policyId=67db1329ce3e463416cd6650)
[policy execution log for v6.1.1](https://github.com/user-attachments/files/19349592/6.1.1.txt)
![image](https://github.com/user-attachments/assets/c80ed37c-afb1-4737-aec2-04187ae93c88)

[applied policy for this PR](https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/107982?policyId=67db12a9ce3e463416cd664e)
[policy execution log for this PR](https://github.com/user-attachments/files/19349594/6.1.2.txt)
![image](https://github.com/user-attachments/assets/327170d4-b172-44ad-891d-39bcbe0345c5)


The main difference is the `mem_average` field.
In previous version, the `mem_average` field was showing "average **available** memory".
In current version, the `mem_average` field is showing "average **used** memory".


### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
