### PR TITLE
POL-1651 Remove "15 minutes" and "Hourly" child schedule options

### DIFF
--- a/automation/aws/aws_missing_regions/aws_missing_regions_meta_parent.pt
+++ b/automation/aws/aws_missing_regions/aws_missing_regions_meta_parent.pt
@@ -58,7 +58,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/compliance/aws/disallowed_regions/aws_disallowed_regions_meta_parent.pt
+++ b/compliance/aws/disallowed_regions/aws_disallowed_regions_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/compliance/aws/ecs_unused/aws_unused_ecs_clusters_meta_parent.pt
+++ b/compliance/aws/ecs_unused/aws_unused_ecs_clusters_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/compliance/aws/iam_role_audit/aws_iam_role_audit_meta_parent.pt
+++ b/compliance/aws/iam_role_audit/aws_iam_role_audit_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent_meta_parent.pt
+++ b/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/compliance/aws/long_stopped_instances/aws_long_stopped_instances_meta_parent.pt
+++ b/compliance/aws/long_stopped_instances/aws_long_stopped_instances_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/compliance/aws/rds_backup/aws_rds_backup_meta_parent.pt
+++ b/compliance/aws/rds_backup/aws_rds_backup_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/compliance/aws/untagged_resources/aws_untagged_resources_meta_parent.pt
+++ b/compliance/aws/untagged_resources/aws_untagged_resources_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/compliance/azure/advisor_carbon/azure_advisor_carbon_meta_parent.pt
+++ b/compliance/azure/advisor_carbon/azure_advisor_carbon_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry_meta_parent.pt
+++ b/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent.pt
+++ b/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/compliance/azure/azure_policy_audit/azure_policy_audit_meta_parent.pt
+++ b/compliance/azure/azure_policy_audit/azure_policy_audit_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent.pt
+++ b/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/compliance/azure/azure_untagged_vms/untagged_vms_meta_parent.pt
+++ b/compliance/azure/azure_untagged_vms/untagged_vms_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/compliance/azure/compliance_score/azure_regulatory_compliance_report_meta_parent.pt
+++ b/compliance/azure/compliance_score/azure_regulatory_compliance_report_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
+++ b/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/compliance/google/long_stopped_instances/google_long_stopped_instances_meta_parent.pt
+++ b/compliance/google/long_stopped_instances/google_long_stopped_instances_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/compliance/google/unlabeled_resources/unlabeled_resources_meta_parent.pt
+++ b/compliance/google/unlabeled_resources/unlabeled_resources_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/burstable_ec2_instances/aws_burstable_ec2_instances_meta_parent.pt
+++ b/cost/aws/burstable_ec2_instances/aws_burstable_ec2_instances_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/cloudtrail_read_logging/aws_cloudtrail_read_logging_meta_parent.pt
+++ b/cost/aws/cloudtrail_read_logging/aws_cloudtrail_read_logging_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/ec2_compute_optimizer/aws_ec2_compute_optimizer_meta_parent.pt
+++ b/cost/aws/ec2_compute_optimizer/aws_ec2_compute_optimizer_meta_parent.pt
@@ -58,7 +58,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/eks_without_spot/aws_eks_without_spot_meta_parent.pt
+++ b/cost/aws/eks_without_spot/aws_eks_without_spot_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume_meta_parent.pt
+++ b/cost/aws/gp3_volume_upgrade/aws_upgrade_to_gp3_volume_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
+++ b/cost/aws/idle_compute_instances/idle_compute_instances_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/idle_nat_gateways/aws_idle_nat_gateways_meta_parent.pt
+++ b/cost/aws/idle_nat_gateways/aws_idle_nat_gateways_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/rds_instance_license_info/rds_instance_license_info_meta_parent.pt
+++ b/cost/aws/rds_instance_license_info/rds_instance_license_info_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/rightsize_ebs_volumes/aws_rightsize_ebs_volumes_meta_parent.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_rightsize_ebs_volumes_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/rightsize_elasticache/aws_rightsize_elasticache_meta_parent.pt
+++ b/cost/aws/rightsize_elasticache/aws_rightsize_elasticache_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/rightsize_redshift/aws_rightsize_redshift_meta_parent.pt
+++ b/cost/aws/rightsize_redshift/aws_rightsize_redshift_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/s3_bucket_size/aws_bucket_size_meta_parent.pt
+++ b/cost/aws/s3_bucket_size/aws_bucket_size_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/s3_lifecycle/aws_s3_lifecycle_meta_parent.pt
+++ b/cost/aws/s3_lifecycle/aws_s3_lifecycle_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/s3_multipart_uploads/aws_s3_multipart_uploads_meta_parent.pt
+++ b/cost/aws/s3_multipart_uploads/aws_s3_multipart_uploads_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check_meta_parent.pt
+++ b/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/schedule_instance/CHANGELOG.md
+++ b/cost/aws/schedule_instance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v8.0.6
+
+- Added metadata specific to meta parent policies. Functionality unchanged.
+
 ## v8.0.5
 
 - Updated API requests to use newer Flexera API. Functionality unchanged.

