### PR TITLE
POL-1565 Meta Parents: Hourly Schedule

### DIFF
--- a/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
@@ -6,7 +6,7 @@ long_description ""
 doc_link "https://github.com/flexera-public/policy_templates/blob/master/README_META_POLICIES.md"
 severity "low"
 category "Meta"
-default_frequency "15 minutes"
+default_frequency "hourly"
 info(
   provider: "AWS",
   version: "__PLACEHOLDER_FOR_CHILD_POLICY_VERSION__", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability

--- a/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
@@ -6,7 +6,7 @@ long_description ""
 doc_link "https://github.com/flexera-public/policy_templates/blob/master/README_META_POLICIES.md"
 severity "low"
 category "Meta"
-default_frequency "15 minutes"
+default_frequency "hourly"
 info(
   provider: "Azure",
   version: "__PLACEHOLDER_FOR_CHILD_POLICY_VERSION__", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability

--- a/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
@@ -6,7 +6,7 @@ long_description ""
 doc_link "https://github.com/flexera-public/policy_templates/blob/master/README_META_POLICIES.md"
 severity "low"
 category "Meta"
-default_frequency "15 minutes"
+default_frequency "hourly"
 info(
   provider: "Google",
   version: "__PLACEHOLDER_FOR_CHILD_POLICY_VERSION__", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability


### PR DESCRIPTION
### Description

This alters the meta parent templates to default to hourly instead of 15 minutes. This is to help reduce the load on the policy engine and Flexera APIs from people using these templates with their default settings. The user can still select 15 minutes intentionally while applying the meta parents.

Note: The policy templates themselves should update automatically once this change is merged.
