### PR TITLE
POL-1511 CloudFormation Generator Fix

### DIFF
--- a/tools/cloudformation-template/FlexeraAutomationPolicies.template
+++ b/tools/cloudformation-template/FlexeraAutomationPolicies.template
@@ -25,8 +25,6 @@ Metadata:
         Parameters:
           ## All AWS Policy Templates
           - paramPermsAllAWSPolicyTemplates
-          ## AWS Account Credentials
-          - paramPermsAWSAccountCredentials
           ## AWS Accounts Missing Service Control Policies
           - paramPermsAWSAccountsMissingServiceControlPolicies
           ## AWS Burstable EC2 Instances
@@ -49,8 +47,6 @@ Metadata:
           - paramPermsAWSCustomerManagedKeysCMKsWithoutRotationEnabled
           ## AWS Disallowed Regions
           - paramPermsAWSDisallowedRegions
-          ## AWS EC2 Compute Optimizer Recommendations
-          - paramPermsAWSEC2ComputeOptimizerRecommendations
           ## AWS EC2 Instances Time Stopped Report
           - paramPermsAWSEC2InstancesTimeStoppedReport
           ## AWS EC2 Instances not running FlexNet Inventory Agent
@@ -101,8 +97,6 @@ Metadata:
           - paramPermsAWSLongRunningInstances
           ## AWS Long Stopped EC2 Instances
           - paramPermsAWSLongStoppedEC2Instances
-          ## AWS Missing Regions
-          - paramPermsAWSMissingRegions
           ## AWS Old Snapshots
           - paramPermsAWSOldSnapshots
           ## AWS Open S3 Buckets
@@ -207,9 +201,6 @@ Metadata:
       ## All AWS Policy Templates
       paramPermsAllAWSPolicyTemplates:
         default: "Permissions for all AWS Policy Templates"
-      ## AWS Account Credentials
-      paramPermsAWSAccountCredentials:
-        default: "Permissions for Policy Template: AWS Account Credentials"
       ## AWS Accounts Missing Service Control Policies
       paramPermsAWSAccountsMissingServiceControlPolicies:
         default: "Permissions for Policy Template: AWS Accounts Missing Service Control Policies"
@@ -243,9 +234,6 @@ Metadata:
       ## AWS Disallowed Regions
       paramPermsAWSDisallowedRegions:
         default: "Permissions for Policy Template: AWS Disallowed Regions"
-      ## AWS EC2 Compute Optimizer Recommendations
-      paramPermsAWSEC2ComputeOptimizerRecommendations:
-        default: "Permissions for Policy Template: AWS EC2 Compute Optimizer Recommendations"
       ## AWS EC2 Instances Time Stopped Report
       paramPermsAWSEC2InstancesTimeStoppedReport:
         default: "Permissions for Policy Template: AWS EC2 Instances Time Stopped Report"
@@ -321,9 +309,6 @@ Metadata:
       ## AWS Long Stopped EC2 Instances
       paramPermsAWSLongStoppedEC2Instances:
         default: "Permissions for Policy Template: AWS Long Stopped EC2 Instances"
-      ## AWS Missing Regions
-      paramPermsAWSMissingRegions:
-        default: "Permissions for Policy Template: AWS Missing Regions"
       ## AWS Old Snapshots
       paramPermsAWSOldSnapshots:
         default: "Permissions for Policy Template: AWS Old Snapshots"
@@ -500,14 +485,6 @@ Parameters:
       - None
       - Read Only
       - Read and Take Action
-  ## AWS Account Credentials
-  paramPermsAWSAccountCredentials:
-    Description: 'What permissions for the "AWS Account Credentials" Policy Template should be granted on the AWS Role that will be created?'
-    Type: String
-    Default: None
-    AllowedValues:
-      - None
-      - Read Only
   ## AWS Accounts Missing Service Control Policies
   paramPermsAWSAccountsMissingServiceControlPolicies:
     Description: 'What permissions for the "AWS Accounts Missing Service Control Policies" Policy Template should be granted on the AWS Role that will be created?'