--- a/cost/aws/schedule_instance/aws_schedule_instance.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance.pt
@@ -8,11 +8,12 @@ severity "low"
 category "Cost"
 default_frequency "15 minutes"
 info(
-  version: "8.0.5",
+  version: "8.0.6",
   provider: "AWS",
   service: "Compute",
   policy_set: "Schedule Instance",
-  hide_skip_approvals: "true"
+  hide_skip_approvals: "true",
+  enable_child_schedule_options: "true"
 )
 
 ###############################################################################

--- a/cost/aws/schedule_instance/aws_schedule_instance_meta_parent.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "8.0.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "8.0.6", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes_meta_parent.pt
+++ b/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/unused_albs/aws_unused_albs_meta_parent.pt
+++ b/cost/aws/unused_albs/aws_unused_albs_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/unused_clbs/aws_unused_clbs_meta_parent.pt
+++ b/cost/aws/unused_clbs/aws_unused_clbs_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/unused_nlbs/aws_unused_nlbs_meta_parent.pt
+++ b/cost/aws/unused_nlbs/aws_unused_nlbs_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/unused_rds/unused_rds_meta_parent.pt
+++ b/cost/aws/unused_rds/unused_rds_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
+++ b/cost/aws/unused_volumes/aws_delete_unused_volumes_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/advisor_compute/azure_advisor_compute_meta_parent.pt
+++ b/cost/azure/advisor_compute/azure_advisor_compute_meta_parent.pt
@@ -85,7 +85,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/blob_storage_optimization/azure_blob_storage_optimization_meta_parent.pt
+++ b/cost/azure/blob_storage_optimization/azure_blob_storage_optimization_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/data_lake_optimization/data_lake_optimization_meta_parent.pt
+++ b/cost/azure/data_lake_optimization/data_lake_optimization_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/databricks/rightsize_compute/azure_databricks_rightsize_compute_meta_parent.pt
+++ b/cost/azure/databricks/rightsize_compute/azure_databricks_rightsize_compute_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
+++ b/cost/azure/idle_compute_instances/azure_idle_compute_instances_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/long_stopped_instances/long_stopped_instances_azure_meta_parent.pt
+++ b/cost/azure/long_stopped_instances/long_stopped_instances_azure_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/reserved_instances/recommendations/azure_reserved_instance_recommendations_meta_parent.pt
+++ b/cost/azure/reserved_instances/recommendations/azure_reserved_instance_recommendations_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks_meta_parent.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql_meta_parent.pt
+++ b/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/rightsize_managed_sql_storage/azure_rightsize_managed_sql_storage_meta_parent.pt
+++ b/cost/azure/rightsize_managed_sql_storage/azure_rightsize_managed_sql_storage_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible_meta_parent.pt
+++ b/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single_meta_parent.pt
+++ b/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/rightsize_netapp/azure_rightsize_netapp_meta_parent.pt
+++ b/cost/azure/rightsize_netapp/azure_rightsize_netapp_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/rightsize_sql_storage/azure_rightsize_sql_storage_meta_parent.pt
+++ b/cost/azure/rightsize_sql_storage/azure_rightsize_sql_storage_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/savings_plan/recommendations/azure_savings_plan_recommendations_meta_parent.pt
+++ b/cost/azure/savings_plan/recommendations/azure_savings_plan_recommendations_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/schedule_instance/CHANGELOG.md
+++ b/cost/azure/schedule_instance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v7.0.8
+
+- Added metadata specific to meta parent policies. Functionality unchanged.
+
 ## v7.0.7
 
 - Updated "Last Start Status" and "Last Stop Status" values from `Unknown` to `No Action` to indicate when no Flexera start/stop action has been performed.

