### PR TITLE
POL-1749 - Add cluster/workload table to Kubernetes Rightsizing Recommendation Report

### DIFF
--- a/cost/flexera/spot/ocean_recommendations/CHANGELOG.md
+++ b/cost/flexera/spot/ocean_recommendations/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.0
+
+- Added workload summary table to incident report, grouped by cluster, showing workload name, type, namespace, vCPU change, memory change, and potential monthly savings
+- Fixed error that caused policy to fail when a cluster returns an error for rightsizing recommendations
+
 ## v0.3.1
 
 - Category of policy template updated to "Cost". Functionality unchanged.

--- a/cost/flexera/spot/ocean_recommendations/spot_ocean_recommendations.pt
+++ b/cost/flexera/spot/ocean_recommendations/spot_ocean_recommendations.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "0.3.1",
+  version: "0.4.0",
   provider: "Flexera",
   service: "Kubernetes",
   policy_set: "Rightsize Containers",
@@ -304,7 +304,8 @@ script "js_spotinst_clusters_rightsizing_suggestions", type: "javascript" do
       },
       body_fields: {
         "clusterResources": {} // Empty object to get all resources in the cluster
-      }
+      },
+      ignore_status: [400, 403, 404]
     }
   EOS
 end
@@ -976,6 +977,56 @@ script "js_report", type: "javascript" do
     report.push("* Estimated Memory Savings Portion: " + formatCurrency(metrics.globalMemoryCostSavings || 0, currency));
     report.push("* Total Underprovisioned: " + metrics.globalUnderprovisioned);
     report.push("* Total Overprovisioned: " + metrics.globalOverprovisioned + "\n");
+
+    // Workload summary table grouped by cluster
+    var clusterKeys = _.keys(metrics.clusters).sort();
+
+    _.each(clusterKeys, function(clusterKey) {
+      var clusterData = metrics.clusters[clusterKey];
+      var items = clusterData.items || [];
+
+      if (items.length === 0) { return; }
+
+      report.push("---");
+      report.push("### " + clusterKey);
+      report.push("**Cluster Savings:** " + formatCurrency(clusterData.estimatedSavings || 0, currency) + " | **Workloads:** " + items.length + " | **Underprovisioned:** " + clusterData.underprovisioned + " | **Overprovisioned:** " + clusterData.overprovisioned);
+      report.push("");
+
+      // Sort by estimated savings descending
+      var sorted = _.sortBy(items, function(item) {
+        return -getNumber(item.estimatedSavings, 0);
+      });
+
+      report.push("| Workload Name | Type | Namespace | vCPU | Memory (MiB) | Monthly Savings |");
+      report.push("|---|---|---|---|---|---|");
+
+      _.each(sorted, function(item) {
+        var suggestion = item.suggestion || {};
+        var workloadName = suggestion.workloadName || "";
+        var workloadType = properCase(suggestion.workloadType || "");
+        var namespace = suggestion.namespace || "";
+        var requestedCpu = roundNumber(getNumber(suggestion.requestedCpu, 0), 3);
+        var suggestedCpu = roundNumber(getNumber(suggestion.suggestedCpu, 0), 3);
+        var requestedMemory = Math.round(getNumber(suggestion.requestedMemory, 0));
+        var suggestedMemory = Math.round(getNumber(suggestion.suggestedMemory, 0));
+        var savings = getNumber(item.estimatedSavings, 0);
+
+        var cpuIndicator = "";
+        if (suggestedCpu < requestedCpu) { cpuIndicator = " ▼"; }
+        else if (suggestedCpu > requestedCpu) { cpuIndicator = " ▲"; }
+
+        var memIndicator = "";
+        if (suggestedMemory < requestedMemory) { memIndicator = " ▼"; }
+        else if (suggestedMemory > requestedMemory) { memIndicator = " ▲"; }
+
+        var cpuStr = requestedCpu + " → " + suggestedCpu + cpuIndicator;
+        var memStr = requestedMemory + " → " + suggestedMemory + memIndicator;
+
+        report.push("| " + workloadName + " | " + workloadType + " | " + namespace + " | " + cpuStr + " | " + memStr + " | " + formatCurrency(savings, currency) + " |");
+      });
+
+      report.push("");
+    });
 
     report.push("\n_Report generated at: " + new Date().toISOString() + "_");
 


### PR DESCRIPTION
### Description

Enhances Kubernetes Rightsizing Recommendation Policy Template to include a table for each cluster, with the net of workload changes (similar to how these recommendations are presented in another view in the platform)

### Link to Example Applied Policy

https://app.flexera.com/orgs/36084/automation/applied-policies/projects/138037?policyId=69d54e3da9aee47adaf71b57

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