@@ -593,15 +570,6 @@ Parameters:
   ## AWS Disallowed Regions
   paramPermsAWSDisallowedRegions:
     Description: 'What permissions for the "AWS Disallowed Regions" Policy Template should be granted on the AWS Role that will be created?'
-    Type: String
-    Default: None
-    AllowedValues:
-      - None
-      - Read Only
-      - Read and Take Action
-  ## AWS EC2 Compute Optimizer Recommendations
-  paramPermsAWSEC2ComputeOptimizerRecommendations:
-    Description: 'What permissions for the "AWS EC2 Compute Optimizer Recommendations" Policy Template should be granted on the AWS Role that will be created?'
     Type: String
     Default: None
     AllowedValues:
@@ -813,14 +781,6 @@ Parameters:
       - None
       - Read Only
       - Read and Take Action
-  ## AWS Missing Regions
-  paramPermsAWSMissingRegions:
-    Description: 'What permissions for the "AWS Missing Regions" Policy Template should be granted on the AWS Role that will be created?'
-    Type: String
-    Default: None
-    AllowedValues:
-      - None
-      - Read Only
   ## AWS Old Snapshots
   paramPermsAWSOldSnapshots:
     Description: 'What permissions for the "AWS Old Snapshots" Policy Template should be granted on the AWS Role that will be created?'
@@ -1204,11 +1164,6 @@ Conditions:
   CreatePolicyAllAWSPolicyTemplatesAction: !Equals
     - !Ref paramPermsAllAWSPolicyTemplates
     - Read and Take Action
-  ## AWS Account Credentials
-  CreatePolicyAWSAccountCredentialsRead: !Not
-    - !Equals
-      - !Ref paramPermsAWSAccountCredentials
-      - None
   ## AWS Accounts Missing Service Control Policies
   CreatePolicyAWSAccountsMissingServiceControlPoliciesRead: !Not
     - !Equals
@@ -1272,14 +1227,6 @@ Conditions:
       - None
   CreatePolicyAWSDisallowedRegionsAction: !Equals
     - !Ref paramPermsAWSDisallowedRegions
-    - Read and Take Action
-  ## AWS EC2 Compute Optimizer Recommendations
-  CreatePolicyAWSEC2ComputeOptimizerRecommendationsRead: !Not
-    - !Equals
-      - !Ref paramPermsAWSEC2ComputeOptimizerRecommendations
-      - None
-  CreatePolicyAWSEC2ComputeOptimizerRecommendationsAction: !Equals
-    - !Ref paramPermsAWSEC2ComputeOptimizerRecommendations
     - Read and Take Action
   ## AWS EC2 Instances Time Stopped Report
   CreatePolicyAWSEC2InstancesTimeStoppedReportRead: !Not
@@ -1421,11 +1368,6 @@ Conditions:
   CreatePolicyAWSLongStoppedEC2InstancesAction: !Equals
     - !Ref paramPermsAWSLongStoppedEC2Instances
     - Read and Take Action
-  ## AWS Missing Regions
-  CreatePolicyAWSMissingRegionsRead: !Not
-    - !Equals
-      - !Ref paramPermsAWSMissingRegions
-      - None
   ## AWS Old Snapshots
   CreatePolicyAWSOldSnapshotsRead: !Not
     - !Equals
@@ -1736,7 +1678,6 @@ Mappings:
         - "cloudwatch:GetMetricData"
         - "cloudwatch:GetMetricStatistics"
         - "cloudwatch:ListMetrics"
-        - "compute-optimizer:GetEC2InstanceRecommendations"
         - "config:DescribeConfigurationRecorderStatus"
         - "ec2:CreateTags"
         - "ec2:DeleteTags"
@@ -1847,11 +1788,6 @@ Mappings:
         - "s3:PutBucketLogging"
         - "s3:PutEncryptionConfiguration"
         - "tag:TagResources"
-    ## AWS Account Credentials
-    AWSAccountCredentials:
-      read:
-        - "sts:GetCallerIdentity"
-      action: []
     ## AWS Accounts Missing Service Control Policies
     AWSAccountsMissingServiceControlPolicies:
       read:
