### PR TITLE
POL-1528 DTU support for Azure Rightsize SQL Databases

### DIFF
--- a/cost/azure/rightsize_sql_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_sql_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v6.0.0
+
+- Policy template now distinguishes between vCore-model and DTU-model databases and checks CPU and DTU metrics to determine usage for each purchase model respectively.
+- Fixed issue where policy template would report new recommendations if a metric other than cpuAverage had changed for an existing recommendation.
+
 ## v5.5.3
 
 - Added batch processing for large datasources as a performance enhancement (reduces memory usage) with no changes to logic or functionality.

--- a/cost/azure/rightsize_sql_instances/README.md
+++ b/cost/azure/rightsize_sql_instances/README.md
@@ -2,21 +2,21 @@
 
 ## What It Does
 
-This policy checks usage for all Azure SQL single database instances in Azure Subscriptions over a user-specified number of days. If there were no connections to the instance, the instance is recommended for deletion. If there were connections but the average CPU/DTU usage was below a user-specified threshold, the instance is recommended for downsizing. Both sets of instances returned from this policy are emailed to the user.
+This policy template checks usage for all Azure SQL single database instances in Azure Subscriptions over a user-specified number of days. If there were no connections to the instance, the instance is recommended for deletion. If there were connections but the average CPU/DTU usage was below a user-specified threshold, the instance is recommended for downsizing. Both sets of instances returned from this policy are emailed to the user.
 
 ## How It Works
 
-- The policy leverages the Azure API to check all Azure SQL single database instances and then checks the number of connections and utilization over a user-specified number of days.
+- The policy template leverages the Azure API to check all Azure SQL single database instances and then checks the number of connections and utilization over a user-specified number of days.
   - Utilization is based on CPU usage for vCore-model databases.
   - Utilization is based on DTU usage for DTU-model databases.
-- The policy identifies all instances that either have had no connections over a user-specified number of days and provides the relevant recommendation.
+- The policy template identifies all instances that either have had no connections over a user-specified number of days and provides the relevant recommendation.
 - The recommendation provided for unused instances is a deletion action. These instances can be deleted in an automated manner or after approval.
-- The policy identifies all instances that have had connections but have average usage below the user-specified threshold over a user-specified number of days and provides the relevant recommendation.
+- The policy template identifies all instances that have had connections but have average usage below the user-specified threshold over a user-specified number of days and provides the relevant recommendation.
 - The recommendation provided for underutilized instances is a downsize action. These instances can be downsized in an automated manner or after approval.
 
 ### Policy Savings Details
 
-The policy includes the estimated monthly savings. The estimated monthly savings is recognized for unused resources if the resource is terminated, and for underutilized resources if the resource is downsized.
+The policy template includes the estimated monthly savings. The estimated monthly savings is recognized for unused resources if the resource is terminated, and for underutilized resources if the resource is downsized.
 
 - The `Estimated Monthly Savings` is calculated by multiplying the amortized cost of the resource for 1 day, as found within Flexera CCO, by 30.44, which is the average number of days in a month.
 - For unused resources, the `Estimated Monthly Savings` is the full cost of the resource.
@@ -29,14 +29,14 @@ The policy includes the estimated monthly savings. The estimated monthly savings
 ## Input Parameters
 
 - *Email Addresses* - Email addresses of the recipients you wish to notify when new incidents are created.
-- *Azure Endpoint* - The endpoint to send Azure API requests to. Recommended to leave this at default unless using this policy with Azure China.
+- *Azure Endpoint* - The endpoint to send Azure API requests to. Recommended to leave this at default unless using this policy template with Azure China.
 - *Minimum Savings Threshold* - Minimum potential savings required to generate a recommendation.
 - *Minimum Age (Days)* - The minimum age, in days, since a SQL database was created to produce recommendations for it. Set to 0 to ignore age entirely.
 - *Allow/Deny Subscriptions* - Determines whether the Allow/Deny Subscriptions List parameter functions as an allow list (only providing results for the listed subscriptions) or a deny list (providing results for all subscriptions except for the listed subscriptions).
 - *Allow/Deny Subscriptions List* - A list of allowed or denied Subscription IDs/names. If empty, no filtering will occur and recommendations will be produced for all subscriptions.
 - *Allow/Deny Regions* - Whether to treat Allow/Deny Regions List parameter as allow or deny list. Has no effect if Allow/Deny Regions List is left empty.
 - *Allow/Deny Regions List* - Filter results by region, either only allowing this list or denying it depending on how the above parameter is set. Leave blank to consider all the regions.
-- *Exclusion Tags* - The policy will filter resources containing the specified tags from the results. The following formats are supported:
+- *Exclusion Tags* - The policy template will filter resources containing the specified tags from the results. The following formats are supported:
   - `Key` - Filter all resources with the specified tag key.
   - `Key==Value` - Filter all resources with the specified tag key:value pair.
   - `Key!=Value` - Filter all resources missing the specified tag key:value pair. This will also filter all resources missing the specified tag key.
