### PR TITLE
POL-1588 AWS Savings Plan Recommendations: Rename Incident Field

### DIFF
--- a/cost/aws/savings_plan/recommendations/CHANGELOG.md
+++ b/cost/aws/savings_plan/recommendations/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v3.3.7
 
-- Changed incident field "Recommendeded Quantity to Purchase" to "Recommended Hourly Commitment" to both correct a spelling error and make the field more clear.
+- Changed incident field "Recommendeded Quantity to Purchase" to "Recommended Hourly Commitment" to both correct a spelling error and make the field clearer.
 
 ## v3.3.6
 

--- a/cost/aws/savings_plan/recommendations/CHANGELOG.md
+++ b/cost/aws/savings_plan/recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.3.7
+
+- Changed incident field "Recommendeded Quantity to Purchase" to "Recommended Hourly Commitment" to both correct a spelling error and make the field more clear.
+
 ## v3.3.6
 
 - Updated API requests to use newer Flexera API. Functionality unchanged.

--- a/cost/aws/savings_plan/recommendations/aws_savings_plan_recommendations.pt
+++ b/cost/aws/savings_plan/recommendations/aws_savings_plan_recommendations.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.3.6",
+  version: "3.3.7",
   provider: "AWS",
   service: "Compute",
   policy_set: "Savings Plans",
@@ -620,7 +620,7 @@ policy "pol_aws_sp_recommendations" do
         label "Payment Option"
       end
       field "recommendedQuantity" do
-        label "Recommendeded Quantity to Purchase"
+        label "Recommended Hourly Commitment"
       end
       field "upfrontCost" do
         label "Upfront Cost"


### PR DESCRIPTION
### Description

 `AWS Savings Plan Recommendations`
- Changed incident field "Recommendeded Quantity to Purchase" to "Recommended Hourly Commitment" to both correct a spelling error and make the field clearer.

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=68bb29ad9ebedfa88031973a

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