@@ -1940,17 +1876,6 @@ Mappings:
       action:
         - "ec2:StopInstances"
         - "ec2:TerminateInstances"
-    ## AWS EC2 Compute Optimizer Recommendations
-    AWSEC2ComputeOptimizerRecommendations:
-      read:
-        - "sts:GetCallerIdentity"
-        - "compute-optimizer:GetEC2InstanceRecommendations"
-        - "ec2:DescribeRegions"
-        - "ec2:DescribeInstances"
-      action:
-        - "ec2:ModifyInstanceAttribute"
-        - "ec2:StartInstances"
-        - "ec2:StopInstances"
     ## AWS EC2 Instances Time Stopped Report
     AWSEC2InstancesTimeStoppedReport:
       read:
@@ -2146,13 +2071,6 @@ Mappings:
       action:
         - "ec2:DescribeInstanceStatus"
         - "ec2:TerminateInstances"
-    ## AWS Missing Regions
-    AWSMissingRegions:
-      read:
-        - "ec2:DescribeRegions"
-        - "ec2:DescribeInstances"
-        - "sts:GetCallerIdentity"
-      action: []
     ## AWS Old Snapshots
     AWSOldSnapshots:
       read:
@@ -2628,26 +2546,6 @@ Resources:
               - AllAWSPolicyTemplates
               - action
             Resource: "*"
-  ## AWS Account Credentials
-  iamPolicyAWSAccountCredentialsRead:
-    Type: "AWS::IAM::Policy"
-    Condition: CreatePolicyAWSAccountCredentialsRead
-    Properties:
-      PolicyName: !Join
-        - "_"
-        - - !Ref paramRoleName
-          - AWSAccountCredentialsReadPermissionPolicy
-      Roles:
-        - !Ref iamRole
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Action: !FindInMap
-              - PermissionMap
-              - AWSAccountCredentials
-              - read
-            Resource: "*"
   ## AWS Accounts Missing Service Control Policies
   iamPolicyAWSAccountsMissingServiceControlPoliciesRead:
     Type: "AWS::IAM::Policy"
@@ -2923,45 +2821,6 @@ Resources:
             Action: !FindInMap
               - PermissionMap
               - AWSDisallowedRegions
-              - action
-            Resource: "*"
-  ## AWS EC2 Compute Optimizer Recommendations
-  iamPolicyAWSEC2ComputeOptimizerRecommendationsRead:
-    Type: "AWS::IAM::Policy"
-    Condition: CreatePolicyAWSEC2ComputeOptimizerRecommendationsRead
-    Properties:
-      PolicyName: !Join
-        - "_"
-        - - !Ref paramRoleName
-          - AWSEC2ComputeOptimizerRecommendationsReadPermissionPolicy
-      Roles:
-        - !Ref iamRole
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Action: !FindInMap
-              - PermissionMap
-              - AWSEC2ComputeOptimizerRecommendations
-              - read
-            Resource: "*"
-  iamPolicyAWSEC2ComputeOptimizerRecommendationsAction:
-    Type: "AWS::IAM::Policy"
-    Condition: CreatePolicyAWSEC2ComputeOptimizerRecommendationsAction
-    Properties:
-      PolicyName: !Join
-        - "_"
-        - - !Ref paramRoleName
-          - AWSEC2ComputeOptimizerRecommendationsActionPermissionPolicy
-      Roles:
-        - !Ref iamRole
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Action: !FindInMap
-              - PermissionMap
-              - AWSEC2ComputeOptimizerRecommendations
               - action
             Resource: "*"
   ## AWS EC2 Instances Time Stopped Report
@@ -3558,26 +3417,6 @@ Resources:
               - PermissionMap
               - AWSLongStoppedEC2Instances
               - action
