### PR TITLE
POL-1529 Fixed Write Permissions in AWS Read Only CFT

### DIFF
--- a/cost/aws/schedule_instance/README.md
+++ b/cost/aws/schedule_instance/README.md
@@ -86,20 +86,22 @@ This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Auto
 
 - [**AWS Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1121575) (*provider=aws*) which has the following permissions:
   - `ec2:DescribeInstances`
-  - `ec2:StartInstances`
-  - `ec2:StopInstances`
-  - `ec2:DeleteTags`
+  - `ec2:StartInstances`*
+  - `ec2:StopInstances`*
+  - `ec2:DeleteTags`*
   - `ec2:DescribeRegions`
-  - `kms:CreateGrant`‡
-  - `kms:Decrypt`‡
-  - `ec2:CreateTags`*
-  - `ec2:TerminateInstances`†
+  - `kms:CreateGrant`*§
+  - `kms:Decrypt`*§
+  - `ec2:CreateTags`*†
+  - `ec2:TerminateInstances`*‡
 
-  \* Only required for `Update Schedule` Action; the policy will still start/stop instance without this permission.
+  \* These permissions enable taking actions against cloud resources.
 
-  † Only required for `Terminate Instance` Action; the policy will still start/stop instance without this permission.
+  † Only required for `Update Schedule` Action; the policy will still start/stop instance without this permission.
 
-  ‡ Only required if using Customer Managed KMS Key on Volumes mounted by EC2 Instance(s)
+  ‡ Only required for `Terminate Instance` Action; the policy will still start/stop instance without this permission.
+
+  § Only required if using Customer Managed KMS Key on Volumes mounted by EC2 Instance(s)
 
   Example IAM Permission Policy:
 

--- a/cost/aws/unused_volumes/README.md
+++ b/cost/aws/unused_volumes/README.md
@@ -69,7 +69,7 @@ This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Auto
   - `ec2:DetachVolume`*
   - `ec2:DeleteVolume`*
 
-\* Only required for taking action; the policy will still function in a read-only capacity without these permissions.
+  \* Only required for taking action; the policy will still function in a read-only capacity without these permissions.
 
   Example IAM Permission Policy:
 

--- a/cost/azure/schedule_instance/README.md
+++ b/cost/azure/schedule_instance/README.md
@@ -88,10 +88,12 @@ This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Auto
 
 - [**Azure Resource Manager Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_109256743_1124668) (*provider=azure_rm*) which has the following permissions:
   - `Microsoft.Compute/virtualMachines/read`
