### PR TITLE
POL-1524 Currency Conversion Fix

### DIFF
--- a/cost/flexera/cco/currency_conversion/CHANGELOG.md
+++ b/cost/flexera/cco/currency_conversion/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.0.2
+
+- Fixed issue where policy template execution would fail if the user builds off of the currency conversion adjustment created by this policy template.
+
 ## v5.0.1
 
 - Added `hide_skip_approvals` field to the info section. It dynamically controls "Skip Action Approvals" visibility.

--- a/cost/flexera/cco/currency_conversion/currency_conversion.pt
+++ b/cost/flexera/cco/currency_conversion/currency_conversion.pt
@@ -413,6 +413,7 @@ script "js_updated_adjustments", type: "javascript" do
         return list['name'] != new_adj_name || adj_name == undefined
       })
 
+      // Make sure Currency Conversion rule is first in case user built off of it
       adjustment_list = adjustment_list.concat(existing_adj)
     }
 

--- a/cost/flexera/cco/currency_conversion/currency_conversion.pt
+++ b/cost/flexera/cco/currency_conversion/currency_conversion.pt
@@ -7,7 +7,7 @@ severity "low"
 default_frequency "monthly"
 category "Cost"
 info(
-  version: "5.0.1",
+  version: "5.0.2",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -405,17 +405,15 @@ script "js_updated_adjustments", type: "javascript" do
 
     if (existing_list != undefined) {
       // Check if a Currency Conversion adjustment rule already exists for current month
-      adj_name = _.find(existing_list, function(list) {
-        return list['name'] == new_adj_name
-      })
+      adj_name = _.find(existing_list, function(list) { return list['name'] == new_adj_name })
 
       // Add CC rule to existing rules while filtering for existing CC rules
-      adjustment_list = _.filter(existing_list, function(list) {
+      existing_adj = _.filter(existing_list, function(list) {
         // Return 'true' for all items if we did not find an existing CC rule
         return list['name'] != new_adj_name || adj_name == undefined
       })
 
-      adjustment_list.push(currency_conversion_rule)
+      adjustment_list = adjustment_list.concat(existing_adj)
     }
 
     // Create the new adjustment list for this month

--- a/data/policy_permissions_list/master_policy_permissions_list.json
+++ b/data/policy_permissions_list/master_policy_permissions_list.json
@@ -5127,7 +5127,7 @@
     {
       "id": "./cost/flexera/cco/currency_conversion/currency_conversion.pt",
       "name": "Currency Conversion",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "providers": [
         {
           "name": "flexera",

--- a/data/policy_permissions_list/master_policy_permissions_list.yaml
+++ b/data/policy_permissions_list/master_policy_permissions_list.yaml
@@ -2960,7 +2960,7 @@
       required: true
 - id: "./cost/flexera/cco/currency_conversion/currency_conversion.pt"
   name: Currency Conversion
-  version: 5.0.1
+  version: 5.0.2
   :providers:
   - :name: flexera
     :permissions:


### PR DESCRIPTION
### Description

This fixes an issue with the Currency Conversion policy template where execution would fail if the user built off of the adjustment created by this policy template.

The currency conversion adjustment is now always first in the list being sent into the API, ensuring no issues if later adjustment rules build off of it.

### Link to Example Applied Policy

Fix tested in client environment where issue was reported.

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
