### PR TITLE
POL-1568 Deprecate Azure China Common Bill Ingestion

### DIFF
--- a/cost/azure/azure_china_cbi/CHANGELOG.md
+++ b/cost/azure/azure_china_cbi/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v2.1.0
+## v2.0.4
 
 - Deprecated: This policy template is no longer being updated. Please see policy README for more information.
 

--- a/cost/azure/azure_china_cbi/CHANGELOG.md
+++ b/cost/azure/azure_china_cbi/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1.0
+
+- Deprecated: This policy template is no longer being updated. Please see policy README for more information.
+
 ## v2.0.3
 
 - Added `doc_link` field to policy template metadata for future UI enhancements. Functionality unchanged.

--- a/cost/azure/azure_china_cbi/README.md
+++ b/cost/azure/azure_china_cbi/README.md
@@ -1,5 +1,9 @@
 # Azure China Common Bill Ingestion
 
+## Deprecated
+
+This policy template is no longer being updated. Flexera Cloud Cost Optimization now supports native ingestion of Azure China bills. Please see the [Azure China documentation](https://docs.flexera.com/flexera/EN/Administration/BillConnectConfigsAzureChina.htm) for more information.
+
 ## What It Does
 
 This Policy Template is used to automatically take billing data for Azure China and send the data to Flexera CBI so that Azure China costs are visible in Flexera One.

--- a/cost/azure/azure_china_cbi/azure_china_cbi.pt
+++ b/cost/azure/azure_china_cbi/azure_china_cbi.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.1.0",
+  version: "2.0.4",
   provider: "Azure China",
   service: "Common Bill Ingestion",
   policy_set: "Common Bill Ingestion",

--- a/cost/azure/azure_china_cbi/azure_china_cbi.pt
+++ b/cost/azure/azure_china_cbi/azure_china_cbi.pt
@@ -1,17 +1,18 @@
 name "Azure China Common Bill Ingestion"
 rs_pt_ver 20180301
 type "policy"
-short_description "Azure China CBI Policy. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/azure_china_cbi/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "**Deprecated: This policy is no longer being updated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/azure_china_cbi/) for more details.**  Azure China CBI Policy. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/azure/azure_china_cbi/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 doc_link "https://github.com/flexera-public/policy_templates/tree/master/cost/azure/azure_china_cbi/"
 severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.0.3",
+  version: "2.1.0",
   provider: "Azure China",
   service: "Common Bill Ingestion",
   policy_set: "Common Bill Ingestion",
+  deprecated: "true",
   hide_skip_approvals: "true"
 )
 


### PR DESCRIPTION
### Description

The Azure China Common Bill Ingestion policy template is being deprecated. The README now directs the user to our documentation on configuring an Azure China bill connection.

### Link to Example Applied Policy

N/A. No functional changes.

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