-  - `Microsoft.Compute/virtualMachines/write`
-  - `Microsoft.Compute/virtualMachines/delete`
-  - `Microsoft.Compute/virtualMachines/start/action`
-  - `Microsoft.Compute/virtualMachines/deallocate/action`
+  - `Microsoft.Compute/virtualMachines/write`*
+  - `Microsoft.Compute/virtualMachines/delete`*
+  - `Microsoft.Compute/virtualMachines/start/action`*
+  - `Microsoft.Compute/virtualMachines/deallocate/action`*
+
+  \* These permissions enable taking actions against cloud resources.
 
 - [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
   - `billing_center_viewer`

--- a/cost/google/schedule_instance/README.md
+++ b/cost/google/schedule_instance/README.md
@@ -84,14 +84,16 @@ This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Auto
   - `compute.zones.list`
   - `compute.instances.list`
   - `compute.instances.get`
-  - `compute.instances.start`
-  - `compute.instances.stop`
-  - `compute.instances.delete`†
-  - `compute.instances.setLabels`*
+  - `compute.instances.start`*
+  - `compute.instances.stop`*
+  - `compute.instances.delete`*‡
+  - `compute.instances.setLabels`*†
 
-  \* Only required for `Update Schedule` Action; the policy will still start/stop instance without this permission.
+  \* These permissions enable taking actions against cloud resources.
 
-  † Only required for `Terminate Instance` Action; the policy will still start/stop instance without this permission.
+  † Only required for `Update Schedule` Action; the policy will still start/stop instance without this permission.
+
+  ‡ Only required for `Terminate Instance` Action; the policy will still start/stop instance without this permission.
 
 - [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
   - `billing_center_viewer`

--- a/data/policy_permissions_list/master_policy_permissions_list.json
+++ b/data/policy_permissions_list/master_policy_permissions_list.json
@@ -2894,18 +2894,21 @@
             },
             {
               "name": "ec2:StartInstances",
-              "read_only": true,
-              "required": true
+              "read_only": false,
+              "required": false,
+              "description": "These permissions enable taking actions against cloud resources."
             },
             {
               "name": "ec2:StopInstances",
-              "read_only": true,
-              "required": true
+              "read_only": false,
+              "required": false,
+              "description": "These permissions enable taking actions against cloud resources."
             },
             {
               "name": "ec2:DeleteTags",
-              "read_only": true,
-              "required": true
+              "read_only": false,
+              "required": false,
+              "description": "These permissions enable taking actions against cloud resources."
             },
             {
               "name": "ec2:DescribeRegions",
@@ -2914,27 +2917,27 @@
             },
             {
               "name": "kms:CreateGrant",
-              "read_only": true,
+              "read_only": false,
               "required": false,
-              "description": "Only required if using Customer Managed KMS Key on Volumes mounted by EC2 Instance(s)"
+              "description": "These permissions enable taking actions against cloud resources."
             },
             {
               "name": "kms:Decrypt",
-              "read_only": true,
+              "read_only": false,
               "required": false,
-              "description": "Only required if using Customer Managed KMS Key on Volumes mounted by EC2 Instance(s)"
+              "description": "These permissions enable taking actions against cloud resources."
             },
             {
               "name": "ec2:CreateTags",
-              "read_only": true,
+              "read_only": false,
               "required": false,
-              "description": "Only required for `Update Schedule` Action; the policy will still start/stop instance without this permission."
+              "description": "These permissions enable taking actions against cloud resources."
             },
             {
               "name": "ec2:TerminateInstances",
-              "read_only": true,
+              "read_only": false,
               "required": false,
-              "description": "Only required for `Terminate Instance` Action; the policy will still start/stop instance without this permission."
+              "description": "These permissions enable taking actions against cloud resources."
             }
           ]
         },

--- a/data/policy_permissions_list/master_policy_permissions_list.json
+++ b/data/policy_permissions_list/master_policy_permissions_list.json
@@ -2895,19 +2895,19 @@
             {
               "name": "ec2:StartInstances",
               "read_only": false,
-              "required": false,
+              "required": true,
               "description": "These permissions enable taking actions against cloud resources."
             },
             {
               "name": "ec2:StopInstances",
               "read_only": false,
-              "required": false,
+              "required": true,
               "description": "These permissions enable taking actions against cloud resources."
             },
             {
               "name": "ec2:DeleteTags",
               "read_only": false,
-              "required": false,
+              "required": true,
               "description": "These permissions enable taking actions against cloud resources."
             },
             {
@@ -2918,25 +2918,25 @@
             {
               "name": "kms:CreateGrant",
               "read_only": false,
-              "required": false,
+              "required": true,
               "description": "These permissions enable taking actions against cloud resources."
             },
             {
               "name": "kms:Decrypt",
               "read_only": false,
-              "required": false,
+              "required": true,
               "description": "These permissions enable taking actions against cloud resources."
             },
             {
               "name": "ec2:CreateTags",
               "read_only": false,
-              "required": false,
+              "required": true,
               "description": "These permissions enable taking actions against cloud resources."
             },
             {
               "name": "ec2:TerminateInstances",
               "read_only": false,
-              "required": false,
+              "required": true,
               "description": "These permissions enable taking actions against cloud resources."
             }
           ]
@@ -4530,25 +4530,25 @@
             {
               "name": "Microsoft.Compute/virtualMachines/write",
               "read_only": false,
-              "required": false,
+              "required": true,
               "description": "These permissions enable taking actions against cloud resources."
             },
             {
               "name": "Microsoft.Compute/virtualMachines/delete",
               "read_only": false,
-              "required": false,
+              "required": true,
               "description": "These permissions enable taking actions against cloud resources."
             },
             {
               "name": "Microsoft.Compute/virtualMachines/start/action",
               "read_only": false,
-              "required": false,
+              "required": true,
               "description": "These permissions enable taking actions against cloud resources."
             },
             {
               "name": "Microsoft.Compute/virtualMachines/deallocate/action",
               "read_only": false,
-              "required": false,
+              "required": true,
               "description": "These permissions enable taking actions against cloud resources."
             }
           ]
