### PR TITLE
POL-1589 Deprecate AWS Savings Realized From Rate Reduction Purchases Policy Template

### DIFF
--- a/cost/aws/savings_realized/CHANGELOG.md
+++ b/cost/aws/savings_realized/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.0.5
+
+- Deprecated: This policy is no longer being updated. Please see policy README for more information.
+
 ## v4.0.4
 
 - Updated API requests to use newer Flexera API. Functionality unchanged.

--- a/cost/aws/savings_realized/README.md
+++ b/cost/aws/savings_realized/README.md
@@ -2,7 +2,7 @@
 
 ## Deprecated
 
-This policy template is no longer being updated. The "Savings" and "Savings Percent" cost metrics now available natively in Flexera CCO, in conjunction with the [Dashboards](https://docs.flexera.com/flexera/EN/Optima/Accessing_the_Cloud_Dashboard.htm#usingcco_3910196062_1183924) and [Tabular View](https://docs.flexera.com/flexera/EN/Optima/TabularView.htm#usingcco_3910196062_1186809) feature, should be used instead.
+This policy template is no longer being updated. The more accurate "Savings" and "Savings Percent" cost metrics now available natively in Flexera CCO, in conjunction with the [Dashboards](https://docs.flexera.com/flexera/EN/Optima/Accessing_the_Cloud_Dashboard.htm#usingcco_3910196062_1183924) and [Tabular View](https://docs.flexera.com/flexera/EN/Optima/TabularView.htm#usingcco_3910196062_1186809) feature, should be used instead.
 
 ## What It Does
 

--- a/cost/aws/savings_realized/README.md
+++ b/cost/aws/savings_realized/README.md
@@ -1,5 +1,9 @@
 # AWS Savings Realized From Rate Reduction Purchases
 
+## Deprecated
+
+This policy template is no longer being updated. The "Savings" and "Savings Percent" cost metrics now available natively in Flexera CCO, in conjunction with the [Dashboards](https://docs.flexera.com/flexera/EN/Optima/Accessing_the_Cloud_Dashboard.htm#usingcco_3910196062_1183924) and [Tabular View](https://docs.flexera.com/flexera/EN/Optima/TabularView.htm#usingcco_3910196062_1186809) feature, should be used instead.
+
 ## What It Does
 
 This policy template produces a report with chart showing the total savings realized from using AWS Reservations, Savings Plans, and Spot Instances. This report can either be for the entire organization or specific Billing Centers. Optionally, this report can be emailed.

--- a/cost/aws/savings_realized/aws_savings_realized.pt
+++ b/cost/aws/savings_realized/aws_savings_realized.pt
@@ -1,17 +1,18 @@
 name "AWS Savings Realized From Rate Reduction Purchases"
 rs_pt_ver 20180301
 type "policy"
-short_description "Reports savings realized from AWS rate reduction purchases, such as Reserved Instances, Savings Plan, and Spot Instance purchases. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/savings_realized/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
+short_description "**Deprecated: This policy is no longer being updated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/savings_realized/) for more details.** Reports savings realized from AWS rate reduction purchases, such as Reserved Instances, Savings Plan, and Spot Instance purchases. See the [README](https://github.com/flexera-public/policy_templates/tree/master/cost/aws/savings_realized/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera/EN/Automation/AutomationGS.htm) to learn more."
 long_description ""
 doc_link "https://github.com/flexera-public/policy_templates/tree/master/cost/aws/savings_realized/"
 severity "low"
 category "Cost"
 default_frequency "monthly"
 info(
-  version: "4.0.4",
+  version: "4.0.5",
   provider: "AWS",
   service: "Compute",
   policy_set: "Reserved Instance",
+  deprecated: "true",
   hide_skip_approvals: "true"
 )
 


### PR DESCRIPTION
### Description

Deprecates `AWS Savings Realized From Rate Reduction Purchases` in favor of more accurate, native product functionality.

### Link to Example Applied Policy

No testing needed, as no meaningful code changes were made.

### Contribution Check List

- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
