### PR TITLE
POL-1521 AWS CloudTrails Without Log File Validation Enabled - Fix Reference Error due to undefined variable

### DIFF
--- a/data/policy_permissions_list/master_policy_permissions_list.json
+++ b/data/policy_permissions_list/master_policy_permissions_list.json
@@ -8934,7 +8934,7 @@
     {
       "id": "./security/aws/log_file_validation_enabled/log_file_validation_enabled.pt",
       "name": "AWS CloudTrails Without Log File Validation Enabled",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "providers": [
         {
           "name": "aws",

--- a/data/policy_permissions_list/master_policy_permissions_list.yaml
+++ b/data/policy_permissions_list/master_policy_permissions_list.yaml
@@ -5122,7 +5122,7 @@
       required: true
 - id: "./security/aws/log_file_validation_enabled/log_file_validation_enabled.pt"
   name: AWS CloudTrails Without Log File Validation Enabled
-  version: 3.0.2
+  version: 3.0.3
   :providers:
   - :name: aws
     :permissions:

--- a/security/aws/log_file_validation_enabled/CHANGELOG.md
+++ b/security/aws/log_file_validation_enabled/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.0.3
+
+- Fixed an issue where applied policy would fail due to an undefined variable.
+
 ## v3.0.2
 
 - Added `hide_skip_approvals` field to the info section. It dynamically controls "Skip Action Approvals" visibility.

--- a/security/aws/log_file_validation_enabled/log_file_validation_enabled.pt
+++ b/security/aws/log_file_validation_enabled/log_file_validation_enabled.pt
@@ -7,7 +7,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.0.2",
+  version: "3.0.3",
   provider: "AWS",
   service: "CloudTrail",
   policy_set: "CIS",

--- a/security/aws/log_file_validation_enabled/log_file_validation_enabled.pt
+++ b/security/aws/log_file_validation_enabled/log_file_validation_enabled.pt
@@ -196,7 +196,7 @@ script "js_trails_without_logfilevalidation", type:"javascript" do
       name: trail['name'],
       id: trail['arn'],
       region: trail['homeregion'],
-      log_file_validation_enabled: log_file_validation_enabled.toString(),
+      log_file_validation_enabled: trail['log_file_validation_enabled'].toString(),
       policy_name: ds_applied_policy['name']
     }
   })


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves below -->
Applied policy fails to run with ReferenceError: 'log_file_validation_enabled' is not defined

This is probably due to the incorrect naming of a variable and/or the code referencing a variable that does not exist.

Link to applied policy where error has been observed - https://app.flexera.com/orgs/39679/automation/applied-policies/projects/141708?policyId=681c8c88d88a69fbd74b297b 

This change adds a fix to mitigate the non-instantiated variable

### Issues Resolved

<!-- List any existing issues this PR resolves below -->
Fixes an issue where the applied policy fails due to `log_file_validation_enabled` variable not being defined.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.--> Applied in the customer's tenant and confirmed to be working as expected post changes.

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
