### PR TITLE
POL-1584 Orgs and Clouds Vendor Accounts Deprecation

### DIFF
--- a/compliance/flexera/msp/orgs_and_cloud_accounts_report/CHANGELOG.md
+++ b/compliance/flexera/msp/orgs_and_cloud_accounts_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.0.3
+
+- Deprecated: This policy is no longer being updated. Please see README for more information.
+
 ## v2.0.2
 
 - Added `doc_link` field to policy template metadata for future UI enhancements. Functionality unchanged.

--- a/compliance/flexera/msp/orgs_and_cloud_accounts_report/README.md
+++ b/compliance/flexera/msp/orgs_and_cloud_accounts_report/README.md
@@ -1,5 +1,9 @@
 # Orgs and Clouds Vendor Accounts
 
+## Deprecated
+
+This policy is no longer being updated. Please use [native MSP functionality in the Flexera One platform](https://docs.flexera.com/flexera/EN/Partners/GetStarted.htm) instead.
+
 ## What It Does
 
 This policy generates a list of cross organization Cloud Vendor Accounts connected to Flexera Cloud Cost Optimization based on the bill connection settings for Azure and Google, as well as full list of AWS accounts under the payer account connected for each Flexera Organization.

--- a/compliance/flexera/msp/orgs_and_cloud_accounts_report/orgs_and_cloud_accounts_report.pt
+++ b/compliance/flexera/msp/orgs_and_cloud_accounts_report/orgs_and_cloud_accounts_report.pt
@@ -1,19 +1,18 @@
 name "Orgs and Clouds Vendor Accounts"
 rs_pt_ver 20180301
 type "policy"
-short_description "This policy generates a list of cross organization Cloud Vendor Accounts connected to Flexera CCO based on
-the bill connection settings for Azure and Google, as well as full list of AWS accounts under the payer account connected for each Flexera Organization.\n
-See [README](https://github.com/flexera-public/policy_templates/tree/master/compliance/flexera/msp/orgs_and_cloud_accounts_report) for more details"
+short_description "**Deprecated: This policy is no longer being updated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/compliance/flexera/msp/orgs_and_cloud_accounts_report/) for more details.**  This policy generates a list of cross organization Cloud Vendor Accounts connected to Flexera CCO based on the bill connection settings for Azure and Google, as well as full list of AWS accounts under the payer account connected for each Flexera Organization. See [README](https://github.com/flexera-public/policy_templates/tree/master/compliance/flexera/msp/orgs_and_cloud_accounts_report) for more details"
 long_description ""
 doc_link "https://github.com/flexera-public/policy_templates/tree/master/compliance/flexera/msp/orgs_and_cloud_accounts_report"
 category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "2.0.2",
+  version: "2.0.3",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Managed Service Provider",
+  deprecated: "true",
   publish: "false"
 )
 


### PR DESCRIPTION
### Description

Due to its reliance on unofficial APIs and the fact that there are zero instances of this policy template actually being used, the `Orgs and Clouds Vendor Accounts` policy template is being deprecated.

The template remains in the repository in case someone does actually need it; this PR does not delete it. The only real change is that users (if they ever exist) will be informed that this policy template is deprecated before use.