@@ -50,7 +50,7 @@ The policy includes the estimated monthly savings. The estimated monthly savings
 - *Underutilized Instance CPU Threshold (%)* - The CPU threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing. Only applies to vCore-model SQL databases (GeneralPurpose, BusinessCritical, Hyperscale)
 - *Underutilized Instance DTU Threshold (%)* - The DTU threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing. Only applies to DTU-model SQL databases (Basic, Standard, Premium)
 - *Skip Instance Sizes* - Whether to recommend downsizing multiple sizes. When set to 'No', only the next smaller size will ever be recommended for downsizing. When set to 'Yes', more aggressive downsizing recommendations will be made when appropriate.
-- *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).
+- *Automatic Actions* - When this value is set, this policy template will automatically take the selected action(s).
 
 Please note that the "Automatic Actions" parameter contains a list of action(s) that can be performed on the resources. When it is selected, the policy will automatically execute the corresponding action on the data that failed the checks, post incident generation. Please leave it blank for *manual* action.
 For example if a user selects the "Delete Unused Instances" action while applying the policy, all the resources that didn't satisfy the policy condition will be deleted.

--- a/cost/azure/rightsize_sql_instances/README.md
+++ b/cost/azure/rightsize_sql_instances/README.md
@@ -2,14 +2,16 @@
 
 ## What It Does
 
-This policy checks all the Azure SQL single database instances in Azure Subscriptions for the average CPU usage and number of connections over a user-specified number of days. If there were no connections to the instance, the instance is recommended for deletion. If there were connections but the average CPU usage was below a user-specified threshold, the instance is recommended for downsizing. Both sets of instances returned from this policy are emailed to the user.
+This policy checks usage for all Azure SQL single database instances in Azure Subscriptions over a user-specified number of days. If there were no connections to the instance, the instance is recommended for deletion. If there were connections but the average CPU/DTU usage was below a user-specified threshold, the instance is recommended for downsizing. Both sets of instances returned from this policy are emailed to the user.
 
 ## How It Works
 
-- The policy leverages the Azure API to check all Azure SQL single database instances and then checks the number of connections and average CPU utilization over a user-specified number of days.
+- The policy leverages the Azure API to check all Azure SQL single database instances and then checks the number of connections and utilization over a user-specified number of days.
+  - Utilization is based on CPU usage for vCore-model databases.
+  - Utilization is based on DTU usage for DTU-model databases.
 - The policy identifies all instances that either have had no connections over a user-specified number of days and provides the relevant recommendation.
 - The recommendation provided for unused instances is a deletion action. These instances can be deleted in an automated manner or after approval.
-- The policy identifies all instances that have had connections but have average CPU usage below the user-specified threshold over a user-specified number of days and provides the relevant recommendation.
+- The policy identifies all instances that have had connections but have average usage below the user-specified threshold over a user-specified number of days and provides the relevant recommendation.
 - The recommendation provided for underutilized instances is a downsize action. These instances can be downsized in an automated manner or after approval.
 
 ### Policy Savings Details
@@ -43,9 +45,10 @@ The policy includes the estimated monthly savings. The estimated monthly savings
 - *Exclusion Tags: Any / All* - Whether to filter instances containing any of the specified tags or only those that contain all of them. Only applicable if more than one value is entered in the `Exclusion Tags` field.
 - *Threshold Statistic* - Statistic to use when determining if a SQL instance is underutilized.
 - *Statistic Interval* - The interval to use when gathering Azure metrics data. Smaller intervals produce more accurate results at the expense of policy memory usage and completion time due to larger data sets.
-- *Statistic Lookback Period* - How many days back to look at connection and CPU utilization data for instances. This value cannot be set higher than 90 because Azure does not retain metrics for longer than 90 days.
+- *Statistic Lookback Period* - How many days back to look at connection and CPU/DTU utilization data for instances. This value cannot be set higher than 90 because Azure does not retain metrics for longer than 90 days.
 - *Report Unused or Underutilized* - Whether to report on unused instances, underutilized instances, or both. If both are selected, unused instances will not appear in the list of underutilized instances regardless of CPU usage.
-- *Underutilized Instance CPU Threshold (%)* - The CPU threshold at which to consider an instance to be underutilized and therefore be flagged for downsizing.
+- *Underutilized Instance CPU Threshold (%)* - The CPU threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing. Only applies to vCore-model SQL databases (GeneralPurpose, BusinessCritical, Hyperscale)
+- *Underutilized Instance DTU Threshold (%)* - The DTU threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing. Only applies to DTU-model SQL databases (Basic, Standard, Premium)
 - *Skip Instance Sizes* - Whether to recommend downsizing multiple sizes. When set to 'No', only the next smaller size will ever be recommended for downsizing. When set to 'Yes', more aggressive downsizing recommendations will be made when appropriate.
 - *Automatic Actions* - When this value is set, this policy will automatically take the selected action(s).
 

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.5.3",
+  version: "6.0.0",
   provider: "Azure",
   service: "SQL",
   policy_set: "Rightsize Database Instances",
