### PR TITLE
POL-1533 AWS Untagged Resources Resource Type Filtering

### DIFF
--- a/compliance/aws/untagged_resources/CHANGELOG.md
+++ b/compliance/aws/untagged_resources/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v5.4.0
+
+- New `Resource Types` parameter allows policy template to only report on specific services or resource types.
+- Small code changes made to improve the speed of policy template execution.
+
 ## v5.3.2
 
 - Added `hide_skip_approvals` field to the info section. It dynamically controls "Skip Action Approvals" visibility.

--- a/compliance/aws/untagged_resources/README.md
+++ b/compliance/aws/untagged_resources/README.md
@@ -34,11 +34,9 @@ This policy template checks for AWS resources missing the user-specified tags. A
 - *Consider Tag Dimensions* - Exclude results when a resource is tagged with a tag key that is normalized by a Tag Dimension.
   - Considers resource tags which are normalized under tag dimensions and excludes those matching from the missing tags results.
   - Mitigates/prevents seeing resources that are tagged using some tag key which is normalized under a matching Tag Dimension.
-  - `Tags` parameter value must match a Tag Dimension Name ("Cost Center") or Tag Dimension ID ("tag_cost_center") for the lookup to occur
-
-  For example,
-   - A resource tagged `app=prod-cluster`
-   - A Tag Dimension named "Application" (tag_application) which normalizes tag resource tag keys `app`, `Application`, `App`, `application`, etc...
+  - `Tags` parameter value must match a Tag Dimension Name ("Cost Center") or Tag Dimension ID ("tag_cost_center") for the lookup to occur. For example:
+    - A resource tagged `app=prod-cluster`
+    - A Tag Dimension named "Application" (tag_application) which normalizes tag resource tag keys `app`, `Application`, `App`, `application`, etc.
 
   If Exclude Tag Dimensions is enabled and `Tags=["Application"]` the example resource would be considered to **not** be missing the `Application` tag, because it has the `app` tag which is normalized under the "Application" tag dimension
 

--- a/compliance/aws/untagged_resources/README.md
+++ b/compliance/aws/untagged_resources/README.md
@@ -17,6 +17,12 @@ This policy template checks for AWS resources missing the user-specified tags. A
 - *Include Savings* - Whether or not to include the total estimated savings opportunities for each resource in the results. Disabling this can speed up policy execution but will result in the relevant fields in the report being empty.
 - *Allow/Deny Regions* - Whether to treat Allow/Deny Regions List parameter as allow or deny list. Has no effect if Allow/Deny Regions List is left empty.
 - *Allow/Deny Regions List* - A list of regions to allow or deny for an AWS account. Please enter the regions code if SCP is enabled. See [Available Regions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) in AWS; otherwise, the policy may fail on regions that are disabled via SCP. Leave blank to consider all the regions.
+- *Resource Types* - A list of resource types to report on. Leave empty to report all taggable resources that aren't compliant. Entries must be in `service` or `service:type` format. The specific values for each service and resource type [can be found in the AWS documentation](https://docs.aws.amazon.com/service-authorization/latest/reference/reference.html). Examples:
+  - ec2
+  - ec2:instance
+  - s3
+  - rds:db
+  - dynamodb:table
 - *Include Account Tags* - Whether or not to include the AWS account itself as a resource whose tags are checked and reported on.
 - *Tags* - The policy will report resources missing the specified tags. The following formats are supported:
   - `Key` - Find all resources missing the specified tag key.

--- a/compliance/aws/untagged_resources/aws_untagged_resources.pt
+++ b/compliance/aws/untagged_resources/aws_untagged_resources.pt
@@ -7,7 +7,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.3.2",
+  version: "5.4.0",
   provider: "AWS",
   service: "Compute",
   policy_set: "Untagged Resources",
@@ -75,6 +75,14 @@ parameter "param_regions_list" do
   label "Allow/Deny Regions List"
   description "A list of allowed or denied regions. See the README for more details."
   allowed_pattern /^([a-zA-Z-_]+-[a-zA-Z0-9-_]+-[0-9-_]+,*|)+$/
+  default []
+end
+
+parameter "param_resource_types" do
+  type "list"
+  category "Filters"
+  label "Resource Types"
+  description "A list of resource types to report on. Leave empty to report all taggable resources that aren't compliant. Entries must be in \"service\" or \"service:type\" format. See the README for more details."
   default []
 end
 
@@ -454,15 +462,7 @@ end
 datasource "ds_aws_resources" do
   iterate $ds_regions
   request do
-    auth $auth_aws
-    pagination $pagination_aws_tagging
-    verb "POST"
-    host join(["tagging.", val(iter_item, "region"), ".amazonaws.com"])
-    path "/"
-    header "X-Amz-Target", "ResourceGroupsTaggingAPI_20170126.GetResources"
-    header "Content-Type", "application/x-amz-json-1.1"
-    body_field "ExcludeCompliantResources", "false"
-    body_field "IncludeComplianceDetails", "true"
+    run_script $js_aws_resources, val(iter_item, "region"), $param_resource_types
   end
   result do
     encoding "json"
@@ -478,6 +478,32 @@ datasource "ds_aws_resources" do
       field "type", "Resource"
     end
   end
+end
+
+script "js_aws_resources", type:"javascript" do
+  parameters "region", "param_resource_types"
+  result "request"
+  code <<-EOS
+  var request = {
+    auth: "auth_aws",
+    pagination: "pagination_aws_tagging",
+    verb: "POST",
+    host: [ "tagging.", region, ".amazonaws.com" ].join(''),
+    path: "/",
+    headers: {
+      "X-Amz-Target": "ResourceGroupsTaggingAPI_20170126.GetResources",
+      "Content-Type": "application/x-amz-json-1.1"
+    },
+    body_fields: {
+      "ExcludeCompliantResources": "false",
+      "IncludeComplianceDetails": "false"
+    }
+  }
+
+  if (param_resource_types.length > 0) {
+    request["body_fields"]["ResourceTypeFilters"] = param_resource_types
+  }
+EOS
 end
 
 datasource "ds_aws_resources_missing_tags" do
@@ -562,6 +588,7 @@ script "js_aws_resources_missing_tags", type:"javascript" do
       })
 
       missing_tags_result = missing_tags
+
       if (param_consider_tag_dimensions == "Consider Tag Dimension") {
         // Exclude resources that have a tag value for one of the tag dimensions
         // For each tag on the resource
@@ -591,7 +618,7 @@ script "js_aws_resources_missing_tags", type:"javascript" do
               }
             }
           }
-        });
+        })
       }
 
       if (missing_tags.length == comparators.length || (missing_tags.length > 0 && param_tags_boolean == 'Any')) {


### PR DESCRIPTION
### Description

AWS Untagged Resources
- New `Resource Types` parameter allows policy template to only report on specific services or resource types.
- Small code changes made to improve the speed of policy template execution.*

(Basically just amounts to changing IncludeComplianceDetails to false since we don't use this data in the policy template anyway)

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=6862abd6a8027c2d05f4c388

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
