### PR TITLE
POL-1478 New Policy Template: Spot Eco - Commitment Source Dimension

### DIFF
--- a/automation/flexera/spot/commitment_source_rbd/CHANGELOG.md
+++ b/automation/flexera/spot/commitment_source_rbd/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+- Initial release

--- a/automation/flexera/spot/commitment_source_rbd/README.md
+++ b/automation/flexera/spot/commitment_source_rbd/README.md
@@ -25,12 +25,7 @@ This policy template creates a rule-based dimension in Flexera Cloud Cost Optimi
 
 This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).
 
-- [**Spot Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=spotinst*) which has the following permission policies:
-  - `Account Viewer` on the Spot account(s) to be used.
-  OR
-  - `Spot Security Full Access` on the Spot account(s) to be used.
-  OR
-  - `Organization Admin`
+- [**Spot Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=spotinst*) created within a Spot organization that has the Spot Eco product.
 
 - [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
   - `observer`

--- a/automation/flexera/spot/commitment_source_rbd/README.md
+++ b/automation/flexera/spot/commitment_source_rbd/README.md
@@ -1,0 +1,46 @@
+# Spot Eco - Commitment Source Dimension
+
+## What It Does
+
+This policy template creates a rule-based dimension in Flexera Cloud Cost Optimization that reports on whether commitments were purchased by Spot Eco or not. Costs will have one of three values for this dimension:
+
+- "Eco" - The commitment was purchased by Spot Eco.
+- "Non-Eco" - The commitment was not purchased by Spot Eco.
+- "None" - The cost is not a commitment and therefore the commitment source is not applicable.
+
+## Input Parameters
+
+- *Spot Organization ID* - The organization ID of the Spot Eco account to use for the commitment source.
+- *Dimension Name* - The name to give the new dimension for the commitment source. This is how the dimension will appear in Flexera One.
+- *Dimension ID* - The internal ID to give the new dimension for the commitment source. Default is recommended for most use cases.
+- *Effective Date* - The month and year in YYYY-MM format that you want the rules to apply. This should be left at its default value in most cases to ensure that the rules apply to all costs, including historical costs.
+
+## Policy Actions
+
+- Create/update rule-based dimension for commitment source.
+
+## Prerequisites
+
+This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).
+
+- [**Spot Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=spotinst*) which has the following permission policies:
+  - `Account Viewer` on the Spot account(s) to be used.
+  OR
+  - `Spot Security Full Access` on the Spot account(s) to be used.
+  OR
+  - `Organization Admin`
+
+- [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
+  - `observer`
+  - `billing_center_viewer`
+  - `rule_based_dimensions_manager`
+
+The [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) page in the docs has detailed instructions for setting up Credentials for the most common providers.
+
+## Supported Clouds
+
+- All clouds supported by Spot Eco
+
+## Cost
+
+This policy template does not incur any cloud costs.

--- a/automation/flexera/spot/commitment_source_rbd/README.md
+++ b/automation/flexera/spot/commitment_source_rbd/README.md
@@ -8,6 +8,8 @@ This policy template creates a rule-based dimension in Flexera Cloud Cost Optimi
 - "Non-Eco" - The commitment was not purchased by Spot Eco.
 - "None" - The cost is not a commitment and therefore the commitment source is not applicable.
 
+**NOTE: This policy template should be considered an alpha release and currently only works with a single Spot Eco organization. Support for multiple organizations may be added in a future iteration.**
+
 ## Input Parameters
 
 - *Spot Organization ID* - The organization ID of the Spot Eco account to use for the commitment source.

--- a/automation/flexera/spot/commitment_source_rbd/commitment_source_rbd.pt
+++ b/automation/flexera/spot/commitment_source_rbd/commitment_source_rbd.pt
@@ -128,26 +128,12 @@ datasource "ds_commitment_sources" do
   request do
     run_script $js_commitment_sources, $param_spot_org_id
   end
-  result do
-    encoding "json"
-    collect jmes_path(response, "rule_based_dimensions") do
-      field "id", jmes_path(col_item, "id")
-      field "name", jmes_path(col_item, "name")
-      field "dated_rules", jmes_path(col_item, "dated_rules")
-    end
-  end
 end
 
 script "js_commitment_sources", type: "javascript" do
   parameters "param_spot_org_id"
   result "request"
   code <<-EOS
-  end_date = new Date().toISOString().split('T')[0]
-
-  start_date = new Date()
-  start_date.setDate(start_date.getDate() - param_lookback)
-  start_date = start_date.toISOString().split('T')[0]
-
   var request = {
     auth: "auth_spot",
     host: "n3hlz25n15.execute-api.us-east-1.amazonaws.com",
@@ -157,7 +143,7 @@ script "js_commitment_sources", type: "javascript" do
     },
     query_params: {
       "start_date": 1735689600,
-      "end_date": null
+      "end_date": 1743847749
     }
   }
 EOS

