### PR TITLE
FOAA-327 - Spot Ocean CBI - Add support for collecting Azure and GCP cluster cost data

### DIFF
--- a/cost/flexera/spot/ocean_cbi/CHANGELOG.md
+++ b/cost/flexera/spot/ocean_cbi/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.0
+
+- Added support for collecting Azure and GCP cluster cost data
+
 ## v0.1.2
 
 - Updated API requests to use newer Flexera API. Functionality unchanged.

--- a/cost/flexera/spot/ocean_cbi/spot_ocean_cbi.pt
+++ b/cost/flexera/spot/ocean_cbi/spot_ocean_cbi.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "hourly"
 info(
-  version: "0.1.2",
+  version: "0.2.0",
   provider: "Flexera",
   service: "Kubernetes",
   policy_set: "Common Bill Ingest",
@@ -142,10 +142,7 @@ end
 datasource "ds_spotinst_clusters" do
   iterate $ds_spotinst_accounts_filtered
   request do
-    auth $auth_spotinst
-    host "api.spotinst.io"
-    path "/ocean/aws/k8s/cluster"
-    query "accountId", val(val(iter_item, "account"), "accountId")
+    run_script $js_spotinst_clusters, val(iter_item, "account")
   end
   result do
     encoding "json"
@@ -171,6 +168,31 @@ datasource "ds_spotinst_clusters" do
   end
 end
 
+script "js_spotinst_clusters", type: "javascript" do
+  parameters "spot_inst_account"
+  result "request"
+  code <<-EOS
+    host = "api.spotinst.io"
+    path = "/ocean/aws/k8s/cluster"
+
+    if (spot_inst_account.cloudProvider == "AZURE") {
+      path = "/ocean/azure/np/cluster"
+    } else if (spot_inst_account.cloudProvider == "GCP") {
+      path = "/ocean/gcp/k8s/cluster"
+    }
+
+    request = {
+      auth: "auth_spotinst",
+      host: host,
+      path: path,
+      query_params: {
+        'accountId': spot_inst_account.accountId
+      }
+    }
+  EOS
+end
+
+# Get Billing Period Dates
 datasource "ds_dates" do
   run_script $js_dates, $param_period, $param_period_specific_month, $param_reallocation_granularity
 end
@@ -294,13 +316,7 @@ end
 datasource "ds_spotinst_cluster_aggregated_costs" do
   iterate $ds_requests_spotinst_cluster_aggregated_costs
   request do
-    auth $auth_spotinst
-    verb "POST"
-    host "api.spotinst.io"
-    path join(["/ocean/aws/k8s/cluster/", val(val(iter_item, "spotinst_cluster"), "id"), "/aggregatedCosts"])
-    query "accountId", jq(iter_item, ".spotinst_cluster.account.accountId")
-    body_field "startTime", val(val(iter_item, "date_period"), "start_date")
-    body_field "endTime", val(val(iter_item, "date_period"), "end_date")
+    run_script $js_spotinst_cluster_aggregated_costs, val(iter_item, "spotinst_cluster"), val(iter_item, "date_period")
   end
   result do
     encoding "json"
@@ -314,6 +330,35 @@ datasource "ds_spotinst_cluster_aggregated_costs" do
       field "summary", jq(col_item, ".summary")
     end
   end
+end
+
+script "js_spotinst_cluster_aggregated_costs", type: "javascript" do
+  parameters "spotinst_cluster", "date_period"
+  result "request"
+  code <<-EOS
+    host = "api.spotinst.io"
+    path = (["/ocean/aws/k8s/cluster/", spotinst_cluster.id, "/aggregatedCosts"]).join("")
+
+    if (spotinst_cluster.account.cloudProvider == "AZURE") {
+      path = (["/ocean/azure/k8s/cluster/", spotinst_cluster.id, "/aggregatedCosts"]).join("")
+    } else if (spotinst_cluster.account.cloudProvider == "GCP" ) {
+      path = (["/ocean/gcp/k8s/cluster/", spotinst_cluster.id, "/aggregatedCosts"]).join("")  
+    }
+
+    request = {
+      auth: "auth_spotinst",
+      verb: "POST",
+      host: host,
+      path: path,
+      query_params: {
+        'accountId': spotinst_cluster.account.accountId
+      },
+      body_fields: {
+        "startTime": date_period.start_date,
+        "endTime": date_period.end_date
+      }
+    }
+  EOS
 end
 
 datasource "ds_calculated_proportions" do
@@ -353,8 +398,8 @@ script "js_calculated_proportions", type: "javascript" do
           _.each(usageCategories, function(usageCategory){
             // Values that are the same for all usage categories
             var obj = {
-              "CloudVendorAccountID": "412879992092", // Should be the Cloud Account the K8S cluster resides in
-              "CloudVendorAccountName": "demo-poc-infra-production", // Should be the Cloud Account Name the K8S cluster resides in
+              "CloudVendorAccountID": cost.spotinst_cluster.account.providerExternalId, // Should be the Cloud Account the K8S cluster resides in
+              "CloudVendorAccountName": "", // Should be the Cloud Account Name the K8S cluster resides in
               "Category": properCase(usageCategory), // Category can be the usage, with proper case (Networking, Storage, Compute)
               "InstanceType": "",
               "LineItemType": "Usage", // Static value used in other bills


### PR DESCRIPTION
### Description

Adds support for AKS and GKE (previously AWS EKS only)

### Issues Resolved

https://flexera.atlassian.net/browse/FOAA-327

### Link to Example Applied Policy

https://app.flexera.com/orgs/36084/automation/applied-policies/projects/138037?policyId=68a62841d071d7debca44608

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
