### PR TITLE
SQ-14908 Fix the error with Last 30 days parameter

### DIFF
--- a/cost/flexera/cco/scheduled_report_unallocated/CHANGELOG.md
+++ b/cost/flexera/cco/scheduled_report_unallocated/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.1
+
+- Fixed issue that would cause policy template to fail when "Last 30 Days" was selected for the "Date Range" parameter.
+
 ## v0.3.0
 
 - Fixed issue that would cause policy template to fail when "Last 7 Days" was selected for the "Date Range" parameter.

--- a/cost/flexera/cco/scheduled_report_unallocated/scheduled_report_unallocated.pt
+++ b/cost/flexera/cco/scheduled_report_unallocated/scheduled_report_unallocated.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "monthly"
 info(
-  version: "0.3.0",
+  version: "0.3.1",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -238,8 +238,8 @@ script "js_cost_request_params", type:"javascript" do
       result['granularity'] = "day"
       break
     case "Last 30 Days":
-      result['start_at'] = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30).toISOString().substring(0, 7)
-      result['end_at'] = now.toISOString().substring(0, 7)
+      result['start_at'] = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30).toISOString().substring(0, 10)
+      result['end_at'] = now.toISOString().substring(0, 10)
       result['granularity'] = "day"
       break
     case "Last 45 Days":


### PR DESCRIPTION
### Description

This change fixes the error that costs/select API returns when the parameter date range is set to 30 days.

### Issues Resolved

- https://flexera.atlassian.net/browse/SQ-14908

### Link to Example Applied Policy

Policy compiles ok https://app.flexeratest.com/orgs/1105/automation/projects/107982/policy-templates/681ceebfeaab44c2bb166f83
Customer confirmed it worked

### Contribution Check List

- [X] New functionality includes testing. Client tested at their env.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