@@ -118,7 +118,17 @@ parameter "param_stats_underutil_threshold_cpu_value" do
   type "number"
   category "Statistics"
   label "Underutilized Instance CPU Threshold (%)"
-  description "The CPU threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing."
+  description "The CPU threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing. Only applies to vCore-model SQL databases (GeneralPurpose, BusinessCritical, Hyperscale)"
+  min_value 0
+  max_value 100
+  default 60
+end
+
+parameter "param_stats_underutil_threshold_dtu_value" do
+  type "number"
+  category "Statistics"
+  label "Underutilized Instance DTU Threshold (%)"
+  description "The DTU threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing. Only applies to DTU-model SQL databases (Basic, Standard, Premium)"
   min_value 0
   max_value 100
   default 60
@@ -429,6 +439,7 @@ datasource "ds_azure_sql_databases" do
       field "type", jmes_path(col_item, "type")
       field "kind", jmes_path(col_item, "kind")
       field "sku", jmes_path(col_item, "sku")
+      field "tier", jmes_path(col_item, "sku.tier")
       field "tags", jmes_path(col_item, "tags")
       field "createdTime", jmes_path(col_item, "properties.creationDate")
       field "status", jmes_path(col_item, "properties.status")
@@ -592,7 +603,7 @@ datasource "ds_azure_sql_database_metrics" do
   batch true
   iterate $ds_azure_sql_databases_region_filtered
   request do
-    run_script $js_azure_sql_database_metrics, val(iter_item, "id"), $ds_stats_interval, $param_azure_endpoint, $param_stats_lookback
+    run_script $js_azure_sql_database_metrics, val(iter_item, "id"), val(iter_item, "tier"), $ds_stats_interval, $param_azure_endpoint, $param_stats_lookback
   end
   result do
     encoding "json"
@@ -621,7 +632,7 @@ end
 
 # https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-sql-servers-databases-metrics
 script "js_azure_sql_database_metrics", type: "javascript" do
-  parameters "resource_id", "ds_stats_interval", "param_azure_endpoint", "param_stats_lookback"
+  parameters "resource_id", "resource_tier", "ds_stats_interval", "param_azure_endpoint", "param_stats_lookback"
   result "request"
   code <<-EOS
   end_date = new Date()
@@ -638,6 +649,12 @@ script "js_azure_sql_database_metrics", type: "javascript" do
 
   timespan = start_date.toISOString() + "/" + end_date.toISOString()
 
+  metricnames = "cpu_percent,connection_successful"
+
+  if (resource_tier == "Basic" || resource_tier == "Standard" || resource_tier == "Premium") {
+    metricnames = "dtu_consumption_percent,connection_successful"
+  }
+
   var request = {
     auth: "auth_azure",
     pagination: "pagination_azure",
@@ -646,7 +663,7 @@ script "js_azure_sql_database_metrics", type: "javascript" do
     query_params: {
       "api-version": "2018-01-01",
       "timespan": timespan,
-      "metricnames": "cpu_percent,connection_successful",
+      "metricnames": metricnames,
       "aggregation": "Average,Minimum,Maximum,count",
       "interval": ds_stats_interval["api"]
     },
@@ -668,11 +685,11 @@ datasource "ds_azure_sql_resize_map" do
 end
 
 datasource "ds_merged_metrics" do
-  run_script $js_merged_metrics, $ds_azure_sql_database_metrics, $ds_azure_sql_resize_map, $ds_applied_policy, $param_stats_underutil_threshold_cpu_value, $param_stats_lookback, $param_unused_or_underutilized, $param_stats_threshold, $param_downsize_multiple
+  run_script $js_merged_metrics, $ds_azure_sql_database_metrics, $ds_azure_sql_resize_map, $ds_applied_policy, $param_stats_underutil_threshold_cpu_value, $param_stats_underutil_threshold_dtu_value, $param_stats_lookback, $param_unused_or_underutilized, $param_stats_threshold, $param_downsize_multiple
 end
 
 script "js_merged_metrics", type: "javascript" do
-  parameters "ds_azure_sql_database_metrics", "ds_azure_sql_resize_map", "ds_applied_policy", "param_stats_underutil_threshold_cpu_value", "param_stats_lookback", "param_unused_or_underutilized", "param_stats_threshold", "param_downsize_multiple"
+  parameters "ds_azure_sql_database_metrics", "ds_azure_sql_resize_map", "ds_applied_policy", "param_stats_underutil_threshold_cpu_value", "param_stats_underutil_threshold_dtu_value", "param_stats_lookback", "param_unused_or_underutilized", "param_stats_threshold", "param_downsize_multiple"
   result "result"
   code <<-EOS
   // Function to calculate percentiles from metrics
@@ -705,6 +722,7 @@ script "js_merged_metrics", type: "javascript" do
       kind: db['kind'],
       type: db['type'],
       sku: db['sku'],
+      tier: db['tier'],
       tags: tags.join(', '),
       createdTime: new Date(db['createdTime']).toISOString(),
       lastAccessed: "> " + param_stats_lookback + " Days Ago",
@@ -719,6 +737,7 @@ script "js_merged_metrics", type: "javascript" do
 
     connection_metrics = null
     cpu_metrics = null
+    dtu_metrics = null
 
     _.each(db['value'], function(metric) {
       if (metric['name']['value'] == 'connection_successful') {
@@ -727,6 +746,12 @@ script "js_merged_metrics", type: "javascript" do
 
       if (metric['name']['value'] == 'cpu_percent') {
         cpu_metrics = metric['timeseries'][0]['data']
+        instance['purchase_model'] = "vCore"
+      }
+
+      if (metric['name']['value'] == 'dtu_consumption_percent') {
+        dtu_metrics = metric['timeseries'][0]['data']
+        instance['purchase_model'] = "DTU"
       }
     })
 
@@ -756,57 +781,72 @@ script "js_merged_metrics", type: "javascript" do
       }
     }
 