@@ -6203,25 +6203,25 @@
             {
               "name": "compute.instances.start",
               "read_only": false,
-              "required": false,
+              "required": true,
               "description": "These permissions enable taking actions against cloud resources."
             },
             {
               "name": "compute.instances.stop",
               "read_only": false,
-              "required": false,
+              "required": true,
               "description": "These permissions enable taking actions against cloud resources."
             },
             {
               "name": "compute.instances.delete",
               "read_only": false,
-              "required": false,
+              "required": true,
               "description": "These permissions enable taking actions against cloud resources."
             },
             {
               "name": "compute.instances.setLabels",
               "read_only": false,
-              "required": false,
+              "required": true,
               "description": "These permissions enable taking actions against cloud resources."
             }
           ]

--- a/data/policy_permissions_list/master_policy_permissions_list.json
+++ b/data/policy_permissions_list/master_policy_permissions_list.json
@@ -4529,23 +4529,27 @@
             },
             {
               "name": "Microsoft.Compute/virtualMachines/write",
-              "read_only": true,
-              "required": true
+              "read_only": false,
+              "required": false,
+              "description": "These permissions enable taking actions against cloud resources."
             },
             {
               "name": "Microsoft.Compute/virtualMachines/delete",
-              "read_only": true,
-              "required": true
+              "read_only": false,
+              "required": false,
+              "description": "These permissions enable taking actions against cloud resources."
             },
             {
               "name": "Microsoft.Compute/virtualMachines/start/action",
-              "read_only": true,
-              "required": true
+              "read_only": false,
+              "required": false,
+              "description": "These permissions enable taking actions against cloud resources."
             },
             {
               "name": "Microsoft.Compute/virtualMachines/deallocate/action",
-              "read_only": true,
-              "required": true
+              "read_only": false,
+              "required": false,
+              "description": "These permissions enable taking actions against cloud resources."
             }
           ]
         },
@@ -6198,25 +6202,27 @@
             },
             {
               "name": "compute.instances.start",
-              "read_only": true,
-              "required": true
+              "read_only": false,
+              "required": false,
+              "description": "These permissions enable taking actions against cloud resources."
             },
             {
               "name": "compute.instances.stop",
-              "read_only": true,
-              "required": true
+              "read_only": false,
+              "required": false,
+              "description": "These permissions enable taking actions against cloud resources."
             },
             {
               "name": "compute.instances.delete",
-              "read_only": true,
+              "read_only": false,
               "required": false,
-              "description": "Only required for `Terminate Instance` Action; the policy will still start/stop instance without this permission."
+              "description": "These permissions enable taking actions against cloud resources."
             },
             {
               "name": "compute.instances.setLabels",
-              "read_only": true,
+              "read_only": false,
               "required": false,
-              "description": "Only required for `Update Schedule` Action; the policy will still start/stop instance without this permission."
+              "description": "These permissions enable taking actions against cloud resources."
             }
           ]
         },

--- a/data/policy_permissions_list/master_policy_permissions_list.yaml
+++ b/data/policy_permissions_list/master_policy_permissions_list.yaml
@@ -2617,17 +2617,21 @@
       read_only: true
       required: true
     - name: Microsoft.Compute/virtualMachines/write
-      read_only: true
-      required: true
+      read_only: false
+      required: false
+      description: These permissions enable taking actions against cloud resources.
     - name: Microsoft.Compute/virtualMachines/delete
-      read_only: true
-      required: true
+      read_only: false
+      required: false
+      description: These permissions enable taking actions against cloud resources.
     - name: Microsoft.Compute/virtualMachines/start/action
-      read_only: true
-      required: true
+      read_only: false
+      required: false
+      description: These permissions enable taking actions against cloud resources.
     - name: Microsoft.Compute/virtualMachines/deallocate/action
