### PR TITLE
FOPTS-12555 Fixed inconsistent type for "nfu" field.

### DIFF
--- a/data/azure/azure_compute_instance_types.json
+++ b/data/azure/azure_compute_instance_types.json
@@ -433,7 +433,7 @@
     "family": "standardAv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "10240",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "1",
@@ -506,7 +506,7 @@
     "family": "standardAv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "20480",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -541,7 +541,7 @@
     "family": "standardAv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "20480",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -652,7 +652,7 @@
     "family": "standardAv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "40960",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -687,7 +687,7 @@
     "family": "standardAv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "40960",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -836,7 +836,7 @@
     "family": "standardAv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "81920",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -871,7 +871,7 @@
     "family": "standardAv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "81920",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -943,7 +943,7 @@
     "family": "standardBasv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -979,7 +979,7 @@
     "family": "standardBasv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -1015,7 +1015,7 @@
     "family": "standardBsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 56.635,
+      "nfu": "56.635",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -1088,7 +1088,7 @@
     "family": "standardBpsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 56.67,
+      "nfu": "56.67",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -1123,7 +1123,7 @@
     "family": "standardBpsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 64.05,
+      "nfu": "64.05",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -1158,7 +1158,7 @@
     "family": "standardBsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 64.04,
+      "nfu": "64.04",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -1342,7 +1342,7 @@
     "family": "standardBasv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -1378,7 +1378,7 @@
     "family": "standardBasv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -1414,7 +1414,7 @@
     "family": "standardBasv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -1449,7 +1449,7 @@
     "family": "standardBsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -1522,7 +1522,7 @@
     "family": "standardBpsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -1557,7 +1557,7 @@
     "family": "standardBpsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -1592,7 +1592,7 @@
     "family": "standardBpsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -1664,7 +1664,7 @@
     "family": "standardBsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -1700,7 +1700,7 @@
     "family": "standardBsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -1735,7 +1735,7 @@
     "family": "standardBasv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -1771,7 +1771,7 @@
     "family": "standardBasv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -1806,7 +1806,7 @@
     "family": "standardBsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 113.365,
+      "nfu": "113.365",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -1842,7 +1842,7 @@
     "family": "standardBsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 127.98,
+      "nfu": "127.98",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -1877,7 +1877,7 @@
     "family": "standardBasv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -1913,7 +1913,7 @@
     "family": "standardBasv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -1949,7 +1949,7 @@
     "family": "standardBsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 14.135,
+      "nfu": "14.135",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -2022,7 +2022,7 @@
     "family": "standardBpsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 14.17,
+      "nfu": "14.17",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -2057,7 +2057,7 @@
     "family": "standardBpsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 15.95,
+      "nfu": "15.95",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -2092,7 +2092,7 @@
     "family": "standardBsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 15.96,
+      "nfu": "15.96",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -2128,7 +2128,7 @@
     "family": "standardBasv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -2164,7 +2164,7 @@
     "family": "standardBasv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -2200,7 +2200,7 @@
     "family": "standardBsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 28.365,
+      "nfu": "28.365",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -2273,7 +2273,7 @@
     "family": "standardBpsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 28.33,
+      "nfu": "28.33",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -2308,7 +2308,7 @@
     "family": "standardBpsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.02,
+      "nfu": "32.02",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -2343,7 +2343,7 @@
     "family": "standardBsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.02,
+      "nfu": "32.02",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -2564,7 +2564,7 @@
     "family": "StandardDdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 63.78,
+      "nfu": "63.78",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "128",
@@ -2606,7 +2606,7 @@
     "family": "StandardDldsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 64.18,
+      "nfu": "64.18",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "128",
@@ -2648,7 +2648,7 @@
     "family": "StandardDlsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 64.0,
+      "nfu": "64",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "128",
@@ -2683,7 +2683,7 @@
     "family": "StandardDsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 64.0,
+      "nfu": "64",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "128",
@@ -3049,7 +3049,7 @@
     "family": "standardDADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "614400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -3087,7 +3087,7 @@
     "family": "standardDadv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -3130,7 +3130,7 @@
     "family": "standardDaldv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -3173,7 +3173,7 @@
     "family": "standardDalv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -3246,7 +3246,7 @@
     "family": "standardDASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -3283,7 +3283,7 @@
     "family": "standardDav6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -3392,7 +3392,7 @@
     "family": "standardDDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "614400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -3429,7 +3429,7 @@
     "family": "StandardDdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -3507,7 +3507,7 @@
     "family": "standardDDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "614400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -3543,7 +3543,7 @@
     "family": "standardDLDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "614400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -3580,7 +3580,7 @@
     "family": "StandardDldsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -3622,7 +3622,7 @@
     "family": "standardDLSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -3658,7 +3658,7 @@
     "family": "StandardDlsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -3693,7 +3693,7 @@
     "family": "standardDPDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "614400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -3730,7 +3730,7 @@
     "family": "StandardDpdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -3772,7 +3772,7 @@
     "family": "standardDPLDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "614400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -3809,7 +3809,7 @@
     "family": "StandardDpldsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -3851,7 +3851,7 @@
     "family": "standardDPLSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -3887,7 +3887,7 @@
     "family": "StandardDplsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -3922,7 +3922,7 @@
     "family": "standardDPSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -3958,7 +3958,7 @@
     "family": "StandardDpsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -4068,7 +4068,7 @@
     "family": "standardDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -4104,7 +4104,7 @@
     "family": "StandardDsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -4209,7 +4209,7 @@
     "family": "standardDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -4316,7 +4316,7 @@
     "family": "standardDADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "76800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -4354,7 +4354,7 @@
     "family": "standardDadv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -4397,7 +4397,7 @@
     "family": "standardDaldv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -4440,7 +4440,7 @@
     "family": "standardDalv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -4513,7 +4513,7 @@
     "family": "standardDASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -4550,7 +4550,7 @@
     "family": "standardDav6Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -4659,7 +4659,7 @@
     "family": "standardDDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "76800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -4696,7 +4696,7 @@
     "family": "StandardDdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -4774,7 +4774,7 @@
     "family": "standardDDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "76800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -4810,7 +4810,7 @@
     "family": "standardDLDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "76800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -4847,7 +4847,7 @@
     "family": "StandardDldsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -4889,7 +4889,7 @@
     "family": "standardDLSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -4925,7 +4925,7 @@
     "family": "StandardDlsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -4960,7 +4960,7 @@
     "family": "standardDPDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "76800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -4997,7 +4997,7 @@
     "family": "StandardDpdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -5039,7 +5039,7 @@
     "family": "standardDPLDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "76800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -5076,7 +5076,7 @@
     "family": "StandardDpldsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -5118,7 +5118,7 @@
     "family": "standardDPLSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -5154,7 +5154,7 @@
     "family": "StandardDplsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -5189,7 +5189,7 @@
     "family": "standardDPSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -5225,7 +5225,7 @@
     "family": "StandardDpsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -5335,7 +5335,7 @@
     "family": "standardDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -5371,7 +5371,7 @@
     "family": "StandardDsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -5550,7 +5550,7 @@
     "family": "standardDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -5622,7 +5622,7 @@
     "family": "standardDADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "1228800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -5659,7 +5659,7 @@
     "family": "standardDadv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -5702,7 +5702,7 @@
     "family": "standardDaldv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -5745,7 +5745,7 @@
     "family": "standardDalv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -5818,7 +5818,7 @@
     "family": "standardDASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -5854,7 +5854,7 @@
     "family": "standardDav6Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -5963,7 +5963,7 @@
     "family": "standardDDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "1228800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -5999,7 +5999,7 @@
     "family": "StandardDdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 15.94,
