### PR TITLE
POL-1613 Multiple Key Support for RBD Policies

### DIFF
--- a/automation/aws/aws_rbd_from_tag/CHANGELOG.md
+++ b/automation/aws/aws_rbd_from_tag/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.0
+
+- Policy template now supports multiple tag keys for a single dimension. See README for details.
+
 ## v3.0.3
 
 - Updated API requests to use newer Flexera API. Functionality unchanged.

--- a/automation/aws/aws_rbd_from_tag/README.md
+++ b/automation/aws/aws_rbd_from_tag/README.md
@@ -13,7 +13,7 @@ NOTE: If updating from a version of this policy template prior to version 3.0, i
 This policy has the following input parameters required when launching the policy.
 
 - *Effective Date* - The month and year in YYYY-MM format that you want the rules to apply. This should be left at its default value in most cases to ensure that the rules apply to all costs, including historical costs.
-- *Tag Keys* - A list of AWS Account tag keys to create custom Rule-Based Dimensions for.
+- *Tag Keys* - A list of AWS account tag keys to build Rule-Based Dimensions from. Multiple tags can be specified for a single dimension by placing a single entry with each tag key separated by a semicolon (;) character. For example, a value of `env;environment;environ` will create one Rule-Based Dimension that checks the keys "env", "environment", and "environ" for values.
 - *Dimension Names* - A list of names to give the Rule-Based Dimensions in the Flexera platform. Enter names in the same order as the tag keys in the `Tag Keys` field. Dimension names will be derived from tag keys directly if this list is left empty.
 - *Lowercase Values* - Whether or not to normalize all values by converting them to lowercase. Note that, if the same value appears multiple times with different casing, and this option is disabled, the rule-based dimension will be rejected and this policy template will fail.
 

--- a/automation/aws/aws_rbd_from_tag/aws_rbd_from_tag.pt
+++ b/automation/aws/aws_rbd_from_tag/aws_rbd_from_tag.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "3.0.3",
+  version: "3.1.0",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Automation",
@@ -23,7 +23,7 @@ parameter "param_tag_list" do
   type "list"
   category "Policy Settings"
   label "Tag Keys"
-  description "A list of AWS account tag keys to build Rule-Based Dimensions from"
+  description "A list of AWS account tag keys to build Rule-Based Dimensions from. Multiple tags can be specified for a single dimension by placing a single entry with each tag key separated by a semicolon (;) character. See README for more info."
   # No default value, user input required
 end
 
@@ -182,22 +182,27 @@ script "js_new_rules", type: "javascript" do
 
     rbd_id = "rbd_" + rbd_name.toLowerCase().replace(/\s+/g, '').replace(/\W/g, "").replace('.', '').replace('-', '').trim()
 