--- a/cost/azure/schedule_instance/azure_schedule_instance.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance.pt
@@ -8,11 +8,12 @@ category "Cost"
 severity "low"
 default_frequency "15 minutes"
 info(
-  version: "7.0.7",
+  version: "7.0.8",
   provider: "Azure",
   service: "Compute",
   policy_set: "Schedule Instance",
-  hide_skip_approvals: "true"
+  hide_skip_approvals: "true",
+  enable_child_schedule_options: "true"
 )
 
 ###############################################################################

--- a/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "7.0.7", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "7.0.8", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/sql_servers_without_elastic_pool/azure_sql_servers_without_elastic_pool_meta_parent.pt
+++ b/cost/azure/sql_servers_without_elastic_pool/azure_sql_servers_without_elastic_pool_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent.pt
+++ b/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/unoptimized_web_app_scaling/azure_unoptimized_web_app_scaling_meta_parent.pt
+++ b/cost/azure/unoptimized_web_app_scaling/azure_unoptimized_web_app_scaling_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/unused_app_service_plans/azure_unused_app_service_plans_meta_parent.pt
+++ b/cost/azure/unused_app_service_plans/azure_unused_app_service_plans_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/unused_firewalls/azure_unused_firewalls_meta_parent.pt
+++ b/cost/azure/unused_firewalls/azure_unused_firewalls_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/unused_load_balancers/azure_unused_load_balancers_meta_parent.pt
+++ b/cost/azure/unused_load_balancers/azure_unused_load_balancers_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
+++ b/cost/azure/unused_sql_databases/azure_unused_sql_databases_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/unused_storage_accounts/azure_unused_storage_accounts_meta_parent.pt
+++ b/cost/azure/unused_storage_accounts/azure_unused_storage_accounts_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/unused_vngs/azure_unused_vngs_meta_parent.pt
+++ b/cost/azure/unused_vngs/azure_unused_vngs_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations_meta_parent.pt
+++ b/cost/google/cloud_sql_idle_instance_recommendations/google_sql_idle_instance_recommendations_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/google/cloud_storage_lifecycle/google_cloud_storage_lifecycle_meta_parent.pt
+++ b/cost/google/cloud_storage_lifecycle/google_cloud_storage_lifecycle_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/google/cud_expiration/google_cud_expiration_report_meta_parent.pt
+++ b/cost/google/cud_expiration/google_cud_expiration_report_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/google/cud_recommendations/google_committed_use_discount_recommendations_meta_parent.pt
+++ b/cost/google/cud_recommendations/google_committed_use_discount_recommendations_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/google/cud_report/google_committed_use_discount_report_meta_parent.pt
+++ b/cost/google/cud_report/google_committed_use_discount_report_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/google/object_storage_optimization/google_object_storage_optimization_meta_parent.pt
+++ b/cost/google/object_storage_optimization/google_object_storage_optimization_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/google/recommender/recommender_meta_parent.pt
+++ b/cost/google/recommender/recommender_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/google/rightsize_cloudsql_recommendations/google_rightsize_cloudsql_recommendations_meta_parent.pt
+++ b/cost/google/rightsize_cloudsql_recommendations/google_rightsize_cloudsql_recommendations_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
+++ b/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/cost/google/schedule_instance/CHANGELOG.md
+++ b/cost/google/schedule_instance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.0.6
+
+- Added metadata specific to meta parent policies. Functionality unchanged.
+
 ## v6.0.5
 
 - Updated API requests to use newer Flexera API. Functionality unchanged.

--- a/cost/google/schedule_instance/google_schedule_instance.pt
+++ b/cost/google/schedule_instance/google_schedule_instance.pt
@@ -8,11 +8,12 @@ category "Cost"
 severity "low"
 default_frequency "15 minutes"
 info(
-  version: "6.0.5",
+  version: "6.0.6",
   provider: "Google",
   service: "Compute",
   policy_set: "Schedule Instance",
-  hide_skip_approvals: "true"
+  hide_skip_approvals: "true",
+  enable_child_schedule_options: "true"
 )
 
 ###############################################################################