-            Resource: "*"
-  ## AWS Missing Regions
-  iamPolicyAWSMissingRegionsRead:
-    Type: "AWS::IAM::Policy"
-    Condition: CreatePolicyAWSMissingRegionsRead
-    Properties:
-      PolicyName: !Join
-        - "_"
-        - - !Ref paramRoleName
-          - AWSMissingRegionsReadPermissionPolicy
-      Roles:
-        - !Ref iamRole
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Action: !FindInMap
-              - PermissionMap
-              - AWSMissingRegions
-              - read
             Resource: "*"
   ## AWS Old Snapshots
   iamPolicyAWSOldSnapshotsRead:

--- a/tools/cloudformation-template/FlexeraAutomationPoliciesReadOnly.template
+++ b/tools/cloudformation-template/FlexeraAutomationPoliciesReadOnly.template
@@ -25,8 +25,6 @@ Metadata:
         Parameters:
           ## All AWS Policy Templates
           - paramPermsAllAWSPolicyTemplates
-          ## AWS Account Credentials
-          - paramPermsAWSAccountCredentials
           ## AWS Accounts Missing Service Control Policies
           - paramPermsAWSAccountsMissingServiceControlPolicies
           ## AWS Burstable EC2 Instances
@@ -49,8 +47,6 @@ Metadata:
           - paramPermsAWSCustomerManagedKeysCMKsWithoutRotationEnabled
           ## AWS Disallowed Regions
           - paramPermsAWSDisallowedRegions
-          ## AWS EC2 Compute Optimizer Recommendations
-          - paramPermsAWSEC2ComputeOptimizerRecommendations
           ## AWS EC2 Instances Time Stopped Report
           - paramPermsAWSEC2InstancesTimeStoppedReport
           ## AWS EC2 Instances not running FlexNet Inventory Agent
@@ -101,8 +97,6 @@ Metadata:
           - paramPermsAWSLongRunningInstances
           ## AWS Long Stopped EC2 Instances
           - paramPermsAWSLongStoppedEC2Instances
-          ## AWS Missing Regions
-          - paramPermsAWSMissingRegions
           ## AWS Old Snapshots
           - paramPermsAWSOldSnapshots
           ## AWS Open S3 Buckets
@@ -207,9 +201,6 @@ Metadata:
       ## All AWS Policy Templates
       paramPermsAllAWSPolicyTemplates:
         default: "Permissions for all AWS Policy Templates"
-      ## AWS Account Credentials
-      paramPermsAWSAccountCredentials:
-        default: "Permissions for Policy Template: AWS Account Credentials"
       ## AWS Accounts Missing Service Control Policies
       paramPermsAWSAccountsMissingServiceControlPolicies:
         default: "Permissions for Policy Template: AWS Accounts Missing Service Control Policies"
@@ -243,9 +234,6 @@ Metadata:
       ## AWS Disallowed Regions
       paramPermsAWSDisallowedRegions:
         default: "Permissions for Policy Template: AWS Disallowed Regions"
-      ## AWS EC2 Compute Optimizer Recommendations
-      paramPermsAWSEC2ComputeOptimizerRecommendations:
-        default: "Permissions for Policy Template: AWS EC2 Compute Optimizer Recommendations"
       ## AWS EC2 Instances Time Stopped Report
       paramPermsAWSEC2InstancesTimeStoppedReport:
         default: "Permissions for Policy Template: AWS EC2 Instances Time Stopped Report"
@@ -321,9 +309,6 @@ Metadata:
       ## AWS Long Stopped EC2 Instances
       paramPermsAWSLongStoppedEC2Instances:
         default: "Permissions for Policy Template: AWS Long Stopped EC2 Instances"
-      ## AWS Missing Regions
-      paramPermsAWSMissingRegions:
-        default: "Permissions for Policy Template: AWS Missing Regions"
       ## AWS Old Snapshots
       paramPermsAWSOldSnapshots:
         default: "Permissions for Policy Template: AWS Old Snapshots"
@@ -499,14 +484,6 @@ Parameters:
     AllowedValues:
       - None
       - Read Only
