### PR TITLE
SQ-18478 Fixed not showing metrics for DTU database.

### DIFF
--- a/cost/azure/rightsize_sql_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_sql_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.0.6
+
+- Fixed bug that was causing metrics for DTU database to be empty.
+
 ## v6.0.5
 
 - Updated API requests to use newer Flexera API. Functionality unchanged.

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.0.5",
+  version: "6.0.6",
   provider: "Azure",
   service: "SQL",
   policy_set: "Rightsize Database Instances",
@@ -832,9 +832,9 @@ script "js_merged_metrics", type: "javascript" do
       metrics = cpu_metrics ? cpu_metrics : dtu_metrics
 
       if (metrics.length > 0) {
-        minimums = _.pluck(cpu_metrics, 'minimum')
-        maximums = _.pluck(cpu_metrics, 'maximum')
-        averages = _.pluck(cpu_metrics, 'average')
+        minimums = _.pluck(metrics, 'minimum')
+        maximums = _.pluck(metrics, 'maximum')
+        averages = _.pluck(metrics, 'average')
 
         metric_minimum = null
         metric_maximum = null

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "6.0.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.0.6", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"


### PR DESCRIPTION
### Description

Fixed an issue for Azure Rightsize SQL Databases policy. The policy was showing empty metrics and has incorrect calculations for DTU databases.

### Issues Resolved

https://flexera.atlassian.net/browse/SQ-18478

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