-      read_only: true
-      required: true
+      read_only: false
+      required: false
+      description: These permissions enable taking actions against cloud resources.
   - :name: flexera
     :permissions:
     - name: billing_center_viewer
@@ -3594,21 +3598,21 @@
       read_only: true
       required: true
     - name: compute.instances.start
-      read_only: true
-      required: true
+      read_only: false
+      required: false
+      description: These permissions enable taking actions against cloud resources.
     - name: compute.instances.stop
-      read_only: true
-      required: true
+      read_only: false
+      required: false
+      description: These permissions enable taking actions against cloud resources.
     - name: compute.instances.delete
-      read_only: true
+      read_only: false
       required: false
-      description: Only required for `Terminate Instance` Action; the policy will
-        still start/stop instance without this permission.
+      description: These permissions enable taking actions against cloud resources.
     - name: compute.instances.setLabels
-      read_only: true
+      read_only: false
       required: false
-      description: Only required for `Update Schedule` Action; the policy will still
-        start/stop instance without this permission.
+      description: These permissions enable taking actions against cloud resources.
   - :name: flexera
     :permissions:
     - name: billing_center_viewer

--- a/data/policy_permissions_list/master_policy_permissions_list.yaml
+++ b/data/policy_permissions_list/master_policy_permissions_list.yaml
@@ -1655,34 +1655,34 @@
       required: true
     - name: ec2:StartInstances
       read_only: false
-      required: false
+      required: true
       description: These permissions enable taking actions against cloud resources.
     - name: ec2:StopInstances
       read_only: false
-      required: false
+      required: true
       description: These permissions enable taking actions against cloud resources.
     - name: ec2:DeleteTags
       read_only: false
-      required: false
+      required: true
       description: These permissions enable taking actions against cloud resources.
     - name: ec2:DescribeRegions
       read_only: true
       required: true
     - name: kms:CreateGrant
       read_only: false
-      required: false
+      required: true
       description: These permissions enable taking actions against cloud resources.
     - name: kms:Decrypt
       read_only: false
-      required: false
+      required: true
       description: These permissions enable taking actions against cloud resources.
     - name: ec2:CreateTags
       read_only: false
-      required: false
+      required: true
       description: These permissions enable taking actions against cloud resources.
     - name: ec2:TerminateInstances
       read_only: false
-      required: false
+      required: true
       description: These permissions enable taking actions against cloud resources.
   - :name: flexera
     :permissions:
@@ -2618,19 +2618,19 @@
       required: true
     - name: Microsoft.Compute/virtualMachines/write
       read_only: false
-      required: false
+      required: true
       description: These permissions enable taking actions against cloud resources.
     - name: Microsoft.Compute/virtualMachines/delete
       read_only: false
-      required: false
+      required: true
       description: These permissions enable taking actions against cloud resources.
     - name: Microsoft.Compute/virtualMachines/start/action
       read_only: false
-      required: false
+      required: true
       description: These permissions enable taking actions against cloud resources.
     - name: Microsoft.Compute/virtualMachines/deallocate/action
       read_only: false
-      required: false
+      required: true
       description: These permissions enable taking actions against cloud resources.
   - :name: flexera
     :permissions:
@@ -3599,19 +3599,19 @@
       required: true
     - name: compute.instances.start
       read_only: false
-      required: false
+      required: true
       description: These permissions enable taking actions against cloud resources.
     - name: compute.instances.stop
       read_only: false
-      required: false
+      required: true
       description: These permissions enable taking actions against cloud resources.
     - name: compute.instances.delete
       read_only: false
-      required: false
+      required: true
       description: These permissions enable taking actions against cloud resources.
     - name: compute.instances.setLabels
       read_only: false
-      required: false
+      required: true
       description: These permissions enable taking actions against cloud resources.
   - :name: flexera
     :permissions:

--- a/data/policy_permissions_list/master_policy_permissions_list.yaml
+++ b/data/policy_permissions_list/master_policy_permissions_list.yaml
@@ -1654,37 +1654,36 @@
       read_only: true
       required: true
     - name: ec2:StartInstances
