### PR TITLE
task: publish Azure Rightsize NetApp PT

### DIFF
--- a/cost/azure/rightsize_netapp/azure_rightsize_netapp.pt
+++ b/cost/azure/rightsize_netapp/azure_rightsize_netapp.pt
@@ -12,6 +12,7 @@ info(
   service: "NetApp Files",
   policy_set: "Rightsize Storage",
   recommendation_type: "Usage Reduction",
+  publish: "true",
   hide_skip_approvals: "true"
 )
 


### PR DESCRIPTION
### Description

https://github.com/flexera-public/policy_templates/blob/master/data/active_policy_list/generally_recommended_templates.json#L32
Azure Rightsize NetApp Template should be publish as it's included in the "Recommended Templates" list and we often find savings with this PT during PoCs

Alternative approach to this would be removing this PT from the Recommended PT list.  There are tools that assume all PTs in the list are in the Catalog though so we need to make a change one way or another