--- a/cost/google/schedule_instance/google_schedule_instance_meta_parent.pt
+++ b/cost/google/schedule_instance/google_schedule_instance_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "6.0.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.0.6", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/operational/aws/ec2_stopped_report/aws_ec2_stopped_report_meta_parent.pt
+++ b/operational/aws/ec2_stopped_report/aws_ec2_stopped_report_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate_meta_parent.pt
+++ b/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/operational/aws/lambda_provisioned_concurrency/aws_lambda_provisioned_concurrency_meta_parent.pt
+++ b/operational/aws/lambda_provisioned_concurrency/aws_lambda_provisioned_concurrency_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
+++ b/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/operational/aws/overutilized_ec2_instances/aws_overutilized_ec2_meta_parent.pt
+++ b/operational/aws/overutilized_ec2_instances/aws_overutilized_ec2_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/operational/aws/scheduled_ec2_events/aws_scheduled_ec2_events_meta_parent.pt
+++ b/operational/aws/scheduled_ec2_events/aws_scheduled_ec2_events_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/operational/aws/tag_cardinality/aws_tag_cardinality_meta_parent.pt
+++ b/operational/aws/tag_cardinality/aws_tag_cardinality_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/operational/azure/aks_nodepools_without_autoscaling/aks_nodepools_without_autoscaling_meta_parent.pt
+++ b/operational/azure/aks_nodepools_without_autoscaling/aks_nodepools_without_autoscaling_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/operational/azure/aks_nodepools_without_zero_autoscaling/aks_nodepools_without_zero_autoscaling_meta_parent.pt
+++ b/operational/azure/aks_nodepools_without_zero_autoscaling/aks_nodepools_without_zero_autoscaling_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
+++ b/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/operational/azure/compute_poweredoff_report/azure_compute_poweredoff_report_meta_parent.pt
+++ b/operational/azure/compute_poweredoff_report/azure_compute_poweredoff_report_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/operational/azure/overutilized_compute_instances/azure_compute_overutilized_meta_parent.pt
+++ b/operational/azure/overutilized_compute_instances/azure_compute_overutilized_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
+++ b/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent.pt
+++ b/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/operational/google/label_cardinality/google_label_cardinality_meta_parent.pt
+++ b/operational/google/label_cardinality/google_label_cardinality_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/operational/google/overutilized_vms/google_overutilized_vms_meta_parent.pt
+++ b/operational/google/overutilized_vms/google_overutilized_vms_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/aws/aws_config_enabled/aws_config_enabled_meta_parent.pt
+++ b/security/aws/aws_config_enabled/aws_config_enabled_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/aws/ebs_ensure_encryption_default/ebs_ensure_encryption_default_meta_parent.pt
+++ b/security/aws/ebs_ensure_encryption_default/ebs_ensure_encryption_default_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes_meta_parent.pt
+++ b/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/aws/elb_unencrypted/aws_elb_encryption_meta_parent.pt
+++ b/security/aws/elb_unencrypted/aws_elb_encryption_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/aws/loadbalancer_internet_facing/aws_internet_facing_elbs_meta_parent.pt
+++ b/security/aws/loadbalancer_internet_facing/aws_internet_facing_elbs_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/aws/public_buckets/aws_public_buckets_meta_parent.pt
+++ b/security/aws/public_buckets/aws_public_buckets_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances_meta_parent.pt
+++ b/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/aws/rds_unencrypted/aws_unencrypted_rds_instances_meta_parent.pt
+++ b/security/aws/rds_unencrypted/aws_unencrypted_rds_instances_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/aws/s3_buckets_deny_http/s3_buckets_deny_http_meta_parent.pt
+++ b/security/aws/s3_buckets_deny_http/s3_buckets_deny_http_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/aws/s3_buckets_without_server_access_logging/aws_s3_buckets_without_server_access_logging_meta_parent.pt
+++ b/security/aws/s3_buckets_without_server_access_logging/aws_s3_buckets_without_server_access_logging_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/aws/s3_ensure_buckets_block_public_access/s3_ensure_buckets_block_public_access_meta_parent.pt
+++ b/security/aws/s3_ensure_buckets_block_public_access/s3_ensure_buckets_block_public_access_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/aws/s3_ensure_mfa_delete_enabled/s3_ensure_mfa_delete_enabled_meta_parent.pt
+++ b/security/aws/s3_ensure_mfa_delete_enabled/s3_ensure_mfa_delete_enabled_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/aws/unencrypted_s3_buckets/aws_unencrypted_s3_buckets_meta_parent.pt
+++ b/security/aws/unencrypted_s3_buckets/aws_unencrypted_s3_buckets_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/aws/vpcs_without_flow_logs_enabled/aws_vpcs_without_flow_logs_enabled_meta_parent.pt
+++ b/security/aws/vpcs_without_flow_logs_enabled/aws_vpcs_without_flow_logs_enabled_meta_parent.pt
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/blob_storage_logging/blob_storage_logging_meta_parent.pt
+++ b/security/azure/blob_storage_logging/blob_storage_logging_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/mysql_ssl/mysql_ssl_meta_parent.pt
+++ b/security/azure/mysql_ssl/mysql_ssl_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/mysql_tls_version/mysql_tls_version_meta_parent.pt
+++ b/security/azure/mysql_tls_version/mysql_tls_version_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/pg_conn_throttling/pg_conn_throttling_meta_parent.pt
+++ b/security/azure/pg_conn_throttling/pg_conn_throttling_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/pg_infra_encryption/pg_infra_encryption_meta_parent.pt
+++ b/security/azure/pg_infra_encryption/pg_infra_encryption_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/pg_log_retention/pg_log_retention_meta_parent.pt
+++ b/security/azure/pg_log_retention/pg_log_retention_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/pg_log_settings/pg_log_settings_meta_parent.pt
+++ b/security/azure/pg_log_settings/pg_log_settings_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/private_blob_containers/private_blob_containers_meta_parent.pt
+++ b/security/azure/private_blob_containers/private_blob_containers_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/queue_storage_logging/queue_storage_logging_meta_parent.pt
+++ b/security/azure/queue_storage_logging/queue_storage_logging_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/restrict_rdp_internet/azure_restrict_rdp_inet_meta_parent.pt
+++ b/security/azure/restrict_rdp_internet/azure_restrict_rdp_inet_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/restrict_ssh_internet/azure_restrict_ssh_inet_meta_parent.pt
+++ b/security/azure/restrict_ssh_internet/azure_restrict_ssh_inet_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/secure_transfer_required/secure_transfer_required_meta_parent.pt
+++ b/security/azure/secure_transfer_required/secure_transfer_required_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/security_alert_owners/security_alert_owners_meta_parent.pt
+++ b/security/azure/security_alert_owners/security_alert_owners_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/security_contact_email/security_contact_email_meta_parent.pt
+++ b/security/azure/security_contact_email/security_contact_email_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/sql_ad_admin/sql_ad_admin_meta_parent.pt
+++ b/security/azure/sql_ad_admin/sql_ad_admin_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/sql_auditing_retention/sql_auditing_retention_meta_parent.pt
+++ b/security/azure/sql_auditing_retention/sql_auditing_retention_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/sql_db_encryption/sql_db_encryption_meta_parent.pt
+++ b/security/azure/sql_db_encryption/sql_db_encryption_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/sql_publicly_accessible_managed_instance/sql_publicly_accessible_managed_instance_meta_parent.pt
+++ b/security/azure/sql_publicly_accessible_managed_instance/sql_publicly_accessible_managed_instance_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/sql_server_atp/sql_server_atp_meta_parent.pt
+++ b/security/azure/sql_server_atp/sql_server_atp_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/sql_server_auditing/sql_server_auditing_meta_parent.pt
+++ b/security/azure/sql_server_auditing/sql_server_auditing_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/sql_server_va/sql_server_va_meta_parent.pt
+++ b/security/azure/sql_server_va/sql_server_va_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/sql_server_va_admins/sql_server_va_admins_meta_parent.pt
+++ b/security/azure/sql_server_va_admins/sql_server_va_admins_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/sql_server_va_emails/sql_server_va_emails_meta_parent.pt
+++ b/security/azure/sql_server_va_emails/sql_server_va_emails_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/sql_server_va_scans/sql_server_va_scans_meta_parent.pt
+++ b/security/azure/sql_server_va_scans/sql_server_va_scans_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/storage_network_deny/storage_network_deny_meta_parent.pt
+++ b/security/azure/storage_network_deny/storage_network_deny_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/storage_soft_delete/storage_soft_delete_meta_parent.pt
+++ b/security/azure/storage_soft_delete/storage_soft_delete_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/storage_tls_version/storage_tls_version_meta_parent.pt
+++ b/security/azure/storage_tls_version/storage_tls_version_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/storage_trusted_services/storage_trusted_services_meta_parent.pt
+++ b/security/azure/storage_trusted_services/storage_trusted_services_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/table_storage_logging/table_storage_logging_meta_parent.pt
+++ b/security/azure/table_storage_logging/table_storage_logging_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/azure/webapp_tls_version_support/azure_webapp_min_tls_version_meta_parent.pt
+++ b/security/azure/webapp_tls_version_support/azure_webapp_min_tls_version_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/security/google/public_buckets/google_public_buckets_meta_parent.pt
+++ b/security/google/public_buckets/google_public_buckets_meta_parent.pt
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values "daily", "weekly", "monthly"
 end
 
 parameter "param_template_source" do

