### PR TITLE
POL-1545 Azure Rightsize Managed Disks Fixes

### DIFF
--- a/cost/azure/rightsize_managed_disks/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_disks/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v2.5.2
+## v2.6.0
 
 - Policy template no longer raises an incident if user does not set any thresholds for determining underutilization.
 - Defaults changed for `IOPS Threshold (%)` and `Throughput Threshold (%)` parameters to something a typical user would expect.

--- a/cost/azure/rightsize_managed_disks/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_disks/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.5.2
+
+- Policy template no longer raises an incident if user does not set any thresholds for determining underutilization.
+- Defaults changed for `IOPS Threshold (%)` and `Throughput Threshold (%)` parameters to something a typical user would expect.
+
 ## v2.5.1
 
 - Added batch processing for large datasources as a performance enhancement (reduces memory usage) with no changes to logic or functionality.

--- a/cost/azure/rightsize_managed_disks/README.md
+++ b/cost/azure/rightsize_managed_disks/README.md
@@ -2,7 +2,7 @@
 
 ## What It Does
 
-This policy template checks managed disks in Azure subscriptions and identifies underutilized disks based on disk performance metrics over a lookback period and a threshold specified by the user; if underutilized disks are found, then disk type downgrade is recommended. An email will be sent to the user-specified email addresses.
+This policy template checks managed disks in Azure subscriptions and identifies underutilized disks based on disk performance metrics over a look back period and a threshold specified by the user; if underutilized disks are found, then disk type downgrade is recommended. An email will be sent to the user-specified email addresses.
 
 Note: It is preferred to keep the disk LUN number constant when detaching and re-attaching a data disk to a virtual machine. LUN number is used to retrieve disk performance metrics (IOPS and throughput).
 

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "monthly"
 info(
-  version: "2.5.1",
+  version: "2.5.2",
   provider: "Azure",
   service: "Managed Disks",
   policy_set: "Rightsize Storage",
@@ -108,10 +108,10 @@ parameter "param_min_used_disk_iops_pct" do
   type "number"
   category "Filters"
   label "IOPS Threshold (%)"
-  description "The IOPs threshold at which to consider a managed disk to be underutilized. Set to -1 to turn off this filter."
+  description "The IOPS threshold at which to consider a managed disk to be underutilized. Set to -1 to turn off this filter."
   min_value -1
   max_value 100
-  default -1
+  default 30
 end
 
 parameter "param_stats_aggregation_for_disk_iops" do
@@ -130,7 +130,7 @@ parameter "param_min_used_disk_throughput_pct" do
   description "The throughput threshold at which to consider a managed disk to be underutilized. Set to -1 to turn off this filter."
   min_value -1
   max_value 100
-  default -1
+  default 30
 end
 
 parameter "param_stats_aggregation_for_disk_throughput" do
@@ -372,20 +372,37 @@ datasource "ds_azure_disks" do
   end
 end
 
+# Make sure the policy template produces no results if the user doesn't set an IOPS or throughput threshold
+datasource "ds_azure_disks_stat_filtered" do
+  run_script $js_azure_disks_stat_filtered, $ds_azure_disks, $param_min_used_disk_iops_pct, $param_min_used_disk_throughput_pct
+end
+
+script "js_azure_disks_stat_filtered", type: "javascript" do
+  parameters "ds_azure_disks", "param_min_used_disk_iops_pct", "param_min_used_disk_throughput_pct"
+  result "result"
+  code <<-EOS
+  result = []
+
+  if (param_min_used_disk_iops_pct != -1 || param_min_used_disk_throughput_pct != -1) {
+    result = ds_azure_disks
+  }
+EOS
+end
+
 datasource "ds_azure_disks_sku_filtered" do
-  run_script $js_azure_disks_sku_filtered, $ds_azure_disks, $param_sku_ignore_list
+  run_script $js_azure_disks_sku_filtered, $ds_azure_disks_stat_filtered, $param_sku_ignore_list
 end
 
 script "js_azure_disks_sku_filtered", type: "javascript" do
-  parameters "ds_azure_disks", "param_sku_ignore_list"
+  parameters "ds_azure_disks_stat_filtered", "param_sku_ignore_list"
   result "result"
   code <<-EOS
   if (param_sku_ignore_list.length > 0) {
-    result = _.reject(ds_azure_disks, function(disk) {
+    result = _.reject(ds_azure_disks_stat_filtered, function(disk) {
       return _.contains(param_sku_ignore_list, disk['tier'])
     })
   } else {
-    result = ds_azure_disks
+    result = ds_azure_disks_stat_filtered
   }
 EOS
 end
@@ -724,7 +741,7 @@ script "js_azure_disks_with_metrics", type: "javascript" do
         return true
       }
     })
-      
+
     if (correspondingVmWithMetrics === undefined) continue;
     // OS disk
     for (var j in correspondingVmWithMetrics.metrics) {

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "monthly"
 info(
-  version: "2.5.2",
+  version: "2.6.0",
   provider: "Azure",
   service: "Managed Disks",
   policy_set: "Rightsize Storage",

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks_meta_parent.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks_meta_parent.pt
@@ -7,7 +7,7 @@ category "Meta"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "2.5.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "2.6.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks_meta_parent.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks_meta_parent.pt
@@ -7,7 +7,7 @@ category "Meta"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "2.5.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "2.5.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -160,10 +160,10 @@ parameter "param_min_used_disk_iops_pct" do
   type "number"
   category "Filters"
   label "IOPS Threshold (%)"
-  description "The IOPs threshold at which to consider a managed disk to be underutilized. Set to -1 to turn off this filter."
+  description "The IOPS threshold at which to consider a managed disk to be underutilized. Set to -1 to turn off this filter."
   min_value -1
   max_value 100
-  default -1
+  default 30
 end
 
 parameter "param_stats_aggregation_for_disk_iops" do
@@ -182,7 +182,7 @@ parameter "param_min_used_disk_throughput_pct" do
   description "The throughput threshold at which to consider a managed disk to be underutilized. Set to -1 to turn off this filter."
   min_value -1
   max_value 100
-  default -1
+  default 30
 end
 
 parameter "param_stats_aggregation_for_disk_throughput" do


### PR DESCRIPTION
### Description

Azure Rightsize Managed Disks
- Policy template no longer raises an incident if user does not set any thresholds for determining underutilization.
- Defaults changed for `IOPS Threshold (%)` and `Throughput Threshold (%)` parameters to something a typical user would expect.

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=684c757c25dc071c491c91e0

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
