### PR TITLE
SQ-16235 | Azure Superseded Compute Instances | Add support for Azure CSP and Azure MCA Enterprise

### DIFF
--- a/cost/azure/superseded_instances/CHANGELOG.md
+++ b/cost/azure/superseded_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1.4
+
+- Fixed error where policy would fail completely when finding the superseded instances prices.
+
 ## v2.1.3
 
 - Added `hide_skip_approvals` field to the info section. It dynamically controls "Skip Action Approvals" visibility.

--- a/cost/azure/superseded_instances/azure_superseded_instances.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances.pt
@@ -766,6 +766,7 @@ script "js_superseded_instances", type: "javascript" do
         }
 
         superseded_type_cost_map = ds_azure_instance_cost_map[region][superseded_type]
+        superseded_type_price_map = undefined
 
         if (superseded_type_cost_map != undefined) {
           superseded_type_price_map = superseded_type_cost_map[operating_system]

--- a/cost/azure/superseded_instances/azure_superseded_instances.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "2.1.3",
+  version: "2.1.4",
   provider: "Azure",
   service: "Compute",
   policy_set: "Superseded Compute Instances",
@@ -755,6 +755,7 @@ script "js_superseded_instances", type: "javascript" do
     if (typeof(superseded_type) == 'string' && typeof(operating_system) == 'string') {
       if (ds_azure_instance_cost_map[region] != undefined) {
         instance_type_cost_map = ds_azure_instance_cost_map[region][instance_type]
+        instance_type_price_map = undefined
 
         if (instance_type_cost_map != undefined) {
           instance_type_price_map = instance_type_cost_map[operating_system]

--- a/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
@@ -7,7 +7,7 @@ category "Meta"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "2.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "2.1.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/operational/flexera/cco/bill_processing_errors_notification/CHANGELOG.md
+++ b/operational/flexera/cco/bill_processing_errors_notification/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.6.0
+
+- Added support for Azure CSP and Azure MCA Enterprise account types.
+
 ## v2.5.3
 
 - Fixed error that caused some incident fields to show invalid negative values for memory statistics for recently rightsized instances. Functionality unchanged.

--- a/operational/flexera/cco/bill_processing_errors_notification/bill_processing_errors_notification.pt
+++ b/operational/flexera/cco/bill_processing_errors_notification/bill_processing_errors_notification.pt
@@ -7,7 +7,7 @@ category "Operational"
 severity "high"
 default_frequency "daily"
 info(
-  version: "2.5.3",
+  version: "2.6.0",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -165,6 +165,29 @@ datasource "ds_bill_connections" do
       # "bigQueryDataset": "someDataset",
       # "billingAccountId": "963d605a-fac2-4263-b90e-bee184d0e045",
       # "projectId": "flexera.com:resat-cloud"
+      field "azureCsp", jmes_path(col_item, "azureCsp")
+      # Sample contents of "azureCsp" key if it exists:
+      # "billingAccountId": "12345678",
+      # "clientId": "856fb4b9-462b-4a17-a875-0756912cbb45",
+      # "startBillingPeriod": "202506",
+      # "tenantId": "b3b19f96-4148-479c-a355-7c34b902ebf9",
+      # "exportDetails": {
+      #     "actualCostExportURL": "https://bucket12345678.blob.core.windows.net/cspexports/sametenant/csp-exp1-c2-actual",
+      #     "amortizedCostExportURL": "https://bucket12345678.blob.core.windows.net/cspexports/sametenant/csp-exp1-c3-amortized",
+      #     "enableOOBExports": false
+      # },
+      # "scopeDetails": {
+      #     "scopeType": "Customer Tenant",
+      #     "customerDetails": {
+      #         "customerTenantId": "b676e2ad-02d1-4d5c-a7f7-86861fd5acd9"
+      #     }
+      # }
+      field "azureMcaEnterprise", jmes_path(col_item, "azureMcaEnterprise")
+      # Sample contents of "azureMcaEnterprise" key if it exists:
+      # "billingAccountId": "a06453bc-6bf9-5ac7-185c-c39764114591",
+      # "billingAccountName": "a06453bc-6bf9-5ac7-185c-c39764114591:3d409245-d37b-44a0-a858-905fe4c6da73_2018-09-30",
+      # "applicationDirectoryId": "700e300f-7d60-4000-8568-699b913c45e4",
+      # "applicationId": "f79f91ea-1e02-4f61-b236-a4d6b8c181b5"
     end
   end
 end
@@ -265,6 +288,12 @@ script "js_bill_connections_combined", type: "javascript" do
         type = "Azure MCA"
       }
 
+      if (metadata["azureCsp"]) {
+        vendor_name = "Azure"
+        bill_account = metadata["azureCsp"]["billingAccountId"]
+        type = "Azure CSP"
+      }
+
       if (metadata["aws"]) {
         vendor_name = "AWS"
         bill_account = metadata["aws"]["billAccountId"]
@@ -281,6 +310,12 @@ script "js_bill_connections_combined", type: "javascript" do
         vendor_name = "Azure"
         bill_account = metadata["azureEaManagement"]["billingAccountId"]
         type = "Azure EA Management"
+      }
+
+      if (metadata["azureMcaEnterprise"]) {
+        vendor_name = "Azure"
+        bill_account = metadata["azureMcaEnterprise"]["billingAccountId"]
+        type = "Azure MCA Enterprise"
       }
 
       if (metadata["gcp"]) {


### PR DESCRIPTION
### Description

Add support for Azure CSP and Azure MCA Enterprise accounts to Azure Superseded Compute Instances policy.

### Issues Resolved

- https://flexera.atlassian.net/browse/SQ-16235

### Link to Example Applied Policy

The applied policy was executed by the customer and they confirmed it worked:
https://flexera.atlassian.net/browse/SQ-16235?focusedCommentId=2818064

### Contribution Check List

- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
