### PR TITLE
POL-1570 Meta Parent: Added Hourly/15 Minute Options

### DIFF
--- a/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "daily", "weekly", "monthly"
+  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "daily", "weekly", "monthly"
+  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "daily", "weekly", "monthly"
+  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do


### PR DESCRIPTION
### Description

Added "hourly" and "15 minutes" options to meta parent policies. This is primarily for policies like the scheduled instance policies where these options are needed.