### PR TITLE
FOPTS-9865 Performance improvement -- migrated to Metrics getBatch API call

### DIFF
--- a/cost/azure/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v6.1.3
 
-- Performance improvement by migrating to metrics getBatch API.
+- Code refactored to improve performance by gathering metrics in batched requests.
 
 ## v6.1.2
 

--- a/cost/azure/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.1.3
+
+- Performance improvement by migrating to metrics getBatch API.
+
 ## v6.1.2
 
 - Fixed incorrect calculation for memory related fields "Memory Average %", "Memory p90", Memory p95", and "Memory p99".

--- a/cost/azure/rightsize_compute_instances/README.md
+++ b/cost/azure/rightsize_compute_instances/README.md
@@ -42,7 +42,7 @@ The policy includes the estimated monthly savings. The estimated monthly savings
 - *Underutilized Instance Memory Threshold (%)* - The Memory threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing. Set to -1 to ignore memory utilization for underutilized instance recommendations.
 - *Idle/Utilized for both CPU/Memory or either* - Set whether an instance should be considered idle and/or underutilized only if both CPU and memory are under the thresholds or if either CPU or memory are under. Has no effect if other parameters are configured such that only CPU or memory is being considered.
 - *Threshold Statistic* - Statistic to use when determining if an instance is idle/underutilized.
-- *Statistic Interval* - The interval to use when gathering Azure metrics data. Smaller intervals produce more accurate results at the expense of policy memory usage and completion time due to larger data sets.
+- *Statistic Interval* - The interval to use when gathering Azure metrics data. Smaller intervals produce more accurate results at the expense of policy memory usage and completion time due to larger data sets. Does not affect the accuracy for 'Average' 'Maximum' 'Minimum', as these stats are aggregated directly by Azure.
 - *Statistic Lookback Period* - How many days back to look at CPU and/or memory data for instances. This value cannot be set higher than 90 because Azure does not retain metrics for longer than 90 days.
 - *Exclusion Tags* - The policy will filter resources containing the specified tags from the results. The following formats are supported:
   - `Key` - Filter all resources with the specified tag key.

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.1.2",
+  version: "6.1.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -663,35 +663,66 @@ script "js_azure_instances_status_filtered", type: "javascript" do
 EOS
 end
 
-datasource "ds_azure_instances_metrics" do
+datasource "ds_azure_instances_batch" do
+  run_script $js_azure_instances_batch, $ds_azure_instances_status_filtered
+end
+
+script "js_azure_instances_batch", type: "javascript" do
+  parameters "ds_azure_instances_status_filtered"
+  result "result"
+  code <<-EOS
+
+  // group by subscription
+  var instances_by_subscription = _.values(_.groupBy(ds_azure_instances_status_filtered, function(instance) {
+    return instance.subscriptionId;
+  }));
+
+  // group by region
+  var instances_by_subscription_region = _.map(instances_by_subscription, function(instances) {
+    return _.values(_.groupBy(instances, function(instance) {
+      return instance.region;
+    }));
+  });
+
+  // group into batches of same region
+  result = [];
+  var batch_size = 50; // Maximum batch size for Azure Metrics getBatch API is 50
+  _.each(instances_by_subscription_region, function(instances_same_subscription) {
+    _.each(instances_same_subscription, function(instances_same_subscription_region) {
+      for (var i = 0; i < instances_same_subscription_region.length; i += batch_size) {
+        result.push(instances_same_subscription_region.slice(i, i + batch_size));
+      }
+    });
+  });
+
+  // 'result' looks like this:
+  /*
+  [
+    [max of 50 instances of same subscription and same region...],
+    [max of 50 instances of same subscription and same region...],
+    ...
+  ]
+  */
+EOS
+end
+
+datasource "ds_azure_metrics_batch" do
   batch true
-  iterate $ds_azure_instances_status_filtered
+  iterate $ds_azure_instances_batch
   request do
-    run_script $js_azure_instances_metrics, val(iter_item, "resourceID"), $ds_stats_interval, $param_azure_endpoint, $param_stats_lookback
+    run_script $js_azure_metrics_batch, iter_item, $ds_stats_interval, $param_azure_endpoint, $param_stats_lookback
   end
   result do
     encoding "json"