-    if (cpu_metrics != null && instance['recommendationType'] != 'Delete' && param_unused_or_underutilized != "Unused") {
-      if (cpu_metrics.length > 0) {
-        minimums = _.pluck(cpu_metrics, 'minimum')
-        maximums = _.pluck(cpu_metrics, 'maximum')
-        averages = _.pluck(cpu_metrics, 'average')
+    if ((cpu_metrics != null || dtu_metrics != null) && instance['recommendationType'] != 'Delete' && param_unused_or_underutilized != "Unused") {
+      metrics = cpu_metrics ? cpu_metrics : dtu_metrics
 
-        cpu_minimum = null
-        cpu_maximum = 0
-        cpu_average = 0
-        cpu_p90 = 0
-        cpu_p95 = 0
-        cpu_p99 = 0
+      if (metrics.length > 0) {
+        minimums = _.pluck(metrics, 'minimum')
+        maximums = _.pluck(metrics, 'maximum')
+        averages = _.pluck(metrics, 'average')
+
+        metric_minimum = null
+        metric_maximum = 0
+        metric_average = 0
+        metric_p90 = 0
+        metric_p95 = 0
+        metric_p99 = 0
 
         _.each(minimums, function(item) {
-          if (cpu_minimum == null || item < cpu_minimum) { cpu_minimum = item }
+          if (metric_minimum == null || item < metric_minimum) { metric_minimum = item }
         })
 
         _.each(maximums, function(item) {
-          if (item > cpu_maximum) { cpu_maximum = item }
+          if (item > metric_maximum) { metric_maximum = item }
         })
 
-        if (cpu_minimum == null) { cpu_minimum = 0 }
+        if (metric_minimum == null) { metric_minimum = 0 }
 
         if (averages.length > 0) {
-          cpu_average = _.reduce(averages, function(memo, num) { return memo + num }, 0) / averages.length
+          metric_average = _.reduce(averages, function(memo, num) { return memo + num }, 0) / averages.length
         }
 
         if (minimums.length + maximums.length + averages.length > 0) {
           // combine all points from minimums, maximums, averages
           // use percentile() function to get the percentile values from all measured utilization points
-          cpu_p90 = percentile(minimums.concat(maximums, averages), 90)
-          cpu_p95 = percentile(minimums.concat(maximums, averages), 95)
-          cpu_p99 = percentile(minimums.concat(maximums, averages), 99)
+          metric_p90 = percentile(minimums.concat(maximums, averages), 90)
+          metric_p95 = percentile(minimums.concat(maximums, averages), 95)
+          metric_p99 = percentile(minimums.concat(maximums, averages), 99)
         }
 
-        if (param_stats_threshold == "Average") { cpu_test_value = cpu_average }
-        if (param_stats_threshold == "Maximum") { cpu_test_value = cpu_maximum }
-        if (param_stats_threshold == "p90") { cpu_test_value = cpu_p90 }
-        if (param_stats_threshold == "p95") { cpu_test_value = cpu_p95 }
-        if (param_stats_threshold == "p99") { cpu_test_value = cpu_p99 }
+        if (param_stats_threshold == "Average") { metric_test_value = metric_average }
+        if (param_stats_threshold == "Maximum") { metric_test_value = metric_maximum }
+        if (param_stats_threshold == "p90") { metric_test_value = metric_p90 }
+        if (param_stats_threshold == "p95") { metric_test_value = metric_p95 }
+        if (param_stats_threshold == "p99") { metric_test_value = metric_p99 }
 
-        if (cpu_test_value <= param_stats_underutil_threshold_cpu_value) {
-          instance['cpu_minimum'] = cpu_minimum
-          instance['cpu_maximum'] = cpu_maximum
-          instance['cpu_average'] = cpu_average
-          instance['cpu_p90'] = cpu_p90
-          instance['cpu_p95'] = cpu_p95
-          instance['cpu_p99'] = cpu_p99
+        if (cpu_metrics && metric_test_value <= param_stats_underutil_threshold_cpu_value) {
+          instance['cpu_minimum'] = metric_minimum
+          instance['cpu_maximum'] = metric_maximum
+          instance['cpu_average'] = metric_average
+          instance['cpu_p90'] = metric_p90
+          instance['cpu_p95'] = metric_p95
+          instance['cpu_p99'] = metric_p99
           instance['thresholdType'] = param_stats_threshold
           instance['recommendationType'] = 'Downsize'
+        }
 
+        if (dtu_metrics && metric_test_value <= param_stats_underutil_threshold_dtu_value) {
+          instance['dtu_minimum'] = metric_minimum
+          instance['dtu_maximum'] = metric_maximum
+          instance['dtu_average'] = metric_average
+          instance['dtu_p90'] = metric_p90
+          instance['dtu_p95'] = metric_p95
+          instance['dtu_p99'] = metric_p99
+          instance['thresholdType'] = param_stats_threshold
+          instance['recommendationType'] = 'Downsize'
+        }
+
+        if (instance['recommendationType'] == 'Downsize') {
           tier = instance['sku']['tier']
           type = instance['sku']['name'] + '_' + instance['sku']['capacity']
 
@@ -818,8 +858,8 @@ script "js_merged_metrics", type: "javascript" do
                 if (param_downsize_multiple == "Yes") {
                   type = instance['sku']['name'] + '_' + instance['newResourceType']
 
-                  while (typeof(ds_azure_sql_resize_map[tier][type]['down']) == 'string' && cpu_test_value * 2 <= param_stats_underutil_threshold_cpu_value) {
-                    cpu_test_value = cpu_test_value * 2
+                  while (typeof(ds_azure_sql_resize_map[tier][type]['down']) == 'string' && metric_test_value * 2 <= param_stats_underutil_threshold_cpu_value) {
+                    metric_test_value = metric_test_value * 2
                     instance['newResourceType'] = ds_azure_sql_resize_map[tier][type]['down']
                     type = instance['sku']['name'] + '_' + instance['newResourceType']
                   }
@@ -1024,6 +1064,8 @@ script "js_downsize_sql_incident", type: "javascript" do
         resourceKind: db['kind'],
         type: db['type'],
         sku: db['sku'],
+        tier: db['tier'],
+        purchase_model: db['purchase_model'],
         resourceType: db['sku']['capacity'],
         tags: db['tags'],
         createdTime: db['createdTime'],
@@ -1035,12 +1077,18 @@ script "js_downsize_sql_incident", type: "javascript" do
         recommendationType: db['recommendationType'],
         recommendationDetails: db['recommendationDetails'],
         newResourceType: db['newResourceType'],
-        cpuAverage: Math.round(db['cpu_average'] * 100) / 100,
-        cpuMinimum: Math.round(db['cpu_minimum'] * 100) / 100,
-        cpuMaximum: Math.round(db['cpu_maximum'] * 100) / 100,
-        cpuP90: Math.round(db['cpu_p90'] * 100) / 100,
-        cpuP95: Math.round(db['cpu_p95'] * 100) / 100,
-        cpuP99: Math.round(db['cpu_p99'] * 100) / 100,
+        cpuAverage: db['cpu_average'] ? Math.round(db['cpu_average'] * 100) / 100 : "",
+        cpuMinimum: db['cpu_minimum'] ? Math.round(db['cpu_minimum'] * 100) / 100 : "",
+        cpuMaximum: db['cpu_maximum'] ? Math.round(db['cpu_maximum'] * 100) / 100 : "",
+        cpuP90: db['cpu_p90'] ? Math.round(db['cpu_p90'] * 100) / 100 : "",
+        cpuP95: db['cpu_p95'] ? Math.round(db['cpu_p95'] * 100) / 100 : "",
+        cpuP99: db['cpu_p99'] ? Math.round(db['cpu_p99'] * 100) / 100 : "",
+        dtuAverage: db['dtu_average'] ? Math.round(db['dtu_average'] * 100) / 100 : "",
+        dtuMinimum: db['dtu_minimum'] ? Math.round(db['dtu_minimum'] * 100) / 100 : "",
+        dtuMaximum: db['dtu_maximum'] ? Math.round(db['dtu_maximum'] * 100) / 100 : "",
+        dtuP90: db['dtu_p90'] ? Math.round(db['dtu_p90'] * 100) / 100 : "",
+        dtuP95: db['dtu_p95'] ? Math.round(db['dtu_p95'] * 100) / 100 : "",
+        dtuP99: db['dtu_p99'] ? Math.round(db['dtu_p99'] * 100) / 100 : "",
         thresholdType: db['thresholdType'],
         lookbackPeriod: db['lookbackPeriod'],
         threshold: db['threshold'],
@@ -1079,16 +1127,24 @@ script "js_downsize_sql_incident", type: "javascript" do
 
   if (param_unused_or_underutilized == 'Underutilized') {
     context_message = [
-      "An Azure SQL Database is considered underutilized if it has a CPU usage " + param_stats_threshold.toLowerCase() + " below ",
+      "A vCore-based Azure SQL Database is considered underutilized if it has a CPU usage " + param_stats_threshold.toLowerCase() + " below ",
       param_stats_underutil_threshold_cpu_value, "% for the last ", param_stats_lookback, " ", day_message,
+      ", regardless of whether it has had any connections to it in that same time period. ",
+      "CPU metrics were gathered at a granularity of '", ds_stats_interval['pretty'], "'.\n\n",
+      "A DTU-based Azure SQL Database is considered underutilized if it has a DTU usage " + param_stats_threshold.toLowerCase() + " below ",
+      param_stats_underutil_threshold_dtu_value, "% for the last ", param_stats_lookback, " ", day_message,
       ", regardless of whether it has had any connections to it in that same time period. ",
       "CPU metrics were gathered at a granularity of '", ds_stats_interval['pretty'], "'.\n\n"
     ].join('')
   } else {
     context_message = [
-      "An Azure SQL Database is considered underutilized if it has had at least one connection to it ",
+      "A vCore-based Azure SQL Database is considered underutilized if it has had at least one connection to it ",
       "in the last ", param_stats_lookback, " ", day_message, " but has an average CPU usage below ",
       param_stats_underutil_threshold_cpu_value, "% for that same time period. ",
+      "These metrics were gathered at a granularity of '", ds_stats_interval['pretty'], "'.\n\n",
+      "A DTU-based Azure SQL Database is considered underutilized if it has had at least one connection to it ",
+      "in the last ", param_stats_lookback, " ", day_message, " but has an average DTU usage below ",
+      param_stats_underutil_threshold_dtu_value, "% for that same time period. ",
       "These metrics were gathered at a granularity of '", ds_stats_interval['pretty'], "'.\n\n"
     ].join('')
   }
@@ -1103,7 +1159,7 @@ script "js_downsize_sql_incident", type: "javascript" do
     min_age_message = "Only Azure SQL Databases created more than " + param_minimum_age + " days ago were included in the results.\n\n"
   }
 
-  disclaimer = "The above settings can be modified by editing the applied policy and changing the appropriate parameters.\n\n"
+  disclaimer = "The above settings can be modified by editing the applied policy and changing the appropriate parameters.\n\n__NOTE__: CPU metrics are only reported for vCore-based databases and DTU metrics for DTU-based databases.\n\n"
 
   savings_message = ds_currency['symbol'] + ' ' + formatNumber(parseFloat(total_savings).toFixed(2), ds_currency['separator'])
 
@@ -1116,6 +1172,8 @@ script "js_downsize_sql_incident", type: "javascript" do
     type: "",
     resourceType: "",
     sku: "",
+    tier: "",
+    purchase_model: "",
     tags: "",
     resourceGroup: "",
     accountID: "",
@@ -1124,6 +1182,17 @@ script "js_downsize_sql_incident", type: "javascript" do
     recommendationDetails: "",
     newResourceType: "",
     cpuAverage: "",
+    cpuMinimum: "",
+    cpuMaximum: "",
+    cpuP90: "",
+    cpuP95: "",
+    cpuP99: "",
+    dtuAverage: "",
+    dtuMinimum: "",
+    dtuMaximum: "",
+    dtuP90: "",
+    dtuP95: "",
+    dtuP99: "",
     lookbackPeriod: "",
     threshold: "",
     policy_name: "",
@@ -1202,6 +1271,8 @@ script "js_unused_sql_incident", type: "javascript" do
         resourceKind: db['kind'],
         type: db['type'],
         sku: db['sku'],
+        tier: db['tier'],
+        purchase_model: db['purchase_model'],
         resourceType: db['sku']['capacity'],
         tags: db['tags'],
         createdTime: db['createdTime'],
@@ -1276,6 +1347,8 @@ script "js_unused_sql_incident", type: "javascript" do
     type: "",
     resourceType: "",
     sku: "",
+    tier: "",
+    purchase_model: "",
     tags: "",
     resourceGroup: "",
     accountID: "",
@@ -1317,7 +1390,7 @@ policy "pol_azure_sql_utilization" do
     check logic_or($ds_parent_policy_terminated, ne(val(item, "recommendationType"), "Downsize"))
     escalate $esc_email
     escalate $esc_downsize_instances
-    hash_exclude "savings", "savingsCurrency", "tags", "cpuAverage", "policy_name", "total_savings", "message"
+    hash_exclude "policy_name", "total_savings", "message", "savings", "savingsCurrency", "tags", "cpuAverage", "cpuMinimum", "cpuMaximum", "cpuP90", "cpuP95", "cpuP99", "dtuAverage", "dtuMinimum", "dtuMaximum", "dtuP90", "dtuP95", "dtuP99"
     export do
       resource_level true
       field "accountID" do
@@ -1362,6 +1435,9 @@ policy "pol_azure_sql_utilization" do
         label "SKU - Tier"
         path "sku.tier"
       end
+      field "purchase_model" do
+        label "Purchase Model"
+      end
       field "type" do
         label "Type"
       end
@@ -1397,6 +1473,24 @@ policy "pol_azure_sql_utilization" do
       end
       field "cpuP99" do
         label "CPU p99"
+      end
+      field "dtuMaximum" do
+        label "DTU Maximum %"
+      end
+      field "dtuMinimum" do
+        label "DTU Minimum %"
+      end
+      field "dtuAverage" do
+        label "DTU Average %"
+      end
+      field "dtuP90" do
+        label "DTU p90"
+      end
+      field "dtuP95" do
+        label "DTU p95"
+      end
+      field "dtuP99" do
+        label "DTU p99"
       end
       field "service" do
         label "Service"
@@ -1472,6 +1566,12 @@ policy "pol_azure_sql_utilization" do
       field "status" do
         label "Status"
       end
+      field "resourceType" do
+        label "Current Capacity"
+      end
+      field "newResourceType" do
+        label "Recommended Capacity"
+      end
       field "skuName" do
         label "SKU - Name"
         path "sku.name"
@@ -1480,11 +1580,8 @@ policy "pol_azure_sql_utilization" do
         label "SKU - Tier"
         path "sku.tier"
       end
-      field "resourceType" do
-        label "SKU - Capacity"
-      end
-      field "newResourceType" do
-        label "Recommended Capacity"
+      field "purchase_model" do
+        label "Purchase Model"
       end
       field "savings" do
         label "Estimated Monthly Savings"

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
@@ -785,38 +785,17 @@ script "js_merged_metrics", type: "javascript" do
       metrics = cpu_metrics ? cpu_metrics : dtu_metrics
 
       if (metrics.length > 0) {
-        minimums = _.pluck(metrics, 'minimum')
-        maximums = _.pluck(metrics, 'maximum')
-        averages = _.pluck(metrics, 'average')
+        minimums = _.pluck(metrics, 'minimum').sort()
+        maximums = _.pluck(metrics, 'maximum').sort()
+        averages = _.pluck(metrics, 'average').sort()
+        all_metrics = minimums.concat(maximums, averages)
 
-        metric_minimum = null
-        metric_maximum = 0
-        metric_average = 0
-        metric_p90 = 0
-        metric_p95 = 0
-        metric_p99 = 0
-
-        _.each(minimums, function(item) {
-          if (metric_minimum == null || item < metric_minimum) { metric_minimum = item }
-        })
-
-        _.each(maximums, function(item) {
-          if (item > metric_maximum) { metric_maximum = item }
-        })
-
-        if (metric_minimum == null) { metric_minimum = 0 }
-
-        if (averages.length > 0) {
-          metric_average = _.reduce(averages, function(memo, num) { return memo + num }, 0) / averages.length
-        }
-
-        if (minimums.length + maximums.length + averages.length > 0) {
-          // combine all points from minimums, maximums, averages
-          // use percentile() function to get the percentile values from all measured utilization points
-          metric_p90 = percentile(minimums.concat(maximums, averages), 90)
-          metric_p95 = percentile(minimums.concat(maximums, averages), 95)
-          metric_p99 = percentile(minimums.concat(maximums, averages), 99)
-        }
+        metric_minimum = minimums && minimums.length > 0 ? _.first(minimums) : 0
+        metric_maximum = maximums && maximums.length > 0 ? _.last(maximums) : 0
+        metric_average = averages && averages.length > 0 ? _.reduce(averages, function(memo, num) { return memo + num }, 0) / averages.length : 0
+        metric_p90 = all_metrics.length > 0 ? percentile(all_metrics, 90) : 0
+        metric_p95 = all_metrics.length > 0 ? percentile(all_metrics, 95) : 0
+        metric_p99 = all_metrics.length > 0 ? percentile(all_metrics, 99) : 0
 
         if (param_stats_threshold == "Average") { metric_test_value = metric_average }
         if (param_stats_threshold == "Maximum") { metric_test_value = metric_maximum }

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
@@ -1005,11 +1005,11 @@ EOS
 end
 
 datasource "ds_downsize_sql_incident" do
-  run_script $js_downsize_sql_incident, $ds_merged_metrics, $ds_azure_sql_databases_region_filtered, $ds_sql_costs_grouped, $ds_currency, $ds_stats_interval, $param_min_savings, $param_stats_lookback, $param_stats_underutil_threshold_cpu_value, $param_unused_or_underutilized, $param_minimum_age, $param_stats_threshold
+  run_script $js_downsize_sql_incident, $ds_merged_metrics, $ds_azure_sql_databases_region_filtered, $ds_sql_costs_grouped, $ds_currency, $ds_stats_interval, $param_min_savings, $param_stats_lookback, $param_stats_underutil_threshold_cpu_value, $param_stats_underutil_threshold_dtu_value, $param_unused_or_underutilized, $param_minimum_age, $param_stats_threshold
 end
 
 script "js_downsize_sql_incident", type: "javascript" do
-  parameters "ds_merged_metrics", "ds_azure_sql_databases_region_filtered", "ds_sql_costs_grouped", "ds_currency", "ds_stats_interval", "param_min_savings", "param_stats_lookback", "param_stats_underutil_threshold_cpu_value", "param_unused_or_underutilized", "param_minimum_age", "param_stats_threshold"
+  parameters "ds_merged_metrics", "ds_azure_sql_databases_region_filtered", "ds_sql_costs_grouped", "ds_currency", "ds_stats_interval", "param_min_savings", "param_stats_lookback", "param_stats_underutil_threshold_cpu_value", "param_stats_underutil_threshold_dtu_value", "param_unused_or_underutilized", "param_minimum_age", "param_stats_threshold"
   result "result"
   code <<-'EOS'
   // Function for formatting currency numbers later

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
@@ -7,7 +7,7 @@ category "Meta"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "5.5.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.0.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -170,7 +170,17 @@ parameter "param_stats_underutil_threshold_cpu_value" do
   type "number"
   category "Statistics"
   label "Underutilized Instance CPU Threshold (%)"
-  description "The CPU threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing."
+  description "The CPU threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing. Only applies to vCore-model SQL databases (GeneralPurpose, BusinessCritical, Hyperscale)"
+  min_value 0
+  max_value 100
+  default 60
+end
+
+parameter "param_stats_underutil_threshold_dtu_value" do
+  type "number"
+  category "Statistics"
+  label "Underutilized Instance DTU Threshold (%)"
+  description "The DTU threshold at which to consider an instance to be 'underutilized' and therefore be flagged for downsizing. Only applies to DTU-model SQL databases (Basic, Standard, Premium)"
   min_value 0
   max_value 100
   default 60
@@ -1165,6 +1175,9 @@ policy "policy_scheduled_report" do
       field "skuTier" do
         label "SKU - Tier"
       end
+      field "purchase_model" do
+        label "Purchase Model"
+      end
       field "type" do
         label "Type"
       end
@@ -1200,6 +1213,24 @@ policy "policy_scheduled_report" do
       end
       field "cpuP99" do
         label "CPU p99"
+      end
+      field "dtuMaximum" do
+        label "DTU Maximum %"
+      end
+      field "dtuMinimum" do
+        label "DTU Minimum %"
+      end
+      field "dtuAverage" do
+        label "DTU Average %"
+      end
+      field "dtuP90" do
+        label "DTU p90"
+      end
+      field "dtuP95" do
+        label "DTU p95"
+      end
+      field "dtuP99" do
+        label "DTU p99"
       end
       field "service" do
         label "Service"
@@ -1272,17 +1303,20 @@ policy "policy_scheduled_report" do
       field "status" do
         label "Status"
       end
+      field "resourceType" do
+        label "Current Capacity"
+      end
+      field "newResourceType" do
+        label "Recommended Capacity"
+      end
       field "skuName" do
         label "SKU - Name"
       end
       field "skuTier" do
         label "SKU - Tier"
       end
-      field "resourceType" do
-        label "SKU - Capacity"
-      end
-      field "newResourceType" do
-        label "Recommended Capacity"
+      field "purchase_model" do
+        label "Purchase Model"
       end
       field "savings" do
         label "Estimated Monthly Savings"

--- a/data/policy_permissions_list/master_policy_permissions_list.json
+++ b/data/policy_permissions_list/master_policy_permissions_list.json
@@ -4263,7 +4263,7 @@
     {
       "id": "./cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt",
       "name": "Azure Rightsize SQL Databases",
-      "version": "5.5.3",
+      "version": "6.0.0",
       "providers": [
         {
           "name": "azure_rm",

--- a/data/policy_permissions_list/master_policy_permissions_list.yaml
+++ b/data/policy_permissions_list/master_policy_permissions_list.yaml
@@ -2471,7 +2471,7 @@
       required: true
 - id: "./cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt"
   name: Azure Rightsize SQL Databases
-  version: 5.5.3
+  version: 6.0.0
   :providers:
   - :name: azure_rm
     :permissions:


### PR DESCRIPTION
### Description

Azure Rightsize SQL Databases changes:

- Policy template now distinguishes between vCore-model and DTU-model databases and checks CPU and DTU metrics to determine usage for each purchase model respectively.
- Fixed issue where policy template would report new recommendations if a metric other than cpuAverage had changed for an existing recommendation.

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=682e33dafb0915fc14dcc30a
(Also tested in client environment with actual incident results)

### Contribution Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
