### PR TITLE
POL-1518 New Policy Template: Azure Reserved Instances Break Even Point Report

### DIFF
--- a/cost/azure/reserved_instances/breakeven_point/CHANGELOG.md
+++ b/cost/azure/reserved_instances/breakeven_point/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+- Initial release

--- a/cost/azure/reserved_instances/breakeven_point/README.md
+++ b/cost/azure/reserved_instances/breakeven_point/README.md
@@ -1,0 +1,4 @@
+# Azure Reserved Instances Breakeven Point Report
+
+## What It Does
+

--- a/cost/azure/reserved_instances/breakeven_point/README.md
+++ b/cost/azure/reserved_instances/breakeven_point/README.md
@@ -1,4 +1,50 @@
-# Azure Reserved Instances Breakeven Point Report
+# Azure Reserved Instances Break Even Point Report
 
 ## What It Does
 
+This policy template produces a report of all upfront Azure reservations along with their breakeven point in both hours and days. Optionally, this report can be emailed.
+
+The Commitment Break Even Point is the estimated length of time to pay off the entire cost of a commitment discount (including upfront and ongoing charges) from the savings provided by that commitment. More information is available on the [FinOps Foundation website](https://www.finops.org/assets/terminology/#:~:text=Commitment%20Break%20Even%20Point).
+
+## How It Works
+
+- Data on reservations is pulled from both Azure directly and the Flexera platform.
+- The Break Even Point in hours is calculated as follows:
+  - `Cost of RI` / (`Hourly On-Demand Rate` - (`Cost of RI` / (`Reserved Hours` * `Purchased Quantity`)))
+- The Break Even Point in months is calculated as follows:
+  - `Break Even Point (Hours)` / (365.25 / 12 * 24)
+- Reservations with no valid Break Even Point will be reported with a Break Even Point of "Never".
+
+## Input Parameters
+
+This policy has the following input parameters required when launching the policy.
+
+- *Email Addresses* - A list of email addresses to notify
+- *Azure Endpoint* - Azure Endpoint to access resources
+- *Allow/Deny Billing Centers* - Allow or Deny entered Billing Centers.
+- *Allow/Deny Billing Center List* - A list of allowed or denied Billing Center names/IDs. Leave blank to report on Reservations in all Billing Centers.
+
+## Policy Actions
+
+- Sends an email report
+
+## Prerequisites
+
+This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).
+
+- [**Azure Resource Manager Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_109256743_1124668) (*provider=azure_rm*) which has the following permissions:
+  - `Microsoft.Capacity/reservationOrders/read`
+  - `Microsoft.Capacity/reservationOrders/reservations/read`
+
+- [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
+  - `billing_center_viewer`
+
+The [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) page in the docs has detailed instructions for setting up Credentials for the most common providers.
+
+## Supported Clouds
+
+- Azure
+
+## Cost
+
+This policy template does not incur any cloud costs.

--- a/cost/azure/reserved_instances/breakeven_point/azure_reserved_instance_bepoint.pt
+++ b/cost/azure/reserved_instances/breakeven_point/azure_reserved_instance_bepoint.pt
@@ -333,61 +333,39 @@ script "js_azure_ris_with_breakeven", type: "javascript" do
   parameters "ds_azure_filtered_ris", "ds_account_list", "ds_region_table", "ds_azure_vm_pricing", "ds_applied_policy"
   result "result"
   code <<-EOS
-  function breakEvenPoint(today, ri, monthly_ondemand_price) {
-    // Determine cost difference between RI and on-demand price
-    monthly_difference = monthly_ondemand_price - ri['monthly_cost']
+  function breakEvenPoint(amount, reserved_hours, purchased_quantity, hourly_ondemand_price) {
+    // Effective hourly rate under the commitment
+    committed_rate = amount / (reserved_hours * purchased_quantity)
 
-    // Determine the term length in months and years
-    year_parse = /^P(\d+)Y$/.exec(ri['term'])
-    month_parse = /^P(\d+)M$/.exec(ri['term'])
+    // Savings per hour when you actually use the instance
+    savings_per_hour = hourly_ondemand_price - committed_rate
 
-    if (year_parse) {
-      termMonths = parseInt(year_parse[1], 10) * 12
-      termYears = parseInt(year_parse[1], 10)
-    } else if (month_parse) {
-      termMonths = parseInt(month_parse[1], 10)
-      termYears = parseInt(month_parse[1], 10) / 12
-    } else {
-      // Return null instead of calculating break even point if term cannot be parsed
-      return null
-    }
-
-    // Determine the purchase date
-    expiration_date = new Date(ri['expiration_date'])
-    expiration_year = Number(expiration.toISOString().substring(0, 4))
-    start_year = expiration_year - termYears
-    purchase_date = new Date(expiration_year + expiration_date.toISOString().substring(4, 99))
-
-    // Determine the time remaining and time used
-    hours_passed = (today - purchase_date) / 1000 / 60 / 60
-    hours_remaining = (expiration_date - today) / 1000 / 60 / 60
-
-    // Determine the monthly savings
-    monthly_savings = monthly_difference * (ri['util_avg_percentage'] / 100)
-    if (monthly_savings <= 0) { return null }
-
-    return {
-      hours: (ri['amount'] / monthlySavings) * (365.25 / 12 * 24),
-      months: ri['amount'] / monthlySavings
-    }
+    // Hours until your cumulative savings = the commitment cost
+    // Return null if there is no breakeven point
+    return savings_per_hour > 0 ? amount / savings_per_hour : null
   }
 
-  // Get today's date
-  today = new Date()
-
-  ris_with_breakeven = _.map(ds_azure_filtered_ris, function(ri) {
+  result = _.map(ds_azure_filtered_ris, function(ri) {
     new_ri = {}
     _.each(_.keys(ri), function(key) { new_ri[key] = ri[key] })
 
     region = ds_region_table[ri['region']]
     sku = ri['arm_sku_name']
-    hourly_price = ds_azure_vm_pricing[region][sku] ? ds_azure_vm_pricing[region][sku]["Linux"]["pricePerUnit"] : null
-    new_ri["monthly_ondemand_price"] = hourly_price ? hourly_price * (365.25 / 12 * 24) : null
+    hourly_ondemand_price = ds_azure_vm_pricing[region][sku] ? ds_azure_vm_pricing[region][sku]["Linux"]["pricePerUnit"] : null
 
-    if (new_ri["monthly_ondemand_price"]) {
-      breakeven = breakEvenPoint(today, ri, new_ri["monthly_ondemand_price"]) ? breakEvenPoint(today, ri, new_ri["monthly_ondemand_price"]) : null
-      new_ri["breakeven_hours"] = breakeven ? breakeven["hours"] : "Never"
-      new_ri["breakeven_months"] = breakeven ? breakeven["months"] : "Never"
+    if (hourly_ondemand_price) {
+      new_ri["hourly_ondemand_price"] = hourly_ondemand_price
+      new_ri["monthly_ondemand_price"] = hourly_ondemand_price * (365.25 / 12 * 24)
+
+      breakeven = breakEvenPoint(ri["amount"], ri["util_reserved_hours"], ri["purchased_quantity"], hourly_ondemand_price)
+
+      new_ri["breakeven_hours"] = breakeven ? Math.round(breakeven * 100) / 100 : "Never"
+      new_ri["breakeven_months"] = breakeven ? Math.round(breakeven / (365.25 / 12 * 24) * 100) / 100 : "Never"
+    } else {
+      new_ri["hourly_ondemand_price"] = "Not Found"
+      new_ri["monthly_ondemand_price"] = "Not Found"
+      new_ri["breakeven_hours"] = "Unknown"
+      new_ri["breakeven_months"] = "Unknown"
     }
 
     new_ri["resourceID"] = ri["util_reservation_id"]
@@ -395,13 +373,11 @@ script "js_azure_ris_with_breakeven", type: "javascript" do
     new_ri["accountName"] = ri["purchasing_subscription_name"]
     new_ri["billing_centers"] = ds_account_list[new_ri["accountID"]] ? ds_account_list[new_ri["accountID"]].join(', ') : null
     new_ri["instanceType"] = ri["util_sku_name"]
-    new_ri["instanceCount"] = Math.round(ri["amount"])
+    new_ri["total_reserved_hours"] = new_ri["util_reserved_hours"] * ri["purchased_quantity"]
     new_ri["policy_name"] = ds_applied_policy["name"]
 
     return new_ri
   })
-
-  result = _.filter(ris_with_vm_pricing, function(ri) { return ri["monthly_ondemand_price"] })
 EOS
 end
 
@@ -437,11 +413,35 @@ policy "pol_azure_ris_with_breakeven" do
       field "instanceType" do
         label "Instance Type"
       end
-      field "instanceCount" do
-        label "Instance Count"
+      field "purchased_quantity" do
+        label "Purchased Quantity"
+      end
+      field "util_reserved_hours" do
+        label "Reserved Hours per Commitment"
+      end
+      field "total_reserved_hours" do
+        label "Total Reserved Hours"
       end
       field "expiration_date" do
         label "Expiration Date"
+      end
+      field "currency" do
+        label "Currency"
+      end
+      field "amount" do
+        label "Purchase Cost"
+      end
+      field "hourly_ondemand_price" do
+        label "On-Demand Price (Hourly)"
+      end
+      field "monthly_ondemand_price" do
+        label "On-Demand Price (Monthly)"
+      end
+      field "breakeven_hours" do
+        label "Breakeven Point (Hours)"
+      end
+      field "breakeven_months" do
+        label "Breakeven Point (Months)"
       end
       field "id" do
         label "ID"

--- a/cost/azure/reserved_instances/breakeven_point/azure_reserved_instance_bepoint.pt
+++ b/cost/azure/reserved_instances/breakeven_point/azure_reserved_instance_bepoint.pt
@@ -26,6 +26,15 @@ parameter "param_email" do
   default []
 end
 
+parameter "param_azure_endpoint" do
+  type "string"
+  category "Policy Settings"
+  label "Azure Endpoint"
+  description "Select the API endpoint to use for Azure. Use default value of management.azure.com unless using Azure China."
+  allowed_values "management.azure.com", "management.chinacloudapi.cn"
+  default "management.azure.com"
+end
+
 parameter "param_bc_allow_or_deny" do
   type "string"
   category "Filters"
@@ -52,6 +61,26 @@ credentials "auth_flexera" do
   label "Flexera"
   description "Select Flexera One OAuth2 credentials"
   tags "provider=flexera"
+end
+
+credentials "auth_azure" do
+  schemes "oauth2"
+  label "Azure"
+  description "Select the Azure Resource Manager Credential from the list."
+  tags "provider=azure_rm"
+end
+
+###############################################################################
+# Pagination
+###############################################################################
+
+pagination "pagination_azure" do
+  get_page_marker do
+    body_path "nextLink"
+  end
+  set_page_marker do
+    uri true
+  end
 end
 
 ###############################################################################
@@ -264,6 +293,64 @@ script "js_account_list", type: "javascript" do
 EOS
 end
 
+datasource "ds_azure_ri_orders" do
+  request do
+    auth $auth_azure
+    pagination $pagination_azure
+    host $param_azure_endpoint
+    path "/providers/Microsoft.Capacity/reservationOrders"
+    query "api-version", "2022-11-01"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "value[*]") do
+      field "id", jmes_path(col_item, "id")
+      field "name", jmes_path(col_item, "name")
+    end
+  end
+end
+
+datasource "ds_azure_ris_from_azure" do
+  iterate $ds_azure_ri_orders
+  request do
+    auth $auth_azure
+    pagination $pagination_azure
+    host $param_azure_endpoint
+    path join([val(iter_item, "id"), "/reservations"])
+    query "api-version", "2022-11-01"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "value[*]") do
+      field "id", jmes_path(col_item, "id")
+      field "name", jmes_path(col_item, "name")
+      field "region", jmes_path(col_item, "location")
+      field "sku", jmes_path(col_item, "sku.name")
+      field "order_id", val(iter_item, "name")
+    end
+  end
+end
+
+datasource "ds_azure_ri_order_table" do
+  run_script $js_azure_ri_order_table, $ds_azure_ris_from_azure
+end
+
+script "js_azure_ri_order_table", type: "javascript" do
+  parameters "ds_azure_ris_from_azure"
+  result "result"
+  code <<-EOS
+  result = {}
+  ris_by_order = _.groupBy(ds_azure_ris_from_azure, "order_id")
+
+  _.each(_.keys(ris_by_order), function(order_id) {
+    result[order_id] = {
+      region: ris_by_order[order_id][0]["region"],
+      sku: ris_by_order[order_id][0]["sku"]
+    }
+  })
+EOS
+end
+
 datasource "ds_azure_ris_from_flexera" do
   request do
     auth $auth_flexera
@@ -326,11 +413,11 @@ EOS
 end
 
 datasource "ds_azure_ris_with_breakeven" do
-  run_script $js_azure_ris_with_breakeven, $ds_azure_filtered_ris, $ds_account_list, $ds_region_table, $ds_azure_vm_pricing, $ds_applied_policy
+  run_script $js_azure_ris_with_breakeven, $ds_azure_filtered_ris, $ds_azure_ri_order_table, $ds_account_list, $ds_region_table, $ds_azure_vm_pricing, $ds_applied_policy
 end
 
 script "js_azure_ris_with_breakeven", type: "javascript" do
-  parameters "ds_azure_filtered_ris", "ds_account_list", "ds_region_table", "ds_azure_vm_pricing", "ds_applied_policy"
+  parameters "ds_azure_filtered_ris", "ds_azure_ri_order_table", "ds_account_list", "ds_region_table", "ds_azure_vm_pricing", "ds_applied_policy"
   result "result"
   code <<-EOS
   function breakEvenPoint(amount, reserved_hours, purchased_quantity, hourly_ondemand_price) {
@@ -349,9 +436,16 @@ script "js_azure_ris_with_breakeven", type: "javascript" do
     new_ri = {}
     _.each(_.keys(ri), function(key) { new_ri[key] = ri[key] })
 
-    region = ri['region'] != "" && ds_region_table[ri['region']] ? ds_region_table[ri['region']] : "US East"
-    sku = ri['util_sku_name']
-    os = sku && sku.toLowerCase().indexOf("windows") != -1 ? "Windows" : "Linux"
+    if (ds_azure_ri_order_table[ri['reservation_order_id']]) {
+      new_ri["region"] = ds_azure_ri_order_table[ri['reservation_order_id']]["region"]
+      new_ri["instanceType"] = ds_azure_ri_order_table[ri['reservation_order_id']]["sku"]
+    } else {
+      new_ri["instanceType"] = ri["util_sku_name"]
+    }
+
+    region = new_ri['region'] != "" && ds_region_table[new_ri['region']] ? ds_region_table[new_ri['region']] : "US East"
+    sku = new_ri["instanceType"]
+    os = ri['arm_sku_name'] && ri['arm_sku_name'].toLowerCase().indexOf("windows") != -1 ? "Windows" : "Linux"
     hourly_ondemand_price = null
 
     if (ds_azure_vm_pricing[region] && ds_azure_vm_pricing[region][sku] && ds_azure_vm_pricing[region][sku][os]) {
@@ -377,7 +471,7 @@ script "js_azure_ris_with_breakeven", type: "javascript" do
     new_ri["accountID"] = ri["purchasing_subscription_guid"]
     new_ri["accountName"] = ri["purchasing_subscription_name"]
     new_ri["billing_centers"] = ds_account_list[new_ri["accountID"]] ? ds_account_list[new_ri["accountID"]].join(', ') : null
-    new_ri["instanceType"] = ri["util_sku_name"]
+    new_ri["os"] = os
     new_ri["total_reserved_hours"] = new_ri["util_reserved_hours"] * ri["purchased_quantity"]
     new_ri["policy_name"] = ds_applied_policy["name"]
 
@@ -406,6 +500,9 @@ policy "pol_azure_ris_with_breakeven" do
       field "billing_centers" do
         label "Associated Billing Center(s)"
       end
+      field "region" do
+        label "Region"
+      end
       field "term" do
         label "Term"
       end
@@ -414,6 +511,9 @@ policy "pol_azure_ris_with_breakeven" do
       end
       field "instanceType" do
         label "Instance Type"
+      end
+      field "os" do
+        label "Operating System"
       end
       field "purchased_quantity" do
         label "Purchased Quantity"

--- a/cost/azure/reserved_instances/breakeven_point/azure_reserved_instance_bepoint.pt
+++ b/cost/azure/reserved_instances/breakeven_point/azure_reserved_instance_bepoint.pt
@@ -1,7 +1,7 @@
-name "Azure Reserved Instances Breakeven Point Report"
+name "Azure Reserved Instances Break Even Point Report"
 rs_pt_ver 20180301
 type "policy"
-short_description "Reports the Breakeven Point on purchased upfront Azure Reserved Instances. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/reserved_instances/breakeven_point) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "Reports the Break Even Point on purchased upfront Azure Reserved Instances. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/reserved_instances/breakeven_point) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 category "Cost"
 severity "low"
@@ -443,7 +443,7 @@ script "js_azure_ris_with_breakeven", type: "javascript" do
       new_ri["instanceType"] = ri["util_sku_name"]
     }
 
-    region = new_ri['region'] != "" && ds_region_table[new_ri['region']] ? ds_region_table[new_ri['region']] : "US East"
+    region = new_ri["region"] != "" && ds_region_table[new_ri["region"]] ? ds_region_table[new_ri["region"]] : new_ri["region"]
     sku = new_ri["instanceType"]
     os = ri['arm_sku_name'] && ri['arm_sku_name'].toLowerCase().indexOf("windows") != -1 ? "Windows" : "Linux"
     hourly_ondemand_price = null
@@ -540,10 +540,10 @@ policy "pol_azure_ris_with_breakeven" do
         label "On-Demand Price (Monthly)"
       end
       field "breakeven_hours" do
-        label "Breakeven Point (Hours)"
+        label "Break Even Point (Hours)"
       end
       field "breakeven_months" do
-        label "Breakeven Point (Months)"
+        label "Break Even Point (Months)"
       end
       field "id" do
         label "ID"

--- a/cost/azure/reserved_instances/breakeven_point/azure_reserved_instance_bepoint.pt
+++ b/cost/azure/reserved_instances/breakeven_point/azure_reserved_instance_bepoint.pt
@@ -1,0 +1,340 @@
+name "Azure Reserved Instances Breakeven Point Report"
+rs_pt_ver 20180301
+type "policy"
+short_description "Reports the Breakeven Point on purchased Azure Reserved Instances. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/reserved_instances/breakeven_point) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+long_description ""
+category "Cost"
+severity "low"
+default_frequency "weekly"
+info(
+  version: "0.1.0",
+  provider: "Azure",
+  service: "Compute",
+  policy_set: "Reserved Instances",
+  hide_skip_approvals: "true"
+)
+
+###############################################################################
+# Parameters
+###############################################################################
+
+parameter "param_email" do
+  type "list"
+  category "Policy Settings"
+  label "Email Addresses"
+  description "Email addresses of the recipients you wish to notify when new incidents are created."
+  default []
+end
+
+parameter "param_bc_allow_or_deny" do
+  type "string"
+  category "Filters"
+  label "Allow/Deny Billing Centers"
+  description "Allow or Deny entered Billing Centers."
+  allowed_values "Allow", "Deny"
+  default "Allow"
+end
+
+parameter "param_billing_centers" do
+  type "list"
+  category "Filters"
+  label "Allow/Deny Billing Center List"
+  description "A list of allowed or denied Billing Center names/IDs. Leave blank to report on Reservations in all Billing Centers."
+  default []
+end
+
+###############################################################################
+# Authentication
+###############################################################################
+
+credentials "auth_flexera" do
+  schemes "oauth2"
+  label "Flexera"
+  description "Select Flexera One OAuth2 credentials"
+  tags "provider=flexera"
+end
+
+###############################################################################
+# Datasources & Scripts
+###############################################################################
+
+# Get applied policy metadata for use later
+datasource "ds_applied_policy" do
+  request do
+    auth $auth_flexera
+    host rs_governance_host
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    header "Api-Version", "1.0"
+  end
+end
+
+datasource "ds_region_table" do
+  run_script $js_region_table
+end
+
+script "js_region_table", type:"javascript" do
+  result "result"
+  code <<-EOS
+  result = {
+    "ukwest": "UK West",
+    "usgovvirginia": "US Gov Virginia",
+    "eastus2": "US East 2",
+    "uaenorth": "AE North",
+    "southafricawest": "ZA West",
+    "francesouth": "FR South",
+    "westcentralus": "US West Central",
+    "koreacentral": "KR Central",
+    "westeurope": "EU West",
+    "southafricanorth": "ZA North",
+    "southeastasia": "AP Southeast",
+    "centralindia": "IN Central",
+    "switzerlandwest": "CH West",
+    "norwayeast": "NO East",
+    "germanywestcentral": "DE West Central",
+    "westus2": "US West 2",
+    "australiacentral": "AU Central",
+    "italynorth": "IT North",
+    "centralus": "US Central",
+    "germanynorth": "DE North",
+    "brazilsoutheast": "BR Southeast",
+    "southindia": "IN South",
+    "swedencentral": "SE Central",
+    "francecentral": "FR Central",
+    "australiasoutheast": "AU Southeast",
+    "northeurope": "EU North",
+    "koreasouth": "KR South",
+    "usgovtexas": "US Gov TX",
+    "polandcentral": "PL Central",
+    "japaneast": "JA East",
+    "westindia": "IN West",
+    "japanwest": "JA West",
+    "westus": "US West",
+    "jioindiawest": "IN West Jio",
+    "northcentralus": "US North Central",
+    "southcentralus": "US South Central",
+    "eastasia": "AP East",
+    "jioindiacentral": "IN Central Jio",
+    "australiacentral2": "AU Central 2",
+    "canadaeast": "CA East",
+    "eastus": "US East",
+    "uaecentral": "AE Central",
+    "norwaywest": "NO West",
+    "canadacentral": "CA Central",
+    "uksouth": "UK South",
+    "qatarcentral": "QA Central",
+    "swedensouth": "SE South",
+    "brazilsouth": "BR South",
+    "australiaeast": "AU East",
+    "switzerlandnorth": "CH North",
+    "usgovarizona": "US Gov AZ",
+    "westus3": "US West 3"
+  }
+EOS
+end
+
+datasource "ds_azure_vm_pricing" do
+  request do
+    host "raw.githubusercontent.com"
+    path "/flexera-public/policy_templates/master/data/azure/azure_vm_pricing.json"
+    header "User-Agent", "RS Policies"
+  end
+end
+
+datasource "ds_billing_centers" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/analytics/orgs/", rs_org_id, "/billing_centers"])
+    header "Api-Version", "1.0"
+    header "User-Agent", "RS Policies"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "href", jmes_path(col_item, "href")
+      field "id", jmes_path(col_item, "id")
+      field "name", jmes_path(col_item, "name")
+      field "parent_id", jmes_path(col_item, "parent_id")
+    end
+  end
+end
+
+datasource "ds_billing_centers_filtered" do
+  run_script $js_billing_centers_filtered, $ds_billing_centers, $param_bc_allow_or_deny, $param_billing_centers
+end
+
+script "js_billing_centers_filtered", type: "javascript" do
+  parameters "ds_billing_centers", "param_bc_allow_or_deny", "param_billing_centers"
+  result "result"
+  code <<-EOS
+  allow_deny_test = { "Allow": true, "Deny": false }
+
+  if (param_billing_centers.length > 0) {
+    billing_centers = _.filter(ds_billing_centers, function(item) {
+      id_found = _.contains(param_billing_centers, item['id']) == allow_deny_test[param_bc_allow_or_deny]
+      name_found = _.contains(param_billing_centers, item['name']) == allow_deny_test[param_bc_allow_or_deny]
+      return id_found || name_found
+    })
+
+    // Check for conflicting parents/children and remove children if present
+    bc_ids = _.compact(_.pluck(billing_centers, 'id'))
+    bad_children = _.filter(ds_billing_centers, function(bc) { return _.contains(bc_ids, bc['parent_id']) })
+    bad_children_ids = _.pluck(bad_children, 'id')
+
+    // Create final result with the bad children removed
+    final_list = _.reject(billing_centers, function(bc) { return _.contains(bad_children_ids, bc['id']) })
+  } else {
+    // If we're not filtering at all, just grab all of the top level billing centers
+    final_list = _.filter(ds_billing_centers, function(bc) {
+      return bc['parent_id'] == null || bc['parent_id'] == undefined
+    })
+  }
+
+  result = _.compact(_.pluck(final_list, 'id'))
+EOS
+end
+
+datasource "ds_accounts_by_billing_center" do
+  request do
+    run_script $js_accounts_by_billing_center, $ds_billing_centers_filtered, rs_org_id, rs_optima_host
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "rows[*]") do
+      field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
+      field "billing_center_id", jmes_path(col_item, "dimensions.billing_center_id")
+      field "vendor_account_id", jmes_path(col_item, "dimensions.vendor_account")
+      field "vendor_account_name", jmes_path(col_item, "dimensions.vendor_account_name")
+      field "timestamp", jmes_path(col_item, "timestamp")
+    end
+  end
+end
+
+script "js_accounts_by_billing_center", type: "javascript" do
+  parameters "ds_billing_centers_filtered", "rs_org_id", "rs_optima_host"
+  result "request"
+  code <<-EOS
+  start_date = new Date().toISOString()
+  start_date = start_date.split('-')[0] + '-' + start_date.split('-')[1]
+
+  end_year = Number(start_date.split('-')[0])
+  end_month = Number(start_date.split('-')[1]) + 1
+  if (end_month == 13) { end_month = 1; end_year++ }
+  if (end_month < 10) { end_month = '0' + end_month.toString() }
+  end_date = end_year.toString() + '-' + end_month.toString()
+
+  var request = {
+    auth: "auth_flexera",
+    verb: "POST",
+    host: rs_optima_host,
+    path: "/bill-analysis/orgs/" + rs_org_id + "/costs/aggregated",
+    body_fields: {
+      "dimensions": [ "billing_center_id", "vendor_account", "vendor_account_name" ],
+      "granularity": "month",
+      "metrics": [ "cost_amortized_unblended_adj" ],
+      "billing_center_ids": ds_billing_centers_filtered,
+      "start_at": start_date,
+      "end_at": end_date
+    }
+  }
+EOS
+end
+
+datasource "ds_azure_ris" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/reserved_instances/orgs/", rs_org_id, "/clouds/azure"])
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "id", jmes_path(col_item, "id")
+      field "account_name", jmes_path(col_item, "account_name")
+      field "amount", jmes_path(col_item, "amount")
+      field "arm_sku_name", jmes_path(col_item, "arm_sku_name")
+      field "billing_frequency", jmes_path(col_item, "billing_frequency")
+      field "cost_center", jmes_path(col_item, "cost_center")
+      field "currency", jmes_path(col_item, "currency")
+      field "current_enrollment", jmes_path(col_item, "current_enrollment")
+      field "department_name", jmes_path(col_item, "department_name")
+      field "description", jmes_path(col_item, "description")
+      field "event_date", jmes_path(col_item, "event_date")
+      field "event_type", jmes_path(col_item, "event_type")
+      field "expiration_date", jmes_path(col_item, "expiration_date")
+      field "monthly_cost", jmes_path(col_item, "monthly_cost")
+      field "purchased_quantity", jmes_path(col_item, "purchased_quantity")
+      field "purchasing_enrollment", jmes_path(col_item, "purchasing_enrollment")
+      field "purchasing_subscription_guid", jmes_path(col_item, "purchasing_subscription_guid")
+      field "purchasing_subscription_name", jmes_path(col_item, "purchasing_subscription_name")
+      field "quantity", jmes_path(col_item, "quantity")
+      field "region", jmes_path(col_item, "region")
+      field "remaining_quantity", jmes_path(col_item, "remaining_quantity")
+      field "reservation_order_id", jmes_path(col_item, "reservation_order_id")
+      field "reservation_order_name", jmes_path(col_item, "reservation_order_name")
+      field "term", jmes_path(col_item, "term")
+      field "util_avg_percentage", jmes_path(col_item, "utilization.avg_utilization_percentage")
+      field "util_max_percentage", jmes_path(col_item, "utilization.max_utilization_percentage")
+      field "util_min_percentage", jmes_path(col_item, "utilization.min_utilization_percentage")
+      field "util_reservation_id", jmes_path(col_item, "utilization.reservation_id")
+      field "util_reserved_hours", jmes_path(col_item, "utilization.reserved_hours")
+      field "util_sku_name", jmes_path(col_item, "utilization.sku_name")
+      field "util_usage_date", jmes_path(col_item, "utilization.usage_date")
+      field "util_used_hours", jmes_path(col_item, "utilization.used_hours")
+    end
+  end
+end
+
+datasource "ds_azure_filtered_ris" do
+  run_script $js_azure_filtered_ris, $ds_accounts_by_billing_center, $ds_azure_ris
+end
+
+script "js_azure_filtered_ris", type: "javascript" do
+  parameters "ds_accounts_by_billing_center", "ds_azure_ris"
+  result "result"
+  code <<-EOS
+  bc_account_ids = _.uniq(_.pluck(ds_accounts_by_billing_center, "vendor_account_id"))
+
+  result = _.filter(ds_azure_ris, function(ri) {
+    return _.contains(bc_account_ids, ri['purchasing_subscription_guid'])
+  })
+EOS
+end
+
+datasource "ds_azure_ris_with_breakeven" do
+  run_script $js_azure_ris_with_breakeven, $ds_azure_filtered_ris, $ds_region_table, $ds_azure_vm_pricing
+end
+
+script "js_azure_ris_with_breakeven", type: "javascript" do
+  parameters "ds_azure_filtered_ris", "ds_region_table", "ds_azure_vm_pricing"
+  result "result"
+  code <<-EOS
+  function calculateBreakEven(reservation, onDemandPricePerHour) {
+    commitmentCost = reservation['amount']
+    utilization = reservation['util_avg_percentage'] / 100
+    termYears = reservation['term'] == "P1Y" ? 1 : 3
+    p_ci_hour = commitmentCost / (termYears * 365 * 24)
+    perHourSavings = (onDemandPricePerHour - p_ci_hour) * utilization
+    return perHourSavings > 0 ? commitmentCost / perHourSavings : null
+  }
+
+  ris_with_breakeven = _.map(ds_azure_filtered_ris, function(ri) {
+    new_ri = {}
+    _.each(_.keys(ri), function(key) { new_ri[key] = ri[key] })
+
+    region = ds_region_table[ri['region']]
+    sku = ri['arm_sku_name']
+    hourly_price = ds_azure_vm_pricing[region][sku] ? ds_azure_vm_pricing[region][sku]["Linux"]["pricePerUnit"] : null
+    new_ri["vm_monthly_list_price"] = hourly_price ? hourly_price * (365.25 / 12 * 24) : null
+
+    total_months = ri['term'] == "P1Y" ? 12 : 36
+    yearly_ri_cost = ri['monthly_cost'] * total_months
+    yearly_vm_cost = new_ri["vm_monthly_list_price"] * total_months
+    percentage_breakeven = yearly_ri_cost / yearly_vm_cost
+  })
+
+  result = _.filter(ris_with_vm_pricing, function(ri) {
+    return ri['vm_monthly_list_price'] && ri['monthly_cost']
+  })
+EOS
+end

--- a/cost/azure/reserved_instances/breakeven_point/azure_reserved_instance_bepoint.pt
+++ b/cost/azure/reserved_instances/breakeven_point/azure_reserved_instance_bepoint.pt
@@ -1,7 +1,7 @@
 name "Azure Reserved Instances Breakeven Point Report"
 rs_pt_ver 20180301
 type "policy"
-short_description "Reports the Breakeven Point on purchased Azure Reserved Instances. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/reserved_instances/breakeven_point) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "Reports the Breakeven Point on purchased upfront Azure Reserved Instances. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/reserved_instances/breakeven_point) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 category "Cost"
 severity "low"
@@ -240,6 +240,30 @@ script "js_accounts_by_billing_center", type: "javascript" do
 EOS
 end
 
+datasource "ds_account_list" do
+  run_script $js_account_list, $ds_accounts_by_billing_center, $ds_billing_centers
+end
+
+script "js_account_list", type: "javascript" do
+  parameters "ds_accounts_by_billing_center", "ds_billing_centers"
+  result "result"
+  code <<-EOS
+  bc_object = {}
+
+  _.each(ds_billing_centers, function(bc) { bc_object[bc['id']] = bc['name'] })
+
+  result = {}
+
+  _.each(ds_accounts_by_billing_center, function(account) {
+    if (result[account['vendor_account_id']] == undefined) {
+      result[account['vendor_account_id']] = []
+    }
+
+    result[account['vendor_account_id']].push(bc_object[account['billing_center_id']])
+  })
+EOS
+end
+
 datasource "ds_azure_ris" do
   request do
     auth $auth_flexera
@@ -296,27 +320,60 @@ script "js_azure_filtered_ris", type: "javascript" do
   bc_account_ids = _.uniq(_.pluck(ds_accounts_by_billing_center, "vendor_account_id"))
 
   result = _.filter(ds_azure_ris, function(ri) {
-    return _.contains(bc_account_ids, ri['purchasing_subscription_guid'])
+    return _.contains(bc_account_ids, ri['purchasing_subscription_guid']) && ri["billing_frequency"] == "Upfront"
   })
 EOS
 end
 
 datasource "ds_azure_ris_with_breakeven" do
-  run_script $js_azure_ris_with_breakeven, $ds_azure_filtered_ris, $ds_region_table, $ds_azure_vm_pricing
+  run_script $js_azure_ris_with_breakeven, $ds_azure_filtered_ris, $ds_account_list, $ds_region_table, $ds_azure_vm_pricing, $ds_applied_policy
 end
 
 script "js_azure_ris_with_breakeven", type: "javascript" do
-  parameters "ds_azure_filtered_ris", "ds_region_table", "ds_azure_vm_pricing"
+  parameters "ds_azure_filtered_ris", "ds_account_list", "ds_region_table", "ds_azure_vm_pricing", "ds_applied_policy"
   result "result"
   code <<-EOS
-  function calculateBreakEven(reservation, onDemandPricePerHour) {
-    commitmentCost = reservation['amount']
-    utilization = reservation['util_avg_percentage'] / 100
-    termYears = reservation['term'] == "P1Y" ? 1 : 3
-    p_ci_hour = commitmentCost / (termYears * 365 * 24)
-    perHourSavings = (onDemandPricePerHour - p_ci_hour) * utilization
-    return perHourSavings > 0 ? commitmentCost / perHourSavings : null
+  function breakEvenPoint(today, ri, monthly_ondemand_price) {
+    // Determine cost difference between RI and on-demand price
+    monthly_difference = monthly_ondemand_price - ri['monthly_cost']
+
+    // Determine the term length in months and years
+    year_parse = /^P(\d+)Y$/.exec(ri['term'])
+    month_parse = /^P(\d+)M$/.exec(ri['term'])
+
+    if (year_parse) {
+      termMonths = parseInt(year_parse[1], 10) * 12
+      termYears = parseInt(year_parse[1], 10)
+    } else if (month_parse) {
+      termMonths = parseInt(month_parse[1], 10)
+      termYears = parseInt(month_parse[1], 10) / 12
+    } else {
+      // Return null instead of calculating break even point if term cannot be parsed
+      return null
+    }
+
+    // Determine the purchase date
+    expiration_date = new Date(ri['expiration_date'])
+    expiration_year = Number(expiration.toISOString().substring(0, 4))
+    start_year = expiration_year - termYears
+    purchase_date = new Date(expiration_year + expiration_date.toISOString().substring(4, 99))
+
+    // Determine the time remaining and time used
+    hours_passed = (today - purchase_date) / 1000 / 60 / 60
+    hours_remaining = (expiration_date - today) / 1000 / 60 / 60
+
+    // Determine the monthly savings
+    monthly_savings = monthly_difference * (ri['util_avg_percentage'] / 100)
+    if (monthly_savings <= 0) { return null }
+
+    return {
+      hours: (ri['amount'] / monthlySavings) * (365.25 / 12 * 24),
+      months: ri['amount'] / monthlySavings
+    }
   }
+
+  // Get today's date
+  today = new Date()
 
   ris_with_breakeven = _.map(ds_azure_filtered_ris, function(ri) {
     new_ri = {}
@@ -325,16 +382,82 @@ script "js_azure_ris_with_breakeven", type: "javascript" do
     region = ds_region_table[ri['region']]
     sku = ri['arm_sku_name']
     hourly_price = ds_azure_vm_pricing[region][sku] ? ds_azure_vm_pricing[region][sku]["Linux"]["pricePerUnit"] : null
-    new_ri["vm_monthly_list_price"] = hourly_price ? hourly_price * (365.25 / 12 * 24) : null
+    new_ri["monthly_ondemand_price"] = hourly_price ? hourly_price * (365.25 / 12 * 24) : null
 
-    total_months = ri['term'] == "P1Y" ? 12 : 36
-    yearly_ri_cost = ri['monthly_cost'] * total_months
-    yearly_vm_cost = new_ri["vm_monthly_list_price"] * total_months
-    percentage_breakeven = yearly_ri_cost / yearly_vm_cost
+    if (new_ri["monthly_ondemand_price"]) {
+      breakeven = breakEvenPoint(today, ri, new_ri["monthly_ondemand_price"]) ? breakEvenPoint(today, ri, new_ri["monthly_ondemand_price"]) : null
+      new_ri["breakeven_hours"] = breakeven ? breakeven["hours"] : "Never"
+      new_ri["breakeven_months"] = breakeven ? breakeven["months"] : "Never"
+    }
+
+    new_ri["resourceID"] = ri["util_reservation_id"]
+    new_ri["accountID"] = ri["purchasing_subscription_guid"]
+    new_ri["accountName"] = ri["purchasing_subscription_name"]
+    new_ri["billing_centers"] = ds_account_list[new_ri["accountID"]] ? ds_account_list[new_ri["accountID"]].join(', ') : null
+    new_ri["instanceType"] = ri["util_sku_name"]
+    new_ri["instanceCount"] = Math.round(ri["amount"])
+    new_ri["policy_name"] = ds_applied_policy["name"]
+
+    return new_ri
   })
 
-  result = _.filter(ris_with_vm_pricing, function(ri) {
-    return ri['vm_monthly_list_price'] && ri['monthly_cost']
-  })
+  result = _.filter(ris_with_vm_pricing, function(ri) { return ri["monthly_ondemand_price"] })
 EOS
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "pol_azure_ris_with_breakeven" do
+  validate_each $ds_azure_ris_with_breakeven do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Azure Upfront Reservations Found"
+    check eq(val(item, "resourceID"), "")
+    escalate $esc_email
+    export do
+      resource_level true
+      field "accountID" do
+        label "Subscription ID"
+      end
+      field "accountName" do
+        label "Subscription Name"
+      end
+      field "billing_centers" do
+        label "Associated Billing Center(s)"
+      end
+      field "region" do
+        label "Region"
+      end
+      field "term" do
+        label "Term"
+      end
+      field "resourceID" do
+        label "Lease ID"
+      end
+      field "instanceType" do
+        label "Instance Type"
+      end
+      field "instanceCount" do
+        label "Instance Count"
+      end
+      field "expiration_date" do
+        label "Expiration Date"
+      end
+      field "id" do
+        label "ID"
+        path "resourceID"
+      end
+    end
+  end
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
 end

--- a/cost/azure/reserved_instances/breakeven_point/azure_reserved_instance_bepoint.pt
+++ b/cost/azure/reserved_instances/breakeven_point/azure_reserved_instance_bepoint.pt
@@ -264,7 +264,7 @@ script "js_account_list", type: "javascript" do
 EOS
 end
 
-datasource "ds_azure_ris" do
+datasource "ds_azure_ris_from_flexera" do
   request do
     auth $auth_flexera
     host rs_optima_host
@@ -310,16 +310,16 @@ datasource "ds_azure_ris" do
 end
 
 datasource "ds_azure_filtered_ris" do
-  run_script $js_azure_filtered_ris, $ds_accounts_by_billing_center, $ds_azure_ris
+  run_script $js_azure_filtered_ris, $ds_accounts_by_billing_center, $ds_azure_ris_from_flexera
 end
 
 script "js_azure_filtered_ris", type: "javascript" do
-  parameters "ds_accounts_by_billing_center", "ds_azure_ris"
+  parameters "ds_accounts_by_billing_center", "ds_azure_ris_from_flexera"
   result "result"
   code <<-EOS
   bc_account_ids = _.uniq(_.pluck(ds_accounts_by_billing_center, "vendor_account_id"))
 
-  result = _.filter(ds_azure_ris, function(ri) {
+  result = _.filter(ds_azure_ris_from_flexera, function(ri) {
     return _.contains(bc_account_ids, ri['purchasing_subscription_guid']) && ri["billing_frequency"] == "Upfront"
   })
 EOS
@@ -349,9 +349,14 @@ script "js_azure_ris_with_breakeven", type: "javascript" do
     new_ri = {}
     _.each(_.keys(ri), function(key) { new_ri[key] = ri[key] })
 
-    region = ds_region_table[ri['region']]
-    sku = ri['arm_sku_name']
-    hourly_ondemand_price = ds_azure_vm_pricing[region][sku] ? ds_azure_vm_pricing[region][sku]["Linux"]["pricePerUnit"] : null
+    region = ri['region'] != "" && ds_region_table[ri['region']] ? ds_region_table[ri['region']] : "US East"
+    sku = ri['util_sku_name']
+    os = sku && sku.toLowerCase().indexOf("windows") != -1 ? "Windows" : "Linux"
+    hourly_ondemand_price = null
+
+    if (ds_azure_vm_pricing[region] && ds_azure_vm_pricing[region][sku] && ds_azure_vm_pricing[region][sku][os]) {
+      hourly_ondemand_price = ds_azure_vm_pricing[region][sku][os]["pricePerUnit"]
+    }
 
     if (hourly_ondemand_price) {
       new_ri["hourly_ondemand_price"] = hourly_ondemand_price
@@ -400,9 +405,6 @@ policy "pol_azure_ris_with_breakeven" do
       end
       field "billing_centers" do
         label "Associated Billing Center(s)"
-      end
-      field "region" do
-        label "Region"
       end
       field "term" do
         label "Term"

--- a/tools/policy_master_permission_generation/validated_policy_templates.yaml
+++ b/tools/policy_master_permission_generation/validated_policy_templates.yaml
@@ -130,6 +130,7 @@ validated_policy_templates:
 -  "./cost/azure/idle_compute_instances/azure_idle_compute_instances.pt"
 -  "./cost/azure/long_stopped_instances/long_stopped_instances_azure.pt"
 -  "./cost/azure/old_snapshots/azure_delete_old_snapshots.pt"
+-  "./cost/azure/reserved_instances/breakeven_point/azure_reserved_instance_bepoint.pt"
 -  "./cost/azure/reserved_instances/expiration/azure_reserved_instance_expiration.pt"
 -  "./cost/azure/reserved_instances/recommendations/azure_reserved_instance_recommendations.pt"
 -  "./cost/azure/reserved_instances/utilization/azure_reserved_instance_utilization.pt"


### PR DESCRIPTION
### Description

This new policy template produces a report of all upfront Azure reservations along with their breakeven point in both hours and days. Optionally, this report can be emailed.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