-      read_only: true
-      required: true
+      read_only: false
+      required: false
+      description: These permissions enable taking actions against cloud resources.
     - name: ec2:StopInstances
-      read_only: true
-      required: true
+      read_only: false
+      required: false
+      description: These permissions enable taking actions against cloud resources.
     - name: ec2:DeleteTags
-      read_only: true
-      required: true
+      read_only: false
+      required: false
+      description: These permissions enable taking actions against cloud resources.
     - name: ec2:DescribeRegions
       read_only: true
       required: true
     - name: kms:CreateGrant
-      read_only: true
+      read_only: false
       required: false
-      description: Only required if using Customer Managed KMS Key on Volumes mounted
-        by EC2 Instance(s)
+      description: These permissions enable taking actions against cloud resources.
     - name: kms:Decrypt
-      read_only: true
+      read_only: false
       required: false
-      description: Only required if using Customer Managed KMS Key on Volumes mounted
-        by EC2 Instance(s)
+      description: These permissions enable taking actions against cloud resources.
     - name: ec2:CreateTags
-      read_only: true
+      read_only: false
       required: false
-      description: Only required for `Update Schedule` Action; the policy will still
-        start/stop instance without this permission.
+      description: These permissions enable taking actions against cloud resources.
     - name: ec2:TerminateInstances
-      read_only: true
+      read_only: false
       required: false
-      description: Only required for `Terminate Instance` Action; the policy will
-        still start/stop instance without this permission.
+      description: These permissions enable taking actions against cloud resources.
   - :name: flexera
     :permissions:
     - name: billing_center_viewer

--- a/tools/cloudformation-template/FlexeraAutomationPolicies.template
+++ b/tools/cloudformation-template/FlexeraAutomationPolicies.template
@@ -1016,6 +1016,7 @@ Parameters:
     AllowedValues:
       - None
       - Read Only
+      - Read and Take Action
   ## AWS Scheduled EC2 Events
   paramPermsAWSScheduledEC2Events:
     Description: 'What permissions for the "AWS Scheduled EC2 Events" Policy Template should be granted on the AWS Role that will be created?'
@@ -1541,6 +1542,9 @@ Conditions:
     - !Equals
       - !Ref paramPermsAWSScheduleInstance
       - None
+  CreatePolicyAWSScheduleInstanceAction: !Equals
+    - !Ref paramPermsAWSScheduleInstance
+    - Read and Take Action
   ## AWS Scheduled EC2 Events
   CreatePolicyAWSScheduledEC2EventsRead: !Not
     - !Equals
@@ -1679,8 +1683,6 @@ Mappings:
         - "cloudwatch:GetMetricStatistics"
         - "cloudwatch:ListMetrics"
         - "config:DescribeConfigurationRecorderStatus"
-        - "ec2:CreateTags"
-        - "ec2:DeleteTags"
         - "ec2:DescribeAddresses"
         - "ec2:DescribeFlowLogs"
         - "ec2:DescribeImages"
@@ -1693,9 +1695,6 @@ Mappings:
         - "ec2:DescribeVolumes"
         - "ec2:DescribeVpcs"
         - "ec2:GetEbsEncryptionByDefault"
-        - "ec2:StartInstances"
-        - "ec2:StopInstances"
-        - "ec2:TerminateInstances"
         - "ecs:DescribeClusters"
         - "ecs:ListClusters"
         - "eks:DescribeCluster"
@@ -1725,8 +1724,6 @@ Mappings:
         - "iam:ListUserPolicies"
         - "iam:ListUsers"
         - "iam:ListVirtualMFADevices"
-        - "kms:CreateGrant"
-        - "kms:Decrypt"
         - "kms:GetKeyRotationStatus"
         - "kms:ListKeys"
         - "lambda:ListFunctions"
@@ -1764,8 +1761,10 @@ Mappings:
         - "tag:GetResources"
       action:
         - "cloudtrail:PutEventSelectors"
+        - "ec2:CreateTags"
         - "ec2:DeleteNatGateway"
         - "ec2:DeleteSnapshot"
