### PR TITLE
FOAA-294 fix: improved savings calculation accuracy for underutilized resources on AWS Rightsize RDS

### DIFF
--- a/cost/aws/rightsize_rds_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_rds_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.8.1
+
+- Improved accuracy of savings calculation for underutilized RDS instances recommending to be resized.  We now consider only the "InstanceUsage" usage type costs when estimating potential savings from resize.
+
 ## v5.8.0
 
 - Savings calculation now incorporates list prices to improve accuracy of savings estimates.

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
@@ -7,7 +7,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "5.8.0",
+  version: "5.8.1",
   provider: "AWS",
   service: "RDS",
   policy_set: "Rightsize Database Instances",
@@ -185,7 +185,7 @@ datasource "ds_applied_policy" do
   request do
     auth $auth_flexera
     host rs_governance_host
-    path join(["/api/governance/projects/", rs_project_id, "/applied_policies/", policy_id])
+    path join(["/api/governance/projects/", rs_project_id, "/applied_policies", switch(policy_id, join(["/",policy_id]), "")])
     header "Api-Version", "1.0"
   end
 end
@@ -463,7 +463,20 @@ end
 
 datasource "ds_instance_costs" do
   request do
-    run_script $js_instance_costs, $ds_aws_account, $ds_top_level_bcs, rs_org_id, rs_optima_host
+    run_script $js_instance_costs, $ds_aws_account, $ds_top_level_bcs, rs_org_id, rs_optima_host, "all"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "rows[*]") do
+      field "id", jmes_path(col_item, "dimensions.resource_id")
+      field "cost", jmes_path(col_item, "metrics.cost_amortized_blended_adj")
+    end
+  end
+end
+
+datasource "ds_instance_costs_instanceusage" do
+  request do
+    run_script $js_instance_costs, $ds_aws_account, $ds_top_level_bcs, rs_org_id, rs_optima_host, "instanceusage"
   end
   result do
     encoding "json"
@@ -475,7 +488,7 @@ datasource "ds_instance_costs" do
 end
 
 script "js_instance_costs", type:"javascript" do
-  parameters "ds_aws_account", "ds_top_level_bcs", "rs_org_id", "rs_optima_host"
+  parameters "ds_aws_account", "ds_top_level_bcs", "rs_org_id", "rs_optima_host", "instanceusage_filter"
   result "request"
   code <<-EOS
   start_date = new Date()
@@ -512,6 +525,9 @@ script "js_instance_costs", type:"javascript" do
             "type": "equal",
             "value": ds_aws_account['id']
           }
+          // Do not filter on usage types
+          // For idle resources that are terminates -- all usage types can be considered savings
+          // For underutilized resources that are downsized -- only "InstanceUsage" can be considered for savings calculation (not DataTransfer,PIOPS, etc..)
         ]
       }
     },
@@ -521,15 +537,24 @@ script "js_instance_costs", type:"javascript" do
     },
     ignore_status: [400]
   }
+  // If instanceusage_filter is set to "instanceusage", filter the request to only include RDS:InstanceUsage usage type
+  if (instanceusage_filter == "instanceusage") {
+    request.body_fields.filter.expressions.push({
+      "dimension": "usage_type",
+      "type": "substring",
+      "substring": "InstanceUsage",
+      "caseInsensitive": true
+    })
+  }
 EOS
 end
 
 datasource "ds_instance_costs_grouped" do
-  run_script $js_instance_costs_grouped, $ds_instance_costs
+  run_script $js_instance_costs_grouped, $ds_instance_costs, $ds_instance_costs_instanceusage
 end
 
 script "js_instance_costs_grouped", type: "javascript" do
-  parameters "ds_instance_costs"
+  parameters "ds_instance_costs", "ds_instance_costs_instanceusage"
   result "result"
   code <<-EOS
   // Multiple a single day's cost by the average number of days in a month.
@@ -537,14 +562,32 @@ script "js_instance_costs_grouped", type: "javascript" do
   cost_multiplier = 365.25 / 12
 
   // Group cost data by resourceId for later use
-  result = {}
+  allusage = {}
+  instanceusage = {}
 
+  // Loop through and generate total costs for each instance
   _.each(ds_instance_costs, function(item) {
     id = item['id'].toLowerCase()
 
-    if (result[id] == undefined) { result[id] = 0.0 }
-    result[id] += item['cost'] * cost_multiplier
+    if (allusage[id] == undefined) {
+      allusage[id] = 0.0
+      instanceusage[id] = 0.0
+    }
+    allusage[id] += item['cost'] * cost_multiplier
   })
+  // Now loop through the InstanceUsage costs to get just InstanceUsage costs for each instance
+  _.each(ds_instance_costs_instanceusage, function(item) {
+    id = item['id'].toLowerCase()
+
+    if (instanceusage[id] == undefined) {
+      instanceusage[id] = 0.0
+    }
+    instanceusage[id] += item['cost'] * cost_multiplier
+  })
+  var result = {
+    "allusage": allusage,
+    "instanceusage": instanceusage
+  }
 EOS
 end
 
@@ -1012,8 +1055,8 @@ script "js_rds_idle_instances", type: "javascript" do
     savings_name = "db:" + instance['name'].toLowerCase()
     new_instance['savings'] = 0.0
 
-    if (typeof(ds_instance_costs_grouped[savings_name]) == 'number') {
-      new_instance['savings'] = ds_instance_costs_grouped[savings_name]
+    if (ds_instance_costs_grouped.allusage && typeof(ds_instance_costs_grouped.allusage[savings_name]) == 'number') {
+      new_instance['savings'] = ds_instance_costs_grouped.allusage[savings_name]
     }
 
     return new_instance
@@ -1409,7 +1452,7 @@ script "js_rds_underutil_instances", type: "javascript" do
       savings = 0.0
 
       cost = 0.0
-      if (typeof(ds_instance_costs_grouped[cost_name]) == 'number') { cost = ds_instance_costs_grouped[cost_name] }
+      if (ds_instance_costs_grouped.instanceusage && typeof(ds_instance_costs_grouped.instanceusage[cost_name]) == 'number') { cost = ds_instance_costs_grouped.instanceusage[cost_name] }
 
       // See if we have list prices for the old and new types based on metadata from the instance
       cost_region = instance['region']
@@ -1635,7 +1678,7 @@ script "js_rds_idle_incident", type: "javascript" do
         lookbackPeriod: param_stats_lookback,
         newResourceType: "Terminate RDS Instance",
         service: "AmazonRDS",
-        policy_name: ds_applied_policy['name'],
+        policy_name: ds_applied_policy['name'] || "AWS Rightsize RDS Instances",
         // Dummy values to ensure hash_exclude works properly
         total_savings: "",
         message: ""


### PR DESCRIPTION
### Description

Improved accuracy of savings calculation for underutilized RDS instances recommending to be resized.  We now consider only the "InstanceUsage" usage type costs when estimating potential savings from resize.

### Issues Resolved

https://flexera.atlassian.net/browse/FOAA-294

### Link to Example Applied Policy

https://app.flexera.eu/orgs/34909/automation/applied-policies/projects/136739?policyId=6870210966389548a39326c3

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