+      "nfu": "15.94",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -6077,7 +6077,7 @@
     "family": "standardDDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "1228800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -6113,7 +6113,7 @@
     "family": "standardDLDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "1228800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -6150,7 +6150,7 @@
     "family": "StandardDldsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -6192,7 +6192,7 @@
     "family": "standardDLSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -6228,7 +6228,7 @@
     "family": "StandardDlsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -6263,7 +6263,7 @@
     "family": "standardDPDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "1228800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -6300,7 +6300,7 @@
     "family": "StandardDpdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -6342,7 +6342,7 @@
     "family": "standardDPLDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "1228800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -6379,7 +6379,7 @@
     "family": "StandardDpldsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -6421,7 +6421,7 @@
     "family": "standardDPLSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -6457,7 +6457,7 @@
     "family": "StandardDplsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -6492,7 +6492,7 @@
     "family": "standardDPSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -6528,7 +6528,7 @@
     "family": "StandardDpsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -6638,7 +6638,7 @@
     "family": "standardDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -6673,7 +6673,7 @@
     "family": "StandardDsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -6778,7 +6778,7 @@
     "family": "standardDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -6924,7 +6924,7 @@
     "family": "standardDADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "1843200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -6961,7 +6961,7 @@
     "family": "standardDadv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -7004,7 +7004,7 @@
     "family": "standardDaldv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -7047,7 +7047,7 @@
     "family": "standardDalv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -7120,7 +7120,7 @@
     "family": "standardDASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -7156,7 +7156,7 @@
     "family": "standardDav6Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -7265,7 +7265,7 @@
     "family": "standardDDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "1843200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -7301,7 +7301,7 @@
     "family": "StandardDdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 23.92,
+      "nfu": "23.92",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -7379,7 +7379,7 @@
     "family": "standardDDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "1843200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -7415,7 +7415,7 @@
     "family": "standardDLDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "1843200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -7451,7 +7451,7 @@
     "family": "StandardDldsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.07,
+      "nfu": "24.07",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -7493,7 +7493,7 @@
     "family": "standardDLSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -7528,7 +7528,7 @@
     "family": "StandardDlsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -7563,7 +7563,7 @@
     "family": "standardDPDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "1843200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -7600,7 +7600,7 @@
     "family": "StandardDpdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -7642,7 +7642,7 @@
     "family": "standardDPLDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "1843200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -7679,7 +7679,7 @@
     "family": "StandardDpldsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -7721,7 +7721,7 @@
     "family": "standardDPLSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -7757,7 +7757,7 @@
     "family": "StandardDplsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -7792,7 +7792,7 @@
     "family": "standardDPSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -7828,7 +7828,7 @@
     "family": "StandardDpsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -7938,7 +7938,7 @@
     "family": "standardDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -7973,7 +7973,7 @@
     "family": "StandardDsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -8078,7 +8078,7 @@
     "family": "standardDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -8113,7 +8113,7 @@
     "family": "standardDADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "153600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -8151,7 +8151,7 @@
     "family": "standardDadv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -8194,7 +8194,7 @@
     "family": "standardDaldv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -8237,7 +8237,7 @@
     "family": "standardDalv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -8310,7 +8310,7 @@
     "family": "standardDASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -8347,7 +8347,7 @@
     "family": "standardDav6Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -8456,7 +8456,7 @@
     "family": "standardDDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "153600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -8493,7 +8493,7 @@
     "family": "StandardDdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -8571,7 +8571,7 @@
     "family": "standardDDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "153600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -8607,7 +8607,7 @@
     "family": "standardDLDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "153600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -8644,7 +8644,7 @@
     "family": "StandardDldsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -8686,7 +8686,7 @@
     "family": "standardDLSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -8722,7 +8722,7 @@
     "family": "StandardDlsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -8757,7 +8757,7 @@
     "family": "standardDPDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "153600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -8794,7 +8794,7 @@
     "family": "StandardDpdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -8836,7 +8836,7 @@
     "family": "standardDPLDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "153600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -8873,7 +8873,7 @@
     "family": "StandardDpldsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -8915,7 +8915,7 @@
     "family": "standardDPLSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -8951,7 +8951,7 @@
     "family": "StandardDplsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -8986,7 +8986,7 @@
     "family": "standardDPSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -9022,7 +9022,7 @@
     "family": "StandardDpsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -9132,7 +9132,7 @@
     "family": "standardDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -9168,7 +9168,7 @@
     "family": "StandardDsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -9347,7 +9347,7 @@
     "family": "standardDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -9456,7 +9456,7 @@
     "family": "standardDADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "2457600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -9493,7 +9493,7 @@
     "family": "standardDadv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -9536,7 +9536,7 @@
     "family": "standardDaldv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -9579,7 +9579,7 @@
     "family": "standardDalv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -9652,7 +9652,7 @@
     "family": "standardDASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -9688,7 +9688,7 @@
     "family": "standardDav6Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -9797,7 +9797,7 @@
     "family": "standardDDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "2457600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -9833,7 +9833,7 @@
     "family": "StandardDdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 31.9,
+      "nfu": "31.9",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -9911,7 +9911,7 @@
     "family": "standardDDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "2457600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -9947,7 +9947,7 @@
     "family": "standardDLDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "2457600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -9983,7 +9983,7 @@
     "family": "StandardDldsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.09,
+      "nfu": "32.09",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -10025,7 +10025,7 @@
     "family": "standardDLSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -10060,7 +10060,7 @@
     "family": "StandardDlsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -10095,7 +10095,7 @@
     "family": "standardDPDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "2457600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -10132,7 +10132,7 @@
     "family": "StandardDpdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -10174,7 +10174,7 @@
     "family": "standardDPLDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "2457600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -10211,7 +10211,7 @@
     "family": "StandardDpldsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -10253,7 +10253,7 @@
     "family": "standardDPLSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -10289,7 +10289,7 @@
     "family": "StandardDplsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -10324,7 +10324,7 @@
     "family": "standardDPSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -10360,7 +10360,7 @@
     "family": "StandardDpsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -10470,7 +10470,7 @@
     "family": "standardDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -10505,7 +10505,7 @@
     "family": "StandardDsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -10610,7 +10610,7 @@
     "family": "standardDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -10645,7 +10645,7 @@
     "family": "standardDADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "307200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -10683,7 +10683,7 @@
     "family": "standardDadv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -10726,7 +10726,7 @@
     "family": "standardDaldv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -10769,7 +10769,7 @@
     "family": "standardDalv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -10842,7 +10842,7 @@
     "family": "standardDASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -10879,7 +10879,7 @@
     "family": "standardDav6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -10988,7 +10988,7 @@
     "family": "standardDDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "307200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -11025,7 +11025,7 @@
     "family": "StandardDdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -11103,7 +11103,7 @@
     "family": "standardDDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "307200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -11139,7 +11139,7 @@
     "family": "standardDLDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "307200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -11176,7 +11176,7 @@
     "family": "StandardDldsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -11218,7 +11218,7 @@
     "family": "standardDLSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -11254,7 +11254,7 @@
     "family": "StandardDlsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -11289,7 +11289,7 @@
     "family": "standardDPDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "307200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -11326,7 +11326,7 @@
     "family": "StandardDpdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -11368,7 +11368,7 @@
     "family": "standardDPLDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "307200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -11405,7 +11405,7 @@
     "family": "StandardDpldsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -11447,7 +11447,7 @@
     "family": "standardDPLSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -11483,7 +11483,7 @@
     "family": "StandardDplsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -11518,7 +11518,7 @@
     "family": "standardDPSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -11554,7 +11554,7 @@
     "family": "StandardDpsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -11664,7 +11664,7 @@
     "family": "standardDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -11700,7 +11700,7 @@
     "family": "StandardDsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -11805,7 +11805,7 @@
     "family": "standardDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -11840,7 +11840,7 @@
     "family": "standardDADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "3686400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -11877,7 +11877,7 @@
     "family": "standardDadv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -11920,7 +11920,7 @@
     "family": "standardDaldv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -11963,7 +11963,7 @@
     "family": "standardDalv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -12036,7 +12036,7 @@
     "family": "standardDASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -12072,7 +12072,7 @@
     "family": "standardDav6Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -12143,7 +12143,7 @@
     "family": "standardDDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "3686400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -12179,7 +12179,7 @@
     "family": "StandardDdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 47.84,