-    field "value", val(response, "value")
-    field "resourceName", val(iter_item, "name")
-    field "resourceGroup", val(iter_item, "resourceGroup")
-    field "resourceID", val(iter_item, "resourceID")
-    field "resourceKind", val(iter_item, "resourceKind")
-    field "region", val(iter_item, "region")
-    field "tags", val(iter_item, "tags")
-    field "statuses", val(iter_item, "statuses")
-    field "imagePublisher", val(iter_item, "imagePublisher")
-    field "imageOffer", val(iter_item, "imageOffer")
-    field "imageSKU", val(iter_item, "imageSKU")
-    field "osType", val(iter_item, "osType")
-    field "dataDiskCount", val(iter_item, "dataDiskCount")
-    field "resourceType", val(iter_item, "resourceType")
-    field "subscriptionId", val(iter_item, "subscriptionId")
-    field "subscriptionName", val(iter_item, "subscriptionName")
+    collect jmes_path(response, "values[*]") do
+      field "value", jmes_path(col_item, "value")
+      field "resourceID", jmes_path(col_item, "resourceid")
+    end
   end
 end
 
-script "js_azure_instances_metrics", type: "javascript" do
-  parameters "resourceID", "ds_stats_interval", "param_azure_endpoint", "param_stats_lookback"
+script "js_azure_metrics_batch", type: "javascript" do
+  parameters "ds_azure_instances_batch", "ds_stats_interval", "param_azure_endpoint", "param_stats_lookback"
   result "request"
   code <<-EOS
   end_date = new Date()
@@ -706,26 +737,79 @@ script "js_azure_instances_metrics", type: "javascript" do
   start_date.setSeconds(0)
   start_date.setMinutes(0)
 
-  timespan = start_date.toISOString() + "/" + end_date.toISOString()
+  function get_host_by_region(region) {
+    if (param_azure_endpoint === "management.chinacloudapi.cn") {
+      // China region has different endpoint for Metric getBatch API
+      return region + ".metrics.monitor.azure.cn";
+    }
+    else
+      return region + ".metrics.monitor.azure.com";
+  }
+
+  var resourceIDs = _.map(ds_azure_instances_batch, function(instance) {
+    return instance.resourceID;
+  });
 
   var request = {
     auth: "auth_azure",
     pagination: "pagination_azure",
-    host: param_azure_endpoint,
-    path: resourceID + "/providers/microsoft.insights/metrics",
+    host: get_host_by_region(ds_azure_instances_batch[0].region),
+    verb: "POST",
+    path: "subscriptions/" + ds_azure_instances_batch[0].subscriptionId + "/metrics:getBatch",
     query_params: {
-      "api-version": "2018-01-01",
-      "timespan": timespan,
+      "api-version": "2023-10-01",
+      "starttime": start_date.toISOString(),
+      "endtime": end_date.toISOString(),
       "interval": ds_stats_interval["api"],
       "metricnames": "Percentage CPU,Available Memory Percentage",
+      "metricnamespace": "Microsoft.Compute/VirtualMachines",
       "aggregation": "average,maximum,minimum"
     },
     headers: {
-      "User-Agent": "RS Policies"
+      "User-Agent": "RS Policies",
+      "Content-Type": "application/json"
     },
-    // Ignore status 400, 403, and 404 which can be returned in certain (legacy) types of Azure Subscriptions
-    ignore_status: [400, 403, 404]
+    body: JSON.stringify({"resourceids": resourceIDs})
   }
