### PR TITLE
POL-1631 AWS Load Balancer Savings Fixes

### DIFF
--- a/cost/aws/unused_albs/CHANGELOG.md
+++ b/cost/aws/unused_albs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.8
+
+- Fixed issue where estimated savings would sometimes be reported as 0 inaccurately.
+
 ## v0.2.7
 
 - Updated API requests to use newer Flexera API. Functionality unchanged.

--- a/cost/aws/unused_albs/aws_unused_albs.pt
+++ b/cost/aws/unused_albs/aws_unused_albs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.7",
+  version: "0.2.8",
   provider: "AWS",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -851,8 +851,11 @@ script "js_bad_albs", type: "javascript" do
 
   _.each(ds_albs_combined, function(lb) {
     lb_id = lb['name'].toLowerCase()
+    lb_arn_id = _.last(lb['arn'].split(':')).toLowerCase()
+
     savings = 0.0
-    if (ds_alb_costs_grouped[lb_id] != undefined) { savings = ds_alb_costs_grouped[lb_id] }
+    if (ds_alb_costs_grouped[lb_id]) { savings += ds_alb_costs_grouped[lb_id] }
+    if (ds_alb_costs_grouped[lb_arn_id]) { savings += ds_alb_costs_grouped[lb_arn_id] }
 
     if (savings >= param_min_savings && (lb['listeners'].length == 0 || lb['healthy_groups'].length == 0)) {
       total_savings += savings

--- a/cost/aws/unused_clbs/CHANGELOG.md
+++ b/cost/aws/unused_clbs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v6.4.8
+
+- Fixed issue where estimated savings would sometimes be reported as 0 inaccurately.
+- Fixed issue where `Resource ARN` field was malformed.
+
 ## v6.4.7
 
 - Updated API requests to use newer Flexera API. Functionality unchanged.

--- a/cost/aws/unused_clbs/aws_unused_clbs.pt
+++ b/cost/aws/unused_clbs/aws_unused_clbs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.4.7",
+  version: "6.4.8",
   provider: "AWS",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -722,12 +722,14 @@ script "js_unused_clb_cost_mapping", type: "javascript" do
   total_savings = 0.0
 
   _.each(ds_unused_clbs, function(clb) {
+    resourceARN = "arn:aws:elasticloadbalancing:" + clb['region'] + ":" + ds_aws_account['id'] + ":loadbalancer/" + clb['name']
+
     clb_id = clb['name'].toLowerCase()
+    clb_arn_id = "loadbalancer/" + clb['name'].toLowerCase()
 
     savings = 0.0
-    if (ds_clb_costs_grouped[clb_id] != undefined) {
-      savings = ds_clb_costs_grouped[clb_id]
-    }
+    if (ds_clb_costs_grouped[clb_id]) { savings += ds_clb_costs_grouped[clb_id] }
+    if (ds_clb_costs_grouped[clb_arn_id]) { savings += ds_clb_costs_grouped[clb_arn_id] }
 
     if (savings >= param_min_savings) {
       total_savings += savings
@@ -745,8 +747,6 @@ script "js_unused_clb_cost_mapping", type: "javascript" do
       })
 
       created = new Date(Math.round(clb['created'] * 1000)).toISOString()
-
-      resourceARN = "arn:aws:elasticloadbalancing:" + clb['region'] + ":" + ds_aws_account['id'] + ":loadbalancer/classic/" + clb['name']
 
       result.push({
         accountID: ds_aws_account['id'],

--- a/cost/aws/unused_nlbs/CHANGELOG.md
+++ b/cost/aws/unused_nlbs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.8
+
+- Fixed issue where estimated savings would sometimes be reported as 0 inaccurately.
+
 ## v0.2.7
 
 - Updated API requests to use newer Flexera API. Functionality unchanged.

--- a/cost/aws/unused_nlbs/aws_unused_nlbs.pt
+++ b/cost/aws/unused_nlbs/aws_unused_nlbs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.7",
+  version: "0.2.8",
   provider: "AWS",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -851,8 +851,11 @@ script "js_bad_nlbs", type: "javascript" do
 
   _.each(ds_nlbs_combined, function(lb) {
     lb_id = lb['name'].toLowerCase()
+    lb_arn_id = _.last(lb['arn'].split(':')).toLowerCase()
+
     savings = 0.0
-    if (ds_nlb_costs_grouped[lb_id] != undefined) { savings = ds_nlb_costs_grouped[lb_id] }
+    if (ds_nlb_costs_grouped[lb_id]) { savings += ds_nlb_costs_grouped[lb_id] }
+    if (ds_nlb_costs_grouped[lb_arn_id]) { savings += ds_nlb_costs_grouped[lb_arn_id] }
 
     if (savings >= param_min_savings && (lb['listeners'].length == 0 || lb['healthy_groups'].length == 0)) {
       total_savings += savings


### PR DESCRIPTION
### Description

`AWS Unused Application Load Balancers`
- Fixed issue where estimated savings would sometimes be reported as 0 inaccurately.

`AWS Unused Classic Load Balancers`
- Fixed issue where estimated savings would sometimes be reported as 0 inaccurately.
- Fixed issue where `Resource ARN` field was malformed.

`AWS Unused Network Load Balancers`
- Fixed issue where estimated savings would sometimes be reported as 0 inaccurately.

### Link to Example Applied Policy

(Also verified savings stuff works as expected in a user environment)

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=68d68e4daeb3e5d723f126c1
https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=68d68e77aeb3e5d723f126c3
https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=68d68ea157ad79c79e4eaf0b

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