-    tag_key = tag.toLowerCase().trim()
+    tag_keys = _.map(tag.split(';'), function(key) { return key.toLowerCase().trim() })
 
     rules = []
 
     _.each(accounts, function(account) {
       if (typeof(account['id']) == 'string' && account['id'] != '' && typeof(account['tags']) == 'object') {
-        if (typeof(account['tags'][tag_key]) == 'string') {
-          if (account['tags'][tag_key].trim() != '') {
-            value = account['tags'][tag_key].trim()
-            if (param_normalize_case == "Yes") { value = value.toLowerCase() }
+        value = null
 
-            rules.push({
-              condition: { type: "dimension_equals", dimension: "vendor_account", value: account['id'] },
-              value: { text: value }
-            })
+        _.each(tag_keys, function(key) {
+          if (typeof(account['tags'][key]) == 'string') {
+            if (account['tags'][key].trim() != '') { value = account['tags'][key].trim() }
           }
+        })
+
+        if (value) {
+          if (param_normalize_case == "Yes") { value = value.toLowerCase() }
+
+          rules.push({
+            condition: { type: "dimension_equals", dimension: "vendor_account", value: account['id'] },
+            value: { text: value }
+          })
         }
       }
     })

--- a/automation/azure/azure_rbd_from_rg_tag/CHANGELOG.md
+++ b/automation/azure/azure_rbd_from_rg_tag/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1.0
+
+- Policy template now supports multiple tag keys for a single dimension. See README for details.
+
 ## v2.0.3
 
 - Updated API requests to use newer Flexera API. Functionality unchanged.

--- a/automation/azure/azure_rbd_from_rg_tag/README.md
+++ b/automation/azure/azure_rbd_from_rg_tag/README.md
@@ -13,7 +13,7 @@ NOTE: If updating from a version of this policy template prior to version 2.0, i
 This policy has the following input parameters required when launching the policy.
 
 - *Effective Date* - The month and year in YYYY-MM format that you want the rules to apply. This should be left at its default value in most cases to ensure that the rules apply to all costs, including historical costs.
-- *Tag Keys* - A list of Azure Resource Group tag keys to create custom Rule-Based Dimensions for.
+- *Tag Keys* - A list of Azure Subscription tag keys to build Rule-Based Dimensions from. Multiple tags can be specified for a single dimension by placing a single entry with each tag key separated by a semicolon (;) character. For example, a value of `env;environment;environ` will create one Rule-Based Dimension that checks the keys "env", "environment", and "environ" for values.
 - *Dimension Names* - A list of names to give the Rule-Based Dimensions in the Flexera platform. Enter names in the same order as the tag keys in the `Tag Keys` field. Dimension names will be derived from tag keys directly if this list is left empty.
 - *Subscription Fallback Rules* - Whether or not to create rules for Subscription tags as a fallback for untagged Resource Groups. These rules have the lowest priority; rules created for Resource Group tags will always take precedence.
 - *Lowercase Values* - Whether or not to normalize all values by converting them to lowercase. Note that, if the same value appears multiple times with different casing, and this option is disabled, the rule-based dimension will be rejected and this policy template will fail.

--- a/automation/azure/azure_rbd_from_rg_tag/azure_rbd_from_rg_tag.pt
+++ b/automation/azure/azure_rbd_from_rg_tag/azure_rbd_from_rg_tag.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.0.3",
+  version: "2.1.0",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Automation",
@@ -23,7 +23,7 @@ parameter "param_tag_list" do
   type "list"
   category "Policy Settings"
   label "Tag Keys"
-  description "A list of Azure account tag keys to build Rule-Based Dimensions from"
+  description "A list of Azure account tag keys to build Rule-Based Dimensions from. Multiple tags can be specified for a single dimension by placing a single entry with each tag key separated by a semicolon (;) character. See README for more info."
   # No default value, user input required
 end
 
@@ -286,40 +286,45 @@ script "js_new_rules", type: "javascript" do
 
     rbd_id = "rbd_" + rbd_name.toLowerCase().replace(/\s+/g, '').replace(/\W/g, "").replace('.', '').replace('-', '').trim()
 
-    tag_key = tag.toLowerCase().trim()
+    tag_keys = _.map(tag.split(';'), function(key) { return key.toLowerCase().trim() })
 
     rules = []
 
     _.each(rgs, function(rg) {
-      if (typeof(rg['tags']) == 'object') {
-        if (typeof(rg['tags'][tag_key]) == 'string') {
-          if (rg['tags'][tag_key].trim() != '') {
-            value = rg['tags'][tag_key].trim()
-            if (param_normalize_case == "Yes") { value = value.toLowerCase() }
+      if (typeof(rg['name']) == 'string' && rg['name'] != '' && typeof(rg['tags']) == 'object') {
+        value = null
 
+        _.each(tag_keys, function(key) {
+          if (typeof(rg['tags'][key]) == 'string') {
+            if (rg['tags'][key].trim() != '') { value = rg['tags'][key].trim() }
+          }
+        })
+
+        if (value) {
+          if (param_normalize_case == "Yes") { value = value.toLowerCase() }
+
+          rules.push({
+            condition: {
+              type: "and",
+              expressions: [
+                { type: "dimension_equals", dimension: "resource_group", value: rg['name'].trim() },
+                { type: "dimension_equals", dimension: "vendor_account", value: rg['subscriptionId'].trim().toLowerCase() }
+              ]
+            },
+            value: { text: value }
+          })
+
+          if (rg['name'].trim() != rg['name'].trim().toLowerCase()) {
             rules.push({
               condition: {
                 type: "and",
                 expressions: [
-                  { type: "dimension_equals", dimension: "resource_group", value: rg['name'].trim() },
+                  { type: "dimension_equals", dimension: "resource_group", value: rg['name'].trim().toLowerCase() },
                   { type: "dimension_equals", dimension: "vendor_account", value: rg['subscriptionId'].trim().toLowerCase() }
                 ]
               },
               value: { text: value }
             })
-
-            if (rg['name'].trim() != rg['name'].trim().toLowerCase()) {
-              rules.push({
-                condition: {
-                  type: "and",
-                  expressions: [
-                    { type: "dimension_equals", dimension: "resource_group", value: rg['name'].trim().toLowerCase() },
-                    { type: "dimension_equals", dimension: "vendor_account", value: rg['subscriptionId'].trim().toLowerCase() }
-                  ]
-                },
-                value: { text: value }
-              })
-            }
           }
         }
       }
@@ -327,17 +332,22 @@ script "js_new_rules", type: "javascript" do
 
     if (param_subscription_fallback == "Yes") {
       _.each(accounts, function(account) {
-        if (typeof(account['tags']) == 'object') {
-          if (typeof(account['tags'][tag_key]) == 'string') {
-            if (account['tags'][tag_key].trim() != '') {
-              value = account['tags'][tag_key].trim()
-              if (param_normalize_case == "Yes") { value = value.toLowerCase() }
+        if (typeof(account['id']) == 'string' && account['id'] != '' && typeof(account['tags']) == 'object') {
+          value = null
 
-              rules.push({
-                condition: { type: "dimension_equals", dimension: "vendor_account", value: account['id'] },
-                value: { text: value }
-              })
+          _.each(tag_keys, function(key) {
+            if (typeof(account['tags'][key]) == 'string') {
+              if (account['tags'][key].trim() != '') { value = account['tags'][key].trim() }
             }
+          })
+
+          if (value) {
+            if (param_normalize_case == "Yes") { value = value.toLowerCase() }
+
+            rules.push({
+              condition: { type: "dimension_equals", dimension: "vendor_account", value: account['id'] },
+              value: { text: value }
+            })
           }
         }
       })

--- a/automation/azure/azure_rbd_from_tag/CHANGELOG.md
+++ b/automation/azure/azure_rbd_from_tag/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1.0
+
+- Policy template now supports multiple tag keys for a single dimension. See README for details.
+
 ## v2.0.3
 
 - Updated API requests to use newer Flexera API. Functionality unchanged.

--- a/automation/azure/azure_rbd_from_tag/README.md
+++ b/automation/azure/azure_rbd_from_tag/README.md
@@ -13,7 +13,7 @@ NOTE: If updating from a version of this policy template prior to version 2.0, i
 This policy has the following input parameters required when launching the policy.
 
 - *Effective Date* - The month and year in YYYY-MM format that you want the rules to apply. This should be left at its default value in most cases to ensure that the rules apply to all costs, including historical costs.
-- *Tag Keys* - A list of Azure Subscription tag keys to create custom Rule-Based Dimensions for.
+- *Tag Keys* - A list of Azure Subscription tag keys to build Rule-Based Dimensions from. Multiple tags can be specified for a single dimension by placing a single entry with each tag key separated by a semicolon (;) character. For example, a value of `env;environment;environ` will create one Rule-Based Dimension that checks the keys "env", "environment", and "environ" for values.
 - *Dimension Names* - A list of names to give the Rule-Based Dimensions in the Flexera platform. Enter names in the same order as the tag keys in the `Tag Keys` field. Dimension names will be derived from tag keys directly if this list is left empty.
 - *Lowercase Values* - Whether or not to normalize all values by converting them to lowercase. Note that, if the same value appears multiple times with different casing, and this option is disabled, the rule-based dimension will be rejected and this policy template will fail.
 

--- a/automation/azure/azure_rbd_from_tag/azure_rbd_from_tag.pt
+++ b/automation/azure/azure_rbd_from_tag/azure_rbd_from_tag.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.0.3",
+  version: "2.1.0",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Automation",
@@ -23,7 +23,7 @@ parameter "param_tag_list" do
   type "list"
   category "Policy Settings"
   label "Tag Keys"
-  description "A list of Azure account tag keys to build Rule-Based Dimensions from"
+  description "A list of Azure account tag keys to build Rule-Based Dimensions from. Multiple tags can be specified for a single dimension by placing a single entry with each tag key separated by a semicolon (;) character. See README for more info."
   # No default value, user input required
 end
 
@@ -223,22 +223,27 @@ script "js_new_rules", type: "javascript" do
 
     rbd_id = "rbd_" + rbd_name.toLowerCase().replace(/\s+/g, '').replace(/\W/g, "").replace('.', '').replace('-', '').trim()
 
-    tag_key = tag.toLowerCase().trim()
+    tag_keys = _.map(tag.split(';'), function(key) { return key.toLowerCase().trim() })
 
     rules = []
 
     _.each(accounts, function(account) {
       if (typeof(account['id']) == 'string' && account['id'] != '' && typeof(account['tags']) == 'object') {
-        if (typeof(account['tags'][tag_key]) == 'string') {
-          if (account['tags'][tag_key].trim() != '') {
-            value = account['tags'][tag_key].trim()
-            if (param_normalize_case == "Yes") { value = value.toLowerCase() }
+        value = null
 
-            rules.push({
-              condition: { type: "dimension_equals", dimension: "vendor_account", value: account['id'] },
-              value: { text: value }
-            })
+        _.each(tag_keys, function(key) {
+          if (typeof(account['tags'][key]) == 'string') {
+            if (account['tags'][key].trim() != '') { value = account['tags'][key].trim() }
           }
+        })
+
+        if (value) {
+          if (param_normalize_case == "Yes") { value = value.toLowerCase() }
+
+          rules.push({
+            condition: { type: "dimension_equals", dimension: "vendor_account", value: account['id'] },
+            value: { text: value }
+          })
         }
       }
     })

--- a/automation/google/google_rbd_from_label/CHANGELOG.md
+++ b/automation/google/google_rbd_from_label/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1.0
+
+- Policy template now supports multiple tag keys for a single dimension. See README for details.
+
 ## v2.0.3
 
 - Updated API requests to use newer Flexera API. Functionality unchanged.

--- a/automation/google/google_rbd_from_label/README.md
+++ b/automation/google/google_rbd_from_label/README.md
@@ -13,7 +13,7 @@ NOTE: If updating from a version of this policy template prior to version 2.0, i
 This policy has the following input parameters required when launching the policy.
 
 - *Effective Date* - The month and year in YYYY-MM format that you want the rules to apply. This should be left at its default value in most cases to ensure that the rules apply to all costs, including historical costs.
-- *Label Keys* - A list of Google Project label keys to create custom Rule-Based Dimensions for.
+- *Label Keys* - A list of Google Project label keys to create custom Rule-Based Dimensions for. Multiple labels can be specified for a single dimension by placing a single entry with each label key separated by a semicolon (;) character. For example, a value of `env;environment;environ` will create one Rule-Based Dimension that checks the keys "env", "environment", and "environ" for values.
 - *Dimension Names* - A list of names to give the Rule-Based Dimensions in the Flexera platform. Enter names in the same order as the label keys in the `Label Keys` field. Dimension names will be derived from label keys directly if this list is left empty.
 - *Lowercase Values* - Whether or not to normalize all values by converting them to lowercase. Note that, if the same value appears multiple times with different casing, and this option is disabled, the rule-based dimension will be rejected and this policy template will fail.
 

--- a/automation/google/google_rbd_from_label/google_rbd_from_label.pt
+++ b/automation/google/google_rbd_from_label/google_rbd_from_label.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.0.3",
+  version: "2.1.0",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Automation",
@@ -23,7 +23,7 @@ parameter "param_tag_list" do
   type "list"
   category "Policy Settings"
   label "Label Keys"
-  description "A list of Google account label keys to build Rule-Based Dimensions from"
+  description "A list of Google account label keys to build Rule-Based Dimensions from. Multiple labels can be specified for a single dimension by placing a single entry with each label key separated by a semicolon (;) character. See README for more info."
   # No default value, user input required
 end
 
@@ -210,22 +210,27 @@ script "js_new_rules", type: "javascript" do
 
     rbd_id = "rbd_" + rbd_name.toLowerCase().replace(/\s+/g, '').replace(/\W/g, "").replace('.', '').replace('-', '').trim()
 
-    tag_key = tag.toLowerCase().trim()
+    tag_keys = _.map(tag.split(';'), function(key) { return key.toLowerCase().trim() })
 
     rules = []
 
     _.each(accounts, function(account) {
       if (typeof(account['id']) == 'string' && account['id'] != '' && typeof(account['tags']) == 'object') {
-        if (typeof(account['tags'][tag_key]) == 'string') {
-          if (account['tags'][tag_key].trim() != '') {
-            value = account['tags'][tag_key].trim()
-            if (param_normalize_case == "Yes") { value = value.toLowerCase() }
+        value = null
 
-            rules.push({
-              condition: { type: "dimension_equals", dimension: "vendor_account", value: account['id'] },
-              value: { text: value }
-            })
+        _.each(tag_keys, function(key) {
+          if (typeof(account['tags'][key]) == 'string') {
+            if (account['tags'][key].trim() != '') { value = account['tags'][key].trim() }
           }
+        })
+
+        if (value) {
+          if (param_normalize_case == "Yes") { value = value.toLowerCase() }
+
+          rules.push({
+            condition: { type: "dimension_equals", dimension: "vendor_account", value: account['id'] },
+            value: { text: value }
+          })
         }
       }
     })

--- a/cost/aws/rightsize_bedrock/rightsize_bedrock_generated.pt
+++ b/cost/aws/rightsize_bedrock/rightsize_bedrock_generated.pt
@@ -1,0 +1,298 @@
+name "AWS > AI > Under-utilized Bedrock Provisioned Throughput (PTU)"
+rs_pt_ver 20180301
+type "policy"
+
+short_description "Identifies Amazon Bedrock Provisioned Throughput (PTU) with low or zero usage over a recent window."
+long_description <<-EOS
+This policy finds Amazon Bedrock Provisioned Throughput (PTU) that appear under-utilized using AWS APIs:
+
+• Enumerates PTUs via ListProvisionedModelThroughputs.
+• Derives the Bedrock ModelId from the model ARN for each PTU.
+• Queries CloudWatch Bedrock metrics (InputTokenCount, OutputTokenCount, Invocations) over a configurable lookback window.
+• Flags PTUs whose total tokens and/or invocations are below thresholds.
+
+No business context is required; findings are purely signal-based from AWS Bedrock and CloudWatch.
+EOS
+
+severity "medium"
+category "Cost"
+default_frequency "daily"
+
+info(
+  version: "0.1.2",
+  provider: "AWS",
+  service: "Bedrock",
+  policy_set: "AI Cost Optimization",
+  recommendation_type: "Rightsizing",
+  hide_skip_approvals: true
+)
+
+###############################################################################
+# Parameters
+###############################################################################
+
+parameter "param_aws_regions" do
+  type "list"
+  label "AWS Regions to check"
+  description "Regions where Bedrock PTUs may exist."
+  default ["us-east-1", "us-east-2", "us-west-2", "eu-west-1", "eu-central-1", "ap-northeast-1", "ap-southeast-1", "ap-southeast-2"]
+end
+
+parameter "param_lookback_days" do
+  type "number"
+  label "Lookback window (days)"
+  description "Days back to sum Bedrock token and invocation metrics."
+  default 7
+  min_value 1
+  max_value 30
+end
+
+parameter "param_min_total_tokens" do
+  type "number"
+  label "Min total tokens over window"
+  description "Flag PTU when (InputTokenCount + OutputTokenCount) over the lookback window is below this number."
+  default 10000
+  min_value 0
+end
+
+parameter "param_min_invocations" do
+  type "number"
+  label "Min invocations over window"
+  description "Flag PTU when total invocations over the lookback window is below this number."
+  default 1
+  min_value 0
+end
+
+parameter "param_excluded_provisioned_model_ids" do
+  type "list"
+  label "Exclude PTUs (by ProvisionedModelId)"
+  description "Optional allowlist to exclude specific PTUs from evaluation."
+  default []
+end
+
+parameter "param_email" do
+  type "string"
+  label "Email recipients"
+  description "Comma-separated email addresses to notify when under-utilized PTUs are found."
+  default ""
+end
+
+parameter "param_aws_account_number" do
+  type "string"
+  label "AWS Account Number (for STS credential)"
+  description "Optional account number when selecting an aws_sts credential."
+  default ""
+end
+
+###############################################################################
+# Credentials
+###############################################################################
+
+credentials "cred_aws" do
+  schemes "aws", "aws_sts"
+  label "AWS credential"
+  description "Credential with read access to Bedrock and CloudWatch (GetMetricData)."
+  tags "provider=aws"
+  aws_account_number $param_aws_account_number
+end
+
+###############################################################################
+# Helpers
+###############################################################################
+
+pagination "aws_json_next_token" do
+  get_page_marker do
+    body_path jmes_path(response, "nextToken")
+  end
+  set_page_marker do
+    query "nextToken"
+  end
+end
+
+datasource "time_window" do
+  result do
+    encoding "json"
+    field "endTimeIso", to_iso8601(now())
+    field "startTimeIso", to_iso8601(timestamp_add(now(), 0 - $param_lookback_days, "days"))
+    field "periodSeconds", 3600
+  end
+end
+
+###############################################################################
+# Datasources
+###############################################################################
+
+# List PTUs and derive ModelId from modelArn
+datasource "ptu_list" do
+  iterate $param_aws_regions
+  request do
+    auth $cred_aws
+    host join(["bedrock.", iter_item, ".amazonaws.com"])
+    path "/provisioned-model-throughputs"
+    query "maxResults", "100"
+    pagination $aws_json_next_token
+  end
+  result do
+    encoding "json"
+    collect jq(response, <<-JQ) do
+      .provisionedModelSummaries[]
+      | {
+          provisionedModelId,
+          provisionedModelArn,
+          modelArn,
+          modelUnits,
+          provisionedModelName,
+          status,
+          commitmentDuration,
+          commitmentExpirationTime,
+          modelId: ((.modelArn // "") | capture("foundation-model/(?<id>.*)$").id? // "")
+        }
+    JQ
+      field "region", iter_item
+      field "provisionedModelId", jmes_path(col_item, "provisionedModelId")
+      field "provisionedModelArn", jmes_path(col_item, "provisionedModelArn")
+      field "modelArn", jmes_path(col_item, "modelArn")
+      field "modelUnits", jmes_path(col_item, "modelUnits")
+      field "provisionedModelName", jmes_path(col_item, "provisionedModelName")
+      field "status", jmes_path(col_item, "status")
+      field "commitmentDuration", jmes_path(col_item, "commitmentDuration")
+      field "commitmentExpirationTime", jmes_path(col_item, "commitmentExpirationTime")
+      field "modelId", jmes_path(col_item, "modelId")
+    end
+  end
+end
+
+# CloudWatch usage for each PTU's ModelId
+datasource "cw_usage" do
+  iterate $ptu_list
+  request do
+    auth $cred_aws
+    host join(["monitoring.", val(iter_item,"region"), ".amazonaws.com"])
+    verb "POST"
+    path "/"
+    header "Content-Type", "application/x-amz-json-1.1"
+    header "X-Amz-Target", "GraniteServiceVersion2010-08-01.GetMetricData"
+    body <<-EOS
+      {
+        "StartTime": "#{val($time_window[0], "startTimeIso")}",
+        "EndTime": "#{val($time_window[0], "endTimeIso")}",
+        "ScanBy": "TimestampAscending",
+        "MaxDatapoints": 5000,
+        "MetricDataQueries": [
+          {
+            "Id": "in",
+            "MetricStat": {
+              "Metric": { "Namespace": "AWS/Bedrock", "MetricName": "InputTokenCount",
+                "Dimensions": [ { "Name": "ModelId", "Value": "#{val(iter_item,"modelId")}" } ]
+              },
+              "Period": #{val($time_window[0], "periodSeconds")},
+              "Stat": "Sum"
+            },
+            "ReturnData": true
+          },
+          {
+            "Id": "out",
+            "MetricStat": {
+              "Metric": { "Namespace": "AWS/Bedrock", "MetricName": "OutputTokenCount",
+                "Dimensions": [ { "Name": "ModelId", "Value": "#{val(iter_item,"modelId")}" } ]
+              },
+              "Period": #{val($time_window[0], "periodSeconds")},
+              "Stat": "Sum"
+            },
+            "ReturnData": true
+          },
+          {
+            "Id": "inv",
+            "MetricStat": {
+              "Metric": { "Namespace": "AWS/Bedrock", "MetricName": "Invocations",
+                "Dimensions": [ { "Name": "ModelId", "Value": "#{val(iter_item,"modelId")}" } ]
+              },
+              "Period": #{val($time_window[0], "periodSeconds")},
+              "Stat": "Sum"
+            },
+            "ReturnData": true
+          }
+        ]
+      }
+    EOS
+  end
+  result do
+    encoding "json"
+    field "region", val(iter_item, "region")
+    field "provisionedModelId", val(iter_item, "provisionedModelId")
+    field "provisionedModelName", val(iter_item, "provisionedModelName")
+    field "modelId", val(iter_item, "modelId")
+    field "modelUnits", val(iter_item, "modelUnits")
+    field "status", val(iter_item, "status")
+    field "commitmentDuration", val(iter_item, "commitmentDuration")
+    field "commitmentExpirationTime", val(iter_item, "commitmentExpirationTime")
+    field "input_tokens", to_n(jq(response, "[.MetricDataResults[] | select(.Id == \"in\") | .Values[]] | add // 0"))
+    field "output_tokens", to_n(jq(response, "[.MetricDataResults[] | select(.Id == \"out\") | .Values[]] | add // 0"))
+    field "invocations", to_n(jq(response, "[.MetricDataResults[] | select(.Id == \"inv\") | .Values[]] | add // 0"))
+  end
+end
+
+###############################################################################
+# Export
+###############################################################################
+
+export "underutilized_ptu" do
+  resource_level false
+  field("region"){ label "Region" }
+  field("provisionedModelId"){ label "ProvisionedModelId" }
+  field("provisionedModelName"){ label "Provisioned Model Name" }
+  field("modelId"){ label "ModelId" }
+  field("modelUnits"){ label "Model Units (MUs)" }
+  field("status"){ label "PTU Status" }
+  field("input_tokens"){ label "Input Tokens (sum)"; format "right %d" }
+  field("output_tokens"){ label "Output Tokens (sum)"; format "right %d" }
+  field("invocations"){ label "Invocations (sum)"; format "right %d" }
+  field("commitmentDuration"){ label "Commitment" }
+  field("commitmentExpirationTime"){ label "Commitment Ends" }
+end
+
+###############################################################################
+# Escalation
+###############################################################################
+
+escalation "email" do
+  automatic true
+  label "Notify owners"
+  email $param_email do
+    subject_template "Under-utilized Bedrock PTUs found in {{ rs_project_name }}"
+    body_template <<-EOS
+The following Amazon Bedrock Provisioned Throughput (PTU) appear under-utilized over the last {{ parameters.param_lookback_days }} days.
+
+Criteria:
+- Total tokens (input + output) < {{ parameters.param_min_total_tokens }}
+- OR total invocations < {{ parameters.param_min_invocations }}
+
+Recommendation:
+- Consider reducing Model Units (MUs) or deleting the PTU if it's no longer needed.
+EOS
+  end
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "underutilized_bedrock_ptu" do
+  validate_each $cw_usage do
+    summary_template "Under-utilized Bedrock PTU detected in project {{ rs_project_name }}"
+    detail_template "Evaluated the last {{ parameters.param_lookback_days }} day(s) of Bedrock metrics for PTUs."
+
+    # Skip if excluded or if we couldn't derive a ModelId (cannot query metrics)
+    check not(in($param_excluded_provisioned_model_ids, field("provisionedModelId"))), "Not excluded"
+    check ne(field("modelId"), ""), "ModelId present"
+
+    # Under-utilization if EITHER low tokens OR low invocations
+    check or(
+      lt(add(field("input_tokens"), field("output_tokens")), $param_min_total_tokens),
+      lt(field("invocations"), $param_min_invocations)
+    ), "Under-utilized"
+
+    export $underutilized_ptu
+    escalate $email
+  end
+end


### PR DESCRIPTION
### Description

This adds the ability to specify multiple keys for a single dimension by using semicolons in order to deal with poor tag hygiene. This is similar to the native Tag Dimension functionality for resource tags.

### Link to Example Applied Policy

https://app.flexera.com/orgs/28010/automation/applied-policies/projects/123559?policyId=68c1dcc8f242000b927455b4

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
