### PR TITLE
SQ-15559 Azure Superseded Compute Instances Reference Error

### DIFF
--- a/cost/azure/superseded_instances/CHANGELOG.md
+++ b/cost/azure/superseded_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1.4
+
+- Fixed error where policy would fail completely when finding the superseded instances prices.
+
 ## v2.1.3
 
 - Added `hide_skip_approvals` field to the info section. It dynamically controls "Skip Action Approvals" visibility.

--- a/cost/azure/superseded_instances/azure_superseded_instances.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances.pt
@@ -766,6 +766,7 @@ script "js_superseded_instances", type: "javascript" do
         }
 
         superseded_type_cost_map = ds_azure_instance_cost_map[region][superseded_type]
+        superseded_type_price_map = undefined
 
         if (superseded_type_cost_map != undefined) {
           superseded_type_price_map = superseded_type_cost_map[operating_system]

--- a/cost/azure/superseded_instances/azure_superseded_instances.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "2.1.3",
+  version: "2.1.4",
   provider: "Azure",
   service: "Compute",
   policy_set: "Superseded Compute Instances",
@@ -755,6 +755,7 @@ script "js_superseded_instances", type: "javascript" do
     if (typeof(superseded_type) == 'string' && typeof(operating_system) == 'string') {
       if (ds_azure_instance_cost_map[region] != undefined) {
         instance_type_cost_map = ds_azure_instance_cost_map[region][instance_type]
+        instance_type_price_map = undefined
 
         if (instance_type_cost_map != undefined) {
           instance_type_price_map = instance_type_cost_map[operating_system]

--- a/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
@@ -7,7 +7,7 @@ category "Meta"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "2.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "2.1.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"


### PR DESCRIPTION
### Description

A ReferenceError is being caused:

```
ReferenceError: 'instance_type_price_map' is not defined\nLocation:\n datasource \"ds_superseded_instances\"\n script \"js_superseded_instances\
```

This is caused because the variable instance_type_price_map is not always declared, so instead of being undefined it's causing a reference error.

![image](https://github.com/user-attachments/assets/0de1be8b-9889-4042-b7e4-04f4b8b871e1)

To fix this we declare the variable before accessing it.

### Issues Resolved

There's a support question related to this PR: https://flexera.atlassian.net/browse/SQ-15559

### Link to Example Applied Policy

Policy compiles well: https://app.flexeratest.com/orgs/1105/automation/projects/60073/policy-templates/68656ecb0e188e7b223c41b0

### Contribution Check List

- [X] New functionality includes testing.
- [] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
