### PR TITLE
FOPTS-9434 Correctly include all RDS snapshots in policy evaluation

### DIFF
--- a/cost/aws/old_snapshots/CHANGELOG.md
+++ b/cost/aws/old_snapshots/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v8.4.4
+- Corrected incorrect filtering of RDS DB snapshots. The policy was previously only considering the most recent snapshot for each DB instance, leading to missed older snapshots. The logic has been updated to include all snapshots.
+
 ## v8.4.3
 
 - Added `hide_skip_approvals` field to the info section. It dynamically controls "Skip Action Approvals" visibility.

--- a/cost/aws/old_snapshots/CHANGELOG.md
+++ b/cost/aws/old_snapshots/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v8.4.4
+
 - Corrected incorrect filtering of RDS DB snapshots. The policy was previously only considering the most recent snapshot for each DB instance, leading to missed older snapshots. The logic has been updated to include all snapshots.
 
 ## v8.4.3

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -535,7 +535,9 @@ script "js_describe_db_snapshots", type:"javascript" do
 
   _.each(_.keys(sorted_by_parent), function(parent) {
     sorted_parents = _.sortBy(sorted_by_parent[parent], "startTime").reverse()
-    result.push(sorted_parents[0])
+    sorted_parents.forEach(function(snapshot) {
+          result.push(snapshot);
+    });
   })
 EOS
 end

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "8.4.3",
+  version: "8.4.4",
   provider: "AWS",
   service: "Storage",
   policy_set: "Old Snapshots",


### PR DESCRIPTION
This PR addresses an issue in the policy template's RDS snapshot filtering logic that was causing some snapshots to be incorrectly excluded from policy evaluation.

### Description

The js_describe_db_snapshots script was incorrectly filtering RDS snapshots. It was grouping snapshots by ParentId (the RDS instance identifier), sorting them by StartTime, and then only retaining the most recent snapshot for each ParentId. This meant that older snapshots, even if they met other policy criteria (like age), were being ignored. This behavior could lead to:

* Data Governance Gaps: Older snapshots, which might be needed for compliance or audit purposes, were not being properly managed by the policy.
* Cost Optimization Inefficiencies: Opportunities to identify and manage older, potentially costly snapshots were being missed.
* Recovery Risks: In some disaster recovery scenarios, the policy might not be able to identify or take action on older snapshots that could be required.



### Issues Resolved

This PR modifies the js_describe_db_snapshots script to correctly include all RDS snapshots in the policy's evaluation. The change involves iterating through all snapshots for each ParentId instead of just selecting the most recent one.

The following code snippet shows the key change in the js_describe_db_snapshots script:

``` golang
--- a/path/to/your/policy/template.rb  # Replace with the actual path
+++ b/path/to/your/policy/template.rb  # Replace with the actual path
@@ -99,10 +99,12 @@
     })
     _.each(_.keys(sorted_by_parent), function(parent) {
       sorted_parents = _.sortBy(sorted_by_parent[parent], "startTime").reverse()
-      result.push(sorted_parents[0])
+      sorted_parents.forEach(function(snapshot) {
+        result.push(snapshot);
+      });
     })
```

### Link to Example Applied Policy

* Link SQ
  https://flexera.atlassian.net/browse/SQ-13605
* Link template:
   https://app.flexeratest.com/orgs/1105/automation/projects/60073/policy-templates/681545c3de8432f627dda48c
* Link policy applied:
  https://app.flexera.eu/orgs/34909/automation/applied-policies/projects/136739?policyId=68116186c6ad95b068404016
  
  
[Logs-Applied-policy.log](https://github.com/user-attachments/files/20018972/Logs-Applied-policy.log)

<img width="956" alt="image" src="https://github.com/user-attachments/assets/10d89496-66b3-4310-bf07-f4d9a4731c33" />


<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