+      "nfu": "47.84",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -12221,7 +12221,7 @@
     "family": "standardDDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "3686400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -12257,7 +12257,7 @@
     "family": "standardDLDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "3686400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -12293,7 +12293,7 @@
     "family": "StandardDldsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.14,
+      "nfu": "48.14",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -12335,7 +12335,7 @@
     "family": "standardDLSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -12370,7 +12370,7 @@
     "family": "StandardDlsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -12405,7 +12405,7 @@
     "family": "StandardDpdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -12447,7 +12447,7 @@
     "family": "StandardDpldsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -12489,7 +12489,7 @@
     "family": "StandardDplsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -12524,7 +12524,7 @@
     "family": "StandardDpsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -12559,7 +12559,7 @@
     "family": "standardDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -12594,7 +12594,7 @@
     "family": "StandardDsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -12629,7 +12629,7 @@
     "family": "standardDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -12702,7 +12702,7 @@
     "family": "standardDCADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "614400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -12777,7 +12777,7 @@
     "family": "standardDCASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -12814,7 +12814,7 @@
     "family": "standardDDCSv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "1228800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -12923,7 +12923,7 @@
     "family": "standardDCSv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -12957,7 +12957,7 @@
     "family": "standardDDCSv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "76800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "1",
@@ -13029,7 +13029,7 @@
     "family": "standardDCSv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "1",
@@ -13063,7 +13063,7 @@
     "family": "standardDDCSv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "1843200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "24",
@@ -13099,7 +13099,7 @@
     "family": "standardDCSv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "24",
@@ -13133,7 +13133,7 @@
     "family": "standardDCADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "76800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -13171,7 +13171,7 @@
     "family": "standardDCASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -13208,7 +13208,7 @@
     "family": "standardDDCSv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "153600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -13353,7 +13353,7 @@
     "family": "standardDCSv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -13425,7 +13425,7 @@
     "family": "standardDCADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "1228800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -13500,7 +13500,7 @@
     "family": "standardDCASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -13537,7 +13537,7 @@
     "family": "standardDDCSv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "2457600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -13646,7 +13646,7 @@
     "family": "standardDCSv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -13718,7 +13718,7 @@
     "family": "standardDCADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "1843200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -13793,7 +13793,7 @@
     "family": "standardDCASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -13830,7 +13830,7 @@
     "family": "standardDDCSv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "2457600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -13939,7 +13939,7 @@
     "family": "standardDCSv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -14011,7 +14011,7 @@
     "family": "standardDCADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "153600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -14086,7 +14086,7 @@
     "family": "standardDCASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -14123,7 +14123,7 @@
     "family": "standardDDCSv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "307200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -14268,7 +14268,7 @@
     "family": "standardDCSv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -14340,7 +14340,7 @@
     "family": "standardDCADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "2457600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -14415,7 +14415,7 @@
     "family": "standardDCASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -14563,7 +14563,7 @@
     "family": "standardDCADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "307200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -14638,7 +14638,7 @@
     "family": "standardDCASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -14675,7 +14675,7 @@
     "family": "standardDDCSv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "614400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -14784,7 +14784,7 @@
     "family": "standardDCSv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -14892,7 +14892,7 @@
     "family": "standardDCADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "3686400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -14967,7 +14967,7 @@
     "family": "standardDCASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -16313,7 +16313,7 @@
     "family": "standardEIDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "3891200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "104",
@@ -16349,7 +16349,7 @@
     "family": "standardEIDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 52.0,
+      "nfu": "52",
       "MaxResourceVolumeMB": "3891200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "104",
@@ -16385,7 +16385,7 @@
     "family": "standardEISv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "104",
@@ -16420,7 +16420,7 @@
     "family": "standardEIv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 52.0,
+      "nfu": "52",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "104",
@@ -16455,7 +16455,7 @@
     "family": "standardEIADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 56.0,
+      "nfu": "56",
       "MaxResourceVolumeMB": "3891200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "112",
@@ -16492,7 +16492,7 @@
     "family": "standardEIASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 56.0,
+      "nfu": "56",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "112",
@@ -16528,7 +16528,7 @@
     "family": "standardEIBDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 112.0,
+      "nfu": "112",
       "MaxResourceVolumeMB": "3891200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "112",
@@ -16565,7 +16565,7 @@
     "family": "standardEIBSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 112.0,
+      "nfu": "112",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "112",
@@ -16601,7 +16601,7 @@
     "family": "StandardEdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 64.0,
+      "nfu": "64",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "128",
@@ -16644,7 +16644,7 @@
     "family": "StandardEsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 64.14,
+      "nfu": "64.14",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "128",
@@ -16680,7 +16680,7 @@
     "family": "StandardEdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 64.0,
+      "nfu": "64",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "128",
@@ -16723,7 +16723,7 @@
     "family": "StandardEsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 64.14,
+      "nfu": "64.14",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "128",
@@ -16759,7 +16759,7 @@
     "family": "StandardEdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 64.0,
+      "nfu": "64",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "128",
@@ -16801,7 +16801,7 @@
     "family": "StandardEsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 64.14,
+      "nfu": "64.14",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "128",
@@ -16836,7 +16836,7 @@
     "family": "standardEADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "614400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -16913,7 +16913,7 @@
     "family": "standardEASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -16989,7 +16989,7 @@
     "family": "standardEDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "614400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -17026,7 +17026,7 @@
     "family": "StandardEdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -17146,7 +17146,7 @@
     "family": "standardESv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -17182,7 +17182,7 @@
     "family": "StandardEsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -17218,7 +17218,7 @@
     "family": "standardEADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "614400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -17295,7 +17295,7 @@
     "family": "standardEASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -17371,7 +17371,7 @@
     "family": "standardEDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "614400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -17408,7 +17408,7 @@
     "family": "StandardEdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -17528,7 +17528,7 @@
     "family": "standardESv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -17564,7 +17564,7 @@
     "family": "StandardEsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -17600,7 +17600,7 @@
     "family": "standardEADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "614400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -17637,7 +17637,7 @@
     "family": "standardEadv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -17719,7 +17719,7 @@
     "family": "standardEASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -17755,7 +17755,7 @@
     "family": "standardEav6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -17826,7 +17826,7 @@
     "family": "standardEBDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "614400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -17863,7 +17863,7 @@
     "family": "standardEBSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -17937,7 +17937,7 @@
     "family": "standardEDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "614400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -17973,7 +17973,7 @@
     "family": "StandardEdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -18050,7 +18050,7 @@
     "family": "standardEDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "614400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -18086,7 +18086,7 @@
     "family": "standardEPDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "614400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -18123,7 +18123,7 @@
     "family": "StandardEpdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -18165,7 +18165,7 @@
     "family": "standardEPSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -18201,7 +18201,7 @@
     "family": "StandardEpsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -18311,7 +18311,7 @@
     "family": "standardESv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -18346,7 +18346,7 @@
     "family": "StandardEsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -18451,7 +18451,7 @@
     "family": "standardEv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -18486,7 +18486,7 @@
     "family": "StandardEdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 96.0,
