### PR TITLE
POL-1542 feat: Update tag resource action to use Tags API and enable Tag Contributor role

### DIFF
--- a/compliance/azure/azure_untagged_resources/CHANGELOG.md
+++ b/compliance/azure/azure_untagged_resources/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.3.0
+
+- Update tag resource action to use Azure Tags API, which enables `Tag Contributor` role to be used for enabling action capabilities with minimum scope.
+
 ## v3.2.2
 
 - Fixed issue where prompt for adding tags incorrectly said to use "key:value" instead of "key=value" format.

--- a/compliance/azure/azure_untagged_resources/README.md
+++ b/compliance/azure/azure_untagged_resources/README.md
@@ -58,7 +58,6 @@ For administrators [creating and managing credentials](https://docs.flexera.com/
   - `Microsoft.Resources/subscriptions/resources/read`
   - `Microsoft.Resources/subscriptions/resourceGroups/read`
   - `Microsoft.Resources/tags/read`
-  - `Microsoft.Resources/subscriptions/resourceGroups/write`*
   - `Microsoft.Resources/tags/write`*
 
   \* Only required for taking action; the policy will still function in a read-only capacity without these permissions.

--- a/compliance/azure/azure_untagged_resources/untagged_resources.pt
+++ b/compliance/azure/azure_untagged_resources/untagged_resources.pt
@@ -7,7 +7,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "3.2.2",
+  version: "3.3.0",
   provider: "Azure",
   service: "Compute",
   policy_set: "Untagged Resources",
@@ -641,17 +641,7 @@ define tag_resources($data, $param_azure_endpoint, $param_tags_to_add) return $a
 
   foreach $resource in $data do
     sub on_error: handle_error() do
-      if $resource["type"] == "Resource"
-        call tag_instance($resource, $param_azure_endpoint, $param_tags_to_add) retrieve $tag_response
-      end
-
-      if $resource["type"] == "Resource Group"
-        call tag_resource_group($resource, $param_azure_endpoint, $param_tags_to_add) retrieve $tag_response
-      end
-
-      if $resource["type"] == "Subscription"
-        call tag_subscription($resource, $param_azure_endpoint, $param_tags_to_add) retrieve $tag_response
-      end
+      call tag_resource($resource, $param_azure_endpoint, $param_tags_to_add)
     end
   end
 
@@ -660,85 +650,8 @@ define tag_resources($data, $param_azure_endpoint, $param_tags_to_add) return $a
   end
 end
 
-define tag_instance($resource, $param_azure_endpoint, $param_tags_to_add) return $response do
-  $tags = $resource["tags_object"]
-
-  if $tags == null
-    $tags = {}
-  end
-
-  foreach $tag in $param_tags_to_add do
-    $key = first(split($tag, "="))
-    $value = last(split($tag, "="))
-    $tags[$key] = $value
-  end
-
-  $host = $param_azure_endpoint
-  $href = $resource["id"]
-  $params = "?api-version=" + $resource["api_version"]
-  $url = $host + $href + $params
-  task_label("PATCH " + $url)
-
-  $response = http_request(
-    auth: $$auth_azure,
-    https: true,
-    verb: "patch",
-    host: $host,
-    href: $href,
-    query_strings: { "api-version": $resource["api_version"] },
-    body: { "tags": $tags }
-  )
-
-  task_label("Patch Azure Resource response: " + $resource["id"] + " " + to_json($response))
-  $$all_responses << to_json({"req": "PATCH " + $url, "resp": $response})
-
-  if $response["code"] != 204 && $response["code"] != 202 && $response["code"] != 200
-    raise "Unexpected response patching Azure Resource: "+ $resource["id"] + " " + to_json($response)
-  else
-    task_label("Patch Azure Resource successful: " + $resource["id"])
-  end
-end
-
-define tag_resource_group($resource, $param_azure_endpoint, $param_tags_to_add) return $response do
-  $tags = $resource["tags_object"]
-
-  if $tags == null
-    $tags = {}
-  end
-
-  foreach $tag in $param_tags_to_add do
-    $key = first(split($tag, "="))
-    $value = last(split($tag, "="))
-    $tags[$key] = $value
-  end
-
-  $host = $param_azure_endpoint
-  $href = $resource["id"]
-  $params = "?api-version=" + $resource["api_version"]
-  $url = $host + $href + $params
-  task_label("PATCH " + $url)
-
-  $response = http_request(
-    auth: $$auth_azure,
-    https: true,
-    verb: "patch",
-    host: $host,
-    href: $href,
-    query_strings: { "api-version": $resource["api_version"] },
-    body: { "tags": $tags }
-  )
-
-  task_label("Patch Azure Resource Group response: " + $resource["id"] + " " + to_json($response))
-  $$all_responses << to_json({"req": "PATCH " + $url, "resp": $response})
-
-  if $response["code"] != 204 && $response["code"] != 202 && $response["code"] != 200
-    raise "Unexpected response patching Azure Resource Group: "+ $resource["id"] + " " + to_json($response)
-  else
-    task_label("Patch Azure Resource Group successful: " + $resource["id"])
-  end
-end
-
-define tag_subscription($resource, $param_azure_endpoint, $param_tags_to_add) return $response do
+# https://learn.microsoft.com/en-us/rest/api/resources/tags/create-or-update-at-scope?view=rest-resources-2025-04-01
+define tag_resource($resource, $param_azure_endpoint, $param_tags_to_add) do
   $tags = $resource["tags_object"]
 
   if $tags == null
@@ -753,8 +666,7 @@ define tag_subscription($resource, $param_azure_endpoint, $param_tags_to_add) re
 
   $host = $param_azure_endpoint
   $href = $resource["id"] + "/providers/Microsoft.Resources/tags/default"
-  $params = "?api-version=2021-04-01"
-  $url = $host + $href + $params
+  $url = $host + $href
   task_label("PUT " + $url)
 
   $response = http_request(
@@ -763,17 +675,21 @@ define tag_subscription($resource, $param_azure_endpoint, $param_tags_to_add) re
     verb: "put",
     host: $host,
     href: $href,
-    query_strings: { "api-version": "2021-04-01" },
-    body: { "properties": { "tags": $tags } }
+    query_strings: { "api-version": "2025-04-01" },
+    body: {
+        "properties": {
+          "tags": $tags
+        }
+      }
   )
 
-  task_label("Put Azure Subscription response: " + $resource["id"] + " " + to_json($response))
+  task_label("Tag Azure Resource response: " + $resource["id"] + " " + to_json($response))
   $$all_responses << to_json({"req": "PUT " + $url, "resp": $response})
 
   if $response["code"] != 204 && $response["code"] != 202 && $response["code"] != 200
-    raise "Unexpected response putting Azure Subscription: "+ $resource["id"] + " " + to_json($response)
+    raise "Unexpected response from Tag Azure Resource: "+ $resource["id"] + " " + to_json($response)
   else
-    task_label("Put Azure Subscription successful: " + $resource["id"])
+    task_label("Tag Azure Resource successful: " + $resource["id"])
   end
 end
 


### PR DESCRIPTION
### Description

Update tag resource action to use Azure Tags API, which enables `Tag Contributor` role to be used for enabling action capabilities with minimum scope.

### Issues Resolved

https://flexera.atlassian.net/browse/POL-1542

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=68655732040e601d900f167b

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