+EOS
+end
+
+datasource "ds_azure_instances_metrics" do
+  batch true
+  run_script $js_azure_instances_metrics, $ds_azure_metrics_batch, $ds_azure_instances_status_filtered
+end
+
+script "js_azure_instances_metrics", type: "javascript" do
+  parameters "ds_azure_metrics_batch", "ds_azure_instances_status_filtered"
+  result "result"
+  code <<-EOS
+
+  var instances_map = {};
+  _.each(ds_azure_instances_status_filtered, function(instance) {
+    instances_map[instance.resourceID] = instance
+  })
+
+  getIterator(ds_azure_metrics_batch).Each(function(metric) {
+    var instance = instances_map[metric.resourceID];
+    appendToResult({
+      resourceName: instance.name,
+      resourceGroup: instance.resourceGroup,
+      resourceID: instance.resourceID,
+      resourceKind: instance.resourceKind,
+      region: instance.region,
+      tags: instance.tags,
+      statuses: instance.statuses,
+      imagePublisher: instance.imagePublisher,
+      imageOffer: instance.imageOffer,
+      imageSKU: instance.imageSKU,
+      osType: instance.osType,
+      dataDiskCount: instance.dataDiskCount,
+      resourceType: instance.resourceType,
+      subscriptionId: instance.subscriptionId,
+      subscriptionName: instance.subscriptionName,
+      value: metric.value,
+    });
+  });
 EOS
 end
 
@@ -861,7 +945,7 @@ script "js_azure_instances_metrics_organized", type: "javascript" do
       })
     }
 
-    status_codes = _.pluck(vm['statuses'], 'code')
+    status_codes = _.pluck(vm['statuses'], 'code');
     powerstate = _.find(status_codes, function(code) { return code.indexOf('PowerState') == 0 })
     state = powerstate.split('/')[1]
 

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -176,7 +176,7 @@ parameter "param_stats_interval" do
   type "string"
   category "Statistics"
   label "Statistic Interval"
-  description "The interval to use when gathering Azure metrics data. Smaller intervals produce more accurate results at the expense of policy memory usage and completion time due to larger data sets."
+  description "The interval to use when gathering Azure metrics data. Smaller intervals produce more accurate results at the expense of policy memory usage and completion time due to larger data sets. Does not affect the accuracy for 'Average' 'Maximum' 'Minimum'."
   allowed_values "1 Minute", "5 Minutes", "15 Minutes", "30 Minutes", "1 Hour", "6 Hours", "12 Hours", "1 Day"
   default "15 Minutes"
 end

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
@@ -7,7 +7,7 @@ category "Meta"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "6.1.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"


### PR DESCRIPTION
### Description

Migrated from "Metrics" API to "Metrics getBatch" API, improving policy performance.

### Issues Resolved

https://flexera.atlassian.net/browse/FOPTS-9865
https://flexera.atlassian.net/browse/SQ-12222

### Link to Example Applied Policy

Stage environment:
https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/60073?policyId=68276c51a41ab021c0742496


Also made multiple runs on customer UAT environment to compare performance with current policy.
https://app.flexera.com/orgs/32682/automation/applied-policies/projects/133896?policyId=68256506ecdd6efd5e309aa7
https://app.flexera.com/orgs/32682/automation/applied-policies/projects/133896?policyId=682541ac045a90c67da137f8
https://app.flexera.com/orgs/32682/automation/applied-policies/projects/133896?policyId=682524c5c092e0cdbfd3a8b0

The most granular "Statistic Interval" that current policy could run on customer UAT without timing out is "1 hour". 
[Azure Rightsize Compute Instances - 6.1.2 interval 1 hour.log](https://github.com/user-attachments/files/20257054/Azure.Rightsize.Compute.Instances.-.6.1.2.az-core-prod-01.I1h.L30D.log)
[Azure Rightsize Compute Instances - 6.1.2 interval 30 minutes (timed out).log](https://github.com/user-attachments/files/20257055/Azure.Rightsize.Compute.Instances.-.6.1.2.az-core-prod-01.I30m.L30D.log)

The most granular "Statistic Interval" that the improved policy could run on customer UAT without timing out is "30 minutes".
[Azure Rightsize Compute Instances - 6.2.0-beta1 interval 1 hour.log](https://github.com/user-attachments/files/20257070/Azure.Rightsize.Compute.Instances.-.6.2.0-beta1.az-core-prod-01.I1h.L30D.log)
[Azure Rightsize Compute Instances - 6.2.0-beta1 interval 30 minutes.log](https://github.com/user-attachments/files/20257073/Azure.Rightsize.Compute.Instances.-.6.2.0-beta1.az-core-prod-01.I30m.L30D.log)


### Contribution Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
