### PR TITLE
Fixed Cost Common Bill Ingestion Regex Fix

### DIFF
--- a/cost/flexera/cco/fixed_cost_cbi/CHANGELOG.md
+++ b/cost/flexera/cco/fixed_cost_cbi/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.4
+
+- Fixed issue where valid CBI Endpoint IDs were not being accepted when applying the policy template.
+
 ## v0.2.3
 
 - Updated API requests to use newer Flexera API. Functionality unchanged.

--- a/cost/flexera/cco/fixed_cost_cbi/fixed_cost_cbi.pt
+++ b/cost/flexera/cco/fixed_cost_cbi/fixed_cost_cbi.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.2.3",
+  version: "0.2.4",
   provider: "Flexera",
   service: "Common Bill Ingestion",
   policy_set: "Common Bill Ingestion",
@@ -58,7 +58,7 @@ parameter "param_cbi_endpoint" do
   category "Policy Settings"
   label "CBI (Common Bill Ingestion) Endpoint ID"
   description "The ID of CBI endpoint to create/use when injecting the fixed cost. Leave blank to have this generated and managed automatically. Ex: cbi-oi-optima-laborcosts"
-  allowed_pattern /^(cbi-oi-optima-[a-z]+|)$/
+  allowed_pattern /^(?:cbi-oi-optima-[a-z_-]+)?$/
   default ""
 end
 


### PR DESCRIPTION
### Description

Fixes an issue with the regex in `Fixed Cost Common Bill Ingestion`. The "CBI (Common Bill Ingestion) Endpoint ID" parameter now allows names to contain additional `-` and `_` characters.

### Link to Example Applied Policy

Only a regex change. The new template's functionality can be verified by applying it and trying values for the above parameter.

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
