### PR TITLE
POL-1582 - fix: superseded_nfu lookup

### DIFF
--- a/cost/azure/superseded_instances/CHANGELOG.md
+++ b/cost/azure/superseded_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.0.1
+
+- Fixed lookup when using NFU comparison for estimated savings.
+
 ## v3.0.0
 
 - Changed savings calculation to improve accuracy. See README for more details.

--- a/cost/azure/superseded_instances/azure_superseded_instances.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.0.0",
+  version: "3.0.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Superseded Compute Instances",
@@ -837,7 +837,7 @@ script "js_superseded_instances", type: "javascript" do
       current_nfu = Number(ds_azure_instance_type_map[instance_type]['specs']['nfu'])
     }
     if (ds_azure_instance_type_map[superseded_type] != undefined) {
-      superseded_nfu = Number(ds_azure_instance_type_map[instance_type]['specs']['nfu'])
+      superseded_nfu = Number(ds_azure_instance_type_map[superseded_type]['specs']['nfu'])
     }
 
     if (typeof(cost) == 'number') {
@@ -1193,7 +1193,7 @@ script "js_make_terminate_request", type: "javascript" do
   var request = {
     auth: "auth_flexera",
     host: ds_flexera_api_hosts["flexera"],
-    path: [ "/policy/v1/orgs/", rs_org_id, "/projects/", rs_project_id, "/applied-policies/", policy_id ].join(''),
+    path: [ "/policy/v1/orgs/", rs_org_id, "/projects/", rs_project_id, "/applied-policies", policy_id ? "/"+policy_id : "" ].join(''),
     verb: ds_parent_policy_terminated ? "DELETE" : "GET"
   }
 EOS


### PR DESCRIPTION
### Description

Fixed lookup when using NFU comparison for estimated savings.  This was causing estimated savings to be $0 for a lot of instances when NFU comparison method was used.

### Issues Resolved

https://flexera.atlassian.net/browse/POL-1582

### Link to Example Applied Policy

https://app.flexera.com/orgs/32682/automation/applied-policies/projects/133896?policyId=68b1ef8045b50292160abfd8

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