--- a/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/aws_meta_parent.pt.template
@@ -59,7 +59,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values __PLACEHOLDER_FOR_CHILD_POLICY_SCHEDULE_OPTIONS__
 end
 
 parameter "param_template_source" do

--- a/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values __PLACEHOLDER_FOR_CHILD_POLICY_SCHEDULE_OPTIONS__
 end
 
 parameter "param_template_source" do

--- a/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/google_meta_parent.pt.template
@@ -86,7 +86,7 @@ parameter "param_policy_schedule" do
   label "Child Policy Schedule"
   description "The interval at which the child policy checks for conditions and generates incidents."
   default "weekly"
-  allowed_values "15 minutes", "hourly", "daily", "weekly", "monthly"
+  allowed_values __PLACEHOLDER_FOR_CHILD_POLICY_SCHEDULE_OPTIONS__
 end
 
 parameter "param_template_source" do

--- a/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
+++ b/tools/meta_parent_policy_compiler/meta_parent_policy_compiler.rb
@@ -97,6 +97,10 @@ def compile_meta_parent_policy(file_path, specified_parent_pt_path)
   hide_skip_approvals_scan = pt.scan(/hide_skip_approvals: "(.*?)"/)
   hide_skip_approvals = ""
   hide_skip_approvals = hide_skip_approvals_scan[0][0] if !hide_skip_approvals_scan.empty?
