### PR TITLE
POL-1678 AWS Savings Plan Policy Template Fix

### DIFF
--- a/cost/aws/savings_plan/recommendations/CHANGELOG.md
+++ b/cost/aws/savings_plan/recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.4.1
+
+- Fixed issue where policy would never complete execution and would fail with an error.
+
 ## v3.4.0
 
 - Added support for attaching CSV files to incident emails.

--- a/cost/aws/savings_plan/recommendations/aws_savings_plan_recommendations.pt
+++ b/cost/aws/savings_plan/recommendations/aws_savings_plan_recommendations.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.4.0",
+  version: "3.4.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Savings Plans",
@@ -426,6 +426,8 @@ script "js_sp_normalization", type: "javascript" do
   parameters "ds_sp_recommendations", "ds_applied_policy", "ds_vendor_account_table", "ds_currency", "ds_currency_conversion", "ds_conditional_currency_conversion", "param_min_savings", "param_days", "param_scope", "param_term", "param_payment_option", "param_savings_plan_type", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  csv_message = param_incident_csv == "false" ? "" : "Incident table CSV file has been attached to emails for this incident."
+
   // Used for formatting numbers to look pretty
   function formatNumber(number, separator) {
     formatted_number = "0"


### PR DESCRIPTION
### Description

Fixes issue where policy template would error out instead of completing execution.

Dangerfile warning can be ignored; no need to update README since this is just a bug fix.

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=6913a098c846996d457e1bfc

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