+      "nfu": "96",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "192",
@@ -18528,7 +18528,7 @@
     "family": "StandardEsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 105.84,
+      "nfu": "105.84",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "192",
@@ -18563,7 +18563,7 @@
     "family": "standardEADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 10.0,
+      "nfu": "10",
       "MaxResourceVolumeMB": "768000",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "20",
@@ -18600,7 +18600,7 @@
     "family": "standardEadv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 10.0,
+      "nfu": "10",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "20",
@@ -18682,7 +18682,7 @@
     "family": "standardEASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 10.0,
+      "nfu": "10",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "20",
@@ -18718,7 +18718,7 @@
     "family": "standardEav6Family",
     "superseded": null,
     "specs": {
-      "nfu": 10.0,
+      "nfu": "10",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "20",
@@ -18827,7 +18827,7 @@
     "family": "standardEDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 10.0,
+      "nfu": "10",
       "MaxResourceVolumeMB": "768000",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "20",
@@ -18863,7 +18863,7 @@
     "family": "StandardEdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 10.0,
+      "nfu": "10",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "20",
@@ -18940,7 +18940,7 @@
     "family": "standardEDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 10.0,
+      "nfu": "10",
       "MaxResourceVolumeMB": "768000",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "20",
@@ -18976,7 +18976,7 @@
     "family": "standardEPDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 10.0,
+      "nfu": "10",
       "MaxResourceVolumeMB": "768000",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "20",
@@ -19013,7 +19013,7 @@
     "family": "standardEPSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 10.0,
+      "nfu": "10",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "20",
@@ -19124,7 +19124,7 @@
     "family": "standardESv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 10.0,
+      "nfu": "10",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "20",
@@ -19159,7 +19159,7 @@
     "family": "StandardEsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 10.0,
+      "nfu": "10",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "20",
@@ -19264,7 +19264,7 @@
     "family": "standardEv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 10.0,
+      "nfu": "10",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "20",
@@ -19299,7 +19299,7 @@
     "family": "standardEADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "76800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -19337,7 +19337,7 @@
     "family": "standardEadv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -19419,7 +19419,7 @@
     "family": "standardEASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -19456,7 +19456,7 @@
     "family": "standardEav6Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -19527,7 +19527,7 @@
     "family": "standardEBDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "76800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -19564,7 +19564,7 @@
     "family": "standardEBSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -19638,7 +19638,7 @@
     "family": "standardEDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "76800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -19675,7 +19675,7 @@
     "family": "StandardEdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -19752,7 +19752,7 @@
     "family": "standardEDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "76800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -19788,7 +19788,7 @@
     "family": "standardEPDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "76800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -19825,7 +19825,7 @@
     "family": "StandardEpdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -19867,7 +19867,7 @@
     "family": "standardEPSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -19903,7 +19903,7 @@
     "family": "StandardEpsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -20013,7 +20013,7 @@
     "family": "standardESv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -20049,7 +20049,7 @@
     "family": "StandardEsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -20154,7 +20154,7 @@
     "family": "standardEv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -20189,7 +20189,7 @@
     "family": "standardEADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "1228800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -20266,7 +20266,7 @@
     "family": "standardEASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -20342,7 +20342,7 @@
     "family": "standardEDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "1228800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -20379,7 +20379,7 @@
     "family": "StandardEdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -20499,7 +20499,7 @@
     "family": "standardESv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -20535,7 +20535,7 @@
     "family": "StandardEsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -20571,7 +20571,7 @@
     "family": "standardEADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "1228800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -20648,7 +20648,7 @@
     "family": "standardEASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -20724,7 +20724,7 @@
     "family": "standardEDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "1228800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -20761,7 +20761,7 @@
     "family": "StandardEdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -20881,7 +20881,7 @@
     "family": "standardESv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -20917,7 +20917,7 @@
     "family": "StandardEsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -20953,7 +20953,7 @@
     "family": "standardEADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "1228800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -20990,7 +20990,7 @@
     "family": "standardEadv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -21072,7 +21072,7 @@
     "family": "standardEASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -21108,7 +21108,7 @@
     "family": "standardEav6Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -21179,7 +21179,7 @@
     "family": "standardEBDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "1228800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -21216,7 +21216,7 @@
     "family": "standardEBSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -21290,7 +21290,7 @@
     "family": "standardEDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "1228800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -21326,7 +21326,7 @@
     "family": "StandardEdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -21403,7 +21403,7 @@
     "family": "standardEDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "1228800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -21439,7 +21439,7 @@
     "family": "standardEPDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "1228800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -21476,7 +21476,7 @@
     "family": "StandardEpdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -21518,7 +21518,7 @@
     "family": "standardEPSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -21554,7 +21554,7 @@
     "family": "StandardEpsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -21664,7 +21664,7 @@
     "family": "standardESv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -21699,7 +21699,7 @@
     "family": "StandardEsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -21804,7 +21804,7 @@
     "family": "standardEv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -21839,7 +21839,7 @@
     "family": "standardEADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "153600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -21916,7 +21916,7 @@
     "family": "standardEASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -21992,7 +21992,7 @@
     "family": "standardEDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "153600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -22029,7 +22029,7 @@
     "family": "StandardEdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -22149,7 +22149,7 @@
     "family": "standardESv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -22185,7 +22185,7 @@
     "family": "StandardEsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -22221,7 +22221,7 @@
     "family": "standardEADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "1843200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -22258,7 +22258,7 @@
     "family": "standardEadv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -22340,7 +22340,7 @@
     "family": "standardEASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -22376,7 +22376,7 @@
     "family": "standardEav6Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -22447,7 +22447,7 @@
     "family": "standardEBDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "1843200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -22484,7 +22484,7 @@
     "family": "standardEBSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -22558,7 +22558,7 @@
     "family": "standardEDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "1843200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -22594,7 +22594,7 @@
     "family": "StandardEdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -22671,7 +22671,7 @@
     "family": "standardEDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "1843200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -22707,7 +22707,7 @@
     "family": "StandardEpdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -22749,7 +22749,7 @@
     "family": "StandardEpsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -22859,7 +22859,7 @@
     "family": "standardESv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -22894,7 +22894,7 @@
     "family": "StandardEsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.05,
+      "nfu": "24.05",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -22999,7 +22999,7 @@
     "family": "standardEv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -23034,7 +23034,7 @@
     "family": "standardEADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "153600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -23072,7 +23072,7 @@
     "family": "standardEadv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -23154,7 +23154,7 @@
     "family": "standardEASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -23191,7 +23191,7 @@
     "family": "standardEav6Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -23262,7 +23262,7 @@
     "family": "standardEBDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "153600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -23299,7 +23299,7 @@
     "family": "standardEBSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -23373,7 +23373,7 @@
     "family": "standardEDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "153600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -23410,7 +23410,7 @@
     "family": "StandardEdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -23487,7 +23487,7 @@
     "family": "standardEDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "153600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -23523,7 +23523,7 @@
     "family": "standardEPDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "153600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -23560,7 +23560,7 @@
     "family": "StandardEpdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -23602,7 +23602,7 @@
     "family": "standardEPSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -23638,7 +23638,7 @@
     "family": "StandardEpsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -23748,7 +23748,7 @@
     "family": "standardESv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -23784,7 +23784,7 @@
     "family": "StandardEsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -23889,7 +23889,7 @@
     "family": "standardEv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -23924,7 +23924,7 @@
     "family": "standardEADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "2457600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -24001,7 +24001,7 @@
     "family": "standardEASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -24077,7 +24077,7 @@
     "family": "standardEDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "2457600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -24114,7 +24114,7 @@
     "family": "StandardEdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -24234,7 +24234,7 @@
     "family": "standardESv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -24270,7 +24270,7 @@
     "family": "StandardEsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.08,
+      "nfu": "32.08",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -24306,7 +24306,7 @@
     "family": "standardEADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "2457600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -24383,7 +24383,7 @@
     "family": "standardEASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -24459,7 +24459,7 @@
     "family": "standardEDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "2457600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -24496,7 +24496,7 @@
     "family": "StandardEdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -24616,7 +24616,7 @@
     "family": "standardESv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -24652,7 +24652,7 @@
     "family": "StandardEsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.08,
+      "nfu": "32.08",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -24688,7 +24688,7 @@
     "family": "standardEADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "2457600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -24725,7 +24725,7 @@
     "family": "standardEadv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -24807,7 +24807,7 @@
     "family": "standardEASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -24843,7 +24843,7 @@
     "family": "standardEav6Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.05,
+      "nfu": "32.05",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -24914,7 +24914,7 @@
     "family": "standardEBDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 64.0,
+      "nfu": "64",
       "MaxResourceVolumeMB": "2457600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -24951,7 +24951,7 @@
     "family": "standardEBSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 64.0,
+      "nfu": "64",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -25025,7 +25025,7 @@
     "family": "standardEDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "2457600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -25061,7 +25061,7 @@
     "family": "StandardEdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -25103,7 +25103,7 @@
     "family": "standardEDv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "2457600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -25138,7 +25138,7 @@
     "family": "standardEDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "2457600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -25247,7 +25247,7 @@
     "family": "StandardEpdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -25289,7 +25289,7 @@
     "family": "StandardEpsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -25399,7 +25399,7 @@
     "family": "standardESv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -25434,7 +25434,7 @@
     "family": "StandardEsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.08,
+      "nfu": "32.08",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -25539,7 +25539,7 @@
     "family": "standardEv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -25574,7 +25574,7 @@
     "family": "standardEADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "307200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -25651,7 +25651,7 @@
     "family": "standardEASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -25727,7 +25727,7 @@
     "family": "standardEDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "307200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -25764,7 +25764,7 @@
     "family": "StandardEdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -25884,7 +25884,7 @@
     "family": "standardESv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -25920,7 +25920,7 @@
     "family": "StandardEsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -25956,7 +25956,7 @@
     "family": "standardEADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "307200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -26033,7 +26033,7 @@
     "family": "standardEASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -26109,7 +26109,7 @@
     "family": "standardEDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "307200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -26146,7 +26146,7 @@
     "family": "StandardEdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -26266,7 +26266,7 @@
     "family": "standardESv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -26302,7 +26302,7 @@
     "family": "StandardEsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -26411,7 +26411,7 @@
     "family": "standardEADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "307200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -26449,7 +26449,7 @@
     "family": "standardEadv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -26531,7 +26531,7 @@
     "family": "standardEASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -26568,7 +26568,7 @@
     "family": "standardEav6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -26639,7 +26639,7 @@
     "family": "standardEBDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "307200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -26676,7 +26676,7 @@
     "family": "standardEBSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -26750,7 +26750,7 @@
     "family": "standardEDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "307200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -26787,7 +26787,7 @@
     "family": "StandardEdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -26864,7 +26864,7 @@
     "family": "standardEDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "307200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -26900,7 +26900,7 @@
     "family": "standardEPDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "307200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -26937,7 +26937,7 @@
     "family": "StandardEpdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -26979,7 +26979,7 @@
     "family": "standardEPSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -27015,7 +27015,7 @@
     "family": "StandardEpsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -27125,7 +27125,7 @@
     "family": "standardESv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -27161,7 +27161,7 @@
     "family": "StandardEsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -27266,7 +27266,7 @@
     "family": "standardEv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -27301,7 +27301,7 @@
     "family": "standardEADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "3686400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -27421,7 +27421,7 @@
     "family": "standardEASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -27458,7 +27458,7 @@
     "family": "standardEDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "3686400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -27495,7 +27495,7 @@
     "family": "StandardEdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -27538,7 +27538,7 @@
     "family": "standardESv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -27574,7 +27574,7 @@
     "family": "StandardEsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.11,
+      "nfu": "48.11",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -27610,7 +27610,7 @@
     "family": "standardEADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "3686400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -27730,7 +27730,7 @@
     "family": "standardEASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -27767,7 +27767,7 @@
     "family": "standardEDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "3686400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -27804,7 +27804,7 @@
     "family": "StandardEdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -27847,7 +27847,7 @@
     "family": "standardESv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -27883,7 +27883,7 @@
     "family": "StandardEsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.11,
+      "nfu": "48.11",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -27919,7 +27919,7 @@
     "family": "standardEADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "3686400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -27956,7 +27956,7 @@
     "family": "standardEadv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -28040,7 +28040,7 @@
     "family": "standardEASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -28076,7 +28076,7 @@
     "family": "standardEav6Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.08,
+      "nfu": "48.08",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -28147,7 +28147,7 @@
     "family": "standardEBDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 96.0,
+      "nfu": "96",
       "MaxResourceVolumeMB": "3686400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -28184,7 +28184,7 @@
     "family": "standardEBSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 96.0,
+      "nfu": "96",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -28220,7 +28220,7 @@
     "family": "standardEDSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "3686400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -28256,7 +28256,7 @@
     "family": "StandardEdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -28298,7 +28298,7 @@
     "family": "standardEDv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "3686400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -28334,7 +28334,7 @@
     "family": "standardEIASv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "1376256",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -28371,7 +28371,7 @@
     "family": "StandardEpdsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -28413,7 +28413,7 @@
     "family": "StandardEpsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -28448,7 +28448,7 @@
     "family": "standardESv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -28483,7 +28483,7 @@
     "family": "StandardEsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.11,
+      "nfu": "48.11",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -28518,7 +28518,7 @@
     "family": "standardEv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -28738,7 +28738,7 @@
     "family": "standardECADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "614400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -28813,7 +28813,7 @@
     "family": "standardECASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -28958,7 +28958,7 @@
     "family": "standardECADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 10.0,
+      "nfu": "10",
       "MaxResourceVolumeMB": "768000",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "20",
@@ -29033,7 +29033,7 @@
     "family": "standardECASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 10.0,
+      "nfu": "10",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "20",
@@ -29070,7 +29070,7 @@
     "family": "standardECADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "76800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -29108,7 +29108,7 @@
     "family": "standardECASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -29253,7 +29253,7 @@
     "family": "standardECADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "1228800",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -29328,7 +29328,7 @@
     "family": "standardECASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -29473,7 +29473,7 @@
     "family": "standardECADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "1843200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -29548,7 +29548,7 @@
     "family": "standardECASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -29696,7 +29696,7 @@
     "family": "standardECADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "153600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -29771,7 +29771,7 @@
     "family": "standardECASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -29916,7 +29916,7 @@
     "family": "standardECADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "2457600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -29991,7 +29991,7 @@
     "family": "standardECASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -30136,7 +30136,7 @@
     "family": "standardECADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "307200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -30211,7 +30211,7 @@
     "family": "standardECASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -30356,7 +30356,7 @@
     "family": "standardECADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "3686400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -30431,7 +30431,7 @@
     "family": "standardECASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -30468,7 +30468,7 @@
     "family": "standardECIADSv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "3686400",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -30506,7 +30506,7 @@
     "family": "standardECIASv5Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -30613,7 +30613,7 @@
     "family": "StandardFalsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -30648,7 +30648,7 @@
     "family": "StandardFamsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -30683,7 +30683,7 @@
     "family": "StandardFasv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -30867,7 +30867,7 @@
     "family": "StandardFalsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -30902,7 +30902,7 @@
     "family": "StandardFamsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -30937,7 +30937,7 @@
     "family": "StandardFasv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -31048,7 +31048,7 @@
     "family": "StandardFalsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -31083,7 +31083,7 @@
     "family": "StandardFamsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -31118,7 +31118,7 @@
     "family": "StandardFasv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -31226,7 +31226,7 @@
     "family": "StandardFalsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -31261,7 +31261,7 @@
     "family": "StandardFamsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -31296,7 +31296,7 @@
     "family": "StandardFasv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -31369,7 +31369,7 @@
     "family": "StandardFalsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -31404,7 +31404,7 @@
     "family": "StandardFamsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -31439,7 +31439,7 @@
     "family": "StandardFasv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -31550,7 +31550,7 @@
     "family": "StandardFalsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 64.0,
+      "nfu": "64",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -31585,7 +31585,7 @@
     "family": "StandardFamsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 64.0,
+      "nfu": "64",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -31620,7 +31620,7 @@
     "family": "StandardFasv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 64.0,
+      "nfu": "64",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -31766,7 +31766,7 @@
     "family": "StandardFalsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -31801,7 +31801,7 @@
     "family": "StandardFamsv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -31836,7 +31836,7 @@
     "family": "StandardFasv6Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -31947,7 +31947,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 6.0,
+      "nfu": "6",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "12",
@@ -31990,7 +31990,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 6.0,
+      "nfu": "6",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "12",
@@ -32026,7 +32026,7 @@
     "family": "standardFXMDVSFamily",
     "superseded": null,
     "specs": {
-      "nfu": 3.0,
+      "nfu": "3",
       "MaxResourceVolumeMB": "516096",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "12",
@@ -32063,7 +32063,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 6.0,
+      "nfu": "6",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "12",
@@ -32105,7 +32105,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 6.0,
+      "nfu": "6",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "12",
@@ -32140,7 +32140,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -32183,7 +32183,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -32219,7 +32219,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -32262,7 +32262,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -32298,7 +32298,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -32340,7 +32340,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -32375,7 +32375,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 12.0,
+      "nfu": "12",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "24",
@@ -32418,7 +32418,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 12.0,
+      "nfu": "12",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "24",
@@ -32454,7 +32454,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 12.0,
+      "nfu": "12",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "24",
@@ -32497,7 +32497,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 12.0,
+      "nfu": "12",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "24",
@@ -32533,7 +32533,7 @@
     "family": "standardFXMDVSFamily",
     "superseded": null,
     "specs": {
-      "nfu": 6.0,
+      "nfu": "6",
       "MaxResourceVolumeMB": "1032192",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "24",
@@ -32570,7 +32570,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 12.0,
+      "nfu": "12",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "24",
@@ -32612,7 +32612,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 12.0,
+      "nfu": "12",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "24",
@@ -32647,7 +32647,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -32689,7 +32689,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -32724,7 +32724,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -32767,7 +32767,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -32803,7 +32803,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -32846,7 +32846,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -32882,7 +32882,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -32924,7 +32924,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -32959,7 +32959,7 @@
     "family": "standardFXMDVSFamily",
     "superseded": null,
     "specs": {
-      "nfu": 9.0,
+      "nfu": "9",
       "MaxResourceVolumeMB": "1548288",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "36",
@@ -32996,7 +32996,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -33039,7 +33039,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -33075,7 +33075,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -33118,7 +33118,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -33154,7 +33154,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -33197,7 +33197,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -33233,7 +33233,7 @@
     "family": "standardFXMDVSFamily",
     "superseded": null,
     "specs": {
-      "nfu": 12.0,
+      "nfu": "12",
       "MaxResourceVolumeMB": "2064384",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -33270,7 +33270,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -33312,7 +33312,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -33347,7 +33347,7 @@
     "family": "standardFXMDVSFamily",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "172032",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -33384,7 +33384,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -33426,7 +33426,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -33461,7 +33461,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -33504,7 +33504,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -33540,7 +33540,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -33583,7 +33583,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -33619,7 +33619,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -33661,7 +33661,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -33696,7 +33696,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -33739,7 +33739,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -33775,7 +33775,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -33818,7 +33818,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -33854,7 +33854,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -33896,7 +33896,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -33931,7 +33931,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -33974,7 +33974,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.07,
+      "nfu": "48.07",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -34010,7 +34010,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -34053,7 +34053,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.07,
+      "nfu": "48.07",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -34089,7 +34089,7 @@
     "family": "StandardFXmdsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -34131,7 +34131,7 @@
     "family": "StandardFXmsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.07,
+      "nfu": "48.07",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -34166,7 +34166,7 @@
     "family": "standardGFamily",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "393216",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -34201,7 +34201,7 @@
     "family": "standardGFamily",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "786432",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -34236,7 +34236,7 @@
     "family": "standardGFamily",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "1572864",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -34341,7 +34341,7 @@
     "family": "standardGSFamily",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "57344",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -34379,7 +34379,7 @@
     "family": "standardGSFamily",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "114688",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -34417,7 +34417,7 @@
     "family": "standardGSFamily",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "229376",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -34687,7 +34687,7 @@
     "family": "standardHBrsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "491520",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "120",
@@ -34768,7 +34768,7 @@
     "family": "standardHBrsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "491520",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "120",
@@ -34849,7 +34849,7 @@
     "family": "standardHBrsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "491520",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "120",
@@ -34930,7 +34930,7 @@
     "family": "standardHBrsv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "491520",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "120",
@@ -35086,7 +35086,7 @@
     "family": "standardHBv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "491520",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "176",
@@ -35123,7 +35123,7 @@
     "family": "standardHBv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "491520",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "176",
@@ -35160,7 +35160,7 @@
     "family": "standardHBv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "491520",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "176",
@@ -35197,7 +35197,7 @@
     "family": "standardHBv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "491520",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "176",
@@ -35234,7 +35234,7 @@
     "family": "standardHBv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "491520",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "176",
@@ -35377,7 +35377,7 @@
     "family": "standardHXFamily",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "491520",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "176",
@@ -35414,7 +35414,7 @@
     "family": "standardHXFamily",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "491520",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "176",
@@ -35451,7 +35451,7 @@
     "family": "standardHXFamily",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "491520",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "176",
@@ -35488,7 +35488,7 @@
     "family": "standardHXFamily",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "491520",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "176",
@@ -35525,7 +35525,7 @@
     "family": "standardHXFamily",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "491520",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "176",
@@ -35561,7 +35561,7 @@
     "family": "standardLaosv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 6.0,
+      "nfu": "6",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "12",
@@ -35603,7 +35603,7 @@
     "family": "standardLaosv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -35645,7 +35645,7 @@
     "family": "standardLASv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "163840",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -35683,7 +35683,7 @@
     "family": "standardLasv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -35799,7 +35799,7 @@
     "family": "standardLSv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "163840",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -35836,7 +35836,7 @@
     "family": "standardLsv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -35878,7 +35878,7 @@
     "family": "standardLaosv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 12.0,
+      "nfu": "12",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "24",
@@ -35920,7 +35920,7 @@
     "family": "standardLaosv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -35962,7 +35962,7 @@
     "family": "standardLasv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -36004,7 +36004,7 @@
     "family": "standardLsv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "2",
@@ -36046,7 +36046,7 @@
     "family": "standardLaosv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -36088,7 +36088,7 @@
     "family": "standardLASv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "327680",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -36126,7 +36126,7 @@
     "family": "standardLasv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -36242,7 +36242,7 @@
     "family": "standardLSv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "327680",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -36279,7 +36279,7 @@
     "family": "standardLsv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.0,
+      "nfu": "16",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -36321,7 +36321,7 @@
     "family": "standardLASv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 6.0,
+      "nfu": "6",
       "MaxResourceVolumeMB": "491520",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -36359,7 +36359,7 @@
     "family": "standardLasv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -36438,7 +36438,7 @@
     "family": "standardLSv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 6.0,
+      "nfu": "6",
       "MaxResourceVolumeMB": "491520",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -36475,7 +36475,7 @@
     "family": "standardLsv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 24.0,
+      "nfu": "24",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -36517,7 +36517,7 @@
     "family": "standardLaosv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -36559,7 +36559,7 @@
     "family": "standardLasv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -36638,7 +36638,7 @@
     "family": "standardLsv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -36680,7 +36680,7 @@
     "family": "standardLASv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "655360",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -36718,7 +36718,7 @@
     "family": "standardLasv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -36797,7 +36797,7 @@
     "family": "standardLSv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "655360",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -36834,7 +36834,7 @@
     "family": "standardLsv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 32.0,
+      "nfu": "32",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -36876,7 +36876,7 @@
     "family": "standardLASv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 10.0,
+      "nfu": "10",
       "MaxResourceVolumeMB": "819200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "80",
@@ -36914,7 +36914,7 @@
     "family": "standardLasv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 40.0,
+      "nfu": "40",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "80",
@@ -36993,7 +36993,7 @@
     "family": "standardLSv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 10.0,
+      "nfu": "10",
       "MaxResourceVolumeMB": "819200",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "80",
@@ -37030,7 +37030,7 @@
     "family": "standardLsv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 40.0,
+      "nfu": "40",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "80",
@@ -37072,7 +37072,7 @@
     "family": "standardLaosv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -37114,7 +37114,7 @@
     "family": "standardLASv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "81920",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -37152,7 +37152,7 @@
     "family": "standardLasv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -37268,7 +37268,7 @@
     "family": "standardLSv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "81920",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -37305,7 +37305,7 @@
     "family": "standardLsv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -37347,7 +37347,7 @@
     "family": "standardLasv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -37389,7 +37389,7 @@
     "family": "standardLsv4Family",
     "superseded": null,
     "specs": {
-      "nfu": 48.0,
+      "nfu": "48",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -37512,7 +37512,7 @@
     "family": "StandardMBDSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 31.5,
+      "nfu": "31.5",
       "MaxResourceVolumeMB": "6144000",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "128",
@@ -37552,7 +37552,7 @@
     "family": "StandardMBDSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "409600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "128",
@@ -37592,7 +37592,7 @@
     "family": "StandardMBSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "128",
@@ -37672,7 +37672,7 @@
     "family": "StandardMBDSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 31.5,
+      "nfu": "31.5",
       "MaxResourceVolumeMB": "6144000",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "128",
@@ -37711,7 +37711,7 @@
     "family": "StandardMBDSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "409600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "128",
@@ -37750,7 +37750,7 @@
     "family": "StandardMBSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.0,
+      "nfu": "8",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "128",
@@ -38062,7 +38062,7 @@
     "family": "standardMDSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "409600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "12",
@@ -38101,7 +38101,7 @@
     "family": "standardMSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "12",
@@ -38221,7 +38221,7 @@
     "family": "StandardMBDSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "409600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -38260,7 +38260,7 @@
     "family": "StandardMBSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -38338,7 +38338,7 @@
     "family": "StandardMBDSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 43.0,
+      "nfu": "43",
       "MaxResourceVolumeMB": "8192000",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "176",
@@ -38378,7 +38378,7 @@
     "family": "StandardMBDSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 11.0,
+      "nfu": "11",
       "MaxResourceVolumeMB": "409600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "176",
@@ -38418,7 +38418,7 @@
     "family": "StandardMBSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 11.0,
+      "nfu": "11",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "176",
@@ -38457,7 +38457,7 @@
     "family": "StandardMBDSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 43.0,
+      "nfu": "43",
       "MaxResourceVolumeMB": "8192000",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "176",
@@ -38496,7 +38496,7 @@
     "family": "StandardMBDSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 11.0,
+      "nfu": "11",
       "MaxResourceVolumeMB": "409600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "176",
@@ -38535,7 +38535,7 @@
     "family": "StandardMBSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 11.0,
+      "nfu": "11",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "176",
@@ -38573,7 +38573,7 @@
     "family": "standardMDSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 11.7,
+      "nfu": "11.7",
       "MaxResourceVolumeMB": "409600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "176",
@@ -38612,7 +38612,7 @@
     "family": "standardMDSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.2,
+      "nfu": "16.2",
       "MaxResourceVolumeMB": "409600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "176",
@@ -38651,7 +38651,7 @@
     "family": "standardMSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 11.6,
+      "nfu": "11.6",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "176",
@@ -38689,7 +38689,7 @@
     "family": "standardMSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 16.2,
+      "nfu": "16.2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "176",
@@ -38959,7 +38959,7 @@
     "family": "standardMDSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "409600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "24",
@@ -38998,7 +38998,7 @@
     "family": "standardMSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "24",
@@ -39118,7 +39118,7 @@
     "family": "StandardMBDSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "409600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -39157,7 +39157,7 @@
     "family": "StandardMBSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -39472,7 +39472,7 @@
     "family": "standardMDSHighMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "409600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "416",
@@ -39511,7 +39511,7 @@
     "family": "standardMDSHighMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.3,
+      "nfu": "1.3",
       "MaxResourceVolumeMB": "409600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "416",
@@ -39589,7 +39589,7 @@
     "family": "standardMSv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.16,
+      "nfu": "8.16",
       "MaxResourceVolumeMB": "4194304",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "416",
@@ -39628,7 +39628,7 @@
     "family": "standardMSHighMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "416",
@@ -39666,7 +39666,7 @@
     "family": "standardMSv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 6.5,
+      "nfu": "6.5",
       "MaxResourceVolumeMB": "4194304",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "416",
@@ -39705,7 +39705,7 @@
     "family": "standardMSHighMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.3,
+      "nfu": "1.3",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "416",
@@ -39743,7 +39743,7 @@
     "family": "standardMSv2Family",
     "superseded": null,
     "specs": {
-      "nfu": 7.36,
+      "nfu": "7.36",
       "MaxResourceVolumeMB": "4194304",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "416",
@@ -39821,7 +39821,7 @@
     "family": "StandardMBDSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 3.0,
+      "nfu": "3",
       "MaxResourceVolumeMB": "409600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -39860,7 +39860,7 @@
     "family": "StandardMBSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 3.0,
+      "nfu": "3",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -39898,7 +39898,7 @@
     "family": "standardMDSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.1,
+      "nfu": "4.1",
       "MaxResourceVolumeMB": "409600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -39937,7 +39937,7 @@
     "family": "standardMSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -39975,7 +39975,7 @@
     "family": "standardMDSHighMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "409600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "624",
@@ -40014,7 +40014,7 @@
     "family": "standardMSHighMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "624",
@@ -40133,7 +40133,7 @@
     "family": "StandardMBDSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 15.7,
+      "nfu": "15.7",
       "MaxResourceVolumeMB": "3072000",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -40214,7 +40214,7 @@
     "family": "StandardMBDSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 15.7,
+      "nfu": "15.7",
       "MaxResourceVolumeMB": "3072000",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -40253,7 +40253,7 @@
     "family": "StandardMBDSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "409600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -40292,7 +40292,7 @@
     "family": "StandardMBSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "64",
@@ -40726,7 +40726,7 @@
     "family": "standardMDSHighMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.2,
+      "nfu": "2.2",
       "MaxResourceVolumeMB": "409600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "832",
@@ -40765,7 +40765,7 @@
     "family": "standardMIDSHighMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.7,
+      "nfu": "2.7",
       "MaxResourceVolumeMB": "409600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "832",
@@ -40804,7 +40804,7 @@
     "family": "standardMISHighMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.7,
+      "nfu": "2.7",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "832",
@@ -40842,7 +40842,7 @@
     "family": "standardMSHighMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.2,
+      "nfu": "2.2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "832",
@@ -40920,7 +40920,7 @@
     "family": "StandardMBDSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 23.6,
+      "nfu": "23.6",
       "MaxResourceVolumeMB": "4608000",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -40960,7 +40960,7 @@
     "family": "StandardMBDSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 23.6,
+      "nfu": "23.6",
       "MaxResourceVolumeMB": "4608000",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -40999,7 +40999,7 @@
     "family": "StandardMBDSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 6.0,
+      "nfu": "6",
       "MaxResourceVolumeMB": "409600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -41038,7 +41038,7 @@
     "family": "StandardMBSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 6.0,
+      "nfu": "6",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -41076,7 +41076,7 @@
     "family": "standardMDSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 6.1,
+      "nfu": "6.1",
       "MaxResourceVolumeMB": "409600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -41115,7 +41115,7 @@
     "family": "standardMDSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.1,
+      "nfu": "8.1",
       "MaxResourceVolumeMB": "409600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -41154,7 +41154,7 @@
     "family": "standardMSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 6.1,
+      "nfu": "6.1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -41192,7 +41192,7 @@
     "family": "standardMSMediumMemoryv3Family",
     "superseded": null,
     "specs": {
-      "nfu": 8.1,
+      "nfu": "8.1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -41267,7 +41267,7 @@
     "family": "StandardNCADSA10v4Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "1474560",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -41344,7 +41344,7 @@
     "family": "StandardNCADSA100v4Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "65536",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "24",
@@ -41451,7 +41451,7 @@
     "family": "StandardNCADSA10v4Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "2949120",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -41490,7 +41490,7 @@
     "family": "StandardNCadsH100v5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "131072",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "40",
@@ -41530,7 +41530,7 @@
     "family": "StandardNCADSA100v4Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "131072",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "48",
@@ -41682,7 +41682,7 @@
     "family": "StandardNCadsH100v5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "262144",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "80",
@@ -41722,7 +41722,7 @@
     "family": "StandardNCADSA10v4Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "737280",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -41799,7 +41799,7 @@
     "family": "StandardNCADSA100v4Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "262144",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -41838,7 +41838,7 @@
     "family": "StandardNCCads2023Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "1048576",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "40",
@@ -41942,7 +41942,7 @@
     "family": "standard NDAMSv4_A100Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "2969600",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -42020,7 +42020,7 @@
     "family": "standardNDSH100v5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "1048576",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -42057,7 +42057,7 @@
     "family": "standardNDISRH200V5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "1048576",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -42094,7 +42094,7 @@
     "family": "standardNDISv5MI300XFamily",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "1048576",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -42131,7 +42131,7 @@
     "family": "standardNDISv5MI300XFamily",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "1048576",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "96",
@@ -42167,7 +42167,7 @@
     "family": "StandardNGADSV620v1Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "524288",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "16",
@@ -42245,7 +42245,7 @@
     "family": "StandardNGADSV620v1Family",
     "superseded": null,
     "specs": {
-      "nfu": 4.0,
+      "nfu": "4",
       "MaxResourceVolumeMB": "1048576",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "32",
@@ -42285,7 +42285,7 @@
     "family": "StandardNGADSV620v1Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "262144",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",
@@ -42431,7 +42431,7 @@
     "family": "StandardNVADSA10v5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "368640",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "12",
@@ -42469,7 +42469,7 @@
     "family": "StandardNVadsV710v5Family",
     "superseded": null,
     "specs": {
-      "nfu": 3.0,
+      "nfu": "3",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "12",
@@ -42624,7 +42624,7 @@
     "family": "StandardNVADSA10v5Family",
     "superseded": null,
     "specs": {
-      "nfu": 3.0,
+      "nfu": "3",
       "MaxResourceVolumeMB": "737280",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "18",
@@ -42661,7 +42661,7 @@
     "family": "StandardNVadsV710v5Family",
     "superseded": null,
     "specs": {
-      "nfu": 6.0,
+      "nfu": "6",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "24",
@@ -42775,7 +42775,7 @@
     "family": "StandardNVadsV710v5Family",
     "superseded": null,
     "specs": {
-      "nfu": 7.19,
+      "nfu": "7.19",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "28",
@@ -42857,7 +42857,7 @@
     "family": "StandardNVADSA10v5Family",
     "superseded": null,
     "specs": {
-      "nfu": 6.0,
+      "nfu": "6",
       "MaxResourceVolumeMB": "2949120",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "36",
@@ -42894,7 +42894,7 @@
     "family": "StandardNVADSA10v5Family",
     "superseded": null,
     "specs": {
-      "nfu": 6.0,
+      "nfu": "6",
       "MaxResourceVolumeMB": "1474560",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "36",
@@ -42965,7 +42965,7 @@
     "family": "StandardNVadsV710v5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "4",
@@ -43046,7 +43046,7 @@
     "family": "StandardNVADSA10v5Family",
     "superseded": null,
     "specs": {
-      "nfu": 1.0,
+      "nfu": "1",
       "MaxResourceVolumeMB": "184320",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "6",
@@ -43121,7 +43121,7 @@
     "family": "StandardNVADSA10v5Family",
     "superseded": null,
     "specs": {
-      "nfu": 12.0,
+      "nfu": "12",
       "MaxResourceVolumeMB": "2949120",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "72",
@@ -43158,7 +43158,7 @@
     "family": "StandardNVadsV710v5Family",
     "superseded": null,
     "specs": {
-      "nfu": 2.0,
+      "nfu": "2",
       "MaxResourceVolumeMB": "0",
       "OSVhdSizeMB": "1047552",
       "vCPUs": "8",

--- a/tools/cloud_data/azure/azure_compute_instance_types.py
+++ b/tools/cloud_data/azure/azure_compute_instance_types.py
@@ -61,7 +61,7 @@ def create_instance_size_flexibility_ratio_table(url):
         for row in reader:
             key = row['ArmSkuName']
             value = row['Ratio']
-            isf_table[key] = float(value)
+            isf_table[key] = value
 
         return isf_table
 


### PR DESCRIPTION
### Description

Fixed PR #3356.
The data type of "nfu" field is changed back to string.

### Issues Resolved

### Link to Example Applied Policy

### Contribution Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