--- a/automation/flexera/spot/commitment_source_rbd/commitment_source_rbd.pt
+++ b/automation/flexera/spot/commitment_source_rbd/commitment_source_rbd.pt
@@ -124,26 +124,45 @@ datasource "ds_applied_policy" do
   end
 end
 
-datasource "ds_commitment_sources" do
+datasource "ds_eco_commitments" do
   request do
-    run_script $js_commitment_sources, $param_spot_org_id
+    run_script $js_eco_commitments, $param_spot_org_id
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "response.items") do
+      field "commitment_type", jmes_path(col_item, "commitment_type")
+      field "commitment_id", jmes_path(col_item, "commitment_id")
+      field "account_id", jmes_path(col_item, "account_id")
+      field "generated_savings", jmes_path(col_item, "generated_savings")
+      field "dollar_used", jmes_path(col_item, "dollar_used")
+      field "percentage_used", jmes_path(col_item, "percentage_used")
+      field "equivalent_od", jmes_path(col_item, "equivalent_od")
+      field "source", jmes_path(col_item, "source")
+    end
   end
 end
 
-script "js_commitment_sources", type: "javascript" do
+script "js_eco_commitments", type: "javascript" do
   parameters "param_spot_org_id"
   result "request"
   code <<-EOS
+  start_date = new Date("2010-01-01")
+  start_date = Math.round(start_date.getTime() / 1000).toString()
+
+  end_date = new Date()
+  end_date = Math.round(end_date.getTime() / 1000).toString()
+
   var request = {
     auth: "auth_spot",
     host: "n3hlz25n15.execute-api.us-east-1.amazonaws.com",
     path: "/prod/aws/v2/billing/commitmentDistribution",
     headers: {
-      "Spotinst-Organization-ID": param_spot_org_id,
+      "Spotinst-Organization-ID": param_spot_org_id
     },
     query_params: {
-      "start_date": 1735689600,
-      "end_date": 1743847749
+      "start_date": start_date,
+      "end_date": end_date
     }
   }
 EOS
@@ -152,43 +171,40 @@ end
 datasource "ds_existing_rbds" do
   request do
     auth $auth_flexera
-    host rs_optima_host
-    path join(["/bill-analysis/orgs/", rs_org_id, "/settings/rule_based_dimensions"])
-    header "Api-Version", "1.0"
-    header "content-type", "application/json"
+    host val($ds_flexera_api_hosts, "flexera")
+    path join(["/finops-customizations/v1/orgs/", rs_org_id, "/rule-based-dimensions"])
   end
   result do
     encoding "json"
-    collect jmes_path(response, "rule_based_dimensions") do
+    collect jmes_path(response, "values[*]") do
       field "id", jmes_path(col_item, "id")
       field "name", jmes_path(col_item, "name")
-      field "dated_rules", jmes_path(col_item, "dated_rules")
+      field "ruleListLinks", jmes_path(col_item, "ruleListLinks")
     end
   end
 end
 
 datasource "ds_rbds" do
-  run_script $js_rbds, $ds_commitment_sources, $ds_existing_rbds, $ds_applied_policy, $param_rbd_name, $param_rbd_id, $param_effective_date
+  run_script $js_rbds, $ds_eco_commitments, $ds_existing_rbds, $ds_applied_policy, $param_rbd_name, $param_rbd_id, $param_effective_date
 end
 
 script "js_rbds", type: "javascript" do
-  parameters "ds_commitment_sources", "ds_existing_rbds", "ds_applied_policy", "param_rbd_name", "param_rbd_id", "param_effective_date"
+  parameters "ds_eco_commitments", "ds_existing_rbds", "ds_applied_policy", "param_rbd_name", "param_rbd_id", "param_effective_date"
   result "result"
   code <<-'EOS'
