### PR TITLE
POL-1557 CBI Policy Daily Granularity Support

### DIFF
--- a/cost/flexera/cco/cbi_ingestion_aws_s3/CHANGELOG.md
+++ b/cost/flexera/cco/cbi_ingestion_aws_s3/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.2.0
 
 - Added support for cost files to use daily granularity instead of monthly.
+- Fixed issue that would sometimes cause the policy template to abort its own bill upload and fail execution.
 
 ## v0.1.1
 

--- a/cost/flexera/cco/cbi_ingestion_aws_s3/CHANGELOG.md
+++ b/cost/flexera/cco/cbi_ingestion_aws_s3/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.0
+
+- Added support for cost files to use daily granularity instead of monthly.
+- Fixed issue where policy template might abort bill uploads created by other policy templates or users.
+
 ## v0.1.1
 
 - Minor code improvements to bring template in line with current standards. Functionality unchanged.

--- a/cost/flexera/cco/cbi_ingestion_aws_s3/CHANGELOG.md
+++ b/cost/flexera/cco/cbi_ingestion_aws_s3/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## v0.2.0
 
 - Added support for cost files to use daily granularity instead of monthly.
-- Fixed issue where policy template might abort bill uploads created by other policy templates or users.
 
 ## v0.1.1
 

--- a/cost/flexera/cco/cbi_ingestion_aws_s3/README.md
+++ b/cost/flexera/cco/cbi_ingestion_aws_s3/README.md
@@ -12,6 +12,9 @@ This policy template uploads a file containing cloud costs from AWS S3 Object St
 - *CBI (Common Bill Ingestion) Endpoint Type* - Whether costs are being sent to an endpoint for [Common Bill Ingestion Format](https://docs.flexera.com/flexera/EN/Optima/OptimaBillConnectConfigsCBIDefaultFormat.htm) or [FOCUS Format](https://docs.flexera.com/flexera/EN/Optima/FOCUS.htm).
 - *CBI (Common Bill Ingestion) Endpoint ID* - The ID of CBI endpoint to create/use for ingested costs. Leave blank to have this generated and managed automatically. Ex: cbi-oi-optima-laborcosts
 - *Cloud Vendor* - The value the fixed cost should have for the `Cloud Vendor` dimension in Flexera CBI. Only has an effect when the CBI endpoint is first created. This is because the `Cloud Vendor` dimension isn't based on billing data but is configured for the CBI endpoint itself.
+- *Granularity* - Whether there will be one file per month of billing data, or one file per day of billing data.
+  - If set to "Daily", file names will be expected to end with a full date like "2024-10-03.csv". The policy template will grab all of the files for a given month to upload to Flexera.
+  - If set to "Monthly", file names will be expected to end with a year and month like "2024-10.csv". The policy template will grab one file for the month to upload to Flexera.
 - *AWS S3 Object Storage Bucket Hostname* - The hostname for the S3 bucket that stores the costs. Ex: billing-files.s3.amazonaws.com
 - *AWS S3 Object Storage Path/Prefix* - The path and prefix for the name of the object in the S3 bucket. The actual objects should always have the year and month in YYYY-MM format at the end of the object name along with the ".csv" file extension.
   - For example, if you set this parameter to `bills/labor-costs-`, the object with the costs for October 2024 should be named `bills/labor-costs-2024-10.csv`

--- a/cost/flexera/cco/cbi_ingestion_aws_s3/cbi_ingestion_aws_s3.pt
+++ b/cost/flexera/cco/cbi_ingestion_aws_s3/cbi_ingestion_aws_s3.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "0.1.1",
+  version: "0.2.0",
   provider: "Flexera",
   service: "Common Bill Ingestion",
   policy_set: "Common Bill Ingestion",
@@ -85,6 +85,15 @@ parameter "param_s3_prefix" do
   label "AWS S3 Object Storage Path/Prefix"
   description "The path and prefix for the name of the object in the S3 bucket. See README for more information on how file names should be structured. Ex: bills/labor-costs-"
   # No default value, user input required
+end
+
+parameter "param_granularity" do
+  type "string"
+  category "Policy Settings"
+  label "Granularity"
+  description "Whether there will be one file per month of billing data, or one file per day of billing data. See README for more details."
+  allowed_values "Monthly", "Daily"
+  default "Monthly"
 end
 
 ###############################################################################
@@ -316,15 +325,15 @@ datasource "ds_existing_bill_uploads" do
 end
 
 datasource "ds_pending_bill_uploads" do
-  run_script $js_pending_bill_uploads, $ds_existing_bill_uploads
+  run_script $js_pending_bill_uploads, $ds_existing_bill_uploads, $ds_cbi_endpoint
 end
 
 script "js_pending_bill_uploads", type: "javascript" do
-  parameters "ds_existing_bill_uploads"
+  parameters "ds_existing_bill_uploads", "ds_cbi_endpoint"
   result "result"
   code <<-EOS
   result = _.filter(ds_existing_bill_uploads, function(item) {
-    return item["status"] != "complete" && item["status"] != "aborted"
+    return item["status"] != "complete" && item["status"] != "aborted" && item["billConnectId"] == ds_cbi_endpoint["id"]
   })
 EOS
 end
@@ -388,42 +397,73 @@ datasource "ds_cbi_create_bill_upload" do
   end
 end
 
-datasource "ds_cost_file" do
+datasource "ds_cost_object_names" do
+  run_script $js_cost_object_names, $ds_dates, $param_s3_prefix, $param_granularity
+end
+
+script "js_cost_object_names", type: "javascript" do
+  parameters "ds_dates", "param_s3_prefix", "param_granularity"
+  result "result"
+  code <<-EOS
+  result = []
+
+  if (param_granularity == "Monthly") {
+    result.push({
+      object: [ param_s3_prefix, ds_dates["period"], ".csv" ].join('')
+    })
+  } else {
+    for (var i = 1; i <= 31; i++) {
+      day = i.toString()
+      if (i < 10) { day = "0" + day }
+
+      result.push({
+        object: [ param_s3_prefix, ds_dates["period"], "-", day, ".csv" ].join('')
+      })
+    }
+  }
+EOS
+end
+
+datasource "ds_cost_objects" do
+  iterate $ds_cost_object_names
   request do
     auth $auth_aws
     host $param_s3_hostname
-    path join([$param_s3_prefix, val($ds_dates, "period"), ".csv"])
+    path val(iter_item, "object")
     header "User-Agent", "RS Policies"
+    ignore_status [404] # Ignore dates that have no associated file instead of failing completely
   end
   result do
     encoding "text"
   end
 end
 
-datasource "ds_cost_file_data" do
-  run_script $js_cost_file_data, $ds_cost_file
+datasource "ds_cost_objects_data" do
+  run_script $js_cost_objects_data, $ds_cost_objects
 end
 
-script "js_cost_file_data", type: "javascript" do
-  parameters "ds_cost_file"
+script "js_cost_objects_data", type: "javascript" do
+  parameters "ds_cost_objects"
   result "result"
   code <<-EOS
-  if (typeof(ds_cost_file) == 'string') {
-    result = { data: ds_cost_file }
-  } else {
-    result = { data: ds_cost_file[0] }
-  }
+  result = _.map(ds_cost_objects, function(object, index) {
+    return {
+      index: index.toString(),
+      data: object
+    }
+  })
 EOS
 end
 
-datasource "ds_cbi_upload_file" do
+datasource "ds_cbi_upload_files" do
+  iterate $ds_cost_objects_data
   request do
     auth $auth_flexera
     verb "POST"
     host rs_optima_host
-    path join(["/optima/orgs/", rs_org_id, "/billUploads/", val($ds_cbi_create_bill_upload, "id"), "/files/cost-", val($ds_dates, "period"), ".csv"])
+    path join(["/optima/orgs/", rs_org_id, "/billUploads/", val($ds_cbi_create_bill_upload, "id"), "/files/cost-", val(iter_item, "index"), ".csv"])
     header "User-Agent", "RS Policies"
-    body val($ds_cost_file_data, "data")
+    body val(iter_item, "data")
   end
   result do
     encoding "json"
@@ -439,7 +479,7 @@ end
 
 datasource "ds_cbi_commit_bill_upload" do
   request do
-    run_script $js_cbi_commit_bill_upload, $ds_cbi_upload_file, $ds_cbi_create_bill_upload, rs_org_id, rs_optima_host
+    run_script $js_cbi_commit_bill_upload, $ds_cbi_upload_files, $ds_cbi_create_bill_upload, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -453,7 +493,7 @@ datasource "ds_cbi_commit_bill_upload" do
 end
 
 script "js_cbi_commit_bill_upload", type: "javascript" do
-  parameters "ds_cbi_upload_file", "ds_cbi_create_bill_upload", "rs_org_id", "rs_optima_host"
+  parameters "ds_cbi_upload_files", "ds_cbi_create_bill_upload", "rs_org_id", "rs_optima_host"
   result "request"
   code <<-EOS
   var request = {
@@ -468,24 +508,26 @@ EOS
 end
 
 datasource "ds_incident" do
-  run_script $js_incident, $ds_cbi_commit_bill_upload, $ds_applied_policy, $ds_dates, $param_s3_hostname, $param_s3_prefix
+  run_script $js_incident, $ds_cbi_commit_bill_upload, $ds_applied_policy, $ds_dates, $ds_cost_object_names, $param_s3_hostname, $param_s3_prefix
 end
 
 script "js_incident", type: "javascript" do
-  parameters "ds_cbi_commit_bill_upload", "ds_applied_policy", "ds_dates", "param_s3_hostname", "param_s3_prefix"
+  parameters "ds_cbi_commit_bill_upload", "ds_applied_policy", "ds_dates", "ds_cost_object_names", "param_s3_hostname", "param_s3_prefix"
   result "result"
   code <<-EOS
-  result = [{
-    policy_name: ds_applied_policy['name'],
-    id: ds_cbi_commit_bill_upload['id'],
-    status: ds_cbi_commit_bill_upload['status'],
-    createdAt: ds_cbi_commit_bill_upload['createdAt'],
-    updatedAt: ds_cbi_commit_bill_upload['updatedAt'],
-    billConnectId: ds_cbi_commit_bill_upload['billConnectId'],
-    billingPeriod: ds_cbi_commit_bill_upload['billingPeriod'],
-    s3_hostname: param_s3_hostname,
-    filename: param_s3_prefix + ds_dates["period"] + ".csv"
-  }]
+  result = _.map(ds_cost_object_names, function(object) {
+    return {
+      policy_name: ds_applied_policy['name'],
+      id: ds_cbi_commit_bill_upload['id'],
+      status: ds_cbi_commit_bill_upload['status'],
+      createdAt: ds_cbi_commit_bill_upload['createdAt'],
+      updatedAt: ds_cbi_commit_bill_upload['updatedAt'],
+      billConnectId: ds_cbi_commit_bill_upload['billConnectId'],
+      billingPeriod: ds_cbi_commit_bill_upload['billingPeriod'],
+      s3_hostname: param_s3_hostname,
+      filename: object
+    }
+  })
 EOS
 end
 

--- a/cost/flexera/cco/cbi_ingestion_aws_s3/cbi_ingestion_aws_s3.pt
+++ b/cost/flexera/cco/cbi_ingestion_aws_s3/cbi_ingestion_aws_s3.pt
@@ -563,9 +563,6 @@ policy "pol_fixed_cost" do
       field "s3_hostname" do
         label "Amazon S3 Host"
       end
-      field "filename" do
-        label "Amazon S3 Object"
-      end
       field "id" do
         label "Bill Upload ID"
       end

--- a/cost/flexera/cco/cbi_ingestion_aws_s3/cbi_ingestion_aws_s3.pt
+++ b/cost/flexera/cco/cbi_ingestion_aws_s3/cbi_ingestion_aws_s3.pt
@@ -325,15 +325,15 @@ datasource "ds_existing_bill_uploads" do
 end
 
 datasource "ds_pending_bill_uploads" do
-  run_script $js_pending_bill_uploads, $ds_existing_bill_uploads, $ds_cbi_endpoint
+  run_script $js_pending_bill_uploads, $ds_existing_bill_uploads
 end
 
 script "js_pending_bill_uploads", type: "javascript" do
-  parameters "ds_existing_bill_uploads", "ds_cbi_endpoint"
+  parameters "ds_existing_bill_uploads"
   result "result"
   code <<-EOS
   result = _.filter(ds_existing_bill_uploads, function(item) {
-    return item["status"] != "complete" && item["status"] != "aborted" && item["billConnectId"] == ds_cbi_endpoint["id"]
+    return item["status"] != "complete" && item["status"] != "aborted"
   })
 EOS
 end
@@ -360,31 +360,9 @@ datasource "ds_abort_pending_bill_uploads" do
   end
 end
 
-# Branching logic: This exists purely to be referenced later to ensure policy execution aborts
-# any pending bill uploads before attempting to create a new one.
-datasource "ds_aborted_pending_bill_uploads_done" do
-  run_script $js_aborted_pending_bill_uploads_done, $ds_abort_pending_bill_uploads
-end
-
-script "js_aborted_pending_bill_uploads_done", type: "javascript" do
-  parameters "ds_abort_pending_bill_uploads"
-  result "result"
-  code <<-EOS
-  result = { abortedUploads: (ds_abort_pending_bill_uploads.length != 0).toString() }
-EOS
-end
-
 datasource "ds_cbi_create_bill_upload" do
   request do
-    auth $auth_flexera
-    verb "POST"
-    host rs_optima_host
-    path join(["/optima/orgs/", rs_org_id, "/billUploads"])
-    header "User-Agent", "RS Policies"
-    # This is to ensure that any pending bill uploads were aborted prior to creating a new one
-    header "AbortedUploads", val($ds_aborted_pending_bill_uploads_done, "abortedUploads")
-    body_field "billConnectId", val($ds_cbi_endpoint, "id")
-    body_field "billingPeriod", val($ds_dates, "period")
+    run_script $js_cbi_create_bill_upload, val($ds_cbi_endpoint, "id"), val($ds_dates, "period"), $ds_abort_pending_bill_uploads, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -395,6 +373,33 @@ datasource "ds_cbi_create_bill_upload" do
     field "billConnectId", jmes_path(response, "billConnectId")
     field "billingPeriod", jmes_path(response, "billingPeriod")
   end
+end
+
+script "js_cbi_create_bill_upload", type: "javascript" do
+  parameters "cbi_endpoint", "period", "ds_abort_pending_bill_uploads", "rs_org_id", "rs_optima_host"
+  result "request"
+  code <<-EOS
+  function sleep(seconds) {
+    now = new Date().getTime()
+    while(new Date().getTime() < now + (seconds * 1000)) { /* Do nothing */ }
+    return now
+  }
+
+  // Slow down rate of requests to prevent throttling
+  sleep(3)
+
+  var request = {
+    auth: "auth_flexera",
+    verb: "POST",
+    host: rs_optima_host,
+    path: "/optima/orgs/" + rs_org_id + "/billUploads",
+    headers: { "Api-Version": "1.0", "User-Agent": "RS Policies" },
+    body_fields: {
+      "billConnectId": cbi_endpoint,
+      "billingPeriod": period
+    }
+  }
+EOS
 end
 
 datasource "ds_cost_object_names" do
@@ -438,32 +443,10 @@ datasource "ds_cost_objects" do
   end
 end
 
-datasource "ds_cost_objects_data" do
-  run_script $js_cost_objects_data, $ds_cost_objects
-end
-
-script "js_cost_objects_data", type: "javascript" do
-  parameters "ds_cost_objects"
-  result "result"
-  code <<-EOS
-  result = _.map(ds_cost_objects, function(object, index) {
-    return {
-      index: index.toString(),
-      data: object
-    }
-  })
-EOS
-end
-
 datasource "ds_cbi_upload_files" do
-  iterate $ds_cost_objects_data
+  iterate $ds_cost_objects
   request do
-    auth $auth_flexera
-    verb "POST"
-    host rs_optima_host
-    path join(["/optima/orgs/", rs_org_id, "/billUploads/", val($ds_cbi_create_bill_upload, "id"), "/files/cost-", val(iter_item, "index"), ".csv"])
-    header "User-Agent", "RS Policies"
-    body val(iter_item, "data")
+    run_script $js_cbi_upload_files, val($ds_cbi_create_bill_upload, "id"), iter_item, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -477,9 +460,33 @@ datasource "ds_cbi_upload_files" do
   end
 end
 
+script "js_cbi_upload_files", type: "javascript" do
+  parameters "bill_upload_id", "object", "rs_org_id", "rs_optima_host"
+  result "request"
+  code <<-EOS
+  function sleep(seconds) {
+    now = new Date().getTime()
+    while(new Date().getTime() < now + (seconds * 1000)) { /* Do nothing */ }
+    return now
+  }
+
+  // Slow down rate of requests to prevent throttling
+  sleep(3)
+
+  var request = {
+    auth: "auth_flexera",
+    verb: "POST",
+    host: rs_optima_host,
+    path: "/optima/orgs/" + rs_org_id + "/billUploads/" + bill_upload_id + "/files/cost-" + Math.random().toString().split('.')[1] + ".csv",
+    headers: { "Api-Version": "1.0", "User-Agent": "RS Policies" },
+    body: object
+  }
+EOS
+end
+
 datasource "ds_cbi_commit_bill_upload" do
   request do
-    run_script $js_cbi_commit_bill_upload, $ds_cbi_upload_files, $ds_cbi_create_bill_upload, rs_org_id, rs_optima_host
+    run_script $js_cbi_commit_bill_upload, $ds_cbi_upload_files, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -493,14 +500,25 @@ datasource "ds_cbi_commit_bill_upload" do
 end
 
 script "js_cbi_commit_bill_upload", type: "javascript" do
-  parameters "ds_cbi_upload_files", "ds_cbi_create_bill_upload", "rs_org_id", "rs_optima_host"
+  parameters "ds_cbi_upload_files", "rs_org_id", "rs_optima_host"
   result "request"
   code <<-EOS
+  function sleep(seconds) {
+    now = new Date().getTime()
+    while(new Date().getTime() < now + (seconds * 1000)) { /* Do nothing */ }
+    return now
+  }
+
+  // Slow down rate of requests to prevent throttling
+  sleep(3)
+
+  bill_upload_id = ds_cbi_upload_files.length > 0 ? ds_cbi_upload_files[0]["billUploadId"] : ""
+
   var request = {
     auth: "auth_flexera",
     verb: "POST",
     host: rs_optima_host,
-    path: ["/optima/orgs/", rs_org_id, "/billUploads/", ds_cbi_create_bill_upload["id"], "/operations"].join(''),
+    path: ["/optima/orgs/", rs_org_id, "/billUploads/", bill_upload_id, "/operations"].join(''),
     headers: { "User-Agent": "RS Policies" },
     body_fields: {"operation": "commit" }
   }
@@ -515,19 +533,16 @@ script "js_incident", type: "javascript" do
   parameters "ds_cbi_commit_bill_upload", "ds_applied_policy", "ds_dates", "ds_cost_object_names", "param_s3_hostname", "param_s3_prefix"
   result "result"
   code <<-EOS
-  result = _.map(ds_cost_object_names, function(object) {
-    return {
-      policy_name: ds_applied_policy['name'],
-      id: ds_cbi_commit_bill_upload['id'],
-      status: ds_cbi_commit_bill_upload['status'],
-      createdAt: ds_cbi_commit_bill_upload['createdAt'],
-      updatedAt: ds_cbi_commit_bill_upload['updatedAt'],
-      billConnectId: ds_cbi_commit_bill_upload['billConnectId'],
-      billingPeriod: ds_cbi_commit_bill_upload['billingPeriod'],
-      s3_hostname: param_s3_hostname,
-      filename: object
-    }
-  })
+  result = [{
+    policy_name: ds_applied_policy['name'],
+    id: ds_cbi_commit_bill_upload['id'],
+    status: ds_cbi_commit_bill_upload['status'],
+    createdAt: ds_cbi_commit_bill_upload['createdAt'],
+    updatedAt: ds_cbi_commit_bill_upload['updatedAt'],
+    billConnectId: ds_cbi_commit_bill_upload['billConnectId'],
+    billingPeriod: ds_cbi_commit_bill_upload['billingPeriod'],
+    s3_hostname: param_s3_hostname
+  }]
 EOS
 end
 

--- a/cost/flexera/cco/cbi_ingestion_azure_blob/CHANGELOG.md
+++ b/cost/flexera/cco/cbi_ingestion_azure_blob/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.0
+
+- Added support for cost files to use daily granularity instead of monthly.
+- Fixed issue where policy template might abort bill uploads created by other policy templates or users.
+
 ## v0.1.2
 
 - Minor code improvements to bring template in line with current standards. Functionality unchanged.

--- a/cost/flexera/cco/cbi_ingestion_azure_blob/CHANGELOG.md
+++ b/cost/flexera/cco/cbi_ingestion_azure_blob/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.2.0
 
 - Added support for cost files to use daily granularity instead of monthly.
+- Fixed issue that would sometimes cause the policy template to abort its own bill upload and fail execution.
 
 ## v0.1.2
 

--- a/cost/flexera/cco/cbi_ingestion_azure_blob/CHANGELOG.md
+++ b/cost/flexera/cco/cbi_ingestion_azure_blob/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## v0.2.0
 
 - Added support for cost files to use daily granularity instead of monthly.
-- Fixed issue where policy template might abort bill uploads created by other policy templates or users.
 
 ## v0.1.2
 

--- a/cost/flexera/cco/cbi_ingestion_azure_blob/README.md
+++ b/cost/flexera/cco/cbi_ingestion_azure_blob/README.md
@@ -12,9 +12,12 @@ This policy template uploads a file containing cloud costs from Azure Blob Stora
 - *CBI (Common Bill Ingestion) Endpoint Type* - Whether costs are being sent to an endpoint for [Common Bill Ingestion Format](https://docs.flexera.com/flexera/EN/Optima/OptimaBillConnectConfigsCBIDefaultFormat.htm) or [FOCUS Format](https://docs.flexera.com/flexera/EN/Optima/FOCUS.htm).
 - *CBI (Common Bill Ingestion) Endpoint ID* - The ID of CBI endpoint to create/use for ingested costs. Leave blank to have this generated and managed automatically. Ex: cbi-oi-optima-laborcosts
 - *Cloud Vendor* - The value the fixed cost should have for the `Cloud Vendor` dimension in Flexera CBI. Only has an effect when the CBI endpoint is first created. This is because the `Cloud Vendor` dimension isn't based on billing data but is configured for the CBI endpoint itself.
+- *Granularity* - Whether there will be one file per month of billing data, or one file per day of billing data.
+  - If set to "Daily", file names will be expected to end with a full date like "2024-10-03.csv". The policy template will grab all of the files for a given month to upload to Flexera.
+  - If set to "Monthly", file names will be expected to end with a year and month like "2024-10.csv". The policy template will grab one file for the month to upload to Flexera.
 - *Azure Blob Storage Hostname* - The hostname for the Azure Blob Storage container that stores the costs. Ex: billing-files.blob.core.windows.net
 - *Azure Blob Storage Path/Prefix* - The path and prefix for the name of the object in the Azure Blob Storage container. The actual objects should always have the year and month in YYYY-MM format at the end of the object name along with the ".csv" file extension.
-  - For example, if you set this parameter to `bills/labor-costs-`, the object with the costs for October 2024 should be named `bills/labor-costs-2024-10.csv`
+  - For example, if you set this parameter to `bills/labor-costs-`, the object with the costs for October 2024, if using "Monthly" granularity, should be named `bills/labor-costs-2024-10.csv`
 
 ## Policy Actions
 

--- a/cost/flexera/cco/cbi_ingestion_azure_blob/cbi_ingestion_azure_blob.pt
+++ b/cost/flexera/cco/cbi_ingestion_azure_blob/cbi_ingestion_azure_blob.pt
@@ -7,7 +7,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "0.1.2",
+  version: "0.2.0",
   provider: "Flexera",
   service: "Common Bill Ingestion",
   policy_set: "Common Bill Ingestion",
@@ -85,6 +85,15 @@ parameter "param_blob_prefix" do
   label "Azure Blob Storage Path/Prefix"
   description "The path and prefix for the name of the object in the Azure Blob Storage container. See README for more information on how file names should be structured. Ex: bills/labor-costs-"
   # No default value, user input required
+end
+
+parameter "param_granularity" do
+  type "string"
+  category "Policy Settings"
+  label "Granularity"
+  description "Whether there will be one file per month of billing data, or one file per day of billing data. See README for more details."
+  allowed_values "Monthly", "Daily"
+  default "Monthly"
 end
 
 ###############################################################################
@@ -315,15 +324,15 @@ datasource "ds_existing_bill_uploads" do
 end
 
 datasource "ds_pending_bill_uploads" do
-  run_script $js_pending_bill_uploads, $ds_existing_bill_uploads
+  run_script $js_pending_bill_uploads, $ds_existing_bill_uploads, $ds_cbi_endpoint
 end
 
 script "js_pending_bill_uploads", type: "javascript" do
-  parameters "ds_existing_bill_uploads"
+  parameters "ds_existing_bill_uploads", "ds_cbi_endpoint"
   result "result"
   code <<-EOS
   result = _.filter(ds_existing_bill_uploads, function(item) {
-    return item["status"] != "complete" && item["status"] != "aborted"
+    return item["status"] != "complete" && item["status"] != "aborted" && item["billConnectId"] == ds_cbi_endpoint["id"]
   })
 EOS
 end
@@ -387,43 +396,74 @@ datasource "ds_cbi_create_bill_upload" do
   end
 end
 
-datasource "ds_cost_file" do
+datasource "ds_cost_object_names" do
+  run_script $js_cost_object_names, $ds_dates, $param_blob_prefix, $param_granularity
+end
+
+script "js_cost_object_names", type: "javascript" do
+  parameters "ds_dates", "param_blob_prefix", "param_granularity"
+  result "result"
+  code <<-EOS
+  result = []
+
+  if (param_granularity == "Monthly") {
+    result.push({
+      object: [ param_blob_prefix, ds_dates["period"], ".csv" ].join('')
+    })
+  } else {
+    for (var i = 1; i <= 31; i++) {
+      day = i.toString()
+      if (i < 10) { day = "0" + day }
+
+      result.push({
+        object: [ param_blob_prefix, ds_dates["period"], "-", day, ".csv" ].join('')
+      })
+    }
+  }
+EOS
+end
+
+datasource "ds_cost_objects" do
+  iterate $ds_cost_object_names
   request do
     auth $auth_azure_storage
     host $param_blob_hostname
-    path join([$param_blob_prefix, val($ds_dates, "period"), ".csv"])
+    path val(iter_item, "object")
     header "User-Agent", "RS Policies"
     header "x-ms-version", "2025-05-05"
+    ignore_status [404] # Ignore dates that have no associated file instead of failing completely
   end
   result do
     encoding "text"
   end
 end
 
-datasource "ds_cost_file_data" do
-  run_script $js_cost_file_data, $ds_cost_file
+datasource "ds_cost_objects_data" do
+  run_script $js_cost_objects_data, $ds_cost_objects
 end
 
-script "js_cost_file_data", type: "javascript" do
-  parameters "ds_cost_file"
+script "js_cost_objects_data", type: "javascript" do
+  parameters "ds_cost_objects"
   result "result"
   code <<-EOS
-  if (typeof(ds_cost_file) == 'string') {
-    result = { data: ds_cost_file }
-  } else {
-    result = { data: ds_cost_file[0] }
-  }
+  result = _.map(ds_cost_objects, function(object, index) {
+    return {
+      index: index.toString(),
+      data: object
+    }
+  })
 EOS
 end
 
-datasource "ds_cbi_upload_file" do
+datasource "ds_cbi_upload_files" do
+  iterate $ds_cost_objects_data
   request do
     auth $auth_flexera
     verb "POST"
     host rs_optima_host
-    path join(["/optima/orgs/", rs_org_id, "/billUploads/", val($ds_cbi_create_bill_upload, "id"), "/files/cost-", val($ds_dates, "period"), ".csv"])
+    path join(["/optima/orgs/", rs_org_id, "/billUploads/", val($ds_cbi_create_bill_upload, "id"), "/files/cost-", val(iter_item, "index"), ".csv"])
     header "User-Agent", "RS Policies"
-    body val($ds_cost_file_data, "data")
+    body val(iter_item, "data")
   end
   result do
     encoding "json"
@@ -439,7 +479,7 @@ end
 
 datasource "ds_cbi_commit_bill_upload" do
   request do
-    run_script $js_cbi_commit_bill_upload, $ds_cbi_upload_file, $ds_cbi_create_bill_upload, rs_org_id, rs_optima_host
+    run_script $js_cbi_commit_bill_upload, $ds_cbi_upload_files, $ds_cbi_create_bill_upload, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -453,7 +493,7 @@ datasource "ds_cbi_commit_bill_upload" do
 end
 
 script "js_cbi_commit_bill_upload", type: "javascript" do
-  parameters "ds_cbi_upload_file", "ds_cbi_create_bill_upload", "rs_org_id", "rs_optima_host"
+  parameters "ds_cbi_upload_files", "ds_cbi_create_bill_upload", "rs_org_id", "rs_optima_host"
   result "request"
   code <<-EOS
   var request = {
@@ -468,24 +508,26 @@ EOS
 end
 
 datasource "ds_incident" do
-  run_script $js_incident, $ds_cbi_commit_bill_upload, $ds_applied_policy, $ds_dates, $param_blob_hostname, $param_blob_prefix
+  run_script $js_incident, $ds_cbi_commit_bill_upload, $ds_applied_policy, $ds_dates, $ds_cost_object_names, $param_blob_hostname, $param_blob_prefix
 end
 
 script "js_incident", type: "javascript" do
-  parameters "ds_cbi_commit_bill_upload", "ds_applied_policy", "ds_dates", "param_blob_hostname", "param_blob_prefix"
+  parameters "ds_cbi_commit_bill_upload", "ds_applied_policy", "ds_dates", "ds_cost_object_names", "param_blob_hostname", "param_blob_prefix"
   result "result"
   code <<-EOS
-  result = [{
-    policy_name: ds_applied_policy['name'],
-    id: ds_cbi_commit_bill_upload['id'],
-    status: ds_cbi_commit_bill_upload['status'],
-    createdAt: ds_cbi_commit_bill_upload['createdAt'],
-    updatedAt: ds_cbi_commit_bill_upload['updatedAt'],
-    billConnectId: ds_cbi_commit_bill_upload['billConnectId'],
-    billingPeriod: ds_cbi_commit_bill_upload['billingPeriod'],
-    blob_hostname: param_blob_hostname,
-    filename: param_blob_prefix + ds_dates["period"] + ".csv"
-  }]
+  result = _.map(ds_cost_object_names, function(object) {
+    return {
+      policy_name: ds_applied_policy['name'],
+      id: ds_cbi_commit_bill_upload['id'],
+      status: ds_cbi_commit_bill_upload['status'],
+      createdAt: ds_cbi_commit_bill_upload['createdAt'],
+      updatedAt: ds_cbi_commit_bill_upload['updatedAt'],
+      billConnectId: ds_cbi_commit_bill_upload['billConnectId'],
+      billingPeriod: ds_cbi_commit_bill_upload['billingPeriod'],
+      blob_hostname: param_blob_hostname,
+      filename: object
+    }
+  })
 EOS
 end
 
@@ -493,7 +535,7 @@ end
 # Policy
 ###############################################################################
 
-policy "pol_fixed_cost" do
+policy "pol_cbi_ingestion" do
   validate_each $ds_incident do
     summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ with index data 0 }}{{ .billingPeriod }}{{ end }}"
     check eq(0, 1)

--- a/cost/flexera/cco/cbi_ingestion_azure_blob/cbi_ingestion_azure_blob.pt
+++ b/cost/flexera/cco/cbi_ingestion_azure_blob/cbi_ingestion_azure_blob.pt
@@ -324,15 +324,15 @@ datasource "ds_existing_bill_uploads" do
 end
 
 datasource "ds_pending_bill_uploads" do
-  run_script $js_pending_bill_uploads, $ds_existing_bill_uploads, $ds_cbi_endpoint
+  run_script $js_pending_bill_uploads, $ds_existing_bill_uploads
 end
 
 script "js_pending_bill_uploads", type: "javascript" do
-  parameters "ds_existing_bill_uploads", "ds_cbi_endpoint"
+  parameters "ds_existing_bill_uploads"
   result "result"
   code <<-EOS
   result = _.filter(ds_existing_bill_uploads, function(item) {
-    return item["status"] != "complete" && item["status"] != "aborted" && item["billConnectId"] == ds_cbi_endpoint["id"]
+    return item["status"] != "complete" && item["status"] != "aborted"
   })
 EOS
 end
@@ -359,31 +359,9 @@ datasource "ds_abort_pending_bill_uploads" do
   end
 end
 
-# Branching logic: This exists purely to be referenced later to ensure policy execution aborts
-# any pending bill uploads before attempting to create a new one.
-datasource "ds_aborted_pending_bill_uploads_done" do
-  run_script $js_aborted_pending_bill_uploads_done, $ds_abort_pending_bill_uploads
-end
-
-script "js_aborted_pending_bill_uploads_done", type: "javascript" do
-  parameters "ds_abort_pending_bill_uploads"
-  result "result"
-  code <<-EOS
-  result = { abortedUploads: (ds_abort_pending_bill_uploads.length != 0).toString() }
-EOS
-end
-
 datasource "ds_cbi_create_bill_upload" do
   request do
-    auth $auth_flexera
-    verb "POST"
-    host rs_optima_host
-    path join(["/optima/orgs/", rs_org_id, "/billUploads"])
-    header "User-Agent", "RS Policies"
-    # This is to ensure that any pending bill uploads were aborted prior to creating a new one
-    header "AbortedUploads", val($ds_aborted_pending_bill_uploads_done, "abortedUploads")
-    body_field "billConnectId", val($ds_cbi_endpoint, "id")
-    body_field "billingPeriod", val($ds_dates, "period")
+    run_script $js_cbi_create_bill_upload, val($ds_cbi_endpoint, "id"), val($ds_dates, "period"), $ds_abort_pending_bill_uploads, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -394,6 +372,33 @@ datasource "ds_cbi_create_bill_upload" do
     field "billConnectId", jmes_path(response, "billConnectId")
     field "billingPeriod", jmes_path(response, "billingPeriod")
   end
+end
+
+script "js_cbi_create_bill_upload", type: "javascript" do
+  parameters "cbi_endpoint", "period", "ds_abort_pending_bill_uploads", "rs_org_id", "rs_optima_host"
+  result "request"
+  code <<-EOS
+  function sleep(seconds) {
+    now = new Date().getTime()
+    while(new Date().getTime() < now + (seconds * 1000)) { /* Do nothing */ }
+    return now
+  }
+
+  // Slow down rate of requests to prevent throttling
+  sleep(3)
+
+  var request = {
+    auth: "auth_flexera",
+    verb: "POST",
+    host: rs_optima_host,
+    path: "/optima/orgs/" + rs_org_id + "/billUploads",
+    headers: { "Api-Version": "1.0", "User-Agent": "RS Policies" },
+    body_fields: {
+      "billConnectId": cbi_endpoint,
+      "billingPeriod": period
+    }
+  }
+EOS
 end
 
 datasource "ds_cost_object_names" do
@@ -438,32 +443,10 @@ datasource "ds_cost_objects" do
   end
 end
 
-datasource "ds_cost_objects_data" do
-  run_script $js_cost_objects_data, $ds_cost_objects
-end
-
-script "js_cost_objects_data", type: "javascript" do
-  parameters "ds_cost_objects"
-  result "result"
-  code <<-EOS
-  result = _.map(ds_cost_objects, function(object, index) {
-    return {
-      index: index.toString(),
-      data: object
-    }
-  })
-EOS
-end
-
 datasource "ds_cbi_upload_files" do
-  iterate $ds_cost_objects_data
+  iterate $ds_cost_objects
   request do
-    auth $auth_flexera
-    verb "POST"
-    host rs_optima_host
-    path join(["/optima/orgs/", rs_org_id, "/billUploads/", val($ds_cbi_create_bill_upload, "id"), "/files/cost-", val(iter_item, "index"), ".csv"])
-    header "User-Agent", "RS Policies"
-    body val(iter_item, "data")
+    run_script $js_cbi_upload_files, val($ds_cbi_create_bill_upload, "id"), iter_item, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -477,9 +460,33 @@ datasource "ds_cbi_upload_files" do
   end
 end
 
+script "js_cbi_upload_files", type: "javascript" do
+  parameters "bill_upload_id", "object", "rs_org_id", "rs_optima_host"
+  result "request"
+  code <<-EOS
+  function sleep(seconds) {
+    now = new Date().getTime()
+    while(new Date().getTime() < now + (seconds * 1000)) { /* Do nothing */ }
+    return now
+  }
+
+  // Slow down rate of requests to prevent throttling
+  sleep(3)
+
+  var request = {
+    auth: "auth_flexera",
+    verb: "POST",
+    host: rs_optima_host,
+    path: "/optima/orgs/" + rs_org_id + "/billUploads/" + bill_upload_id + "/files/cost-" + Math.random().toString().split('.')[1] + ".csv",
+    headers: { "Api-Version": "1.0", "User-Agent": "RS Policies" },
+    body: object
+  }
+EOS
+end
+
 datasource "ds_cbi_commit_bill_upload" do
   request do
-    run_script $js_cbi_commit_bill_upload, $ds_cbi_upload_files, $ds_cbi_create_bill_upload, rs_org_id, rs_optima_host
+    run_script $js_cbi_commit_bill_upload, $ds_cbi_upload_files, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -493,14 +500,25 @@ datasource "ds_cbi_commit_bill_upload" do
 end
 
 script "js_cbi_commit_bill_upload", type: "javascript" do
-  parameters "ds_cbi_upload_files", "ds_cbi_create_bill_upload", "rs_org_id", "rs_optima_host"
+  parameters "ds_cbi_upload_files", "rs_org_id", "rs_optima_host"
   result "request"
   code <<-EOS
+  function sleep(seconds) {
+    now = new Date().getTime()
+    while(new Date().getTime() < now + (seconds * 1000)) { /* Do nothing */ }
+    return now
+  }
+
+  // Slow down rate of requests to prevent throttling
+  sleep(3)
+
+  bill_upload_id = ds_cbi_upload_files.length > 0 ? ds_cbi_upload_files[0]["billUploadId"] : ""
+
   var request = {
     auth: "auth_flexera",
     verb: "POST",
     host: rs_optima_host,
-    path: ["/optima/orgs/", rs_org_id, "/billUploads/", ds_cbi_create_bill_upload["id"], "/operations"].join(''),
+    path: ["/optima/orgs/", rs_org_id, "/billUploads/", bill_upload_id, "/operations"].join(''),
     headers: { "User-Agent": "RS Policies" },
     body_fields: {"operation": "commit" }
   }
@@ -515,19 +533,16 @@ script "js_incident", type: "javascript" do
   parameters "ds_cbi_commit_bill_upload", "ds_applied_policy", "ds_dates", "ds_cost_object_names", "param_blob_hostname", "param_blob_prefix"
   result "result"
   code <<-EOS
-  result = _.map(ds_cost_object_names, function(object) {
-    return {
-      policy_name: ds_applied_policy['name'],
-      id: ds_cbi_commit_bill_upload['id'],
-      status: ds_cbi_commit_bill_upload['status'],
-      createdAt: ds_cbi_commit_bill_upload['createdAt'],
-      updatedAt: ds_cbi_commit_bill_upload['updatedAt'],
-      billConnectId: ds_cbi_commit_bill_upload['billConnectId'],
-      billingPeriod: ds_cbi_commit_bill_upload['billingPeriod'],
-      blob_hostname: param_blob_hostname,
-      filename: object
-    }
-  })
+  result = [{
+    policy_name: ds_applied_policy['name'],
+    id: ds_cbi_commit_bill_upload['id'],
+    status: ds_cbi_commit_bill_upload['status'],
+    createdAt: ds_cbi_commit_bill_upload['createdAt'],
+    updatedAt: ds_cbi_commit_bill_upload['updatedAt'],
+    billConnectId: ds_cbi_commit_bill_upload['billConnectId'],
+    billingPeriod: ds_cbi_commit_bill_upload['billingPeriod'],
+    blob_hostname: param_blob_hostname
+  }]
 EOS
 end
 
@@ -547,9 +562,6 @@ policy "pol_cbi_ingestion" do
       end
       field "blob_hostname" do
         label "Azure Blob Storage Hostname"
-      end
-      field "filename" do
-        label "Azure Blob Storage Object"
       end
       field "id" do
         label "Bill Upload ID"


### PR DESCRIPTION
### Description

Updates the "Common Bill Ingestion from AWS S3 Object Storage" and "Common Bill Ingestion from Azure Blob Storage" policy templates to support billing data stored at a daily, rather than a monthly, granularity. From the READMEs:

- *Granularity* - Whether there will be one file per month of billing data, or one file per day of billing data.
  - If set to "Daily", file names will be expected to end with a full date like "2024-10-03.csv". The policy template will grab all of the files for a given month to upload to Flexera.
  - If set to "Monthly", file names will be expected to end with a year and month like "2024-10.csv". The policy template will grab one file for the month to upload to Flexera.

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=686d7beb86eaa862688a8b95

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