+        - "ec2:DeleteTags"
         - "ec2:DeregisterImage"
         - "ec2:DescribeInstanceStatus"
         - "ec2:ModifyInstanceAttribute"
@@ -1777,6 +1776,8 @@ Mappings:
         - "ecs:DeleteCluster"
         - "elasticache:ModifyCacheCluster"
         - "elasticloadbalancing:DeleteLoadBalancer"
+        - "kms:CreateGrant"
+        - "kms:Decrypt"
         - "organizations:TagResource"
         - "rds:DeleteDBClusterSnapshot"
         - "rds:DeleteDBInstance"
@@ -2327,15 +2328,15 @@ Mappings:
     AWSScheduleInstance:
       read:
         - "ec2:DescribeInstances"
+        - "ec2:DescribeRegions"
+      action:
         - "ec2:StartInstances"
         - "ec2:StopInstances"
         - "ec2:DeleteTags"
-        - "ec2:DescribeRegions"
         - "kms:CreateGrant"
         - "kms:Decrypt"
         - "ec2:CreateTags"
         - "ec2:TerminateInstances"
-      action: []
     ## AWS Scheduled EC2 Events
     AWSScheduledEC2Events:
       read:
@@ -4186,6 +4187,25 @@ Resources:
               - PermissionMap
               - AWSScheduleInstance
               - read
+            Resource: "*"
+  iamPolicyAWSScheduleInstanceAction:
+    Type: "AWS::IAM::Policy"
+    Condition: CreatePolicyAWSScheduleInstanceAction
+    Properties:
+      PolicyName: !Join
+        - "_"
+        - - !Ref paramRoleName
+          - AWSScheduleInstanceActionPermissionPolicy
+      Roles:
+        - !Ref iamRole
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: !FindInMap
+              - PermissionMap
+              - AWSScheduleInstance
+              - action
             Resource: "*"
   ## AWS Scheduled EC2 Events
   iamPolicyAWSScheduledEC2EventsRead:

--- a/tools/cloudformation-template/FlexeraAutomationPoliciesReadOnly.template
+++ b/tools/cloudformation-template/FlexeraAutomationPoliciesReadOnly.template
@@ -1563,8 +1563,6 @@ Mappings:
         - "cloudwatch:GetMetricStatistics"
         - "cloudwatch:ListMetrics"
         - "config:DescribeConfigurationRecorderStatus"
-        - "ec2:CreateTags"
-        - "ec2:DeleteTags"
         - "ec2:DescribeAddresses"
         - "ec2:DescribeFlowLogs"
         - "ec2:DescribeImages"
@@ -1577,9 +1575,6 @@ Mappings:
         - "ec2:DescribeVolumes"
         - "ec2:DescribeVpcs"
         - "ec2:GetEbsEncryptionByDefault"
-        - "ec2:StartInstances"
-        - "ec2:StopInstances"
-        - "ec2:TerminateInstances"
         - "ecs:DescribeClusters"
         - "ecs:ListClusters"
         - "eks:DescribeCluster"
@@ -1609,8 +1604,6 @@ Mappings:
         - "iam:ListUserPolicies"
         - "iam:ListUsers"
         - "iam:ListVirtualMFADevices"
-        - "kms:CreateGrant"
-        - "kms:Decrypt"
         - "kms:GetKeyRotationStatus"
         - "kms:ListKeys"
         - "lambda:ListFunctions"
@@ -2145,14 +2138,7 @@ Mappings:
     AWSScheduleInstance:
       read:
         - "ec2:DescribeInstances"
-        - "ec2:StartInstances"
-        - "ec2:StopInstances"
-        - "ec2:DeleteTags"
         - "ec2:DescribeRegions"
-        - "kms:CreateGrant"
-        - "kms:Decrypt"
-        - "ec2:CreateTags"
-        - "ec2:TerminateInstances"
       action: []
     ## AWS Scheduled EC2 Events
     AWSScheduledEC2Events:

--- a/tools/policy_master_permission_generation/generate_policy_master_permissions.rb
+++ b/tools/policy_master_permission_generation/generate_policy_master_permissions.rb
@@ -159,7 +159,7 @@ def extract_permissions_from_readme(readme_content)
               permission = permission.chomp(symbol_if_exists[:symbol])
 
               # Failsafe to ensure that write permissions are not marked as read-only due to README errors
