### PR TITLE
POL-1532 Catalog Update Teams Notifications Failing

### DIFF
--- a/.github/workflows/generate-policy-release-notifications.yaml
+++ b/.github/workflows/generate-policy-release-notifications.yaml
@@ -25,35 +25,8 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
 
-      - name: Run Generate Policy Release Notification Content Script
-        id: changelog_content
-        run: |
-          ruby tools/policy_template_release_generation/generate_policy_release_notification_contents.rb
-      # - name: Capture Outputs
-      #   run: |
-      #     echo "Section Content: ${{ steps.changelog_content.outputs.notification_content }}"
-      #     echo "Commit URL: ${{ steps.changelog_content.outputs.commit_url }}"
-
       - name: Send Teams Notification
-        if: steps.changelog_content.outputs.notification_content != '[]'
         env:
           TEAMS_WEBHOOK_URL: ${{ secrets.POLICY_CATALOG_UPDATE_TEAMS_WEBHOOK_URL_PROD }}
         run: |
-          notification_content="${{ steps.changelog_content.outputs.notification_content }}"
-          commit_url="${{ steps.changelog_content.outputs.commit_url }}"
-          payload="{
-            \"@type\": \"MessageCard\",
-            \"@content\": \"http://schema.org/extensions\",
-            \"themeColor\": \"0076D7\",
-            \"summary\": \"New Policy Updates\",
-            \"sections\": ${notification_content},
-            \"potentialAction\": [{
-              \"@type\": \"OpenUri\",
-              \"name\": \"See Change Details in GitHub\",
-              \"targets\": [{
-                \"os\": \"default\",
-                \"uri\": \"${commit_url}\"
-              }]
-            }]
-          }"
-          curl -X POST -H "Content-Type: application/json" -d "$payload" "$TEAMS_WEBHOOK_URL"
+          ruby tools/policy_template_release_generation/generate_policy_release_notification_contents.rb

--- a/tools/policy_template_release_generation/generate_policy_release_notification_contents.rb
+++ b/tools/policy_template_release_generation/generate_policy_release_notification_contents.rb
@@ -120,7 +120,7 @@ if all_notification_content_array.length > 0
     "@content": "http://schema.org/extensions",
     "themeColor": "0076D7",
     "summary": "New Policy Updates",
-    "sections": JSON.dump(all_notification_content_array),
+    "sections": all_notification_content_array,
     "potentialAction": [{
       "@type": "OpenUri",
       "name": "See Change Details in GitHub",

--- a/tools/policy_template_release_generation/generate_policy_release_notification_contents.rb
+++ b/tools/policy_template_release_generation/generate_policy_release_notification_contents.rb
@@ -77,7 +77,7 @@ changelogs.each do |changelog|
     formatted_changes_html = formatted_changes.map { |change| "<li>#{change}</li>"}.join('')
 
     notification_content_json = {
-      activityTitle: "<h2 style='font-size: 18px;'><a href='#{readme_path}'>#{matching_template.name}</h2>",
+      activityTitle: "<h2 style='font-size: 18px;'><a href='#{readme_path}'>#{matching_template.name}</a></h2>",
       facts: [{
         name: "Template Version",
         value: changelog.version
@@ -95,7 +95,7 @@ end
 # TEST CODE. DELETE LATER
 all_notification_content_array = [
   {
-    activityTitle: "<h2 style='font-size: 18px;'><a href='https://fakereadme'>Test</h2>",
+    activityTitle: "<h2 style='font-size: 18px;'>Test</h2>",
     facts: [{
       name: "Template Version",
       value: "0.0"
@@ -117,7 +117,7 @@ if all_notification_content_array.length > 0
   # Create the final JSON payload
   payload = JSON.dump({
     "@type": "MessageCard",
-    "@content": "http://schema.org/extensions",
+    "@context": "http://schema.org/extensions",
     "themeColor": "0076D7",
     "summary": "New Policy Updates",
     "sections": all_notification_content_array,

--- a/tools/policy_template_release_generation/generate_policy_release_notification_contents.rb
+++ b/tools/policy_template_release_generation/generate_policy_release_notification_contents.rb
@@ -92,6 +92,23 @@ changelogs.each do |changelog|
   end
 end
 
+# TEST CODE. DELETE LATER
+all_notification_content_array = [
+  {
+    activityTitle: "<h2 style='font-size: 18px;'><a href='https://fakereadme'>Test</h2>",
+    facts: [{
+      name: "Template Version",
+      value: "0.0"
+    },
+    {
+      name: "Policy Updates",
+      value: "<ul>This is a test notification. Ignore.</ul>"
+    }]
+  }
+]
+# TEST CODE. DELETE LATER
+
+
 # Only send notification if there is something worth notifying about
 if all_notification_content_array.length > 0
   # Generate GitHub Commit URL

--- a/tools/policy_template_release_generation/generate_policy_release_notification_contents.rb
+++ b/tools/policy_template_release_generation/generate_policy_release_notification_contents.rb
@@ -92,23 +92,6 @@ changelogs.each do |changelog|
   end
 end
 
-# TEST CODE. DELETE LATER
-all_notification_content_array = [
-  {
-    activityTitle: "<h2 style='font-size: 18px;'>Test</h2>",
-    facts: [{
-      name: "Template Version",
-      value: "0.0"
-    },
-    {
-      name: "Policy Updates",
-      value: "<ul>This is a test notification. Ignore.</ul>"
-    }]
-  }
-]
-# TEST CODE. DELETE LATER
-
-
 # Only send notification if there is something worth notifying about
 if all_notification_content_array.length > 0
   # Generate GitHub Commit URL


### PR DESCRIPTION
### Description

Updates the Ruby script and Github Workflow for sending release notifications to Teams.

### Issues Resolved

Workflow now completes execution as expected. I tested it with some mock data and it now sends a notification.

### Contribution Check List

- [X] New functionality includes testing.