+  # get the enable_child_schedule_options string if it exists, defaulting to false if not present
+  enable_child_schedule_options_scan = pt.scan(/enable_child_schedule_options: "(.*?)"/)
+  enable_child_schedule_options = "false"
+  enable_child_schedule_options = enable_child_schedule_options_scan[0][0] if !enable_child_schedule_options_scan.empty?
   # print("Name: #{name}\n")
   # print("Description: #{description}\n")
   # print("\n###########################\n")
@@ -346,6 +350,7 @@ end
   output_pt = output_pt.gsub("__PLACEHOLDER_FOR_CHILD_POLICY_VERSION__", version)
   output_pt = output_pt.gsub("__PLACEHOLDER_FOR_CHILD_POLICY_PUBLISH__", publish)
   output_pt = output_pt.gsub("__PLACEHOLDER_FOR_CHILD_POLICY_DEPRECATED__", deprecated)
+
   if !hide_skip_approvals.empty?
     output_pt = output_pt.gsub("__PLACEHOLDER_FOR_CHILD_POLICY_HIDE_SKIP_APPROVALS__", hide_skip_approvals)
   else
@@ -353,6 +358,13 @@ end
     output_pt = output_pt.gsub(/^\s*,?\s*hide_skip_approvals: "__PLACEHOLDER_FOR_CHILD_POLICY_HIDE_SKIP_APPROVALS__",?\s*\n/, "")
     output_pt = output_pt.gsub(/,\s*\)/, "\n)")
   end
+
+  if enable_child_schedule_options == "true"
+    output_pt = output_pt.gsub("__PLACEHOLDER_FOR_CHILD_POLICY_SCHEDULE_OPTIONS__", '"15 minutes", "hourly", "daily", "weekly", "monthly"')
+  else
+    output_pt = output_pt.gsub("__PLACEHOLDER_FOR_CHILD_POLICY_SCHEDULE_OPTIONS__", '"daily", "weekly", "monthly"')
+  end
+
   # Attempt to identify the URL to the child policy template file on github using the file_path provided
   # This would only work if the pt file is located under the `policy_templates` repo directory
   # If it is not, then the URL will be incorrect


### PR DESCRIPTION
### Description

Removes the "15 minutes" and "Hourly" child schedule options from most meta policies. Adds logic in the meta parent compiler to allow for exceptions if the info() block contains enable_child_schedule_options: "true"