-  ## AWS Account Credentials
-  paramPermsAWSAccountCredentials:
-    Description: 'What permissions for the "AWS Account Credentials" Policy Template should be granted on the AWS Role that will be created?'
-    Type: String
-    Default: None
-    AllowedValues:
-      - None
-      - Read Only
   ## AWS Accounts Missing Service Control Policies
   paramPermsAWSAccountsMissingServiceControlPolicies:
     Description: 'What permissions for the "AWS Accounts Missing Service Control Policies" Policy Template should be granted on the AWS Role that will be created?'
@@ -590,14 +567,6 @@ Parameters:
   ## AWS Disallowed Regions
   paramPermsAWSDisallowedRegions:
     Description: 'What permissions for the "AWS Disallowed Regions" Policy Template should be granted on the AWS Role that will be created?'
-    Type: String
-    Default: None
-    AllowedValues:
-      - None
-      - Read Only
-  ## AWS EC2 Compute Optimizer Recommendations
-  paramPermsAWSEC2ComputeOptimizerRecommendations:
-    Description: 'What permissions for the "AWS EC2 Compute Optimizer Recommendations" Policy Template should be granted on the AWS Role that will be created?'
     Type: String
     Default: None
     AllowedValues:
@@ -798,14 +767,6 @@ Parameters:
   ## AWS Long Stopped EC2 Instances
   paramPermsAWSLongStoppedEC2Instances:
     Description: 'What permissions for the "AWS Long Stopped EC2 Instances" Policy Template should be granted on the AWS Role that will be created?'
-    Type: String
-    Default: None
-    AllowedValues:
-      - None
-      - Read Only
-  ## AWS Missing Regions
-  paramPermsAWSMissingRegions:
-    Description: 'What permissions for the "AWS Missing Regions" Policy Template should be granted on the AWS Role that will be created?'
     Type: String
     Default: None
     AllowedValues:
@@ -1171,11 +1132,6 @@ Conditions:
     - !Equals
       - !Ref paramPermsAllAWSPolicyTemplates
       - None
-  ## AWS Account Credentials
-  CreatePolicyAWSAccountCredentialsRead: !Not
-    - !Equals
-      - !Ref paramPermsAWSAccountCredentials
-      - None
   ## AWS Accounts Missing Service Control Policies
   CreatePolicyAWSAccountsMissingServiceControlPoliciesRead: !Not
     - !Equals
@@ -1230,11 +1186,6 @@ Conditions:
   CreatePolicyAWSDisallowedRegionsRead: !Not
     - !Equals
       - !Ref paramPermsAWSDisallowedRegions
-      - None
-  ## AWS EC2 Compute Optimizer Recommendations
-  CreatePolicyAWSEC2ComputeOptimizerRecommendationsRead: !Not
-    - !Equals
-      - !Ref paramPermsAWSEC2ComputeOptimizerRecommendations
       - None
   ## AWS EC2 Instances Time Stopped Report
   CreatePolicyAWSEC2InstancesTimeStoppedReportRead: !Not
@@ -1360,11 +1311,6 @@ Conditions:
   CreatePolicyAWSLongStoppedEC2InstancesRead: !Not
     - !Equals
       - !Ref paramPermsAWSLongStoppedEC2Instances
-      - None
-  ## AWS Missing Regions
-  CreatePolicyAWSMissingRegionsRead: !Not
-    - !Equals
-      - !Ref paramPermsAWSMissingRegions
       - None
   ## AWS Old Snapshots
   CreatePolicyAWSOldSnapshotsRead: !Not
@@ -1616,7 +1562,6 @@ Mappings:
         - "cloudwatch:GetMetricData"
         - "cloudwatch:GetMetricStatistics"
         - "cloudwatch:ListMetrics"
-        - "compute-optimizer:GetEC2InstanceRecommendations"
         - "config:DescribeConfigurationRecorderStatus"
         - "ec2:CreateTags"
         - "ec2:DeleteTags"
@@ -1702,11 +1647,6 @@ Mappings:
         - "sts:GetCallerIdentity"
         - "tag:GetResources"
       action: []