-              if permission.downcase().include?("write") || permission.downcase().include?("create") || permission.downcase().include?("delete") || permission.downcase().include?("start") || permission.downcase().include?("stop") || permission.downcase().include?("modify") || permission.downcase().include?("update")
+              if permission.downcase().include?("write") || permission.downcase().include?("create") || permission.downcase().include?("delete") || permission.downcase().include?("start") || permission.downcase().include?("stop") || permission.downcase().include?("modify") || permission.downcase().include?("update") || permission.downcase().include?("change")
                 read_only_permission = false
               end
 

--- a/tools/policy_master_permission_generation/generate_policy_master_permissions.rb
+++ b/tools/policy_master_permission_generation/generate_policy_master_permissions.rb
@@ -147,7 +147,7 @@ def extract_permissions_from_readme(readme_content)
 
             if symbol_if_exists != nil && !symbol_if_exists[:detail].strip.empty?
               required = false
-              if symbol_if_exists[:detail].include?("Only required for taking action") || symbol_if_exists[:detail].include?("These permissions enable taking actions against cloud resources")
+              if symbol_if_exists[:detail].include?("taking action")
                 read_only_permission = false
               end
 

--- a/tools/policy_master_permission_generation/generate_policy_master_permissions.rb
+++ b/tools/policy_master_permission_generation/generate_policy_master_permissions.rb
@@ -158,6 +158,11 @@ def extract_permissions_from_readme(readme_content)
 
               permission = permission.chomp(symbol_if_exists[:symbol])
 
+              # Failsafe to ensure that write permissions are not marked as read-only due to README errors
+              if permission.downcase().include?("write") || permission.downcase().include?("create") || permission.downcase().include?("delete") || permission.downcase().include?("start") || permission.downcase().include?("stop") || permission.downcase().include?("modify") || permission.downcase().include?("update")
+                read_only_permission = false
+              end
+
               if credentials_section == "roles"
                 policy_credentials << { role: permission, provider: provider, read_only: read_only_permission, required: required, description: symbol_if_exists[:detail] }
               elsif credentials_section == "permissions"

--- a/tools/policy_master_permission_generation/generate_policy_master_permissions.rb
+++ b/tools/policy_master_permission_generation/generate_policy_master_permissions.rb
@@ -147,7 +147,7 @@ def extract_permissions_from_readme(readme_content)
 
             if symbol_if_exists != nil && !symbol_if_exists[:detail].strip.empty?
               required = false
-              if symbol_if_exists[:detail].include?("Only required for taking action")
+              if symbol_if_exists[:detail].include?("Only required for taking action") || symbol_if_exists[:detail].include?("These permissions enable taking actions against cloud resources")
                 read_only_permission = false
               end
 

--- a/tools/policy_master_permission_generation/generate_policy_master_permissions.rb
+++ b/tools/policy_master_permission_generation/generate_policy_master_permissions.rb
@@ -147,8 +147,13 @@ def extract_permissions_from_readme(readme_content)
 
             if symbol_if_exists != nil && !symbol_if_exists[:detail].strip.empty?
               required = false
+
               if symbol_if_exists[:detail].include?("taking action")
                 read_only_permission = false
+              end
+
+              if symbol_if_exists[:detail].include?("These permissions enable taking actions against cloud resources.")
+                required = true
               end
 
               permission = permission.chomp(symbol_if_exists[:symbol])


### PR DESCRIPTION
### Description

Read-only CFT for AWS contained some write permissions that appear to be related to how the AWS Schedule Instance policy template README.md file was being scraped.

- Added * with comment "These permissions enable taking actions against cloud resources." to the READMEs for all 3 Schedule Instance policy templates.
- Modified permissions scraper to account for the above.
- Modified permissions scraper to check permission for words that indicate a permission is not read-only, such as "write" and "create", as a failsafe in case the README is not properly configured.
- Reran the permissions scraper and CFT generation to confirm that the issue is now resolved.