-  rbd_id_list = _.pluck(ds_existing_rbds, 'id')
+  eco_rbd = _.find(ds_existing_rbds, function(rbd) { return rbd['id'] == param_rbd_id })
+  eco_purchased = _.filter(ds_eco_commitments, function(entry) { return entry["source"] == "Eco" })
 
-  rules = []
-
-  _.each(ds_commitment_sources, function(entry) {
-    rules.push({
+  rules = _.map(eco_purchased, function(entry) {
+    return {
       condition: {
         type: "dimension_contains",
         dimension: "commitment_id",
-        value: "",
+        substring: entry["commitment_id"],
         caseInsensitive: true
       },
       value: { text: "Eco" }
-    })
+    }
   })
 
   // Catch-all rule for commitments not purchased by Eco
@@ -220,7 +236,7 @@ script "js_rbds", type: "javascript" do
     {
       id: param_rbd_id,
       name: param_rbd_name,
-      verb: _.contains(rbd_id_list, param_rbd_id) ? "PATCH" : "POST",
+      verb: eco_rbd ? "PATCH" : "POST",
       effective_at: param_effective_date,
       rules: rules
     }

--- a/automation/flexera/spot/commitment_source_rbd/commitment_source_rbd.pt
+++ b/automation/flexera/spot/commitment_source_rbd/commitment_source_rbd.pt
@@ -11,7 +11,8 @@ info(
   provider: "Flexera",
   service: "Spot Eco",
   policy_set: "Spot Eco",
-  hide_skip_approvals: "true"
+  hide_skip_approvals: "true",
+  skip_permissions: "true"
 )
 
 ###############################################################################
@@ -22,7 +23,7 @@ parameter "param_spot_org_id" do
   type "string"
   category "Policy Settings"
   label "Spot Organization ID"
-  description "The organization ID of the Spot account to use for the commitment source."
+  description "The organization ID of the Spot Eco account to use for the commitment source."
   # No default value, user input required
 end
 
@@ -30,7 +31,7 @@ parameter "param_rbd_name" do
   type "string"
   category "Policy Settings"
   label "Dimension Name"
-  description "The name to give the new dimension for the commitment source."
+  description "The name to give the new dimension for the commitment source. This is how the dimension will appear in Flexera One."
   default "Commitment Source (Eco)"
 end
 
@@ -121,6 +122,45 @@ datasource "ds_applied_policy" do
     path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
     header "Api-Version", "1.0"
   end
+end
+
+datasource "ds_commitment_sources" do
+  request do
+    run_script $js_commitment_sources, $param_spot_org_id
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "rule_based_dimensions") do
+      field "id", jmes_path(col_item, "id")
+      field "name", jmes_path(col_item, "name")
+      field "dated_rules", jmes_path(col_item, "dated_rules")
+    end
+  end
+end
+
+script "js_commitment_sources", type: "javascript" do
+  parameters "param_spot_org_id"
+  result "request"
+  code <<-EOS
+  end_date = new Date().toISOString().split('T')[0]
+
+  start_date = new Date()
+  start_date.setDate(start_date.getDate() - param_lookback)
+  start_date = start_date.toISOString().split('T')[0]
+
+  var request = {
+    auth: "auth_spot",
+    host: "n3hlz25n15.execute-api.us-east-1.amazonaws.com",
+    path: "/prod/aws/v2/billing/commitmentDistribution",
+    headers: {
+      "Spotinst-Organization-ID": param_spot_org_id,
+    },
+    query_params: {
+      "start_date": 1735689600,
+      "end_date": null
+    }
+  }
+EOS
 end
 
 datasource "ds_existing_rbds" do

--- a/automation/flexera/spot/commitment_source_rbd/commitment_source_rbd.pt
+++ b/automation/flexera/spot/commitment_source_rbd/commitment_source_rbd.pt
@@ -194,13 +194,38 @@ script "js_rbds", type: "javascript" do
   rules = []
 
   _.each(ds_commitment_sources, function(entry) {
-
+    rules.push({
+      condition: {
+        type: "dimension_contains",
+        dimension: "commitment_id",
+        value: "",
+        caseInsensitive: true
+      },
+      value: { text: "Eco" }
+    })
   })
 
+  // Catch-all rule for commitments not purchased by Eco
   rules.push({
     condition: {
       type: "not",
-      expression: { type: "dimension_equals", dimension: "commitment_id", value: "", caseInsensitive: false }
+      expression: {
+        type: "or",
+        expressions: [
+          {
+            type: "dimension_equals",
+            dimension: "commitment_id",
+            value: "",
+            caseInsensitive: true
+          },
+          {
+            type: "dimension_equals",
+            dimension: "commitment_id",
+            value: "None",
+            caseInsensitive: true
+          }
+        ]
+      }
     },
     value: { text: "Non-Eco" }
   })

--- a/automation/flexera/spot/commitment_source_rbd/commitment_source_rbd.pt
+++ b/automation/flexera/spot/commitment_source_rbd/commitment_source_rbd.pt
@@ -1,0 +1,239 @@
+name "Spot Eco - Commitment Source Dimension"
+rs_pt_ver 20180301
+type "policy"
+short_description "Creates and maintains a rule-based dimension to show the source for commitments from Spot Eco in Flexera CCO. See the [README](https://github.com/flexera-public/policy_templates/tree/master/automation/flexera/spot/commitment_source_rbd/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+long_description ""
+severity "low"
+category "Cost"
+default_frequency "daily"
+info(
+  version: "0.1.0",
+  provider: "Flexera",
+  service: "Spot Eco",
+  policy_set: "Spot Eco",
+  hide_skip_approvals: "true"
+)
+
+###############################################################################
+# Parameters
+###############################################################################
+
+parameter "param_spot_org_id" do
+  type "string"
+  category "Policy Settings"
+  label "Spot Organization ID"
+  description "The organization ID of the Spot account to use for the commitment source."
+  # No default value, user input required
+end
+
+parameter "param_rbd_name" do
+  type "string"
+  category "Policy Settings"
+  label "Dimension Name"
+  description "The name to give the new dimension for the commitment source."
+  default "Commitment Source (Eco)"
+end
+
+parameter "param_rbd_id" do
+  type "string"
+  category "Policy Settings"
+  label "Dimension ID"
+  description "The internal ID to give the new dimension for the commitment source. Default is recommended for most use cases."
+  default "rbd_commitment_source_eco"
+end
+
+parameter "param_effective_date" do
+  type "string"
+  category "Policy Settings"
+  label "Effective Date"
+  description "Year/month you want rules to start applying in YYYY-MM format"
+  default "2010-01"
+end
+
+###############################################################################
+# Authentication
+###############################################################################
+
+credentials "auth_flexera" do
+  schemes "oauth2"
+  label "Flexera"
+  description "Select Flexera One OAuth2 credentials"
+  tags "provider=flexera"
+end
+
+credentials "auth_spot" do
+  schemes "api_key"
+  label "Spot"
+  description "Select the Spot Credential from the list."
+  tags "provider=spotinst"
+end
+
+###############################################################################
+# Pagination
+###############################################################################
+
+pagination "pagination_spot" do
+  get_page_marker do
+    body_path jq(response, ".response.paginationInfo.nextKey")
+  end
+  set_page_marker do
+    query "paginationKey"
+  end
+end
+
+###############################################################################
+# Datasources & Scripts
+###############################################################################
+
+# Get region-specific Flexera API endpoints
+datasource "ds_flexera_api_hosts" do
+  run_script $js_flexera_api_hosts, rs_optima_host
+end
+
+script "js_flexera_api_hosts", type: "javascript" do
+  parameters "rs_optima_host"
+  result "result"
+  code <<-EOS
+  host_table = {
+    "api.optima.flexeraeng.com": {
+      flexera: "api.flexera.com",
+      fsm: "api.fsm.flexeraeng.com"
+    },
+    "api.optima-eu.flexeraeng.com": {
+      flexera: "api.flexera.eu",
+      fsm: "api.fsm-eu.flexeraeng.com"
+    },
+    "api.optima-apac.flexeraeng.com": {
+      flexera: "api.flexera.au",
+      fsm: "api.fsm-apac.flexeraeng.com"
+    }
+  }
+
+  result = host_table[rs_optima_host]
+EOS
+end
+
+# Get applied policy metadata for use later
+datasource "ds_applied_policy" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    header "Api-Version", "1.0"
+  end
+end
+
+datasource "ds_existing_rbds" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/bill-analysis/orgs/", rs_org_id, "/settings/rule_based_dimensions"])
+    header "Api-Version", "1.0"
+    header "content-type", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "rule_based_dimensions") do
+      field "id", jmes_path(col_item, "id")
+      field "name", jmes_path(col_item, "name")
+      field "dated_rules", jmes_path(col_item, "dated_rules")
+    end
+  end
+end
+
+datasource "ds_rbds" do
+  run_script $js_rbds, $ds_commitment_sources, $ds_existing_rbds, $ds_applied_policy, $param_rbd_name, $param_rbd_id, $param_effective_date
+end
+
+script "js_rbds", type: "javascript" do
+  parameters "ds_commitment_sources", "ds_existing_rbds", "ds_applied_policy", "param_rbd_name", "param_rbd_id", "param_effective_date"
+  result "result"
+  code <<-'EOS'
+  rbd_id_list = _.pluck(ds_existing_rbds, 'id')
+
+  rules = []
+
+  _.each(ds_commitment_sources, function(entry) {
+
+  })
+
+  rules.push({
+    condition: {
+      type: "not",
+      expression: { type: "dimension_equals", dimension: "commitment_id", value: "", caseInsensitive: false }
+    },
+    value: { text: "Non-Eco" }
+  })
+
+  result = [
+    {
+      id: param_rbd_id,
+      name: param_rbd_name,
+      verb: _.contains(rbd_id_list, param_rbd_id) ? "PATCH" : "POST",
+      effective_at: param_effective_date,
+      rules: rules
+    }
+  ]
+EOS
+end
+
+datasource "ds_create_rbds" do
+  iterate $ds_rbds
+  request do
+    run_script $js_create_rbds, val(iter_item, "id"), val(iter_item, "verb"), val(iter_item, "name"), val($ds_flexera_api_hosts, "flexera"), rs_org_id
+  end
+  result do
+    encoding "text"
+  end
+end
+
+script "js_create_rbds", type: "javascript" do
+  parameters "rbd_id", "verb", "name", "api_host", "rs_org_id"
+  result "request"
+  code <<-EOS
+  var request = {
+    auth: "auth_flexera",
+    verb: verb,
+    host: api_host,
+    path: ["/finops-customizations/v1/orgs/", rs_org_id, "/rule-based-dimensions/", rbd_id].join(''),
+    body_fields: { name: name }
+  }
+EOS
+end
+
+datasource "ds_apply_rbds" do
+  iterate $ds_rbds
+  request do
+    # ds_create_rbds is a parameter to ensure that it executes before ds_apply_rbds does
+    run_script $js_apply_rbds, val(iter_item, "id"), val(iter_item, "effective_at"), val(iter_item, "rules"), val($ds_flexera_api_hosts, "flexera"), $ds_create_rbds, rs_org_id
+  end
+  result do
+    encoding "text"
+  end
+end
+
+script "js_apply_rbds", type: "javascript" do
+  parameters "rbd_id", "effective_at", "rules", "api_host", "ds_create_rbds", "rs_org_id"
+  result "request"
+  code <<-EOS
+  var request = {
+    auth: "auth_flexera",
+    verb: "PUT",
+    host: api_host,
+    path: ["/finops-customizations/v1/orgs/", rs_org_id, "/rule-based-dimensions/", rbd_id, "/rules/", effective_at].join(''),
+    body_fields: { rules: rules }
+  }
+EOS
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "pol_rbds" do
+  validate $ds_apply_rbds do
+    summary_template "Commitment Source RBD Generated & Applied"
+    detail_template ""
+    check eq(0, 0)
+  end
+end


### PR DESCRIPTION
### Description

This policy template creates a rule-based dimension in Flexera Cloud Cost Optimization that reports on whether commitments were purchased by Spot Eco or not. Costs will have one of three values for this dimension:

- "Eco" - The commitment was purchased by Spot Eco.
- "Non-Eco" - The commitment was not purchased by Spot Eco.
- "None" - The cost is not a commitment and therefore the commitment source is not applicable.

**NOTE: This policy template should be considered an alpha release and currently only works with a single Spot Eco organization. Support for multiple organizations may be added in a future iteration.**

### Link to Example Applied Policy

https://app.flexera.com/orgs/36084/automation/applied-policies/projects/138037?policyId=67f580d881d6318dd46d9d6b

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
