### PR TITLE
POL-1562 AWS Old Snapshots: RDS Fix

### DIFF
--- a/cost/aws/old_snapshots/CHANGELOG.md
+++ b/cost/aws/old_snapshots/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v8.4.6
+
+- Fixed issue that caused RDS DB snapshots to be reported with overinflated estimated savings. Added additional context around these snapshots to the incident description.
+
 ## v8.4.5
 
 - Added `doc_link` field to policy template metadata for future UI enhancements. Functionality unchanged.

--- a/cost/aws/old_snapshots/README.md
+++ b/cost/aws/old_snapshots/README.md
@@ -13,6 +13,7 @@ The policy includes the estimated monthly savings. The estimated monthly savings
 - If the resource cannot be found in Flexera CCO, the `Estimated Monthly Savings` is 0.
 - The incident message detail includes the sum of each resource `Estimated Monthly Savings` as `Potential Monthly Savings`.
 - Both `Estimated Monthly Savings` and `Potential Monthly Savings` will be reported in the currency of the Flexera organization the policy is applied in.
+- Note: [AWS RDS snapshots are incremental](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithAutomatedBackups.html); for this reason, the `Estimated Monthly Savings` will only be fully realized if all snapshots of a given RDS instance are deleted.
 
 ## Input Parameters
 

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "8.4.5",
+  version: "8.4.6",
   provider: "AWS",
   service: "Storage",
   policy_set: "Old Snapshots",
@@ -536,9 +536,7 @@ script "js_describe_db_snapshots", type:"javascript" do
 
   _.each(_.keys(sorted_by_parent), function(parent) {
     sorted_parents = _.sortBy(sorted_by_parent[parent], "startTime").reverse()
-    sorted_parents.forEach(function(snapshot) {
-          result.push(snapshot);
-    });
+    result.push(sorted_parents[0])
   })
 EOS
 end
@@ -1026,7 +1024,9 @@ script "js_snapshots_cost_mapping", type: "javascript" do
 
   disclaimer = "The above settings can be modified by editing the applied policy and changing the appropriate parameters.\n\n"
 
-  empty_message = "Empty values either indicate that data was unavailable or that particular field is not applicable to that specific resource. Only EC2 snapshots will have a Description and only RDS snapshots will have a Snapshot Type."
+  empty_message = "Empty values either indicate that data was unavailable or that particular field is not applicable to that specific resource. Only EC2 snapshots will have a Description and only RDS snapshots will have a Snapshot Type.\n\n"
+
+  rds_message = "Note: AWS RDS snapshots are incremental. To avoid reporting overinflated savings estimates, only the most recent snapshot of a given RDS instance is reported. The estimated savings will only be fully realized if all snapshots of a given RDS instance are deleted."
 
   savings_message = [
     ds_currency['symbol'], ' ',
@@ -1048,7 +1048,7 @@ script "js_snapshots_cost_mapping", type: "javascript" do
   })
 
   result[0]['total_savings'] = savings_message
-  result[0]['message'] = findings + ami_message + disclaimer + empty_message
+  result[0]['message'] = findings + ami_message + disclaimer + empty_message + rds_message
   result[0]['policy_name'] = ds_applied_policy['name']
 EOS
 end


### PR DESCRIPTION
### Description

RDS snapshots are incremental; for this reason, the `AWS Old Snapshots` policy template has been modified to only report the most recent RDS snapshot. A disclaimer has also been added to both the incident page and the README explaining why this is done.

This is because we don't have a straightforward way to assign a savings value to incremental snapshots; deleting one will only save you the amount of space freed up from removing that particular version.

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=687e35a42dabda2883e1a652

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
