### PR TITLE
FOPTS-12555 Use actual cost to calculate savings for AWS superseded instance policy

### DIFF
--- a/cost/aws/superseded_instances/CHANGELOG.md
+++ b/cost/aws/superseded_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.0.0
+
+- Changed savings calculation to improve accuracy. See README for more details.
+
 ## v2.4.3
 
 - Updated meta policy code to use newer Flexera API. Functionality unchanged.

--- a/cost/aws/superseded_instances/README.md
+++ b/cost/aws/superseded_instances/README.md
@@ -12,9 +12,17 @@ This policy template checks all the EC2 instances in an AWS Account to determine
 
 ### Policy Savings Details
 
-The policy includes the estimated monthly savings. The estimated monthly savings is recognized if the instance type is changed to the recommended instance type. The savings is calculated by taking the difference in the hourly list price between the current instance type and the recommended instance type. This value is then multiplied by 24 to get the daily savings, and then by 30.44 (the average number of days in a month) to get the monthly savings. The savings value is 0 if no cost information for the resource type was found in our internal database.
+The policy includes the estimated monthly savings. The estimated monthly savings is recognized if the instance type is changed to the recommended instance type.
 
-The savings is displayed in the Estimated Monthly Savings column. The incident message detail includes the sum of each resource *Estimated Monthly Savings* as *Potential Monthly Savings*. If the Flexera organization is configured to use a currency other than USD, the savings values will be converted from USD using the exchange rate at the time that the policy executes.
+- The `Estimated Monthly Cost` is calculated by multiplying the amortized cost of the resource for 1 day, as found within Flexera CCO, by 30.44, which is the average number of days in a month.
+- Since the `Estimated Monthly Cost` of individual resources is obtained from Flexera CCO, it will take into account any Flexera adjustment rules or cloud provider discounts present in the Flexera platform.
+- The `Estimated Monthly Savings` is calculated as the percentage differences between either the ["AWS VM listed price"](https://github.com/flexera-public/policy_templates/blob/master/data/aws/aws_ec2_pricing.json) or ["NFUs (Normal Form Units)"](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/apply_ri.html) between current instance type and the recommended instance type. More specifically:
+  - If the "listed price" of both instance types is available, the `Estimated Monthly Savings` is calculated as ("actual cost" * (1 - "list price of recommended instance type" / "list price of current instance type"))
+  - If the "listed price" is unavailable but the "NFU" is available, the `Estimated Monthly Savings` is calculated as ("actual cost" * (1 - "NFU of recommended instance type" - "NFU of current instance type"))
+  - If neither the "listed price" nor the "NFU" is available, the `Estimated Monthly Savings` will be 0.
+- If no cost information for the resource type was found in our internal database, the `Estimated Monthly Savings` will also be 0.
+- The incident message detail includes the sum of each resource `Estimated Monthly Savings` as `Potential Monthly Savings`.
+- If the Flexera organization is configured to use a currency other than USD, the savings values will be converted from USD using the exchange rate at the time that the policy executes.
 
 ## Input Parameters
 

--- a/cost/aws/superseded_instances/aws_superseded_instances.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "2.4.3",
+  version: "3.0.0",
   provider: "AWS",
   service: "Compute",
   policy_set: "Superseded Compute Instances",
@@ -736,6 +736,8 @@ script "js_superseded_instances", type: "javascript" do
     superseded_type = null
     instance_type_price = null
     superseded_type_price = null
+    instance_size_rank = null
+    superseded_size_rank = null
     savings = 0.0
     hourly_cost_multiplier = 365.25 / 12 * 24
 
@@ -763,15 +765,17 @@ script "js_superseded_instances", type: "javascript" do
     superseded_parameter = type_table[param_instance_type]
 
     if (ds_aws_instance_type_map[instance_type]) {
+      instance_size_rank = ds_aws_instance_type_map[instance_type]['size_rank']
       superseded_table = ds_aws_instance_type_map[instance_type]['superseded']
 
       if (typeof(superseded_table) == 'object') {
         superseded_type = superseded_table[superseded_parameter]
+        superseded_size_rank = ds_aws_instance_type_map[superseded_type]['size_rank']
         recommendationType = param_instance_type
       }
     }
 
-    if ((typeof(superseded_type) != 'string' || superseded_type != '') && param_fallback_instance_type != "None") {
+    if ((typeof(superseded_type) != 'string' || superseded_type == '') && param_fallback_instance_type != "None") {
       superseded_parameter = type_table[param_fallback_instance_type]
 
       if (ds_aws_instance_type_map[instance_type]) {
@@ -809,10 +813,15 @@ script "js_superseded_instances", type: "javascript" do
         }
       }
 
+      savings_multiplier = 0.0
       if (typeof(instance_type_price) == 'number' && typeof(superseded_type_price) == 'number') {
-        instance_type_price *= ds_currency['exchange_rate'] * hourly_cost_multiplier
-        superseded_type_price *= ds_currency['exchange_rate'] * hourly_cost_multiplier
-        savings = instance_type_price - superseded_type_price
+        savings_multiplier = 1 - superseded_type_price / instance_type_price
+      } else if (typeof(instance_size_rank) == 'number' && typeof(superseded_size_rank) == 'number' && instance_size_rank > 0 && superseded_size_rank > 0) {
+        savings_multiplier = 1 - superseded_size_rank / instance_size_rank
+      }
+
+      if (typeof(cost) == 'number') {
+        savings = cost * savings_multiplier
       }
 
       if (savings >= param_min_savings) {

--- a/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "2.4.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.0.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/superseded_instances/README.md
+++ b/cost/azure/superseded_instances/README.md
@@ -20,7 +20,7 @@ The policy includes the estimated monthly savings. The estimated monthly savings
   - If the "listed price" of both instance types is available, the `Estimated Monthly Savings` is calculated as ("actual cost" * (1 - "list price of recommended instance type" / "list price of current instance type"))
   - If the "listed price" is unavailable but the "Instance Size Flexibility Ratio" is available, the `Estimated Monthly Savings` is calculated as ("actual cost" * (1 - "Instance Size Flexibility Ratio of recommended instance type" - "Instance Size Flexibility Ratio of current instance type"))
   - If neither the "listed price" nor the "Instance Size Flexibility Ratio" is available, the `Estimated Monthly Savings` will be 0.
-- If no cost information for the resource type was found in our internal database, the `Estimated Monthly Savings` is 0.
+- If no cost information for the resource type was found in our internal database, the `Estimated Monthly Savings` will also be 0.
 - The incident message detail includes the sum of each resource `Estimated Monthly Savings` as `Potential Monthly Savings`.
 - If the Flexera organization is configured to use a currency other than USD, the savings values will be converted from USD using the exchange rate at the time that the policy executes.
 


### PR DESCRIPTION
### Description

Similar to #3393, but this PR is for AWS.

Changed how savings is calculated.
Savings will be calculated using actual cost, multiplied by the percentage difference between the "list price" (or "NFU" if "list price" does not exists) of the current instance type and the recommended instance type.

This new calculation method aligns with [AWS Rightsize RDS](https://github.com/flexera-public/policy_templates/blob/master/cost/aws/rightsize_rds_instances/README.md#policy-savings-details).

----

Also fixed a bug related to "fallback instance type".

### Issues Resolved

https://flexera.atlassian.net/browse/FOPTS-12555
https://flexera.atlassian.net/browse/SQ-16042

### Link to Example Applied Policy

### Contribution Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
