### PR TITLE
FOAA-306 - Scheduled Report fix issue with ignore current mont and month granularity

### DIFF
--- a/cost/flexera/cco/scheduled_reports/CHANGELOG.md
+++ b/cost/flexera/cco/scheduled_reports/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.0.2
+
+- Fixed issue with "Ignore Current Month" when "Month" granularity is used.
+
 ## v4.0.1
 
 - Added `doc_link` field to policy template metadata for future UI enhancements. Functionality unchanged.

--- a/cost/flexera/cco/scheduled_reports/scheduled_report.pt
+++ b/cost/flexera/cco/scheduled_reports/scheduled_report.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "monthly"
 info(
-  version: "4.0.1",
+  version: "4.0.2",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -515,17 +515,15 @@ script "js_cost_request_list", type: "javascript" do
       result.push(request)
     }
   } else {
-    index = param_ignore_current_month == "Yes" ? 0 : 1
-
-    end_at = new Date().toISOString()
+    today = new Date().toISOString()
 
     if (param_ignore_current_month == "Yes") {
-      end_at = end_at.substring(0, 7)
-      start_at = move_month(end_at, -param_date_range - 1)
+      end_at = today.slice(0, 7) // Use YYYY-MM from today's date to end on the first of current month
     } else {
-      end_at = move_month(end_at, 1)
-      start_at = move_month(end_at, -param_date_range)
+      end_at = move_month(today, 1) // include entire current month, ending on the first of next month
     }
+    // Based on the end_at, use param_date_range to calculate start_at
+    start_at = move_month(end_at, -param_date_range)
 
     request = {
       "billing_center_ids": billing_center_ids,
@@ -534,7 +532,8 @@ script "js_cost_request_list", type: "javascript" do
       "filter": null,
       "granularity": "month",
       "start_at": start_at,
-      "end_at": end_at
+      "end_at": end_at,
+      "foo": new Date().toISOString()  // Placeholder to ensure the request is not empty
     }
 
     if (filter['type'] != undefined) { request['filter'] = filter }


### PR DESCRIPTION
### Description

Fixes issue with ignore current month and month granularity with the expected outcome that the result would show 1 month in the chart and it would be the previous month.  Currently it's showing 2 months (current and previous)

### Issues Resolved

Identified during work related to https://flexera.atlassian.net/browse/FOAA-307

### Link to Example Applied Policy

https://app.flexera.com/orgs/28010/automation/applied-policies/projects/123559?policyId=689101912dabda2883e2e5b1

### Contribution Check List

- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
