### PR TITLE
SQ-17255 - fix: mapping in ds_flexera_api_hosts

### DIFF
--- a/cost/aws/schedule_instance/CHANGELOG.md
+++ b/cost/aws/schedule_instance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v8.0.3
+
+- Fixed mapping in datasource `ds_flexera_api_hosts` which as causing error during evaluation: "invalid request host", "host must be a string"
+
 ## v8.0.2
 
 - Updated API requests to use newer Flexera API. Functionality unchanged.

--- a/cost/aws/schedule_instance/aws_schedule_instance.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "15 minutes"
 info(
-  version: "8.0.2",
+  version: "8.0.3",
   provider: "AWS",
   service: "Compute",
   policy_set: "Schedule Instance",
@@ -140,6 +140,7 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+# Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
 end
@@ -150,21 +151,31 @@ script "js_flexera_api_hosts", type: "javascript" do
   code <<-EOS
   host_table = {
     "api.optima.flexeraeng.com": {
-      api: "api.flexera.com",
+	    api: "api.flexera.com",
+      flexera: "api.flexera.com",
+      fsm: "api.fsm.flexeraeng.com",
+      grs: "grs-front.iam-us-east-1.flexeraeng.com",
       ui: "app.flexera.com",
       tld: "flexera.com"
     },
     "api.optima-eu.flexeraeng.com": {
-      api: "api.flexera.eu",
+	    api: "api.flexera.eu",
+      flexera: "api.flexera.eu",
+      fsm: "api.fsm-eu.flexeraeng.com",
+      grs: "grs-front.eu-central-1.iam-eu.flexeraeng.com",
       ui: "app.flexera.eu",
       tld: "flexera.eu"
     },
     "api.optima-apac.flexeraeng.com": {
-      api: "api.flexera.au",
+	    api: "api.flexera.au",
+      flexera: "api.flexera.au",
+      fsm: "api.fsm-apac.flexeraeng.com",
+      grs: "grs-front.ap-southeast-2.iam-apac.flexeraeng.com",
       ui: "app.flexera.au",
       tld: "flexera.au"
     }
   }
+
   result = host_table[rs_optima_host]
 EOS
 end

--- a/cost/azure/schedule_instance/CHANGELOG.md
+++ b/cost/azure/schedule_instance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v7.0.4
+
+- Fixed mapping in datasource `ds_flexera_api_hosts` which as causing error during evaluation: "invalid request host", "host must be a string"
+
 ## v7.0.3
 
 - Updated API requests to use newer Flexera API. Functionality unchanged.

--- a/cost/azure/schedule_instance/azure_schedule_instance.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "15 minutes"
 info(
-  version: "7.0.3",
+  version: "7.0.4",
   provider: "Azure",
   service: "Compute",
   policy_set: "Schedule Instance",
@@ -165,6 +165,7 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+# Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
 end
@@ -175,21 +176,31 @@ script "js_flexera_api_hosts", type: "javascript" do
   code <<-EOS
   host_table = {
     "api.optima.flexeraeng.com": {
-      api: "api.flexera.com",
+	    api: "api.flexera.com",
+      flexera: "api.flexera.com",
+      fsm: "api.fsm.flexeraeng.com",
+      grs: "grs-front.iam-us-east-1.flexeraeng.com",
       ui: "app.flexera.com",
       tld: "flexera.com"
     },
     "api.optima-eu.flexeraeng.com": {
-      api: "api.flexera.eu",
+	    api: "api.flexera.eu",
+      flexera: "api.flexera.eu",
+      fsm: "api.fsm-eu.flexeraeng.com",
+      grs: "grs-front.eu-central-1.iam-eu.flexeraeng.com",
       ui: "app.flexera.eu",
       tld: "flexera.eu"
     },
     "api.optima-apac.flexeraeng.com": {
-      api: "api.flexera.au",
+	    api: "api.flexera.au",
+      flexera: "api.flexera.au",
+      fsm: "api.fsm-apac.flexeraeng.com",
+      grs: "grs-front.ap-southeast-2.iam-apac.flexeraeng.com",
       ui: "app.flexera.au",
       tld: "flexera.au"
     }
   }
+
   result = host_table[rs_optima_host]
 EOS
 end

--- a/cost/google/schedule_instance/CHANGELOG.md
+++ b/cost/google/schedule_instance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.0.3
+
+- Fixed mapping in datasource `ds_flexera_api_hosts` which as causing error during evaluation: "invalid request host", "host must be a string"
+
 ## v6.0.2
 
 - Updated API requests to use newer Flexera API. Functionality unchanged.

--- a/cost/google/schedule_instance/google_schedule_instance.pt
+++ b/cost/google/schedule_instance/google_schedule_instance.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "15 minutes"
 info(
-  version: "6.0.2",
+  version: "6.0.3",
   provider: "Google",
   service: "Compute",
   policy_set: "Schedule Instance",
@@ -147,6 +147,7 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+# Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
 end
@@ -157,17 +158,26 @@ script "js_flexera_api_hosts", type: "javascript" do
   code <<-EOS
   host_table = {
     "api.optima.flexeraeng.com": {
-      api: "api.flexera.com",
+	    api: "api.flexera.com",
+      flexera: "api.flexera.com",
+      fsm: "api.fsm.flexeraeng.com",
+      grs: "grs-front.iam-us-east-1.flexeraeng.com",
       ui: "app.flexera.com",
       tld: "flexera.com"
     },
     "api.optima-eu.flexeraeng.com": {
-      api: "api.flexera.eu",
+	    api: "api.flexera.eu",
+      flexera: "api.flexera.eu",
+      fsm: "api.fsm-eu.flexeraeng.com",
+      grs: "grs-front.eu-central-1.iam-eu.flexeraeng.com",
       ui: "app.flexera.eu",
       tld: "flexera.eu"
     },
     "api.optima-apac.flexeraeng.com": {
-      api: "api.flexera.au",
+	    api: "api.flexera.au",
+      flexera: "api.flexera.au",
+      fsm: "api.fsm-apac.flexeraeng.com",
+      grs: "grs-front.ap-southeast-2.iam-apac.flexeraeng.com",
       ui: "app.flexera.au",
       tld: "flexera.au"
     }


### PR DESCRIPTION
### Description

- Fixes mapping in datasource `ds_flexera_api_hosts` which as causing error during evaluation: "invalid request host", "host must be a string" for the Scheduled Instance Policy Templates

### Issues Resolved

https://flexera.atlassian.net/browse/SQ-17255

### Link to Example Applied Policy


### Contribution Check List

- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
