### PR TITLE
POL-1468  Bug/fixing retired status in results ITAM Expiring Licenses

### DIFF
--- a/compliance/flexera/fnms/fnms_licenses_expiring/CHANGELOG.md
+++ b/compliance/flexera/fnms/fnms_licenses_expiring/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.4.2
+
+- Fixed 'Retired' status not being filtered out of the results
+
 ## v2.4.1
 
 - Added `hide_skip_approvals` field to the info section. It dynamically controls "Skip Action Approvals" visibility.

--- a/compliance/flexera/fnms/fnms_licenses_expiring/expiring_licenses.pt
+++ b/compliance/flexera/fnms/fnms_licenses_expiring/expiring_licenses.pt
@@ -31,6 +31,7 @@ parameter "param_email" do
   category "Policy Settings"
   label "Email addresses of the recipients you wish to notify"
   description "A list of email addresse(s) to notify"
+  default []
 end
 
 ###############################################################################
@@ -107,7 +108,7 @@ end
 policy 'itam_policy' do
   validate_each $ds_check_date do
     summary_template 'IT Asset - Expiring Licenses'
-    check eq(to_n(val(item,"expiring")),0)
+    check eq(to_n(val(item, "expiring")), 0)
     escalate $esc_send_report
     export do
       field "licenseId"

--- a/compliance/flexera/fnms/fnms_licenses_expiring/expiring_licenses.pt
+++ b/compliance/flexera/fnms/fnms_licenses_expiring/expiring_licenses.pt
@@ -7,7 +7,7 @@ severity "medium"
 category "Compliance"
 default_frequency "weekly"
 info(
-  version: "2.4.1",
+  version: "2.4.2",
   provider: "Flexera",
   service: "IT Asset Management",
   policy_set: "IT Asset Management",

--- a/compliance/flexera/fnms/fnms_licenses_expiring/expiring_licenses.pt
+++ b/compliance/flexera/fnms/fnms_licenses_expiring/expiring_licenses.pt
@@ -90,7 +90,7 @@ script "js_check_date", type: "javascript" do
     var endDate = new Date();
     var timeDifference =  startDate.getTime() - endDate.getTime();
     var daysDifference = parseInt(timeDifference / (1000 * 3600 * 24));
-    if ((daysDifference <= param_expiring) && license.licenseStatus != '[Retired]' && license.expiryDate.length != '') {
+    if ((daysDifference <= param_expiring && license.expiryDate.length != '') && (license.licenseStatus != 'Retired' && license.licenseStatus != '[Retired]')) {
       license.expiring = 1;
       results.push(license);
     }

--- a/compliance/flexera/fnms/fnms_licenses_expiring/expiring_licenses.pt
+++ b/compliance/flexera/fnms/fnms_licenses_expiring/expiring_licenses.pt
@@ -105,7 +105,7 @@ end
 # Policy
 ###############################################################################
 
-policy 'pol_expiring_license' do
+policy "pol_expiring_license" do
   validate_each $ds_check_date do
     summary_template 'IT Asset - Expiring Licenses'
     check eq(to_n(val(item, "expiring")), 0)

--- a/compliance/flexera/fnms/fnms_licenses_expiring/expiring_licenses.pt
+++ b/compliance/flexera/fnms/fnms_licenses_expiring/expiring_licenses.pt
@@ -105,7 +105,7 @@ end
 # Policy
 ###############################################################################
 
-policy 'itam_policy' do
+policy 'pol_expiring_license' do
   validate_each $ds_check_date do
     summary_template 'IT Asset - Expiring Licenses'
     check eq(to_n(val(item, "expiring")), 0)


### PR DESCRIPTION
### Description

Fixed issue with retired status not being filtered out of the results

### Issues Resolved

Fixed issue with retired status not being filtered out of the results

### Link to Example Applied Policy
Test: (also verified in customer tenant)
https://app.flexera.com/orgs/36084/automation/incidents/projects/138037?incidentId=67e42fe1b9cfdee216feadb4

### Contribution Check List

- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
