### PR TITLE
POL-1558 New Unpublished CBI Policy Templates

### DIFF
--- a/cost/flexera/cco/cbi_ingestion_aws_s3_iterating/CHANGELOG.md
+++ b/cost/flexera/cco/cbi_ingestion_aws_s3_iterating/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+- Initial release

--- a/cost/flexera/cco/cbi_ingestion_aws_s3_iterating/README.md
+++ b/cost/flexera/cco/cbi_ingestion_aws_s3_iterating/README.md
@@ -1,0 +1,76 @@
+# Common Bill Ingestion from AWS S3 Object Storage (Iterating)
+
+## What It Does
+
+This policy template uploads a file containing cloud costs from AWS S3 Object Storage into the Flexera Cloud Cost Optimization (CCO) platform via [Common Bill Ingestion](https://docs.flexera.com/flexera/EN/Optima/OptimaBillConnectConfigsCBI.htm). Both [Common Bill Ingestion Format](https://docs.flexera.com/flexera/EN/Optima/OptimaBillConnectConfigsCBIDefaultFormat.htm) and [FOCUS Format](https://docs.flexera.com/flexera/EN/Optima/FOCUS.htm) are supported. An incident is raised on every execution of the policy to provide status information to the user.
+
+## How It Works
+
+- The policy uses the AWS API to connect to the bucket containing the CSV files with cost data and obtain the relevant files for the specified month (or current month if none is specified.)
+- The policy then sends those reports, unmodified, into a Flexera CBI endpoint so that they can be ingested and then visible on the platform.
+- The policy does this over the course of multiple runs to avoid hitting memory and other constraints. **It is recommended that the default frequency of 15 minutes be used; the policy may not function correctly or as expected if a longer frequency is selected.**
+- It is recommended that this policy be applied twice, with Month To Ingest set to Current Month for one instance and with it set to Previous Month for the other. This is to ensure that any changes made to billing data after the month ends are brought into the Flexera platform.
+
+## Input Parameters
+
+This policy has the following input parameters required when launching the policy.
+
+- *Month To Ingest* - Whether to process bills for the current month, previous month, or a specific month.
+- *Billing Period* - The year and month to process bills for in YYYY-MM format. Only relevant if Specific Month is selected for the Month To Ingest parameter. Example: 2022-09
+- *Flexera CBI Endpoint* - The name of the Flexera CBI endpoint to use. Example: cbi-oi-optima-laborcosts
+- *AWS S3 Object Storage Bucket Hostname* - The hostname for the S3 bucket that stores the costs. Ex: billing-files.s3.amazonaws.com
+- *AWS S3 Object Storage Path/Prefix* - The path and prefix for the name of the object in the S3 bucket. The actual objects should always have the year and month in YYYY-MM format at the end of the object name along with the ".csv" file extension.
+  - For example, if you set this parameter to `bills/labor-costs-`, the object with the costs for October 2024 should be named `bills/labor-costs-2024-10.csv`
+- *Block Size* - The number of files to upload with each execution of the policy. The default value of 20 is recommended.
+- *Commit Delay (Hours)* - The number of hours to wait between committing bill uploads. This is to avoid overloading the CBI system and to ensure bill ingestion occurs at a predictable cadence. The default value of 12 is recommended.
+
+## Policy Actions
+
+- Uploads stored billing data to Flexera CCO
+- Sends an email notification
+
+## Prerequisites
+
+This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).
+
+- [**AWS Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1121575) (*provider=aws*) which has the following permissions:
+  - `s3:ListBucket`*
+  - `s3:GetObject`*
+
+  \* Only required for the specific S3 bucket that contain the billing data. Broad access across all resources, like the example below, is not required.
+
+  Example IAM Permission Policy:
+
+  ```json
+  {
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "s3:ListBucket",
+                  "s3:GetObject"
+              ],
+              "Resource": "*"
+          }
+      ]
+  }
+  ```
+
+- [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
+  - `billing_center_viewer`
+  - `csm_bill_upload_admin`
+
+The [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) page in the docs has detailed instructions for setting up Credentials for the most common providers.
+
+### Additional Requirements
+
+This policy template also requires a valid CBI endpoint created using the [Flexera Bill Connect API](https://reference.rightscale.com/optima-bill/#/CBIBillConnects/CBIBillConnects_create).
+
+## Supported Clouds
+
+- All
+
+## Cost
+
+This policy template does not incur any cloud costs

--- a/cost/flexera/cco/cbi_ingestion_aws_s3_iterating/README.md
+++ b/cost/flexera/cco/cbi_ingestion_aws_s3_iterating/README.md
@@ -4,6 +4,8 @@
 
 This policy template uploads a file containing cloud costs from AWS S3 Object Storage into the Flexera Cloud Cost Optimization (CCO) platform via [Common Bill Ingestion](https://docs.flexera.com/flexera/EN/Optima/OptimaBillConnectConfigsCBI.htm). Both [Common Bill Ingestion Format](https://docs.flexera.com/flexera/EN/Optima/OptimaBillConnectConfigsCBIDefaultFormat.htm) and [FOCUS Format](https://docs.flexera.com/flexera/EN/Optima/FOCUS.htm) are supported. An incident is raised on every execution of the policy to provide status information to the user.
 
+NOTE: Because of the complexities involved in this policy template, it is recommended for use only in situations where the standard [Common Bill Ingestion from AWS S3 Object Storage](https://github.com/flexera-public/policy_templates/tree/master/cost/flexera/cco/cbi_ingestion_aws_s3) policy template is unable to handle the amount of data being processed for CBI.
+
 ## How It Works
 
 - The policy uses the AWS API to connect to the bucket containing the CSV files with cost data and obtain the relevant files for the specified month (or current month if none is specified.)
@@ -64,6 +66,8 @@ This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Auto
 The [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) page in the docs has detailed instructions for setting up Credentials for the most common providers.
 
 ### Additional Requirements
+
+The objects containing costs must have the `.csv` file extension and must contain the year and month in YYYY-MM format. Example: cost_data_2025-04-08.csv
 
 This policy template also requires a valid CBI endpoint created using the [Flexera Bill Connect API](https://reference.rightscale.com/optima-bill/#/CBIBillConnects/CBIBillConnects_create).
 

--- a/cost/flexera/cco/cbi_ingestion_aws_s3_iterating/cbi_ingestion_aws_s3_iterating.pt
+++ b/cost/flexera/cco/cbi_ingestion_aws_s3_iterating/cbi_ingestion_aws_s3_iterating.pt
@@ -295,8 +295,8 @@ datasource "ds_objects" do
     auth $auth_aws
     pagination $pagination_aws_s3
     host $param_s3_hostname
-    header "User-Agent", "RS Policies"
     query "list-type", "2"
+    header "User-Agent", "RS Policies"
   end
   result do
     encoding "xml"

--- a/cost/flexera/cco/cbi_ingestion_aws_s3_iterating/cbi_ingestion_aws_s3_iterating.pt
+++ b/cost/flexera/cco/cbi_ingestion_aws_s3_iterating/cbi_ingestion_aws_s3_iterating.pt
@@ -3,6 +3,7 @@ rs_pt_ver 20180301
 type "policy"
 short_description "Downloads cost reports stored in the Flexera Common Bill Ingestion format from AWS S3 Object Storage and then uploads them to a Flexera CBI endpoint. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/flexera/cco/cbi_ingestion_aws_s3_iterating) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
+doc_link "https://github.com/flexera-public/policy_templates/tree/master/cost/flexera/cco/cbi_ingestion_aws_s3_iterating"
 severity "low"
 category "Cost"
 default_frequency "15 minutes"

--- a/cost/flexera/cco/cbi_ingestion_aws_s3_iterating/cbi_ingestion_aws_s3_iterating.pt
+++ b/cost/flexera/cco/cbi_ingestion_aws_s3_iterating/cbi_ingestion_aws_s3_iterating.pt
@@ -1,0 +1,553 @@
+name "Common Bill Ingestion from AWS S3 Object Storage (Iterating)"
+rs_pt_ver 20180301
+type "policy"
+short_description "Downloads cost reports stored in the Flexera Common Bill Ingestion format from AWS S3 Object Storage and then uploads them to a Flexera CBI endpoint. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/flexera/cco/cbi_ingestion_aws_s3_iterating) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+long_description ""
+severity "low"
+category "Cost"
+default_frequency "15 minutes"
+info(
+  version: "0.1.0",
+  provider: "Flexera",
+  service: "Common Bill Ingestion",
+  policy_set: "Common Bill Ingestion",
+  hide_skip_approvals: "true",
+  publish: "false"
+)
+
+###############################################################################
+# Parameters
+###############################################################################
+
+parameter "param_billing_period" do
+  type "string"
+  category "Policy Settings"
+  label "Month To Ingest"
+  description "Month to process bills for."
+  allowed_values "Current Month", "Previous Month", "Specific Month"
+  default "Current Month"
+end
+
+parameter "param_specific_period" do
+  type "string"
+  category "Policy Settings"
+  label "Billing Period"
+  description "Billing period to process bills for in YYYY-MM format. Only relevant if Specific Month is selected for Month To Ingest."
+  allowed_pattern /^(19|20)\d\d-(0[1-9]|1[0-2])$/
+  default "2020-01"
+end
+
+parameter "param_cbi_endpoint" do
+  type "string"
+  category "Policy Settings"
+  label "CBI (Common Bill Ingestion) Endpoint ID"
+  description "The ID of CBI endpoint to create/use for ingested costs. Ex: cbi-oi-optima-laborcosts"
+  allowed_pattern /^(cbi-oi-optima-[a-z]+|cbi-oi-focus-[a-z]+|)$/
+  # No default value, user input required
+end
+
+parameter "param_s3_hostname" do
+  type "string"
+  category "Policy Settings"
+  label "AWS S3 Object Storage Bucket Hostname"
+  description "The hostname for the S3 bucket that stores the costs. Ex: billing-files.s3.amazonaws.com"
+  # No default value, user input required
+end
+
+parameter "param_s3_prefix" do
+  type "string"
+  category "Policy Settings"
+  label "AWS S3 Object Storage Path/Prefix"
+  description "The path and prefix for the name of the object in the S3 bucket. See README for more information on how file names should be structured. Ex: bills/labor-costs-"
+  # No default value, user input required
+end
+
+parameter "param_block_size" do
+  type "number"
+  category "Policy Settings"
+  label "Block Size"
+  description "The number of files in a single block."
+  min_value 1
+  max_value 16
+  default 8
+end
+
+parameter "param_commit_delay" do
+  type "number"
+  category "Policy Settings"
+  label "Commit Delay (Hours)"
+  description "Number of hours to wait between committing bill uploads."
+  min_value 8
+  max_value 24
+  default 12
+end
+
+###############################################################################
+# Authentication
+###############################################################################
+
+credentials "auth_flexera" do
+  schemes "oauth2"
+  label "Flexera"
+  description "Select Flexera One OAuth2 credentials"
+  tags "provider=flexera"
+end
+
+credentials "auth_aws" do
+  schemes "aws", "aws_sts"
+  label "AWS"
+  description "Select the AWS Credential from the list"
+  tags "provider=aws"
+  aws_account_number $param_aws_account_number
+end
+
+###############################################################################
+# Pagination
+###############################################################################
+
+pagination "pagination_aws_s3" do
+  get_page_marker do
+    body_path "//ListBucketResult/NextContinuationToken"
+  end
+  set_page_marker do
+    query "continuation-token"
+  end
+end
+
+###############################################################################
+# Datasources & Scripts
+###############################################################################
+
+datasource "ds_dates" do
+  run_script $js_dates, $param_billing_period, $param_specific_period
+end
+
+script "js_dates", type: "javascript" do
+  parameters "param_billing_period", "param_specific_period"
+  result "result"
+  code <<-EOS
+  result = { period: param_specific_period }
+
+  if (param_billing_period != 'Specific Month') {
+    date = new Date()
+    date.setDate(date.getDate() - 1)
+
+    if (param_billing_period == 'Previous Month') {
+      date.setMonth(date.getMonth() - 1)
+    }
+
+    year = date.toISOString().split('-')[0]
+    month = date.toISOString().split('-')[1]
+
+    result = { period: year + '-' + month }
+  }
+EOS
+end
+
+datasource "ds_existing_bill_uploads" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/optima/orgs/", rs_org_id, "/billUploads"])
+    query "billConnectId", $param_cbi_endpoint
+    query "billingPeriod", val($ds_dates, 'period')
+    header "User-Agent", "RS Policies"
+    header "allow_redirects", "False"
+  end
+end
+
+# This datasource looks for any in-progress bill uploads that are broken
+# due to an in-progress file upload so that they can be aborted.
+datasource "ds_broken_bill_uploads" do
+  run_script $js_broken_bill_uploads, $ds_existing_bill_uploads
+end
+
+script "js_broken_bill_uploads", type: "javascript" do
+  parameters "ds_existing_bill_uploads"
+  result "result"
+  code <<-EOS
+  result = _.filter(ds_existing_bill_uploads, function(bill_upload) {
+    broken_files = false
+
+    if (typeof(bill_upload['files']) == 'object') {
+      _.each(bill_upload['files'], function(file) {
+        if (file['status'] != 'uploaded') {
+          broken_files = true
+        }
+      })
+    }
+
+    // Make sure we ignore any bill uploads that aren't actually in-progress
+    return broken_files && bill_upload['status'] == 'in-progress'
+  })
+EOS
+end
+
+datasource "ds_abort_broken_uploads" do
+  iterate $ds_broken_bill_uploads
+  request do
+    run_script $js_abort_broken_uploads, val(iter_item, 'id'), rs_org_id, rs_optima_host
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+  end
+end
+
+script "js_abort_broken_uploads", type: "javascript" do
+  parameters "bill_upload_id", "rs_org_id", "rs_optima_host"
+  result "request"
+  code <<-EOS
+  // Slow down rate of requests to prevent throttling
+  api_wait = 5
+  var now = new Date().getTime()
+  while(new Date().getTime() < now + (api_wait * 1000)) { /* Do nothing */ }
+
+  var request = {
+    auth: "auth_flexera",
+    verb: "POST",
+    host: rs_optima_host,
+    path: ['/optima/orgs/', rs_org_id, '/billUploads/', bill_upload_id, '/operations'].join(''),
+    headers: {
+      "User-Agent": "RS Policies",
+    },
+    body_fields: { "operation": "abort" }
+  }
+EOS
+end
+
+# Branching logic:
+# This datasource contains an empty array if a bill upload is already in-progress.
+# Broken bill uploads aborted above are not considered in-progress.
+# Otherwise, it contains a single item for the next datasource to iterate over.
+datasource "ds_bill_upload_check" do
+  run_script $js_bill_upload_check, $ds_existing_bill_uploads, $ds_abort_broken_uploads
+end
+
+script "js_bill_upload_check", type: "javascript" do
+  parameters "ds_existing_bill_uploads", "ds_abort_broken_uploads"
+  result "result"
+  code <<-EOS
+  result = [1]
+  broken_upload_ids = _.pluck(ds_abort_broken_uploads, 'id')
+
+  in_progress_uploads = _.filter(ds_existing_bill_uploads, function(bill_upload) {
+    return bill_upload['status'] == 'in-progress' && _.contains(broken_upload_ids, bill_upload['id']) == false
+  })
+
+  if (in_progress_uploads.length > 0) { result = [] }
+EOS
+end
+
+# Branching logic:
+# If the above datasource did not find an existing bill upload, then we iterate
+# across its single item to create a new bill upload and store information about it.
+# Otherwise, it iterates over an empty list and produces an empty list as a result.
+datasource "ds_create_bill_upload" do
+  iterate $ds_bill_upload_check
+  request do
+    auth $auth_flexera
+    verb "POST"
+    host rs_optima_host
+    path join(["/optima/orgs/", rs_org_id, "/billUploads"])
+    header "User-Agent", "RS Policies"
+    header "allow_redirects", "False"
+    body_field "billConnectId", $param_cbi_endpoint
+    body_field "billingPeriod", val($ds_dates, 'period')
+  end
+  result do
+    encoding "json"
+    field "billConnectId", jmes_path(response, "billConnectId")
+    field "billingPeriod", jmes_path(response, "billingPeriod")
+    field "createdAt", jmes_path(response, "createdAt")
+    field "files", jmes_path(response, "files")
+    field "id", jmes_path(response, "id")
+    field "status", jmes_path(response, "status")
+    field "updatedAt", jmes_path(response, "updatedAt")
+  end
+end
+
+# Branching logic:
+# This datasource looks at both the list of existing bill uploads and the above
+# datasource for creating a new bill upload and contains either the data for the
+# new bill upload, or if one was not created, the data for the existing
+# in progress bill upload.
+datasource "ds_bill_upload" do
+  run_script $js_bill_upload, $ds_existing_bill_uploads, $ds_create_bill_upload
+end
+
+script "js_bill_upload", type: "javascript" do
+  parameters "ds_existing_bill_uploads", "ds_create_bill_upload"
+  result "result"
+  code <<-EOS
+  if (ds_create_bill_upload.length != 0) {
+    result = ds_create_bill_upload[0]
+  } else {
+    result = _.find(ds_existing_bill_uploads, function(upload) {
+      return upload['status'] == 'in-progress'
+    })
+  }
+EOS
+end
+
+datasource "ds_objects" do
+  request do
+    auth $auth_aws
+    pagination $pagination_aws_s3
+    host $param_s3_hostname
+    header "User-Agent", "RS Policies"
+    query "list-type", "2"
+  end
+  result do
+    encoding "xml"
+    collect xpath(response, "//ListBucketResult/Contents", "array") do
+      field "key", xpath(col_item, "Key")
+      field "lastModified", xpath(col_item, "LastModified")
+    end
+  end
+end
+
+datasource "ds_cost_object_keys" do
+  run_script $js_cost_object_keys, $ds_objects, $ds_dates, $param_s3_prefix
+end
+
+script "js_cost_object_keys", type: "javascript" do
+  parameters "ds_objects", "ds_dates", "param_s3_prefix"
+  result "result"
+  code <<-EOS
+  // Gather the list of objects for the current month's bill
+  normed_prefix = param_s3_prefix.indexOf('/') != 0 ? param_s3_prefix : param_s3_prefix.substring(1)
+
+  result = _.filter(ds_objects, function(object) {
+    return object['key'].indexOf(normed_prefix) == 0 && object['key'].indexOf(ds_dates["period"]) != -1 && object['key'].indexOf(".csv") != -1
+  })
+EOS
+end
+
+datasource "ds_cost_object_keys_sliced" do
+  run_script $js_cost_object_keys_sliced, $ds_cost_object_keys, $ds_bill_upload, $param_block_size
+end
+
+script "js_cost_object_keys_sliced", type: "javascript" do
+  parameters "ds_cost_object_keys", "ds_bill_upload", "param_block_size"
+  result "result"
+  code <<-EOS
+  // Slice off just the one's that we're uploading
+  bill_upload_length = 0
+
+  if (ds_bill_upload['files'] != null && ds_bill_upload['files'] != undefined) {
+    bill_upload_length = ds_bill_upload['files'].length
+  }
+
+  if (bill_upload_length < ds_cost_object_keys.length) {
+    end_block = bill_upload_length + param_block_size
+    result = _.sortBy(ds_cost_object_keys, "lastModified").slice(bill_upload_length, end_block)
+  }
+EOS
+end
+
+datasource "ds_cost_objects" do
+  iterate $ds_cost_object_keys_sliced
+  request do
+    auth $auth_aws
+    host $param_s3_hostname
+    path join(["/", val(iter_item, "key")])
+    header "User-Agent", "RS Policies"
+  end
+  result do
+    encoding "text"
+  end
+end
+
+datasource "ds_upload_file" do
+  iterate $ds_cost_objects
+  request do
+    run_script $js_upload_file, iter_item, $ds_bill_upload, $ds_dates, rs_org_id, rs_optima_host
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+    field "billUploadId", jmes_path(response, "billUploadId")
+    field "createdAt", jmes_path(response, "createdAt")
+    field "length", jmes_path(response, "length")
+    field "md5", jmes_path(response, "md5")
+    field "status", jmes_path(response, "status")
+    field "updatedAt", jmes_path(response, "updatedAt")
+  end
+end
+
+script "js_upload_file", type: "javascript" do
+  parameters "cost_file", "ds_bill_upload", "ds_dates", "rs_org_id", "rs_optima_host"
+  result "request"
+  code <<-EOS
+  // Slow down rate of requests to prevent throttling
+  api_wait = 3
+  var now = new Date().getTime()
+  while(new Date().getTime() < now + (api_wait * 1000)) { /* Do nothing */ }
+
+  var request = {
+    auth: "auth_flexera",
+    verb: "POST",
+    host: rs_optima_host,
+    path: ["/optima/orgs/", rs_org_id, "/billUploads/", ds_bill_upload['id'], '/files/', now, '_', Math.random().toString().split('.')[1], '_', ds_dates['period'], '.csv'].join(''),
+    headers: { "User-Agent": "RS Policies" },
+    body: cost_file
+  }
+EOS
+end
+
+# Branching logic:
+# This datasource contains an empty list if we still have files to upload.
+# Otherwise, it contains the details of the bill upload so we can commit it.
+datasource "ds_commit_assess" do
+  run_script $js_commit_assess, $ds_upload_file, $ds_cost_object_keys, $ds_dates, $ds_bill_upload, $param_commit_delay
+end
+
+script "js_commit_assess", type: "javascript" do
+  parameters "ds_upload_file", "ds_cost_object_keys", "ds_dates", "ds_bill_upload", "param_commit_delay"
+  result "result"
+  code <<-EOS
+  result = []
+
+  if (ds_bill_upload['files'] != null && ds_bill_upload['files'] != undefined) {
+    bill_upload_length = ds_bill_upload['files'].length
+  } else {
+    bill_upload_length = 0
+  }
+
+  now = new Date()
+  now = now.getTime()
+
+  bill_upload_created = new Date(ds_bill_upload['createdAt'])
+  bill_upload_created = bill_upload_created.getTime()
+
+  time_difference = (now - bill_upload_created) / 1000 / 60 / 60
+
+  if (bill_upload_length >= ds_cost_object_keys.length && time_difference >= param_commit_delay) {
+    result = [ds_bill_upload]
+  }
+EOS
+end
+
+# Branching logic:
+# If the above datasource returned an empty list, it means we still have files to upload
+# and this datasource won't do anything. Otherwise, we'll commit the bill upload.
+datasource "ds_commit_bill_upload" do
+  iterate $ds_commit_assess
+  request do
+    run_script $js_commit_bill_upload, val(iter_item, 'id'), rs_org_id, rs_optima_host
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+    field "billConnectId", jmes_path(response, "billConnectId")
+    field "billingPeriod", jmes_path(response, "billingPeriod")
+    field "createdAt", jmes_path(response, "createdAt")
+    field "files", jmes_path(response, "files")
+    field "status", jmes_path(response, "status")
+    field "updatedAt", jmes_path(response, "updatedAt")
+  end
+end
+
+script "js_commit_bill_upload", type: "javascript" do
+  parameters "bill_upload_id", "rs_org_id", "rs_optima_host"
+  result "request"
+  code <<-EOS
+  // Slow down rate of requests to prevent throttling
+  api_wait = 5
+  var now = new Date().getTime()
+  while(new Date().getTime() < now + (api_wait * 1000)) { /* Do nothing */ }
+
+  var request = {
+    auth: "auth_flexera",
+    verb: "POST",
+    host: rs_optima_host,
+    path: ['/optima/orgs/', rs_org_id, '/billUploads/', bill_upload_id, '/operations'].join(''),
+    headers: {
+      "User-Agent": "RS Policies",
+    },
+    body_fields: { "operation": "commit" }
+  }
+EOS
+end
+
+datasource "ds_status" do
+  run_script $js_status, $ds_create_bill_upload, $ds_commit_bill_upload, $ds_bill_upload, $ds_cost_object_keys, $ds_cost_object_keys_sliced, $ds_dates, $param_commit_delay, $param_cbi_endpoint
+end
+
+script "js_status", type: "javascript" do
+  parameters "ds_create_bill_upload", "ds_commit_bill_upload", "ds_bill_upload", "ds_cost_object_keys", "ds_cost_object_keys_sliced", "ds_dates", "param_commit_delay", "param_cbi_endpoint"
+  result "result"
+  code <<-'EOS'
+  result = {
+    message: '',
+    title: '',
+    files: ds_cost_object_list_filtered
+  }
+
+  message = []
+
+  if (ds_create_bill_upload.length == 0) {
+    message.push("Existing bill upload ", ds_bill_upload['id'], " found. Bill uploaded was created at ", ds_bill_upload['createdAt'], '.', "\n\n\n")
+  } else {
+    message.push("New bill upload ", ds_bill_upload['id'], " created at ", ds_bill_upload['createdAt'], '.', "\n\n\n")
+  }
+
+  total_files = ds_cost_object_keys.length
+  files_uploaded = ds_cost_object_keys_sliced.length
+  total_files_uploaded = ds_bill_upload['files'].length + ds_cost_object_keys_sliced.length
+  files_remaining = total_files - total_files_uploaded
+
+  message.push('Total files to upload for ', ds_dates['period'], ': ', total_files, "\n\n")
+  message.push('Files uploaded so far: ', total_files_uploaded, "\n\n")
+  message.push('Files uploaded during most recent execution: ', files_uploaded, "\n\n")
+  message.push('Files remaining: ', files_remaining, "\n\n\n")
+
+  if (ds_commit_bill_upload.length != 0) {
+    message.push('Bill Upload was committed. Cycle will restart with next execution.')
+    result['title'] = param_cbi_endpoint + ' Bill Ingestion: Bill Upload Committed'
+  }
+
+  if (ds_commit_bill_upload.length == 0 && files_remaining == 0) {
+    message.push('All files uploaded. Bill Upload will be committed on next execution if ', param_commit_delay, ' hour(s) have passed since previous commit.')
+    result['title'] = param_cbi_endpoint + ' Bill Ingestion: All Files Uploaded'
+  }
+
+  if (ds_commit_bill_upload.length == 0 && files_remaining != 0) {
+    message.push('Additional files still need to be uploaded. More files will be uploaded on next execution.')
+    result['title'] = param_cbi_endpoint + ' Bill Ingestion: Some Files Uploaded. More Files Remain.'
+  }
+
+  result['message'] = message.join('')
+EOS
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "pol_bill_ingestion" do
+  validate $ds_status do
+    summary_template "{{ data.title }}"
+    detail_template "{{ data.message }}"
+    check eq(0, 1)
+    export "files" do
+      resource_level false
+      field "name" do
+        label "Object Name"
+      end
+      field "timeCreated" do
+        label "Created"
+      end
+      field "timeModified" do
+        label "Last Modified"
+      end
+      field "etag" do
+        label "Entity Tag"
+      end
+      field "md5" do
+        label "MD5"
+      end
+    end
+  end
+end

--- a/cost/flexera/cco/cbi_ingestion_aws_s3_iterating/cbi_ingestion_aws_s3_iterating.pt
+++ b/cost/flexera/cco/cbi_ingestion_aws_s3_iterating/cbi_ingestion_aws_s3_iterating.pt
@@ -482,7 +482,7 @@ script "js_status", type: "javascript" do
   result = {
     message: '',
     title: '',
-    files: ds_cost_object_list_filtered
+    files: ds_cost_object_keys_sliced
   }
 
   message = []

--- a/cost/flexera/cco/cbi_ingestion_azure_blob_iterating/CHANGELOG.md
+++ b/cost/flexera/cco/cbi_ingestion_azure_blob_iterating/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+- Initial release

--- a/cost/flexera/cco/cbi_ingestion_azure_blob_iterating/README.md
+++ b/cost/flexera/cco/cbi_ingestion_azure_blob_iterating/README.md
@@ -4,6 +4,8 @@
 
 This policy template uploads a file containing cloud costs from Azure Blob Storage into the Flexera Cloud Cost Optimization (CCO) platform via [Common Bill Ingestion](https://docs.flexera.com/flexera/EN/Optima/OptimaBillConnectConfigsCBI.htm). Both [Common Bill Ingestion Format](https://docs.flexera.com/flexera/EN/Optima/OptimaBillConnectConfigsCBIDefaultFormat.htm) and [FOCUS Format](https://docs.flexera.com/flexera/EN/Optima/FOCUS.htm) are supported. An incident is raised on every execution of the policy to provide status information to the user.
 
+NOTE: Because of the complexities involved in this policy template, it is recommended for use only in situations where the standard [Common Bill Ingestion from Azure Blob Storage](https://github.com/flexera-public/policy_templates/tree/master/cost/flexera/cco/cbi_ingestion_azure_blob) policy template is unable to handle the amount of data being processed for CBI.
+
 ## How It Works
 
 - The policy uses the Azure Storage API to connect to the storage container containing the CSV files with cost data and obtain the relevant files for the specified month (or current month if none is specified.)

--- a/cost/flexera/cco/cbi_ingestion_azure_blob_iterating/README.md
+++ b/cost/flexera/cco/cbi_ingestion_azure_blob_iterating/README.md
@@ -1,0 +1,58 @@
+# Common Bill Ingestion from Azure Blob Storage (Iterating)
+
+## What It Does
+
+This policy template uploads a file containing cloud costs from Azure Blob Storage into the Flexera Cloud Cost Optimization (CCO) platform via [Common Bill Ingestion](https://docs.flexera.com/flexera/EN/Optima/OptimaBillConnectConfigsCBI.htm). Both [Common Bill Ingestion Format](https://docs.flexera.com/flexera/EN/Optima/OptimaBillConnectConfigsCBIDefaultFormat.htm) and [FOCUS Format](https://docs.flexera.com/flexera/EN/Optima/FOCUS.htm) are supported. An incident is raised on every execution of the policy to provide status information to the user.
+
+## How It Works
+
+- The policy uses the Azure Storage API to connect to the storage container containing the CSV files with cost data and obtain the relevant files for the specified month (or current month if none is specified.)
+- The policy then sends those reports, unmodified, into a Flexera CBI endpoint so that they can be ingested and then visible on the platform.
+- The policy does this over the course of multiple runs to avoid hitting memory and other constraints. **It is recommended that the default frequency of 15 minutes be used; the policy may not function correctly or as expected if a longer frequency is selected.**
+- It is recommended that this policy be applied twice, with Month To Ingest set to Current Month for one instance and with it set to Previous Month for the other. This is to ensure that any changes made to billing data after the month ends are brought into the Flexera platform.
+
+## Input Parameters
+
+This policy has the following input parameters required when launching the policy.
+
+- *Month To Ingest* - Whether to process bills for the current month, previous month, or a specific month.
+- *Billing Period* - The year and month to process bills for in YYYY-MM format. Only relevant if Specific Month is selected for the Month To Ingest parameter. Example: 2022-09
+- *Flexera CBI Endpoint* - The name of the Flexera CBI endpoint to use. Example: cbi-oi-optima-laborcosts
+- *Azure Blob Storage Hostname* - The hostname for the Azure Blob Storage container that stores the costs. Ex: billing-files.blob.core.windows.net
+- *Azure Blob Storage Container* - The name of the Azure Blob Storage container that stores the costs. Ex: cost_reports
+- *Block Size* - The number of files to upload with each execution of the policy. The default value of 20 is recommended.
+- *Commit Delay (Hours)* - The number of hours to wait between committing bill uploads. This is to avoid overloading the CBI system and to ensure bill ingestion occurs at a predictable cadence. The default value of 12 is recommended.
+
+## Policy Actions
+
+- Uploads stored billing data to Flexera CCO
+- Sends an email notification
+
+## Prerequisites
+
+This Policy Template uses [Credentials](https://docs.flexera.com/flexera/EN/Automation/ManagingCredentialsExternal.htm) for authenticating to datasources -- in order to apply this policy you must have a Credential registered in the system that is compatible with this policy. If there are no Credentials listed when you apply the policy, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy. The information below should be consulted when creating the credential(s).
+
+- [**Azure Storage Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm#automationadmin_1982464505_1121576) (*provider=azure_storage*). Note that a credential can be made with access to several storage accounts by setting `resource` to `https://storage.azure.com` in the Additional Parameters when creating this credential in Flexera One. This credential should have the following permissions for the storage account with the cost data:
+  - `Microsoft.Storage/storageAccounts/blobServices/containers/read`
+  - `Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read`
+  - `Microsoft.Storage/storageAccounts/blobServices/containers/blobs/list/action`
+
+- [**Flexera Credential**](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) (*provider=flexera*) which has the following roles:
+  - `billing_center_viewer`
+  - `csm_bill_upload_admin`
+
+The [Provider-Specific Credentials](https://docs.flexera.com/flexera/EN/Automation/ProviderCredentials.htm) page in the docs has detailed instructions for setting up Credentials for the most common providers.
+
+### Additional Requirements
+
+The blobs containing costs must have the `.csv` file extension and must contain the year and month in YYYY-MM format. Example: cost_data_2025-04-08.csv
+
+This policy template also requires a valid CBI endpoint created using the [Flexera Bill Connect API](https://reference.rightscale.com/optima-bill/#/CBIBillConnects/CBIBillConnects_create).
+
+## Supported Clouds
+
+- All
+
+## Cost
+
+This policy template does not incur any cloud costs

--- a/cost/flexera/cco/cbi_ingestion_azure_blob_iterating/cbi_ingestion_azure_blob_iterating.pt
+++ b/cost/flexera/cco/cbi_ingestion_azure_blob_iterating/cbi_ingestion_azure_blob_iterating.pt
@@ -3,6 +3,7 @@ rs_pt_ver 20180301
 type "policy"
 short_description "Downloads cost reports stored in the Flexera Common Bill Ingestion format from Azure Blob Storage and then uploads them to a Flexera CBI endpoint. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/flexera/cco/cbi_ingestion_azure_blob_iterating) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
+doc_link "https://github.com/flexera-public/policy_templates/tree/master/cost/flexera/cco/cbi_ingestion_azure_blob_iterating"
 severity "low"
 category "Cost"
 default_frequency "15 minutes"

--- a/cost/flexera/cco/cbi_ingestion_azure_blob_iterating/cbi_ingestion_azure_blob_iterating.pt
+++ b/cost/flexera/cco/cbi_ingestion_azure_blob_iterating/cbi_ingestion_azure_blob_iterating.pt
@@ -483,7 +483,7 @@ script "js_status", type: "javascript" do
   result = {
     message: '',
     title: '',
-    files: ds_cost_object_list_filtered
+    files: ds_cost_object_keys_sliced
   }
 
   message = []

--- a/cost/flexera/cco/cbi_ingestion_azure_blob_iterating/cbi_ingestion_azure_blob_iterating.pt
+++ b/cost/flexera/cco/cbi_ingestion_azure_blob_iterating/cbi_ingestion_azure_blob_iterating.pt
@@ -1,0 +1,554 @@
+name "Common Bill Ingestion from Azure Blob Storage (Iterating)"
+rs_pt_ver 20180301
+type "policy"
+short_description "Downloads cost reports stored in the Flexera Common Bill Ingestion format from Azure Blob Storage and then uploads them to a Flexera CBI endpoint. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/flexera/cco/cbi_ingestion_azure_blob_iterating) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+long_description ""
+severity "low"
+category "Cost"
+default_frequency "15 minutes"
+info(
+  version: "0.1.0",
+  provider: "Flexera",
+  service: "Common Bill Ingestion",
+  policy_set: "Common Bill Ingestion",
+  hide_skip_approvals: "true",
+  publish: "false"
+)
+
+###############################################################################
+# Parameters
+###############################################################################
+
+parameter "param_billing_period" do
+  type "string"
+  category "Policy Settings"
+  label "Month To Ingest"
+  description "Month to process bills for."
+  allowed_values "Current Month", "Previous Month", "Specific Month"
+  default "Current Month"
+end
+
+parameter "param_specific_period" do
+  type "string"
+  category "Policy Settings"
+  label "Billing Period"
+  description "Billing period to process bills for in YYYY-MM format. Only relevant if Specific Month is selected for Month To Ingest."
+  allowed_pattern /^(19|20)\d\d-(0[1-9]|1[0-2])$/
+  default "2020-01"
+end
+
+parameter "param_cbi_endpoint" do
+  type "string"
+  category "Policy Settings"
+  label "CBI (Common Bill Ingestion) Endpoint ID"
+  description "The ID of CBI endpoint to create/use for ingested costs. Ex: cbi-oi-optima-laborcosts"
+  allowed_pattern /^(cbi-oi-optima-[a-z]+|cbi-oi-focus-[a-z]+|)$/
+  # No default value, user input required
+end
+
+parameter "param_blob_hostname" do
+  type "string"
+  category "Policy Settings"
+  label "Azure Blob Storage Hostname"
+  description "The hostname for the Azure Blob Storage container that stores the costs. Ex: billing-files.blob.core.windows.net"
+  # No default value, user input required
+end
+
+parameter "param_blob_container" do
+  type "string"
+  category "Policy Settings"
+  label "Azure Blob Storage Container"
+  description "The name of the Azure Blob Storage container that stores the costs. Ex: cost_reports"
+  # No default value, user input required
+end
+
+parameter "param_block_size" do
+  type "number"
+  category "Policy Settings"
+  label "Block Size"
+  description "The number of files in a single block."
+  min_value 1
+  max_value 16
+  default 8
+end
+
+parameter "param_commit_delay" do
+  type "number"
+  category "Policy Settings"
+  label "Commit Delay (Hours)"
+  description "Number of hours to wait between committing bill uploads."
+  min_value 8
+  max_value 24
+  default 12
+end
+
+###############################################################################
+# Authentication
+###############################################################################
+
+credentials "auth_flexera" do
+  schemes "oauth2"
+  label "Flexera"
+  description "Select Flexera One OAuth2 credentials"
+  tags "provider=flexera"
+end
+
+credentials "auth_azure_storage" do
+  schemes "oauth2"
+  label "Azure"
+  description "Select the Azure Storage Credential from the list."
+  tags "provider=azure_storage"
+end
+
+###############################################################################
+# Pagination
+###############################################################################
+
+pagination "pagination_azure_xml" do
+  get_page_marker do
+    body_path "//EnumerationResults/NextMarker"
+  end
+  set_page_marker do
+    query "marker"
+  end
+end
+
+###############################################################################
+# Datasources & Scripts
+###############################################################################
+
+datasource "ds_dates" do
+  run_script $js_dates, $param_billing_period, $param_specific_period
+end
+
+script "js_dates", type: "javascript" do
+  parameters "param_billing_period", "param_specific_period"
+  result "result"
+  code <<-EOS
+  result = { period: param_specific_period }
+
+  if (param_billing_period != 'Specific Month') {
+    date = new Date()
+    date.setDate(date.getDate() - 1)
+
+    if (param_billing_period == 'Previous Month') {
+      date.setMonth(date.getMonth() - 1)
+    }
+
+    year = date.toISOString().split('-')[0]
+    month = date.toISOString().split('-')[1]
+
+    result = { period: year + '-' + month }
+  }
+EOS
+end
+
+datasource "ds_existing_bill_uploads" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/optima/orgs/", rs_org_id, "/billUploads"])
+    query "billConnectId", $param_cbi_endpoint
+    query "billingPeriod", val($ds_dates, 'period')
+    header "User-Agent", "RS Policies"
+    header "allow_redirects", "False"
+  end
+end
+
+# This datasource looks for any in-progress bill uploads that are broken
+# due to an in-progress file upload so that they can be aborted.
+datasource "ds_broken_bill_uploads" do
+  run_script $js_broken_bill_uploads, $ds_existing_bill_uploads
+end
+
+script "js_broken_bill_uploads", type: "javascript" do
+  parameters "ds_existing_bill_uploads"
+  result "result"
+  code <<-EOS
+  result = _.filter(ds_existing_bill_uploads, function(bill_upload) {
+    broken_files = false
+
+    if (typeof(bill_upload['files']) == 'object') {
+      _.each(bill_upload['files'], function(file) {
+        if (file['status'] != 'uploaded') {
+          broken_files = true
+        }
+      })
+    }
+
+    // Make sure we ignore any bill uploads that aren't actually in-progress
+    return broken_files && bill_upload['status'] == 'in-progress'
+  })
+EOS
+end
+
+datasource "ds_abort_broken_uploads" do
+  iterate $ds_broken_bill_uploads
+  request do
+    run_script $js_abort_broken_uploads, val(iter_item, 'id'), rs_org_id, rs_optima_host
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+  end
+end
+
+script "js_abort_broken_uploads", type: "javascript" do
+  parameters "bill_upload_id", "rs_org_id", "rs_optima_host"
+  result "request"
+  code <<-EOS
+  // Slow down rate of requests to prevent throttling
+  api_wait = 5
+  var now = new Date().getTime()
+  while(new Date().getTime() < now + (api_wait * 1000)) { /* Do nothing */ }
+
+  var request = {
+    auth: "auth_flexera",
+    verb: "POST",
+    host: rs_optima_host,
+    path: ['/optima/orgs/', rs_org_id, '/billUploads/', bill_upload_id, '/operations'].join(''),
+    headers: {
+      "User-Agent": "RS Policies",
+    },
+    body_fields: { "operation": "abort" }
+  }
+EOS
+end
+
+# Branching logic:
+# This datasource contains an empty array if a bill upload is already in-progress.
+# Broken bill uploads aborted above are not considered in-progress.
+# Otherwise, it contains a single item for the next datasource to iterate over.
+datasource "ds_bill_upload_check" do
+  run_script $js_bill_upload_check, $ds_existing_bill_uploads, $ds_abort_broken_uploads
+end
+
+script "js_bill_upload_check", type: "javascript" do
+  parameters "ds_existing_bill_uploads", "ds_abort_broken_uploads"
+  result "result"
+  code <<-EOS
+  result = [1]
+  broken_upload_ids = _.pluck(ds_abort_broken_uploads, 'id')
+
+  in_progress_uploads = _.filter(ds_existing_bill_uploads, function(bill_upload) {
+    return bill_upload['status'] == 'in-progress' && _.contains(broken_upload_ids, bill_upload['id']) == false
+  })
+
+  if (in_progress_uploads.length > 0) { result = [] }
+EOS
+end
+
+# Branching logic:
+# If the above datasource did not find an existing bill upload, then we iterate
+# across its single item to create a new bill upload and store information about it.
+# Otherwise, it iterates over an empty list and produces an empty list as a result.
+datasource "ds_create_bill_upload" do
+  iterate $ds_bill_upload_check
+  request do
+    auth $auth_flexera
+    verb "POST"
+    host rs_optima_host
+    path join(["/optima/orgs/", rs_org_id, "/billUploads"])
+    header "User-Agent", "RS Policies"
+    header "allow_redirects", "False"
+    body_field "billConnectId", $param_cbi_endpoint
+    body_field "billingPeriod", val($ds_dates, 'period')
+  end
+  result do
+    encoding "json"
+    field "billConnectId", jmes_path(response, "billConnectId")
+    field "billingPeriod", jmes_path(response, "billingPeriod")
+    field "createdAt", jmes_path(response, "createdAt")
+    field "files", jmes_path(response, "files")
+    field "id", jmes_path(response, "id")
+    field "status", jmes_path(response, "status")
+    field "updatedAt", jmes_path(response, "updatedAt")
+  end
+end
+
+# Branching logic:
+# This datasource looks at both the list of existing bill uploads and the above
+# datasource for creating a new bill upload and contains either the data for the
+# new bill upload, or if one was not created, the data for the existing
+# in progress bill upload.
+datasource "ds_bill_upload" do
+  run_script $js_bill_upload, $ds_existing_bill_uploads, $ds_create_bill_upload
+end
+
+script "js_bill_upload", type: "javascript" do
+  parameters "ds_existing_bill_uploads", "ds_create_bill_upload"
+  result "result"
+  code <<-EOS
+  if (ds_create_bill_upload.length != 0) {
+    result = ds_create_bill_upload[0]
+  } else {
+    result = _.find(ds_existing_bill_uploads, function(upload) {
+      return upload['status'] == 'in-progress'
+    })
+  }
+EOS
+end
+
+datasource "ds_objects" do
+  request do
+    auth $auth_azure_storage
+    pagination $pagination_azure_xml
+    host $param_blob_hostname
+    path join(["/", $param_blob_container])
+    query "restype", "container"
+    query "comp", "list"
+    header "User-Agent", "RS Policies"
+    header "x-ms-version", "2018-03-28"
+  end
+  result do
+    encoding "xml"
+    collect xpath(response, "//EnumerationResults/Blobs/Blob", "array") do
+      field "key", xpath(col_item, "Name")
+      field "lastModified", xpath(col_item, "Properties/Last-Modified")
+    end
+  end
+end
+
+datasource "ds_cost_object_keys" do
+  run_script $js_cost_object_keys, $ds_objects, $ds_dates
+end
+
+script "js_cost_object_keys", type: "javascript" do
+  parameters "ds_objects", "ds_dates"
+  result "result"
+  code <<-EOS
+  result = _.filter(ds_objects, function(object) {
+    return object['key'].indexOf(ds_dates["period"]) != -1 && object['key'].indexOf(".csv") != -1
+  })
+EOS
+end
+
+datasource "ds_cost_object_keys_sliced" do
+  run_script $js_cost_object_keys_sliced, $ds_cost_object_keys, $ds_bill_upload, $param_block_size
+end
+
+script "js_cost_object_keys_sliced", type: "javascript" do
+  parameters "ds_cost_object_keys", "ds_bill_upload", "param_block_size"
+  result "result"
+  code <<-EOS
+  // Slice off just the one's that we're uploading
+  bill_upload_length = 0
+
+  if (ds_bill_upload['files'] != null && ds_bill_upload['files'] != undefined) {
+    bill_upload_length = ds_bill_upload['files'].length
+  }
+
+  if (bill_upload_length < ds_cost_object_keys.length) {
+    end_block = bill_upload_length + param_block_size
+    result = _.sortBy(ds_cost_object_keys, "lastModified").slice(bill_upload_length, end_block)
+  }
+EOS
+end
+
+datasource "ds_cost_objects" do
+  iterate $ds_cost_object_keys_sliced
+  request do
+    auth $auth_azure_storage
+    host $param_blob_hostname
+    path join(["/", $param_blob_container, "/", val(iter_item, "key")])
+    header "User-Agent", "RS Policies"
+    header "x-ms-version", "2025-05-05"
+    ignore_status [404] # Ignore dates that have no associated file instead of failing completely
+  end
+  result do
+    encoding "text"
+  end
+end
+
+datasource "ds_upload_file" do
+  iterate $ds_cost_objects
+  request do
+    run_script $js_upload_file, iter_item, $ds_bill_upload, $ds_dates, rs_org_id, rs_optima_host
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+    field "billUploadId", jmes_path(response, "billUploadId")
+    field "createdAt", jmes_path(response, "createdAt")
+    field "length", jmes_path(response, "length")
+    field "md5", jmes_path(response, "md5")
+    field "status", jmes_path(response, "status")
+    field "updatedAt", jmes_path(response, "updatedAt")
+  end
+end
+
+script "js_upload_file", type: "javascript" do
+  parameters "cost_file", "ds_bill_upload", "ds_dates", "rs_org_id", "rs_optima_host"
+  result "request"
+  code <<-EOS
+  // Slow down rate of requests to prevent throttling
+  api_wait = 3
+  var now = new Date().getTime()
+  while(new Date().getTime() < now + (api_wait * 1000)) { /* Do nothing */ }
+
+  var request = {
+    auth: "auth_flexera",
+    verb: "POST",
+    host: rs_optima_host,
+    path: ["/optima/orgs/", rs_org_id, "/billUploads/", ds_bill_upload['id'], '/files/', now, '_', Math.random().toString().split('.')[1], '_', ds_dates['period'], '.csv'].join(''),
+    headers: { "User-Agent": "RS Policies" },
+    body: cost_file
+  }
+EOS
+end
+
+# Branching logic:
+# This datasource contains an empty list if we still have files to upload.
+# Otherwise, it contains the details of the bill upload so we can commit it.
+datasource "ds_commit_assess" do
+  run_script $js_commit_assess, $ds_upload_file, $ds_cost_object_keys, $ds_dates, $ds_bill_upload, $param_commit_delay
+end
+
+script "js_commit_assess", type: "javascript" do
+  parameters "ds_upload_file", "ds_cost_object_keys", "ds_dates", "ds_bill_upload", "param_commit_delay"
+  result "result"
+  code <<-EOS
+  result = []
+
+  if (ds_bill_upload['files'] != null && ds_bill_upload['files'] != undefined) {
+    bill_upload_length = ds_bill_upload['files'].length
+  } else {
+    bill_upload_length = 0
+  }
+
+  now = new Date()
+  now = now.getTime()
+
+  bill_upload_created = new Date(ds_bill_upload['createdAt'])
+  bill_upload_created = bill_upload_created.getTime()
+
+  time_difference = (now - bill_upload_created) / 1000 / 60 / 60
+
+  if (bill_upload_length >= ds_cost_object_keys.length && time_difference >= param_commit_delay) {
+    result = [ds_bill_upload]
+  }
+EOS
+end
+
+# Branching logic:
+# If the above datasource returned an empty list, it means we still have files to upload
+# and this datasource won't do anything. Otherwise, we'll commit the bill upload.
+datasource "ds_commit_bill_upload" do
+  iterate $ds_commit_assess
+  request do
+    run_script $js_commit_bill_upload, val(iter_item, 'id'), rs_org_id, rs_optima_host
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+    field "billConnectId", jmes_path(response, "billConnectId")
+    field "billingPeriod", jmes_path(response, "billingPeriod")
+    field "createdAt", jmes_path(response, "createdAt")
+    field "files", jmes_path(response, "files")
+    field "status", jmes_path(response, "status")
+    field "updatedAt", jmes_path(response, "updatedAt")
+  end
+end
+
+script "js_commit_bill_upload", type: "javascript" do
+  parameters "bill_upload_id", "rs_org_id", "rs_optima_host"
+  result "request"
+  code <<-EOS
+  // Slow down rate of requests to prevent throttling
+  api_wait = 5
+  var now = new Date().getTime()
+  while(new Date().getTime() < now + (api_wait * 1000)) { /* Do nothing */ }
+
+  var request = {
+    auth: "auth_flexera",
+    verb: "POST",
+    host: rs_optima_host,
+    path: ['/optima/orgs/', rs_org_id, '/billUploads/', bill_upload_id, '/operations'].join(''),
+    headers: {
+      "User-Agent": "RS Policies",
+    },
+    body_fields: { "operation": "commit" }
+  }
+EOS
+end
+
+datasource "ds_status" do
+  run_script $js_status, $ds_create_bill_upload, $ds_commit_bill_upload, $ds_bill_upload, $ds_cost_object_keys, $ds_cost_object_keys_sliced, $ds_dates, $param_commit_delay, $param_cbi_endpoint
+end
+
+script "js_status", type: "javascript" do
+  parameters "ds_create_bill_upload", "ds_commit_bill_upload", "ds_bill_upload", "ds_cost_object_keys", "ds_cost_object_keys_sliced", "ds_dates", "param_commit_delay", "param_cbi_endpoint"
+  result "result"
+  code <<-'EOS'
+  result = {
+    message: '',
+    title: '',
+    files: ds_cost_object_list_filtered
+  }
+
+  message = []
+
+  if (ds_create_bill_upload.length == 0) {
+    message.push("Existing bill upload ", ds_bill_upload['id'], " found. Bill uploaded was created at ", ds_bill_upload['createdAt'], '.', "\n\n\n")
+  } else {
+    message.push("New bill upload ", ds_bill_upload['id'], " created at ", ds_bill_upload['createdAt'], '.', "\n\n\n")
+  }
+
+  total_files = ds_cost_object_keys.length
+  files_uploaded = ds_cost_object_keys_sliced.length
+  total_files_uploaded = ds_bill_upload['files'].length + ds_cost_object_keys_sliced.length
+  files_remaining = total_files - total_files_uploaded
+
+  message.push('Total files to upload for ', ds_dates['period'], ': ', total_files, "\n\n")
+  message.push('Files uploaded so far: ', total_files_uploaded, "\n\n")
+  message.push('Files uploaded during most recent execution: ', files_uploaded, "\n\n")
+  message.push('Files remaining: ', files_remaining, "\n\n\n")
+
+  if (ds_commit_bill_upload.length != 0) {
+    message.push('Bill Upload was committed. Cycle will restart with next execution.')
+    result['title'] = param_cbi_endpoint + ' Bill Ingestion: Bill Upload Committed'
+  }
+
+  if (ds_commit_bill_upload.length == 0 && files_remaining == 0) {
+    message.push('All files uploaded. Bill Upload will be committed on next execution if ', param_commit_delay, ' hour(s) have passed since previous commit.')
+    result['title'] = param_cbi_endpoint + ' Bill Ingestion: All Files Uploaded'
+  }
+
+  if (ds_commit_bill_upload.length == 0 && files_remaining != 0) {
+    message.push('Additional files still need to be uploaded. More files will be uploaded on next execution.')
+    result['title'] = param_cbi_endpoint + ' Bill Ingestion: Some Files Uploaded. More Files Remain.'
+  }
+
+  result['message'] = message.join('')
+EOS
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "pol_bill_ingestion" do
+  validate $ds_status do
+    summary_template "{{ data.title }}"
+    detail_template "{{ data.message }}"
+    check eq(0, 1)
+    export "files" do
+      resource_level false
+      field "name" do
+        label "Object Name"
+      end
+      field "timeCreated" do
+        label "Created"
+      end
+      field "timeModified" do
+        label "Last Modified"
+      end
+      field "etag" do
+        label "Entity Tag"
+      end
+      field "md5" do
+        label "MD5"
+      end
+    end
+  end
+end

--- a/tools/policy_master_permission_generation/validated_policy_templates.yaml
+++ b/tools/policy_master_permission_generation/validated_policy_templates.yaml
@@ -260,6 +260,8 @@ validated_policy_templates:
 -  "./cost/flexera/cco/cheaper_regions/cheaper_regions.pt"
 -  "./cost/flexera/cco/cbi_ingestion_aws_s3/cbi_ingestion_aws_s3.pt"
 -  "./cost/flexera/cco/cbi_ingestion_azure_blob/cbi_ingestion_azure_blob.pt"
+-  "./cost/flexera/cco/cbi_ingestion_aws_s3_iterating/cbi_ingestion_aws_s3_iterating.pt"
+-  "./cost/flexera/cco/cbi_ingestion_azure_blob_iterating/cbi_ingestion_azure_blob_iterating.pt"
 -  "./cost/flexera/cco/email_recommendations/email_recommendations.pt"
 -  "./cost/flexera/cco/fixed_cost_cbi/fixed_cost_cbi.pt"
 -  "./cost/flexera/cco/focus_report/focus_report.pt"


### PR DESCRIPTION
### Description

Adds two new unpublished policy templates for sending CSV files from AWS S3 or Azure Blob Storage to Flexera CBI.

Unpublished because these policy templates require some extra knowhow to use, since they send in CSV files over multiple executions, similar to the Oracle CBI policy template. They should generally only be used as a fallback, with guidance from Flexera, when the published policy templates that work in a much more straight-forward and user-friendly way are not able to be used due to the amount of data being sent to CBI.

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=686fb68486eaa862688b28ff

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