-    ## AWS Account Credentials
-    AWSAccountCredentials:
-      read:
-        - "sts:GetCallerIdentity"
-      action: []
     ## AWS Accounts Missing Service Control Policies
     AWSAccountsMissingServiceControlPolicies:
       read:
@@ -1785,14 +1725,6 @@ Mappings:
     AWSDisallowedRegions:
       read:
         - "sts:GetCallerIdentity"
-        - "ec2:DescribeRegions"
-        - "ec2:DescribeInstances"
-      action: []
-    ## AWS EC2 Compute Optimizer Recommendations
-    AWSEC2ComputeOptimizerRecommendations:
-      read:
-        - "sts:GetCallerIdentity"
-        - "compute-optimizer:GetEC2InstanceRecommendations"
         - "ec2:DescribeRegions"
         - "ec2:DescribeInstances"
       action: []
@@ -1979,13 +1911,6 @@ Mappings:
         - "cloudwatch:GetMetricStatistics"
         - "cloudwatch:GetMetricData"
         - "cloudwatch:ListMetrics"
-        - "sts:GetCallerIdentity"
-      action: []
-    ## AWS Missing Regions
-    AWSMissingRegions:
-      read:
-        - "ec2:DescribeRegions"
-        - "ec2:DescribeInstances"
         - "sts:GetCallerIdentity"
       action: []
     ## AWS Old Snapshots
@@ -2407,26 +2332,6 @@ Resources:
               - AllAWSPolicyTemplates
               - read
             Resource: "*"
-  ## AWS Account Credentials
-  iamPolicyAWSAccountCredentialsRead:
-    Type: "AWS::IAM::Policy"
-    Condition: CreatePolicyAWSAccountCredentialsRead
-    Properties:
-      PolicyName: !Join
-        - "_"
-        - - !Ref paramRoleName
-          - AWSAccountCredentialsReadPermissionPolicy
-      Roles:
-        - !Ref iamRole
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Action: !FindInMap
-              - PermissionMap
-              - AWSAccountCredentials
-              - read
-            Resource: "*"
   ## AWS Accounts Missing Service Control Policies
   iamPolicyAWSAccountsMissingServiceControlPoliciesRead:
     Type: "AWS::IAM::Policy"
@@ -2645,26 +2550,6 @@ Resources:
             Action: !FindInMap
               - PermissionMap
               - AWSDisallowedRegions
-              - read
-            Resource: "*"
-  ## AWS EC2 Compute Optimizer Recommendations
-  iamPolicyAWSEC2ComputeOptimizerRecommendationsRead:
-    Type: "AWS::IAM::Policy"
-    Condition: CreatePolicyAWSEC2ComputeOptimizerRecommendationsRead
-    Properties:
-      PolicyName: !Join
-        - "_"
-        - - !Ref paramRoleName
-          - AWSEC2ComputeOptimizerRecommendationsReadPermissionPolicy
-      Roles:
-        - !Ref iamRole
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Action: !FindInMap
-              - PermissionMap
-              - AWSEC2ComputeOptimizerRecommendations
               - read
             Resource: "*"
   ## AWS EC2 Instances Time Stopped Report
@@ -3165,26 +3050,6 @@ Resources:
             Action: !FindInMap
               - PermissionMap
               - AWSLongStoppedEC2Instances
-              - read
-            Resource: "*"
-  ## AWS Missing Regions
-  iamPolicyAWSMissingRegionsRead:
-    Type: "AWS::IAM::Policy"
-    Condition: CreatePolicyAWSMissingRegionsRead
-    Properties:
-      PolicyName: !Join
-        - "_"
-        - - !Ref paramRoleName
-          - AWSMissingRegionsReadPermissionPolicy
-      Roles:
-        - !Ref iamRole
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Action: !FindInMap
-              - PermissionMap
-              - AWSMissingRegions
               - read
             Resource: "*"
   ## AWS Old Snapshots


### PR DESCRIPTION
### Description

Fixed issue with the AWS CloudFormation Template generator script that was causing it to include deprecated policies and not remove deleted policies.
