### PR TITLE
POL-1753 "message" Fix

### DIFF
--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -1682,7 +1682,7 @@ def policy_bad_param_category_order?(file, file_lines)
   file_lines.each do |line|
     stripped = line.strip
 
-    if stripped.match?(/^parameter\s+"/)
+    if line.match?(/^parameter\s+"/)
       in_param = true
     end
 

--- a/.github/agents/policy-dev.agent.md
+++ b/.github/agents/policy-dev.agent.md
@@ -1059,7 +1059,7 @@ end
 
 **Meta Policy termination check:** Always include `logic_or($ds_parent_policy_terminated, ...)` as first argument in `check` for Meta Policy support.
 
-**`hash_exclude`:** Prevents listed fields from contributing to incident deduplication hash. Exclude volatile fields (tags, savings) that change without indicating meaningful state change.
+**`hash_exclude`:** Prevents listed fields from contributing to incident deduplication hash. Exclude volatile fields (tags, savings) that change without indicating meaningful state change. **Only list fields that are actually declared in the `export` block** — listing a field that is not exported has no effect and is misleading.
 
 **`export <field_name> do`:** Optional field name before `do` extracts a nested sub-array as the exported table. Omit when the incident data itself is the flat array.
 
@@ -1188,10 +1188,10 @@ export do
 end
 ```
 
-**`hash_exclude` minimum** — always exclude these volatile fields that change without indicating a meaningful state change. Extend as needed for utilization metrics or age fields:
+**`hash_exclude` minimum** — always exclude volatile fields that change without indicating a meaningful state change. Extend as needed for utilization metrics or age fields. **Only include field names that are actually declared in the `export` block** — `hash_exclude` has no effect on fields that are not exported. The fields `message`, `policy_name`, and `total_savings` are metadata set on `result[0]` for use in `summary_template` / `detail_template`; only add them to `hash_exclude` if they are explicitly declared in the `export` block:
 
 ```
-hash_exclude "message", "total_savings", "tags", "savings", "savingsCurrency"
+hash_exclude "tags", "savings", "savingsCurrency"
 ```
 
 ```javascript
@@ -1217,7 +1217,7 @@ result.push({
 })
 ```
 
-Always add `"savings"`, `"savingsCurrency"`, `"total_savings"`, and `"message"` to `hash_exclude` in the `validate_each` block so that savings recalculations and message updates don't trigger spurious incident re-opens.
+Always add `"savings"`, `"savingsCurrency"`, and `"tags"` to `hash_exclude` in the `validate_each` block so that savings recalculations don't trigger spurious incident re-opens. If `"message"` or `"total_savings"` are declared as fields in the `export` block, add them too — but do **not** add them if they are not exported, as `hash_exclude` only operates on exported fields.
 
 For cost templates, the `ds_currency` datasource (fetched from the Flexera billing API) provides the org's currency symbol. Copy the boilerplate from a reference template such as `cost/aws/old_snapshots/aws_delete_old_snapshots.pt`.
 

--- a/compliance/aws/disallowed_regions/CHANGELOG.md
+++ b/compliance/aws/disallowed_regions/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v5.1.1
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v5.1.0

--- a/compliance/aws/disallowed_regions/CHANGELOG.md
+++ b/compliance/aws/disallowed_regions/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v5.1.1
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v5.1.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/compliance/aws/disallowed_regions/CHANGELOG.md
+++ b/compliance/aws/disallowed_regions/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v5.1.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/compliance/aws/disallowed_regions/aws_disallowed_regions.pt
+++ b/compliance/aws/disallowed_regions/aws_disallowed_regions.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.1.0",
+  version: "5.1.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Disallowed Regions",
@@ -525,7 +525,7 @@ policy "pol_disallowed_regions" do
     escalate $esc_email
     escalate $esc_stop_instances
     escalate $esc_terminate_instances
-    hash_exclude "message", "tags"
+    hash_exclude "tags"
     export do
       resource_level true
       field "accountID" do

--- a/compliance/aws/long_stopped_instances/CHANGELOG.md
+++ b/compliance/aws/long_stopped_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v6.1.3
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/compliance/aws/long_stopped_instances/CHANGELOG.md
+++ b/compliance/aws/long_stopped_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v6.1.4
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v6.1.3

--- a/compliance/aws/long_stopped_instances/CHANGELOG.md
+++ b/compliance/aws/long_stopped_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v6.1.4
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v6.1.3
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt
+++ b/compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Compliance"
 default_frequency "weekly"
 info(
-  version: "6.1.3",
+  version: "6.1.4",
   provider: "AWS",
   service: "Compute",
   policy_set: "Long Stopped Instances",
@@ -784,7 +784,7 @@ policy "pol_long_stopped_instances" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_terminate_instances
-    hash_exclude "message", "tags"
+    hash_exclude "tags"
     export do
       resource_level true
       field "accountID" do

--- a/compliance/aws/untagged_resources/CHANGELOG.md
+++ b/compliance/aws/untagged_resources/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v5.6.1
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v5.6.0
 
 - Added graceful error handling for inaccessible AWS regions

--- a/compliance/aws/untagged_resources/CHANGELOG.md
+++ b/compliance/aws/untagged_resources/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v5.6.0
 
 - Added graceful error handling for inaccessible AWS regions

--- a/compliance/aws/untagged_resources/CHANGELOG.md
+++ b/compliance/aws/untagged_resources/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v5.6.1
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v5.6.0

--- a/compliance/aws/untagged_resources/aws_untagged_resources.pt
+++ b/compliance/aws/untagged_resources/aws_untagged_resources.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.6.0",
+  version: "5.6.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Untagged Resources",
@@ -974,7 +974,6 @@ policy "pol_untagged_resources" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_tag_resources
-    hash_exclude "message"
     export do
       resource_level true
       field "type" do

--- a/compliance/azure/ahub_manual/CHANGELOG.md
+++ b/compliance/azure/ahub_manual/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.1.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v4.1.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/compliance/azure/ahub_manual/CHANGELOG.md
+++ b/compliance/azure/ahub_manual/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v4.1.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/compliance/azure/ahub_manual/CHANGELOG.md
+++ b/compliance/azure/ahub_manual/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.1.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v4.1.2

--- a/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry.pt
+++ b/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Compliance"
 default_frequency "weekly"
 info(
-  version: "4.1.2",
+  version: "4.1.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "Hybrid Use Benefit",
@@ -608,7 +608,7 @@ policy "pol_azure_ahub" do
     detail_template "{{ with index data 0 }}{{ .message }}{{ end }}"
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
-    hash_exclude "summary", "message", "tags"
+    hash_exclude "summary", "tags"
     export do
       resource_level true
       field "accountID" do

--- a/compliance/azure/azure_disallowed_regions/CHANGELOG.md
+++ b/compliance/azure/azure_disallowed_regions/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.2.1
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v4.2.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/compliance/azure/azure_disallowed_regions/CHANGELOG.md
+++ b/compliance/azure/azure_disallowed_regions/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.2.1
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v4.2.0

--- a/compliance/azure/azure_disallowed_regions/CHANGELOG.md
+++ b/compliance/azure/azure_disallowed_regions/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v4.2.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/compliance/azure/azure_disallowed_regions/azure_disallowed_regions.pt
+++ b/compliance/azure/azure_disallowed_regions/azure_disallowed_regions.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.2.0",
+  version: "4.2.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Disallowed Regions",
@@ -437,7 +437,7 @@ policy "pol_disallowed_regions" do
     escalate $esc_email
     escalate $esc_poweroff_instances
     escalate $esc_delete_instances
-    hash_exclude "message", "tags"
+    hash_exclude "tags"
     export do
       resource_level true
       field "accountID" do

--- a/compliance/azure/azure_untagged_resources/CHANGELOG.md
+++ b/compliance/azure/azure_untagged_resources/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v3.4.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v3.4.2

--- a/compliance/azure/azure_untagged_resources/CHANGELOG.md
+++ b/compliance/azure/azure_untagged_resources/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.4.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v3.4.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/compliance/azure/azure_untagged_resources/CHANGELOG.md
+++ b/compliance/azure/azure_untagged_resources/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v3.4.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/compliance/azure/azure_untagged_resources/untagged_resources.pt
+++ b/compliance/azure/azure_untagged_resources/untagged_resources.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "3.4.2",
+  version: "3.4.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "Untagged Resources",
@@ -619,7 +619,7 @@ policy "pol_azure_missing_tags" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_tag_resources
-    hash_exclude "message", "api_version"
+    hash_exclude "api_version"
     export do
       resource_level true
       field "type" do

--- a/compliance/azure/azure_untagged_vms/CHANGELOG.md
+++ b/compliance/azure/azure_untagged_vms/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v1.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/compliance/azure/azure_untagged_vms/CHANGELOG.md
+++ b/compliance/azure/azure_untagged_vms/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.2.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v1.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/compliance/azure/azure_untagged_vms/CHANGELOG.md
+++ b/compliance/azure/azure_untagged_vms/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.2.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v1.2.2

--- a/compliance/azure/azure_untagged_vms/untagged_vms.pt
+++ b/compliance/azure/azure_untagged_vms/untagged_vms.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "1.2.2",
+  version: "1.2.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "Untagged Resources",
@@ -469,7 +469,6 @@ policy "pol_azure_missing_tags" do
     escalate $esc_tag_instances
     escalate $esc_poweroff_instances
     escalate $esc_delete_instances
-    hash_exclude "message"
     export do
       resource_level true
       field "accountID" do

--- a/compliance/azure/deprecated_storage_accounts/CHANGELOG.md
+++ b/compliance/azure/deprecated_storage_accounts/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.4
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.2.3
 
 - Category of policy template updated to "Compliance". Functionality unchanged.

--- a/compliance/azure/deprecated_storage_accounts/CHANGELOG.md
+++ b/compliance/azure/deprecated_storage_accounts/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.4
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.2.3

--- a/compliance/azure/deprecated_storage_accounts/CHANGELOG.md
+++ b/compliance/azure/deprecated_storage_accounts/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.2.3
 
 - Category of policy template updated to "Compliance". Functionality unchanged.

--- a/compliance/azure/deprecated_storage_accounts/azure_deprecated_storage_accounts.pt
+++ b/compliance/azure/deprecated_storage_accounts/azure_deprecated_storage_accounts.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.3",
+  version: "0.2.4",
   provider: "Azure",
   service: "Storage Accounts",
   policy_set: "Deprecated Storage Accounts",
@@ -757,7 +757,7 @@ policy "pol_deprecated_storage_accounts" do
     detail_template "{{ with index data 0 }}{{ .message }}{{ end }}"
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
-    hash_exclude "cost_total", "cost_storage", "cost_network", "cost_operations", "cost_storage_percent", "cost_network_percent", "cost_operations_percent", "tags", "message"
+    hash_exclude "cost_total", "cost_storage", "cost_network", "cost_operations", "cost_storage_percent", "cost_network_percent", "cost_operations_percent", "tags"
     export do
       resource_level true
       field "accountID" do

--- a/compliance/google/long_stopped_instances/CHANGELOG.md
+++ b/compliance/google/long_stopped_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.2.5
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v4.2.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/compliance/google/long_stopped_instances/CHANGELOG.md
+++ b/compliance/google/long_stopped_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.2.5
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v4.2.4

--- a/compliance/google/long_stopped_instances/CHANGELOG.md
+++ b/compliance/google/long_stopped_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v4.2.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/compliance/google/long_stopped_instances/google_long_stopped_instances.pt
+++ b/compliance/google/long_stopped_instances/google_long_stopped_instances.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.2.4",
+  version: "4.2.5",
   provider: "Google",
   service: "Compute",
   policy_set: "Long Stopped Instances",
@@ -710,7 +710,7 @@ policy "pol_long_stopped_instances" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_instances
-    hash_exclude "tags", "message"
+    hash_exclude "tags"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/cheaper_regions/CHANGELOG.md
+++ b/cost/aws/cheaper_regions/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v1.2.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/cost/aws/cheaper_regions/CHANGELOG.md
+++ b/cost/aws/cheaper_regions/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.2.1
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v1.2.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/cost/aws/cheaper_regions/CHANGELOG.md
+++ b/cost/aws/cheaper_regions/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.2.1
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v1.2.0

--- a/cost/aws/cheaper_regions/aws_cheaper_regions.pt
+++ b/cost/aws/cheaper_regions/aws_cheaper_regions.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "1.2.0",
+  version: "1.2.1",
   provider: "AWS",
   service: "All",
   policy_set: "Cheaper Regions",
@@ -479,7 +479,7 @@ policy "pol_cheaper_regions" do
     EOS
     check eq(val(item, "id"), "")
     escalate $esc_email
-    hash_exclude "message", "total_savings", "savings", "savingsCurrency"
+    hash_exclude "total_savings", "savings", "savingsCurrency"
     export do
       resource_level true
       field "id" do

--- a/cost/aws/cheaper_regions/aws_cheaper_regions.pt
+++ b/cost/aws/cheaper_regions/aws_cheaper_regions.pt
@@ -479,7 +479,7 @@ policy "pol_cheaper_regions" do
     EOS
     check eq(val(item, "id"), "")
     escalate $esc_email
-    hash_exclude "total_savings", "savings", "savingsCurrency"
+    hash_exclude "savings", "savingsCurrency"
     export do
       resource_level true
       field "id" do

--- a/cost/aws/ec2_compute_optimizer/CHANGELOG.md
+++ b/cost/aws/ec2_compute_optimizer/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.6.0
 
 - Added graceful error handling for inaccessible AWS regions

--- a/cost/aws/ec2_compute_optimizer/CHANGELOG.md
+++ b/cost/aws/ec2_compute_optimizer/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.6.1
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.6.0
 
 - Added graceful error handling for inaccessible AWS regions

--- a/cost/aws/ec2_compute_optimizer/CHANGELOG.md
+++ b/cost/aws/ec2_compute_optimizer/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.6.1
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.6.0

--- a/cost/aws/ec2_compute_optimizer/aws_ec2_compute_optimizer.pt
+++ b/cost/aws/ec2_compute_optimizer/aws_ec2_compute_optimizer.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.6.0",
+  version: "0.6.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -1063,7 +1063,7 @@ policy "pol_utilization" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_resize_instances
-    hash_exclude "message", "total_savings", "tags", "savings", "savings_after_discount", "savingsCurrency", "cpuMaximum", "memMaximum", "ebsReadOps", "ebsWriteOps", "ebsReadBytes", "ebsWriteBytes", "netInBytes", "netOutBytes", "netInPackets", "netOutPackets", "gpuMaximum", "gpuMemoryMaximum"
+    hash_exclude "total_savings", "tags", "savings", "savings_after_discount", "savingsCurrency", "cpuMaximum", "memMaximum", "ebsReadOps", "ebsWriteOps", "ebsReadBytes", "ebsWriteBytes", "netInBytes", "netOutBytes", "netInPackets", "netOutPackets", "gpuMaximum", "gpuMemoryMaximum"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/ec2_compute_optimizer/aws_ec2_compute_optimizer.pt
+++ b/cost/aws/ec2_compute_optimizer/aws_ec2_compute_optimizer.pt
@@ -12,7 +12,8 @@ info(
   provider: "AWS",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
-  recommendation_type: "Usage Reduction"
+  recommendation_type: "Usage Reduction",
+  hide_skip_approvals: "true"
 )
 
 ###############################################################################

--- a/cost/aws/ec2_compute_optimizer/aws_ec2_compute_optimizer.pt
+++ b/cost/aws/ec2_compute_optimizer/aws_ec2_compute_optimizer.pt
@@ -1063,7 +1063,7 @@ policy "pol_utilization" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_resize_instances
-    hash_exclude "total_savings", "tags", "savings", "savings_after_discount", "savingsCurrency", "cpuMaximum", "memMaximum", "ebsReadOps", "ebsWriteOps", "ebsReadBytes", "ebsWriteBytes", "netInBytes", "netOutBytes", "netInPackets", "netOutPackets", "gpuMaximum", "gpuMemoryMaximum"
+    hash_exclude "tags", "savings", "savings_after_discount", "savingsCurrency", "cpuMaximum", "memMaximum", "ebsReadOps", "ebsWriteOps", "ebsReadBytes", "ebsWriteBytes", "netInBytes", "netOutBytes", "netInPackets", "netOutPackets", "gpuMaximum", "gpuMemoryMaximum"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/eks_without_spot/CHANGELOG.md
+++ b/cost/aws/eks_without_spot/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.2.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/eks_without_spot/CHANGELOG.md
+++ b/cost/aws/eks_without_spot/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.5
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.2.4

--- a/cost/aws/eks_without_spot/CHANGELOG.md
+++ b/cost/aws/eks_without_spot/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.5
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.2.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/eks_without_spot/aws_eks_without_spot.pt
+++ b/cost/aws/eks_without_spot/aws_eks_without_spot.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.4",
+  version: "0.2.5",
   provider: "AWS",
   service: "Compute",
   policy_set: "Autoscaling",
@@ -703,7 +703,7 @@ policy "pol_eks_clusters_without_spot" do
     detail_template "{{ with index data 0 }}{{ .message }}{{ end }}"
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
-    hash_exclude "tags", "message"
+    hash_exclude "tags"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/extended_support/CHANGELOG.md
+++ b/cost/aws/extended_support/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.1
+
+- Fixed issue with incident table that cause policy execution to fail
+
 ## v1.0.0
 
 - Policy template is now named `AWS Resources Under or Approaching Extended Support`.

--- a/cost/aws/extended_support/aws_extended_support.pt
+++ b/cost/aws/extended_support/aws_extended_support.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "1.0.0",
+  version: "1.0.1",
   provider: "AWS",
   service: "All",
   policy_set: "Deprecated Resources",
@@ -1287,7 +1287,7 @@ policy "pol_extended_support_resources" do
     EOS
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
-    hash_exclude "tags", "savings", "savingsCurrency", "daysUntilExtendedSupport", "total_savings"
+    hash_exclude "tags", "savings", "savingsCurrency", "daysUntilExtendedSupport"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/idle_fsx/CHANGELOG.md
+++ b/cost/aws/idle_fsx/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.1
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.2.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/cost/aws/idle_fsx/CHANGELOG.md
+++ b/cost/aws/idle_fsx/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.1
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.2.0

--- a/cost/aws/idle_fsx/CHANGELOG.md
+++ b/cost/aws/idle_fsx/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.2.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/cost/aws/idle_fsx/aws_idle_fsx.pt
+++ b/cost/aws/idle_fsx/aws_idle_fsx.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.0",
+  version: "0.2.1",
   provider: "AWS",
   service: "Storage",
   policy_set: "Unused Storage",
@@ -1076,7 +1076,7 @@ policy "pol_idle_fsx" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_filesystems
-    hash_exclude "total_savings", "message", "tags", "age", "savings", "savingsCurrency"
+    hash_exclude "total_savings", "tags", "age", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/idle_fsx/aws_idle_fsx.pt
+++ b/cost/aws/idle_fsx/aws_idle_fsx.pt
@@ -1076,7 +1076,7 @@ policy "pol_idle_fsx" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_filesystems
-    hash_exclude "total_savings", "tags", "age", "savings", "savingsCurrency"
+    hash_exclude "tags", "age", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/idle_lambda_functions/CHANGELOG.md
+++ b/cost/aws/idle_lambda_functions/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.1.1
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.1.0
 
 - Initial release

--- a/cost/aws/idle_lambda_functions/CHANGELOG.md
+++ b/cost/aws/idle_lambda_functions/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.1.0
 
 - Initial release

--- a/cost/aws/idle_lambda_functions/CHANGELOG.md
+++ b/cost/aws/idle_lambda_functions/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.1.1
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.1.0

--- a/cost/aws/idle_lambda_functions/aws_idle_lambda_functions.pt
+++ b/cost/aws/idle_lambda_functions/aws_idle_lambda_functions.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.1.0",
+  version: "0.1.1",
   provider: "AWS",
   service: "PaaS",
   policy_set: "Idle Lambda Functions",
@@ -1186,7 +1186,7 @@ policy "pol_idle_lambda_functions" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_functions
-    hash_exclude "message", "total_savings", "tags", "savings", "savingsCurrency", "savingsSource", "invocations"
+    hash_exclude "total_savings", "tags", "savings", "savingsCurrency", "savingsSource", "invocations"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/idle_lambda_functions/aws_idle_lambda_functions.pt
+++ b/cost/aws/idle_lambda_functions/aws_idle_lambda_functions.pt
@@ -1186,7 +1186,7 @@ policy "pol_idle_lambda_functions" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_functions
-    hash_exclude "total_savings", "tags", "savings", "savingsCurrency", "savingsSource", "invocations"
+    hash_exclude "tags", "savings", "savingsCurrency", "savingsSource", "invocations"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/idle_nat_gateways/CHANGELOG.md
+++ b/cost/aws/idle_nat_gateways/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.6
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.3.5
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/idle_nat_gateways/CHANGELOG.md
+++ b/cost/aws/idle_nat_gateways/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3.6
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.3.5

--- a/cost/aws/idle_nat_gateways/CHANGELOG.md
+++ b/cost/aws/idle_nat_gateways/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.3.5
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/idle_nat_gateways/aws_idle_nat_gateways.pt
+++ b/cost/aws/idle_nat_gateways/aws_idle_nat_gateways.pt
@@ -978,7 +978,7 @@ policy "pol_idle_gateways" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_gateways
-    hash_exclude "total_savings", "tags", "savings", "savingsCurrency"
+    hash_exclude "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/idle_nat_gateways/aws_idle_nat_gateways.pt
+++ b/cost/aws/idle_nat_gateways/aws_idle_nat_gateways.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.5",
+  version: "0.3.6",
   provider: "AWS",
   service: "Network",
   policy_set: "Idle NAT Gateways",
@@ -978,7 +978,7 @@ policy "pol_idle_gateways" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_gateways
-    hash_exclude "message", "total_savings", "tags", "savings", "savingsCurrency"
+    hash_exclude "total_savings", "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/object_storage_optimization/CHANGELOG.md
+++ b/cost/aws/object_storage_optimization/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v4.0.11
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/object_storage_optimization/CHANGELOG.md
+++ b/cost/aws/object_storage_optimization/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.0.12
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v4.0.11

--- a/cost/aws/object_storage_optimization/CHANGELOG.md
+++ b/cost/aws/object_storage_optimization/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.0.12
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v4.0.11
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.0.11",
+  version: "4.0.12",
   provider: "AWS",
   service: "Storage",
   policy_set: "Object Store Optimization",
@@ -622,7 +622,7 @@ policy "pol_s3_object_list" do
     escalate $esc_email
     escalate $esc_update
     escalate $esc_delete
-    hash_exclude "message", "tags"
+    hash_exclude "tags"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/old_snapshots/CHANGELOG.md
+++ b/cost/aws/old_snapshots/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v8.6.6
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v8.6.5
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/old_snapshots/CHANGELOG.md
+++ b/cost/aws/old_snapshots/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v8.6.5
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/old_snapshots/CHANGELOG.md
+++ b/cost/aws/old_snapshots/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v8.6.6
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v8.6.5

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -1289,7 +1289,7 @@ policy "pol_utilization" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), "")) # Policy check fails and incident is created only if data is not empty and the Parent Policy has not been terminated
     escalate $esc_email
     escalate $esc_delete_snapshot
-    hash_exclude "total_savings", "tags", "age", "savings", "savingsCurrency"
+    hash_exclude "tags", "age", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "8.6.5",
+  version: "8.6.6",
   provider: "AWS",
   service: "Storage",
   policy_set: "Old Snapshots",
@@ -1289,7 +1289,7 @@ policy "pol_utilization" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), "")) # Policy check fails and incident is created only if data is not empty and the Parent Policy has not been terminated
     escalate $esc_email
     escalate $esc_delete_snapshot
-    hash_exclude "total_savings", "message", "tags", "age", "savings", "savingsCurrency"
+    hash_exclude "total_savings", "tags", "age", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.5.5
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.5.6
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.5.5

--- a/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.5.6
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.5.5
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/rightsize_ebs_volumes/aws_rightsize_ebs_volumes.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_rightsize_ebs_volumes.pt
@@ -1537,7 +1537,7 @@ policy "pol_unused_volumes" do
     escalate $esc_email
     escalate $esc_delete_volumes
     escalate $esc_modify_volumes
-    hash_exclude "age", "total_savings", "tags", "savings", "savingsCurrency"
+    hash_exclude "age", "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do
@@ -1627,7 +1627,7 @@ policy "pol_unused_volumes" do
     escalate $esc_email
     escalate $esc_delete_volumes
     escalate $esc_modify_volumes
-    hash_exclude "age", "total_savings", "tags", "savings", "savingsCurrency"
+    hash_exclude "age", "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/rightsize_ebs_volumes/aws_rightsize_ebs_volumes.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_rightsize_ebs_volumes.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.5",
+  version: "0.5.6",
   provider: "AWS",
   service: "EBS",
   policy_set: "Unused Volumes",
@@ -1537,7 +1537,7 @@ policy "pol_unused_volumes" do
     escalate $esc_email
     escalate $esc_delete_volumes
     escalate $esc_modify_volumes
-    hash_exclude "age", "message", "total_savings", "tags", "savings", "savingsCurrency"
+    hash_exclude "age", "total_savings", "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do
@@ -1627,7 +1627,7 @@ policy "pol_unused_volumes" do
     escalate $esc_email
     escalate $esc_delete_volumes
     escalate $esc_modify_volumes
-    hash_exclude "age", "message", "total_savings", "tags", "savings", "savingsCurrency"
+    hash_exclude "age", "total_savings", "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/rightsize_elasticache/CHANGELOG.md
+++ b/cost/aws/rightsize_elasticache/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.5.7
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.5.6

--- a/cost/aws/rightsize_elasticache/CHANGELOG.md
+++ b/cost/aws/rightsize_elasticache/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.5.7
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.5.6
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/rightsize_elasticache/CHANGELOG.md
+++ b/cost/aws/rightsize_elasticache/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.5.6
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/rightsize_elasticache/aws_rightsize_elasticache.pt
+++ b/cost/aws/rightsize_elasticache/aws_rightsize_elasticache.pt
@@ -1556,7 +1556,7 @@ policy "pol_underutilized_elasticache_clusters" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_resize_clusters
-    hash_exclude "total_savings", "tags", "savings", "savingsCurrency"
+    hash_exclude "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/rightsize_elasticache/aws_rightsize_elasticache.pt
+++ b/cost/aws/rightsize_elasticache/aws_rightsize_elasticache.pt
@@ -1556,7 +1556,7 @@ policy "pol_underutilized_elasticache_clusters" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_resize_clusters
-    hash_exclude "tags", "savings", "savingsCurrency"
+    hash_exclude "tags", "savings", "savingsCurrency", "cpuMaximum", "cpuMinimum", "cpuAverage", "cpuP99", "cpuP95", "cpuP90", "memMaximum", "memMinimum", "memAverage", "memP99", "memP95", "memP90"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/rightsize_elasticache/aws_rightsize_elasticache.pt
+++ b/cost/aws/rightsize_elasticache/aws_rightsize_elasticache.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.6",
+  version: "0.5.7",
   provider: "AWS",
   service: "Database",
   policy_set: "Rightsize Database Instances",
@@ -1556,7 +1556,7 @@ policy "pol_underutilized_elasticache_clusters" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_resize_clusters
-    hash_exclude "message", "total_savings", "tags", "savings", "savingsCurrency"
+    hash_exclude "total_savings", "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/rightsize_rds_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_rds_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v5.10.5
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/rightsize_rds_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_rds_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v5.10.6
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v5.10.5

--- a/cost/aws/rightsize_rds_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_rds_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v5.10.6
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v5.10.5
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
@@ -2129,7 +2129,7 @@ policy "pol_rightsize_rds" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_downsize_rds_instances
-    hash_exclude "tags", "savings", "savingsCurrency"
+    hash_exclude "tags", "savings", "savingsCurrency", "cpuMaximum", "cpuMinimum", "cpuAverage", "cpuP99", "cpuP95", "cpuP90", "memMaximum", "memMinimum", "memAverage", "netinMaximum", "netinMinimum", "netinAverage", "netoutMaximum", "netoutMinimum", "netoutAverage"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "5.10.5",
+  version: "5.10.6",
   provider: "AWS",
   service: "RDS",
   policy_set: "Rightsize Database Instances",
@@ -2129,7 +2129,7 @@ policy "pol_rightsize_rds" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_downsize_rds_instances
-    hash_exclude "tags", "total_savings", "message", "savings", "savingsCurrency"
+    hash_exclude "tags", "total_savings", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do
@@ -2266,7 +2266,7 @@ policy "pol_rightsize_rds" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_terminate_rds_instances
-    hash_exclude "tags", "total_savings", "message", "savings", "savingsCurrency"
+    hash_exclude "tags", "total_savings", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
@@ -2129,7 +2129,7 @@ policy "pol_rightsize_rds" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_downsize_rds_instances
-    hash_exclude "tags", "total_savings", "savings", "savingsCurrency"
+    hash_exclude "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do
@@ -2266,7 +2266,7 @@ policy "pol_rightsize_rds" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_terminate_rds_instances
-    hash_exclude "tags", "total_savings", "savings", "savingsCurrency"
+    hash_exclude "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/rightsize_redshift/CHANGELOG.md
+++ b/cost/aws/rightsize_redshift/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.3.0
 
 - Added graceful error handling for inaccessible AWS regions

--- a/cost/aws/rightsize_redshift/CHANGELOG.md
+++ b/cost/aws/rightsize_redshift/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.1
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.3.0
 
 - Added graceful error handling for inaccessible AWS regions

--- a/cost/aws/rightsize_redshift/CHANGELOG.md
+++ b/cost/aws/rightsize_redshift/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3.1
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.3.0

--- a/cost/aws/rightsize_redshift/aws_rightsize_redshift.pt
+++ b/cost/aws/rightsize_redshift/aws_rightsize_redshift.pt
@@ -1301,7 +1301,7 @@ policy "pol_underutilized_redshift_clusters" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_resize_clusters
-    hash_exclude "total_savings", "tags", "savings", "savingsCurrency"
+    hash_exclude "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/rightsize_redshift/aws_rightsize_redshift.pt
+++ b/cost/aws/rightsize_redshift/aws_rightsize_redshift.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.0",
+  version: "0.3.1",
   provider: "AWS",
   service: "Database",
   policy_set: "Rightsize Database Instances",
@@ -1301,7 +1301,7 @@ policy "pol_underutilized_redshift_clusters" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_resize_clusters
-    hash_exclude "message", "total_savings", "tags", "savings", "savingsCurrency"
+    hash_exclude "total_savings", "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/rightsize_redshift/aws_rightsize_redshift.pt
+++ b/cost/aws/rightsize_redshift/aws_rightsize_redshift.pt
@@ -1301,7 +1301,7 @@ policy "pol_underutilized_redshift_clusters" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_resize_clusters
-    hash_exclude "tags", "savings", "savingsCurrency"
+    hash_exclude "tags", "savings", "savingsCurrency", "cpuMaximum", "cpuMinimum", "cpuAverage", "cpuP99", "cpuP95", "cpuP90"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/superseded_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/superseded_ebs_volumes/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v6.5.5
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/superseded_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/superseded_ebs_volumes/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v6.5.6
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v6.5.5
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/superseded_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/superseded_ebs_volumes/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v6.5.6
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v6.5.5

--- a/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
+++ b/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
@@ -1294,7 +1294,7 @@ policy "pol_underutil_volumes" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_upgrade_volumes
-    hash_exclude "age", "tags", "resourceName", "savings", "savingsCurrency", "total_savings", "attachmentStatus"
+    hash_exclude "age", "tags", "resourceName", "savings", "savingsCurrency", "attachmentStatus"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
+++ b/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "6.5.5",
+  version: "6.5.6",
   provider: "AWS",
   service: "Compute",
   policy_set: "Inefficient Disk Usage",
@@ -1294,7 +1294,7 @@ policy "pol_underutil_volumes" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_upgrade_volumes
-    hash_exclude "age", "tags", "resourceName", "savings", "savingsCurrency", "total_savings", "message", "attachmentStatus"
+    hash_exclude "age", "tags", "resourceName", "savings", "savingsCurrency", "total_savings", "attachmentStatus"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/superseded_instances/CHANGELOG.md
+++ b/cost/aws/superseded_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v3.2.6
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v3.2.5

--- a/cost/aws/superseded_instances/CHANGELOG.md
+++ b/cost/aws/superseded_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v3.2.5
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/superseded_instances/CHANGELOG.md
+++ b/cost/aws/superseded_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.2.6
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v3.2.5
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/superseded_instances/aws_superseded_instances.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances.pt
@@ -1214,7 +1214,7 @@ policy "pol_superseded_instances" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_change_type
-    hash_exclude "total_savings", "resourceName", "tags", "cost", "instance_type_price", "superseded_type_price", "savings", "savingsCurrency"
+    hash_exclude "resourceName", "tags", "cost", "instance_type_price", "superseded_type_price", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/superseded_instances/aws_superseded_instances.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.2.5",
+  version: "3.2.6",
   provider: "AWS",
   service: "Compute",
   policy_set: "Superseded Compute Instances",
@@ -1214,7 +1214,7 @@ policy "pol_superseded_instances" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_change_type
-    hash_exclude "message", "total_savings", "resourceName", "tags", "cost", "instance_type_price", "superseded_type_price", "savings", "savingsCurrency"
+    hash_exclude "total_savings", "resourceName", "tags", "cost", "instance_type_price", "superseded_type_price", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/unused_albs/CHANGELOG.md
+++ b/cost/aws/unused_albs/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.4.5
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/unused_albs/CHANGELOG.md
+++ b/cost/aws/unused_albs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.4.6
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.4.5

--- a/cost/aws/unused_albs/CHANGELOG.md
+++ b/cost/aws/unused_albs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.6
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.4.5
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/unused_albs/aws_unused_albs.pt
+++ b/cost/aws/unused_albs/aws_unused_albs.pt
@@ -1168,7 +1168,7 @@ policy "pol_unused_albs" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_albs
-    hash_exclude "total_savings", "tags", "savings", "savingsCurrency"
+    hash_exclude "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/unused_albs/aws_unused_albs.pt
+++ b/cost/aws/unused_albs/aws_unused_albs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.5",
+  version: "0.4.6",
   provider: "AWS",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -1168,7 +1168,7 @@ policy "pol_unused_albs" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_albs
-    hash_exclude "message", "total_savings", "tags", "savings", "savingsCurrency"
+    hash_exclude "total_savings", "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/unused_clbs/CHANGELOG.md
+++ b/cost/aws/unused_clbs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v6.6.1
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v6.6.0
 
 - Added graceful error handling for inaccessible AWS regions

--- a/cost/aws/unused_clbs/CHANGELOG.md
+++ b/cost/aws/unused_clbs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v6.6.1
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v6.6.0

--- a/cost/aws/unused_clbs/CHANGELOG.md
+++ b/cost/aws/unused_clbs/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v6.6.0
 
 - Added graceful error handling for inaccessible AWS regions

--- a/cost/aws/unused_clbs/aws_unused_clbs.pt
+++ b/cost/aws/unused_clbs/aws_unused_clbs.pt
@@ -1044,7 +1044,7 @@ policy "pol_unused_clbs" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_clbs
-    hash_exclude "instances", "total_savings", "tags", "savings", "savingsCurrency"
+    hash_exclude "instances", "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/unused_clbs/aws_unused_clbs.pt
+++ b/cost/aws/unused_clbs/aws_unused_clbs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.6.0",
+  version: "6.6.1",
   provider: "AWS",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -1044,7 +1044,7 @@ policy "pol_unused_clbs" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_clbs
-    hash_exclude "instances", "message", "total_savings", "tags", "savings", "savingsCurrency"
+    hash_exclude "instances", "total_savings", "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/unused_ip_addresses/CHANGELOG.md
+++ b/cost/aws/unused_ip_addresses/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v9.5.1
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v9.5.0

--- a/cost/aws/unused_ip_addresses/CHANGELOG.md
+++ b/cost/aws/unused_ip_addresses/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v9.5.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/cost/aws/unused_ip_addresses/CHANGELOG.md
+++ b/cost/aws/unused_ip_addresses/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v9.5.1
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v9.5.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
@@ -1032,7 +1032,7 @@ policy "pol_unused_ips" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "publicIp"), ""))
     escalate $esc_email
     escalate $esc_release_ip_address
-    hash_exclude "age", "tags", "savings", "savingsCurrency", "total_savings"
+    hash_exclude "age", "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "9.5.0",
+  version: "9.5.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Unused IP Addresses",
@@ -1032,7 +1032,7 @@ policy "pol_unused_ips" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "publicIp"), ""))
     escalate $esc_email
     escalate $esc_release_ip_address
-    hash_exclude "age", "tags", "savings", "savingsCurrency", "total_savings", "message"
+    hash_exclude "age", "tags", "savings", "savingsCurrency", "total_savings"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/unused_nlbs/CHANGELOG.md
+++ b/cost/aws/unused_nlbs/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.4.5
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/unused_nlbs/CHANGELOG.md
+++ b/cost/aws/unused_nlbs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.4.6
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.4.5

--- a/cost/aws/unused_nlbs/CHANGELOG.md
+++ b/cost/aws/unused_nlbs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.6
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.4.5
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/unused_nlbs/aws_unused_nlbs.pt
+++ b/cost/aws/unused_nlbs/aws_unused_nlbs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.5",
+  version: "0.4.6",
   provider: "AWS",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -1168,7 +1168,7 @@ policy "pol_unused_nlbs" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_nlbs
-    hash_exclude "message", "total_savings", "tags", "savings", "savingsCurrency"
+    hash_exclude "total_savings", "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/aws/unused_nlbs/aws_unused_nlbs.pt
+++ b/cost/aws/unused_nlbs/aws_unused_nlbs.pt
@@ -1168,7 +1168,7 @@ policy "pol_unused_nlbs" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_nlbs
-    hash_exclude "total_savings", "tags", "savings", "savingsCurrency"
+    hash_exclude "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/advisor_compute/CHANGELOG.md
+++ b/cost/azure/advisor_compute/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/advisor_compute/CHANGELOG.md
+++ b/cost/azure/advisor_compute/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/advisor_compute/CHANGELOG.md
+++ b/cost/azure/advisor_compute/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.2.2

--- a/cost/azure/advisor_compute/azure_advisor_compute.pt
+++ b/cost/azure/advisor_compute/azure_advisor_compute.pt
@@ -864,7 +864,7 @@ policy "pol_recommendations_merged" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_resize_instances
-    hash_exclude "total_savings", "tags", "savings", "savingsCurrency", "cpuP95", "memP95", "netP95"
+    hash_exclude "tags", "savings", "savingsCurrency", "cpuP95", "memP95", "netP95"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/advisor_compute/azure_advisor_compute.pt
+++ b/cost/azure/advisor_compute/azure_advisor_compute.pt
@@ -13,6 +13,7 @@ info(
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
   recommendation_type: "Usage Reduction",
+  hide_skip_approvals: "true",
   publish: "false"
 )
 

--- a/cost/azure/advisor_compute/azure_advisor_compute.pt
+++ b/cost/azure/advisor_compute/azure_advisor_compute.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.2",
+  version: "0.2.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -864,7 +864,7 @@ policy "pol_recommendations_merged" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_resize_instances
-    hash_exclude "message", "total_savings", "tags", "savings", "savingsCurrency", "cpuP95", "memP95", "netP95"
+    hash_exclude "total_savings", "tags", "savings", "savingsCurrency", "cpuP95", "memP95", "netP95"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/blob_storage_optimization/CHANGELOG.md
+++ b/cost/azure/blob_storage_optimization/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v4.0.11
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/blob_storage_optimization/CHANGELOG.md
+++ b/cost/azure/blob_storage_optimization/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.0.12
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v4.0.11

--- a/cost/azure/blob_storage_optimization/CHANGELOG.md
+++ b/cost/azure/blob_storage_optimization/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.0.12
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v4.0.11
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/blob_storage_optimization/azure_blob_storage_optimization.pt
+++ b/cost/azure/blob_storage_optimization/azure_blob_storage_optimization.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.0.11",
+  version: "4.0.12",
   provider: "Azure",
   service: "Storage",
   policy_set: "Object Store Optimization",
@@ -671,7 +671,7 @@ policy "pol_azure_blobs_list" do
     escalate $esc_email
     escalate $esc_update
     escalate $esc_delete
-    hash_exclude "message", "tags"
+    hash_exclude "tags"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/cheaper_regions/CHANGELOG.md
+++ b/cost/azure/cheaper_regions/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v1.2.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/cost/azure/cheaper_regions/CHANGELOG.md
+++ b/cost/azure/cheaper_regions/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.2.1
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v1.2.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/cost/azure/cheaper_regions/CHANGELOG.md
+++ b/cost/azure/cheaper_regions/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.2.1
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v1.2.0

--- a/cost/azure/cheaper_regions/azure_cheaper_regions.pt
+++ b/cost/azure/cheaper_regions/azure_cheaper_regions.pt
@@ -489,7 +489,7 @@ policy "pol_cheaper_regions" do
     EOS
     check eq(val(item, "id"), "")
     escalate $esc_email
-    hash_exclude "total_savings", "savings", "savingsCurrency"
+    hash_exclude "savings", "savingsCurrency"
     export do
       resource_level true
       field "id" do

--- a/cost/azure/cheaper_regions/azure_cheaper_regions.pt
+++ b/cost/azure/cheaper_regions/azure_cheaper_regions.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "1.2.0",
+  version: "1.2.1",
   provider: "Azure",
   service: "All",
   policy_set: "Cheaper Regions",
@@ -489,7 +489,7 @@ policy "pol_cheaper_regions" do
     EOS
     check eq(val(item, "id"), "")
     escalate $esc_email
-    hash_exclude "message", "total_savings", "savings", "savingsCurrency"
+    hash_exclude "total_savings", "savings", "savingsCurrency"
     export do
       resource_level true
       field "id" do

--- a/cost/azure/data_lake_optimization/CHANGELOG.md
+++ b/cost/azure/data_lake_optimization/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/data_lake_optimization/CHANGELOG.md
+++ b/cost/azure/data_lake_optimization/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/data_lake_optimization/CHANGELOG.md
+++ b/cost/azure/data_lake_optimization/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.2.2

--- a/cost/azure/data_lake_optimization/data_lake_optimization.pt
+++ b/cost/azure/data_lake_optimization/data_lake_optimization.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "0.2.2",
+  version: "0.2.3",
   provider: "Azure",
   service: "Storage Accounts",
   policy_set: "Data Lake Optimization",
@@ -877,7 +877,7 @@ policy "pol_azure_blobs_list" do
     escalate $esc_email
     escalate $esc_update
     escalate $esc_delete
-    hash_exclude "message", "tags"
+    hash_exclude "tags"
     export "recommendations" do
       resource_level true
       field "accountID" do

--- a/cost/azure/databricks/rightsize_compute/CHANGELOG.md
+++ b/cost/azure/databricks/rightsize_compute/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.6.3
 
 - Added `hash_exclude` directives to idle and underutilized incident blocks to prevent spurious incident re-opens when savings estimates or utilization metrics change between runs.

--- a/cost/azure/databricks/rightsize_compute/CHANGELOG.md
+++ b/cost/azure/databricks/rightsize_compute/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.6.4
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.6.3
 
 - Added `hash_exclude` directives to idle and underutilized incident blocks to prevent spurious incident re-opens when savings estimates or utilization metrics change between runs.

--- a/cost/azure/databricks/rightsize_compute/CHANGELOG.md
+++ b/cost/azure/databricks/rightsize_compute/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.6.4
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.6.3

--- a/cost/azure/databricks/rightsize_compute/azure_databricks_rightsize_compute.pt
+++ b/cost/azure/databricks/rightsize_compute/azure_databricks_rightsize_compute.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.6.3",
+  version: "0.6.4",
   provider: "Azure",
   service: "Databricks",
   policy_set: "Databricks",
@@ -1847,7 +1847,7 @@ EOS
     EOS
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceId"), ""))
     escalate $esc_email
-    hash_exclude "message", "savings", "savingsCurrency", "cpuMaximum", "cpuMinimum", "cpuAverage", "cpuP99", "cpuP95", "cpuP90", "memMaximum", "memMinimum", "memAverage", "memP99", "memP95", "memP90"
+    hash_exclude "savings", "savingsCurrency", "cpuMaximum", "cpuMinimum", "cpuAverage", "cpuP99", "cpuP95", "cpuP90", "memMaximum", "memMinimum", "memAverage", "memP99", "memP95", "memP90"
     export do
       resource_level true
       field "savings" do
@@ -1999,7 +1999,7 @@ EOS
     EOS
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceId"), ""))
     escalate $esc_email
-    hash_exclude "message", "savings", "savingsCurrency", "cpuMaximum", "cpuMinimum", "cpuAverage", "cpuP99", "cpuP95", "cpuP90", "memMaximum", "memMinimum", "memAverage", "memP99", "memP95", "memP90"
+    hash_exclude "savings", "savingsCurrency", "cpuMaximum", "cpuMinimum", "cpuAverage", "cpuP99", "cpuP95", "cpuP90", "memMaximum", "memMinimum", "memAverage", "memP99", "memP95", "memP90"
     export do
       resource_level true
       field "savings" do

--- a/cost/azure/hybrid_use_benefit/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v5.3.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v5.3.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/hybrid_use_benefit/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v5.3.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/hybrid_use_benefit/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v5.3.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v5.3.2

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit.pt
@@ -914,7 +914,7 @@ policy "pol_azure_ahub_recommendations" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
     escalate $esc_email
     escalate $esc_license_instances
-    hash_exclude "total_savings", "tags", "savings", "savingsCurrency"
+    hash_exclude "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "5.3.2",
+  version: "5.3.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "Hybrid Use Benefit",
@@ -914,7 +914,7 @@ policy "pol_azure_ahub_recommendations" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
     escalate $esc_email
     escalate $esc_license_instances
-    hash_exclude "total_savings", "message", "tags", "savings", "savingsCurrency"
+    hash_exclude "total_savings", "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/hybrid_use_benefit_linux/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit_linux/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v5.2.4
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v5.2.3

--- a/cost/azure/hybrid_use_benefit_linux/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit_linux/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v5.2.4
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v5.2.3
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/hybrid_use_benefit_linux/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit_linux/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v5.2.3
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "5.2.3",
+  version: "5.2.4",
   provider: "Azure",
   service: "Compute",
   policy_set: "Hybrid Use Benefit",
@@ -761,7 +761,7 @@ policy "pol_azure_ahub_recommendations" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
     escalate $esc_email
     escalate $esc_license_instances
-    hash_exclude "message", "tags"
+    hash_exclude "tags"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/long_stopped_instances/CHANGELOG.md
+++ b/cost/azure/long_stopped_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v6.1.6
 
 - Category of policy template updated to "Cost". Functionality unchanged.

--- a/cost/azure/long_stopped_instances/CHANGELOG.md
+++ b/cost/azure/long_stopped_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v6.1.7
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v6.1.6
 
 - Category of policy template updated to "Cost". Functionality unchanged.

--- a/cost/azure/long_stopped_instances/CHANGELOG.md
+++ b/cost/azure/long_stopped_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v6.1.7
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v6.1.6

--- a/cost/azure/long_stopped_instances/long_stopped_instances_azure.pt
+++ b/cost/azure/long_stopped_instances/long_stopped_instances_azure.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.1.6",
+  version: "6.1.7",
   provider: "Azure",
   service: "Compute",
   policy_set: "Long Stopped Instances",
@@ -1087,7 +1087,7 @@ policy "pol_stopped_instances" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_instances
-    hash_exclude "message", "total_savings", "tags", "vmCost", "diskCost", "diskNames", "diskCount", "savings", "savingsCurrency"
+    hash_exclude "total_savings", "tags", "vmCost", "diskCost", "diskNames", "diskCount", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/long_stopped_instances/long_stopped_instances_azure.pt
+++ b/cost/azure/long_stopped_instances/long_stopped_instances_azure.pt
@@ -1087,7 +1087,7 @@ policy "pol_stopped_instances" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_instances
-    hash_exclude "total_savings", "tags", "vmCost", "diskCost", "diskNames", "diskCount", "savings", "savingsCurrency"
+    hash_exclude "tags", "vmCost", "diskCost", "diskNames", "diskCount", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/old_snapshots/CHANGELOG.md
+++ b/cost/azure/old_snapshots/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v7.3.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v7.3.2

--- a/cost/azure/old_snapshots/CHANGELOG.md
+++ b/cost/azure/old_snapshots/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v7.3.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v7.3.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/old_snapshots/CHANGELOG.md
+++ b/cost/azure/old_snapshots/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v7.3.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "7.3.2",
+  version: "7.3.3",
   provider: "Azure",
   service: "Storage",
   policy_set: "Old Snapshots",
@@ -778,7 +778,7 @@ policy "pol_azure_old_snapshots" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_snapshot
-    hash_exclude "total_savings", "message", "tags", "age", "savings", "savingsCurrency"
+    hash_exclude "total_savings", "tags", "age", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots.pt
@@ -778,7 +778,7 @@ policy "pol_azure_old_snapshots" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_snapshot
-    hash_exclude "total_savings", "tags", "age", "savings", "savingsCurrency"
+    hash_exclude "tags", "age", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/rightsize_managed_sql/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_sql/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.4.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/rightsize_managed_sql/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_sql/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.4.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/rightsize_managed_sql/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_sql/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.4.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.4.2

--- a/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql.pt
+++ b/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.2",
+  version: "0.4.3",
   provider: "Azure",
   service: "SQL",
   policy_set: "Rightsize Database Instances",
@@ -1098,7 +1098,7 @@ policy "pol_azure_sql_utilization" do
     escalate $esc_email
     escalate $esc_downsize_instances
     escalate $esc_delete_instances
-    hash_exclude "savings", "savingsCurrency", "tags", "cpuAverage", "cpuMinimum", "cpuMaximum", "cpuP90", "cpuP95", "cpuP99", "policy_name", "total_savings", "message"
+    hash_exclude "savings", "savingsCurrency", "tags", "cpuAverage", "cpuMinimum", "cpuMaximum", "cpuP90", "cpuP95", "cpuP99", "policy_name", "total_savings"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql.pt
+++ b/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql.pt
@@ -1098,7 +1098,7 @@ policy "pol_azure_sql_utilization" do
     escalate $esc_email
     escalate $esc_downsize_instances
     escalate $esc_delete_instances
-    hash_exclude "savings", "savingsCurrency", "tags", "cpuAverage", "cpuMinimum", "cpuMaximum", "cpuP90", "cpuP95", "cpuP99", "policy_name", "total_savings"
+    hash_exclude "savings", "savingsCurrency", "tags", "cpuAverage", "cpuMinimum", "cpuMaximum", "cpuP90", "cpuP95", "cpuP99", "policy_name"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/rightsize_managed_sql_storage/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_sql_storage/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.3.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/rightsize_managed_sql_storage/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_sql_storage/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.3.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/rightsize_managed_sql_storage/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_sql_storage/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.3.2

--- a/cost/azure/rightsize_managed_sql_storage/azure_rightsize_managed_sql_storage.pt
+++ b/cost/azure/rightsize_managed_sql_storage/azure_rightsize_managed_sql_storage.pt
@@ -832,7 +832,7 @@ policy "pol_azure_sql_utilization" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
     escalate $esc_email
     escalate $esc_downsize_sqlmi_storage
-    hash_exclude "tags", "usedSpaceGB", "policy_name"
+    hash_exclude "tags", "usedSpaceGB", "policy_name", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/rightsize_managed_sql_storage/azure_rightsize_managed_sql_storage.pt
+++ b/cost/azure/rightsize_managed_sql_storage/azure_rightsize_managed_sql_storage.pt
@@ -832,7 +832,7 @@ policy "pol_azure_sql_utilization" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
     escalate $esc_email
     escalate $esc_downsize_sqlmi_storage
-    hash_exclude "tags", "usedSpaceGB", "policy_name", "total_savings"
+    hash_exclude "tags", "usedSpaceGB", "policy_name"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/rightsize_managed_sql_storage/azure_rightsize_managed_sql_storage.pt
+++ b/cost/azure/rightsize_managed_sql_storage/azure_rightsize_managed_sql_storage.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.2",
+  version: "0.3.3",
   provider: "Azure",
   service: "SQL",
   policy_set: "Rightsize Database Instances",
@@ -832,7 +832,7 @@ policy "pol_azure_sql_utilization" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
     escalate $esc_email
     escalate $esc_downsize_sqlmi_storage
-    hash_exclude "tags", "usedSpaceGB", "policy_name", "total_savings", "message"
+    hash_exclude "tags", "usedSpaceGB", "policy_name", "total_savings"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/rightsize_mysql_flexible/CHANGELOG.md
+++ b/cost/azure/rightsize_mysql_flexible/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.3.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/rightsize_mysql_flexible/CHANGELOG.md
+++ b/cost/azure/rightsize_mysql_flexible/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.3.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/rightsize_mysql_flexible/CHANGELOG.md
+++ b/cost/azure/rightsize_mysql_flexible/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.3.2

--- a/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible.pt
+++ b/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible.pt
@@ -1296,7 +1296,7 @@ policy "pol_azure_mysql_utilization" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
     escalate $esc_email
     escalate $esc_downsize_servers
-    hash_exclude "savings", "savingsCurrency", "tags", "cpuAverage", "policy_name", "total_savings"
+    hash_exclude "savings", "savingsCurrency", "tags", "cpuAverage", "policy_name"
     export do
       resource_level true
       field "accountID" do
@@ -1406,7 +1406,7 @@ policy "pol_azure_mysql_utilization" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
     escalate $esc_email
     escalate $esc_delete_servers
-    hash_exclude "savings", "savingsCurrency", "tags", "policy_name", "total_savings"
+    hash_exclude "savings", "savingsCurrency", "tags", "policy_name"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible.pt
+++ b/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible.pt
@@ -1296,7 +1296,7 @@ policy "pol_azure_mysql_utilization" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
     escalate $esc_email
     escalate $esc_downsize_servers
-    hash_exclude "savings", "savingsCurrency", "tags", "cpuAverage", "policy_name"
+    hash_exclude "savings", "savingsCurrency", "tags", "cpuAverage", "policy_name", "cpuMaximum", "cpuMinimum", "cpuP99", "cpuP95", "cpuP90"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible.pt
+++ b/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.2",
+  version: "0.3.3",
   provider: "Azure",
   service: "MySQL",
   policy_set: "Rightsize Database Instances",
@@ -1296,7 +1296,7 @@ policy "pol_azure_mysql_utilization" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
     escalate $esc_email
     escalate $esc_downsize_servers
-    hash_exclude "savings", "savingsCurrency", "tags", "cpuAverage", "policy_name", "total_savings", "message"
+    hash_exclude "savings", "savingsCurrency", "tags", "cpuAverage", "policy_name", "total_savings"
     export do
       resource_level true
       field "accountID" do
@@ -1406,7 +1406,7 @@ policy "pol_azure_mysql_utilization" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
     escalate $esc_email
     escalate $esc_delete_servers
-    hash_exclude "savings", "savingsCurrency", "tags", "policy_name", "total_savings", "message"
+    hash_exclude "savings", "savingsCurrency", "tags", "policy_name", "total_savings"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/rightsize_mysql_single/CHANGELOG.md
+++ b/cost/azure/rightsize_mysql_single/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.3.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/rightsize_mysql_single/CHANGELOG.md
+++ b/cost/azure/rightsize_mysql_single/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.3.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/rightsize_mysql_single/CHANGELOG.md
+++ b/cost/azure/rightsize_mysql_single/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.3.2

--- a/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single.pt
+++ b/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single.pt
@@ -1287,7 +1287,7 @@ policy "pol_azure_mysql_utilization" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
     escalate $esc_email
     escalate $esc_downsize_servers
-    hash_exclude "savings", "savingsCurrency", "tags", "cpuAverage", "policy_name", "total_savings"
+    hash_exclude "savings", "savingsCurrency", "tags", "cpuAverage", "policy_name"
     export do
       resource_level true
       field "accountID" do
@@ -1394,7 +1394,7 @@ policy "pol_azure_mysql_utilization" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
     escalate $esc_email
     escalate $esc_delete_servers
-    hash_exclude "savings", "savingsCurrency", "tags", "policy_name", "total_savings"
+    hash_exclude "savings", "savingsCurrency", "tags", "policy_name"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single.pt
+++ b/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single.pt
@@ -1287,7 +1287,7 @@ policy "pol_azure_mysql_utilization" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
     escalate $esc_email
     escalate $esc_downsize_servers
-    hash_exclude "savings", "savingsCurrency", "tags", "cpuAverage", "policy_name"
+    hash_exclude "savings", "savingsCurrency", "tags", "cpuAverage", "policy_name", "cpuMaximum", "cpuMinimum", "cpuP99", "cpuP95", "cpuP90"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single.pt
+++ b/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.2",
+  version: "0.3.3",
   provider: "Azure",
   service: "MySQL",
   policy_set: "Rightsize Database Instances",
@@ -1287,7 +1287,7 @@ policy "pol_azure_mysql_utilization" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
     escalate $esc_email
     escalate $esc_downsize_servers
-    hash_exclude "savings", "savingsCurrency", "tags", "cpuAverage", "policy_name", "total_savings", "message"
+    hash_exclude "savings", "savingsCurrency", "tags", "cpuAverage", "policy_name", "total_savings"
     export do
       resource_level true
       field "accountID" do
@@ -1394,7 +1394,7 @@ policy "pol_azure_mysql_utilization" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
     escalate $esc_email
     escalate $esc_delete_servers
-    hash_exclude "savings", "savingsCurrency", "tags", "policy_name", "total_savings", "message"
+    hash_exclude "savings", "savingsCurrency", "tags", "policy_name", "total_savings"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/rightsize_sql_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_sql_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v6.1.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/rightsize_sql_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_sql_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v6.1.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v6.1.2

--- a/cost/azure/rightsize_sql_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_sql_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v6.1.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v6.1.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.1.2",
+  version: "6.1.3",
   provider: "Azure",
   service: "SQL",
   policy_set: "Rightsize Database Instances",
@@ -1444,7 +1444,7 @@ policy "pol_azure_sql_utilization" do
     check logic_or($ds_parent_policy_terminated, ne(val(item, "recommendationType"), "Downsize"))
     escalate $esc_email
     escalate $esc_downsize_instances
-    hash_exclude "policy_name", "total_savings", "message", "savings", "savingsCurrency", "tags", "cpuAverage", "cpuMinimum", "cpuMaximum", "cpuP90", "cpuP95", "cpuP99", "dtuAverage", "dtuMinimum", "dtuMaximum", "dtuP90", "dtuP95", "dtuP99"
+    hash_exclude "policy_name", "total_savings", "savings", "savingsCurrency", "tags", "cpuAverage", "cpuMinimum", "cpuMaximum", "cpuP90", "cpuP95", "cpuP99", "dtuAverage", "dtuMinimum", "dtuMaximum", "dtuP90", "dtuP95", "dtuP99"
     export do
       resource_level true
       field "accountID" do
@@ -1577,7 +1577,7 @@ policy "pol_azure_sql_utilization" do
     check logic_or($ds_parent_policy_terminated, ne(val(item, "recommendationType"), "Delete"))
     escalate $esc_email
     escalate $esc_delete_instances
-    hash_exclude "savings", "savingsCurrency", "tags", "policy_name", "total_savings", "message"
+    hash_exclude "savings", "savingsCurrency", "tags", "policy_name", "total_savings"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
@@ -1444,7 +1444,7 @@ policy "pol_azure_sql_utilization" do
     check logic_or($ds_parent_policy_terminated, ne(val(item, "recommendationType"), "Downsize"))
     escalate $esc_email
     escalate $esc_downsize_instances
-    hash_exclude "policy_name", "total_savings", "savings", "savingsCurrency", "tags", "cpuAverage", "cpuMinimum", "cpuMaximum", "cpuP90", "cpuP95", "cpuP99", "dtuAverage", "dtuMinimum", "dtuMaximum", "dtuP90", "dtuP95", "dtuP99"
+    hash_exclude "policy_name", "savings", "savingsCurrency", "tags", "cpuAverage", "cpuMinimum", "cpuMaximum", "cpuP90", "cpuP95", "cpuP99", "dtuAverage", "dtuMinimum", "dtuMaximum", "dtuP90", "dtuP95", "dtuP99"
     export do
       resource_level true
       field "accountID" do
@@ -1577,7 +1577,7 @@ policy "pol_azure_sql_utilization" do
     check logic_or($ds_parent_policy_terminated, ne(val(item, "recommendationType"), "Delete"))
     escalate $esc_email
     escalate $esc_delete_instances
-    hash_exclude "savings", "savingsCurrency", "tags", "policy_name", "total_savings"
+    hash_exclude "savings", "savingsCurrency", "tags", "policy_name"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/rightsize_sql_storage/CHANGELOG.md
+++ b/cost/azure/rightsize_sql_storage/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/rightsize_sql_storage/CHANGELOG.md
+++ b/cost/azure/rightsize_sql_storage/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/rightsize_sql_storage/CHANGELOG.md
+++ b/cost/azure/rightsize_sql_storage/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.2.2

--- a/cost/azure/rightsize_sql_storage/azure_rightsize_sql_storage.pt
+++ b/cost/azure/rightsize_sql_storage/azure_rightsize_sql_storage.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.2",
+  version: "0.2.3",
   provider: "Azure",
   service: "SQL",
   policy_set: "Rightsize Database Instances",
@@ -1090,7 +1090,7 @@ policy "pol_azure_sql_utilization" do
     # Policy check fails and incident is created only if data is not empty and the Parent Policy has not been terminated
     check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
     escalate $esc_email
-    hash_exclude "tags", "usedSpace", "usedPercentage", "policy_name", "total_savings", "message"
+    hash_exclude "tags", "usedSpace", "usedPercentage", "policy_name", "total_savings"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/rightsize_sql_storage/azure_rightsize_sql_storage.pt
+++ b/cost/azure/rightsize_sql_storage/azure_rightsize_sql_storage.pt
@@ -1090,7 +1090,7 @@ policy "pol_azure_sql_utilization" do
     # Policy check fails and incident is created only if data is not empty and the Parent Policy has not been terminated
     check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
     escalate $esc_email
-    hash_exclude "tags", "usedSpace", "usedPercentage", "policy_name", "total_savings"
+    hash_exclude "tags", "usedSpace", "usedPercentage", "policy_name"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/rightsize_sql_storage/azure_rightsize_sql_storage.pt
+++ b/cost/azure/rightsize_sql_storage/azure_rightsize_sql_storage.pt
@@ -1090,7 +1090,7 @@ policy "pol_azure_sql_utilization" do
     # Policy check fails and incident is created only if data is not empty and the Parent Policy has not been terminated
     check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
     escalate $esc_email
-    hash_exclude "tags", "usedSpace", "usedPercentage", "policy_name"
+    hash_exclude "tags", "usedSpace", "usedPercentage", "policy_name", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/savings_plan/expiration/CHANGELOG.md
+++ b/cost/azure/savings_plan/expiration/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/savings_plan/expiration/CHANGELOG.md
+++ b/cost/azure/savings_plan/expiration/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/savings_plan/expiration/CHANGELOG.md
+++ b/cost/azure/savings_plan/expiration/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.2.2

--- a/cost/azure/savings_plan/expiration/azure_savings_plan_expiration.pt
+++ b/cost/azure/savings_plan/expiration/azure_savings_plan_expiration.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "medium"
 default_frequency "daily"
 info(
-  version: "0.2.2",
+  version: "0.2.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "Savings Plans",
@@ -396,7 +396,7 @@ policy "pol_azure_expiring_savings_plans" do
     detail_template "{{ with index data 0 }}{{ .message }}{{ end }}"
     check eq(val(item, "id"), "")
     escalate $esc_email
-    hash_exclude "daysUntilExpiration", "message"
+    hash_exclude "daysUntilExpiration"
     export do
       resource_level false
       field "id" do

--- a/cost/azure/superseded_instances/CHANGELOG.md
+++ b/cost/azure/superseded_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.1.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v4.1.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/superseded_instances/CHANGELOG.md
+++ b/cost/azure/superseded_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v4.1.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/superseded_instances/CHANGELOG.md
+++ b/cost/azure/superseded_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.1.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v4.1.2

--- a/cost/azure/superseded_instances/azure_superseded_instances.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances.pt
@@ -1080,7 +1080,7 @@ policy "pol_superseded_instances" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_change_type
-    hash_exclude "total_savings", "tags", "cost", "instance_type_price", "superseded_type_price", "savings", "savingsCurrency"
+    hash_exclude "tags", "cost", "instance_type_price", "superseded_type_price", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/superseded_instances/azure_superseded_instances.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.1.2",
+  version: "4.1.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "Superseded Compute Instances",
@@ -1080,7 +1080,7 @@ policy "pol_superseded_instances" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_change_type
-    hash_exclude "message", "total_savings", "tags", "cost", "instance_type_price", "superseded_type_price", "savings", "savingsCurrency"
+    hash_exclude "total_savings", "tags", "cost", "instance_type_price", "superseded_type_price", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/unused_app_service_plans/CHANGELOG.md
+++ b/cost/azure/unused_app_service_plans/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/unused_app_service_plans/CHANGELOG.md
+++ b/cost/azure/unused_app_service_plans/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/unused_app_service_plans/CHANGELOG.md
+++ b/cost/azure/unused_app_service_plans/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.2.2

--- a/cost/azure/unused_app_service_plans/azure_unused_app_service_plans.pt
+++ b/cost/azure/unused_app_service_plans/azure_unused_app_service_plans.pt
@@ -790,7 +790,7 @@ policy "pol_unused_azure_app_service_plans" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_app_service_plan
-    hash_exclude "total_savings", "tags", "savings", "savingsCurrency"
+    hash_exclude "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/unused_app_service_plans/azure_unused_app_service_plans.pt
+++ b/cost/azure/unused_app_service_plans/azure_unused_app_service_plans.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.2",
+  version: "0.2.3",
   provider: "Azure",
   service: "PaaS",
   policy_set: "PaaS Optimization",
@@ -790,7 +790,7 @@ policy "pol_unused_azure_app_service_plans" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_app_service_plan
-    hash_exclude "total_savings", "message", "tags", "savings", "savingsCurrency"
+    hash_exclude "total_savings", "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/unused_firewalls/CHANGELOG.md
+++ b/cost/azure/unused_firewalls/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.3.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/unused_firewalls/CHANGELOG.md
+++ b/cost/azure/unused_firewalls/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.3.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/unused_firewalls/CHANGELOG.md
+++ b/cost/azure/unused_firewalls/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.3.2

--- a/cost/azure/unused_firewalls/azure_unused_firewalls.pt
+++ b/cost/azure/unused_firewalls/azure_unused_firewalls.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.2",
+  version: "0.3.3",
   provider: "Azure",
   service: "Network",
   policy_set: "Unused Firewalls",
@@ -875,7 +875,7 @@ policy "pol_azure_unused_firewalls" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_firewall
-    hash_exclude "total_savings", "message", "tags", "savings", "savingsCurrency"
+    hash_exclude "total_savings", "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/unused_firewalls/azure_unused_firewalls.pt
+++ b/cost/azure/unused_firewalls/azure_unused_firewalls.pt
@@ -875,7 +875,7 @@ policy "pol_azure_unused_firewalls" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_firewall
-    hash_exclude "total_savings", "tags", "savings", "savingsCurrency"
+    hash_exclude "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/unused_ip_addresses/CHANGELOG.md
+++ b/cost/azure/unused_ip_addresses/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v7.4.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v7.4.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/unused_ip_addresses/CHANGELOG.md
+++ b/cost/azure/unused_ip_addresses/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v7.4.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/unused_ip_addresses/CHANGELOG.md
+++ b/cost/azure/unused_ip_addresses/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v7.4.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v7.4.2

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses.pt
@@ -924,7 +924,7 @@ policy "pol_unused_ip_addresses" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_ip_address
-    hash_exclude "total_savings", "tags", "savings", "savingsCurrency"
+    hash_exclude "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "7.4.2",
+  version: "7.4.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "Unused IP Addresses",
@@ -924,7 +924,7 @@ policy "pol_unused_ip_addresses" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_ip_address
-    hash_exclude "total_savings", "message", "tags", "savings", "savingsCurrency"
+    hash_exclude "total_savings", "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/unused_load_balancers/CHANGELOG.md
+++ b/cost/azure/unused_load_balancers/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/unused_load_balancers/CHANGELOG.md
+++ b/cost/azure/unused_load_balancers/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/unused_load_balancers/CHANGELOG.md
+++ b/cost/azure/unused_load_balancers/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.2.2

--- a/cost/azure/unused_load_balancers/azure_unused_load_balancers.pt
+++ b/cost/azure/unused_load_balancers/azure_unused_load_balancers.pt
@@ -904,7 +904,7 @@ policy "pol_azure_unused_loadbalancers" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_loadbalancers
-    hash_exclude "total_savings", "tags", "savings", "savingsCurrency"
+    hash_exclude "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/unused_load_balancers/azure_unused_load_balancers.pt
+++ b/cost/azure/unused_load_balancers/azure_unused_load_balancers.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.2",
+  version: "0.2.3",
   provider: "Azure",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -904,7 +904,7 @@ policy "pol_azure_unused_loadbalancers" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_loadbalancers
-    hash_exclude "total_savings", "message", "tags", "savings", "savingsCurrency"
+    hash_exclude "total_savings", "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/azure/unused_vngs/CHANGELOG.md
+++ b/cost/azure/unused_vngs/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/unused_vngs/CHANGELOG.md
+++ b/cost/azure/unused_vngs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/azure/unused_vngs/CHANGELOG.md
+++ b/cost/azure/unused_vngs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.2.2

--- a/cost/azure/unused_vngs/azure_unused_vngs.pt
+++ b/cost/azure/unused_vngs/azure_unused_vngs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.2",
+  version: "0.2.3",
   provider: "Azure",
   service: "Network",
   policy_set: "Unused Virtual Networks",
@@ -516,7 +516,7 @@ policy "pol_azure_unused_vngs" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_vng
-    hash_exclude "message", "tags"
+    hash_exclude "tags"
     export do
       resource_level true
       field "accountID" do

--- a/cost/flexera/cco/new_usage/CHANGELOG.md
+++ b/cost/flexera/cco/new_usage/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v3.1.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/flexera/cco/new_usage/CHANGELOG.md
+++ b/cost/flexera/cco/new_usage/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.1.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v3.1.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/flexera/cco/new_usage/CHANGELOG.md
+++ b/cost/flexera/cco/new_usage/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v3.1.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v3.1.2

--- a/cost/flexera/cco/new_usage/new_usage.pt
+++ b/cost/flexera/cco/new_usage/new_usage.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "3.1.2",
+  version: "3.1.3",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -512,7 +512,7 @@ policy "pol_new_usage" do
     EOS
     check eq(val(item, "value"), "")
     escalate $esc_email
-    hash_exclude "message", "total_cost", "cost", "currency"
+    hash_exclude "total_cost", "cost", "currency"
     export do
       resource_level false
       field "value" do

--- a/cost/google/cheaper_regions/CHANGELOG.md
+++ b/cost/google/cheaper_regions/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v1.2.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/cost/google/cheaper_regions/CHANGELOG.md
+++ b/cost/google/cheaper_regions/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.2.1
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v1.2.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/cost/google/cheaper_regions/CHANGELOG.md
+++ b/cost/google/cheaper_regions/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.2.1
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v1.2.0

--- a/cost/google/cheaper_regions/google_cheaper_regions.pt
+++ b/cost/google/cheaper_regions/google_cheaper_regions.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "1.2.0",
+  version: "1.2.1",
   provider: "Google",
   service: "All",
   policy_set: "Cheaper Regions",
@@ -487,7 +487,7 @@ policy "pol_cheaper_regions" do
     EOS
     check eq(val(item, "id"), "")
     escalate $esc_email
-    hash_exclude "message", "total_savings", "savings", "savingsCurrency"
+    hash_exclude "total_savings", "savings", "savingsCurrency"
     export do
       resource_level true
       field "id" do

--- a/cost/google/cheaper_regions/google_cheaper_regions.pt
+++ b/cost/google/cheaper_regions/google_cheaper_regions.pt
@@ -487,7 +487,7 @@ policy "pol_cheaper_regions" do
     EOS
     check eq(val(item, "id"), "")
     escalate $esc_email
-    hash_exclude "total_savings", "savings", "savingsCurrency"
+    hash_exclude "savings", "savingsCurrency"
     export do
       resource_level true
       field "id" do

--- a/cost/google/cud_recommendations/CHANGELOG.md
+++ b/cost/google/cud_recommendations/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v4.5.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/cud_recommendations/CHANGELOG.md
+++ b/cost/google/cud_recommendations/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.5.5
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v4.5.4

--- a/cost/google/cud_recommendations/CHANGELOG.md
+++ b/cost/google/cud_recommendations/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.5.5
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v4.5.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/cud_recommendations/google_committed_use_discount_recommendations.pt
+++ b/cost/google/cud_recommendations/google_committed_use_discount_recommendations.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.5.4",
+  version: "4.5.5",
   provider: "Google",
   service: "Compute",
   recommendation_type: "Rate Reduction",
@@ -697,7 +697,7 @@ policy "pol_recommendations" do
     EOS
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
-    hash_exclude "savings", "savingsCurrency", "total_savings", "message"
+    hash_exclude "savings", "savingsCurrency", "total_savings"
     export do
       resource_level true
       field "accountID" do

--- a/cost/google/cud_recommendations/google_committed_use_discount_recommendations.pt
+++ b/cost/google/cud_recommendations/google_committed_use_discount_recommendations.pt
@@ -697,7 +697,7 @@ policy "pol_recommendations" do
     EOS
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
-    hash_exclude "savings", "savingsCurrency", "total_savings"
+    hash_exclude "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/google/idle_ip_address_recommendations/CHANGELOG.md
+++ b/cost/google/idle_ip_address_recommendations/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v4.4.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/idle_ip_address_recommendations/CHANGELOG.md
+++ b/cost/google/idle_ip_address_recommendations/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.4.5
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v4.4.4

--- a/cost/google/idle_ip_address_recommendations/CHANGELOG.md
+++ b/cost/google/idle_ip_address_recommendations/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.4.5
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v4.4.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
@@ -790,7 +790,7 @@ policy "pol_recommendations" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_ip_address
-    hash_exclude "tags", "savings", "savingsCurrency", "total_savings"
+    hash_exclude "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.4.4",
+  version: "4.4.5",
   provider: "Google",
   service: "Compute",
   policy_set: "Unused IP Addresses",
@@ -790,7 +790,7 @@ policy "pol_recommendations" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_ip_address
-    hash_exclude "tags", "savings", "savingsCurrency", "total_savings", "message"
+    hash_exclude "tags", "savings", "savingsCurrency", "total_savings"
     export do
       resource_level true
       field "accountID" do

--- a/cost/google/idle_persistent_disk_recommendations/CHANGELOG.md
+++ b/cost/google/idle_persistent_disk_recommendations/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v4.4.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/idle_persistent_disk_recommendations/CHANGELOG.md
+++ b/cost/google/idle_persistent_disk_recommendations/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.4.5
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v4.4.4

--- a/cost/google/idle_persistent_disk_recommendations/CHANGELOG.md
+++ b/cost/google/idle_persistent_disk_recommendations/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.4.5
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v4.4.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.4.4",
+  version: "4.4.5",
   provider: "Google",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -1057,7 +1057,7 @@ policy "pol_recommendations" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_disks
-    hash_exclude "age", "tags", "savings", "savingsCurrency", "total_savings", "message"
+    hash_exclude "age", "tags", "savings", "savingsCurrency", "total_savings"
     export do
       resource_level true
       field "accountID" do

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
@@ -1057,7 +1057,7 @@ policy "pol_recommendations" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_disks
-    hash_exclude "age", "tags", "savings", "savingsCurrency", "total_savings"
+    hash_exclude "age", "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/google/object_storage_optimization/CHANGELOG.md
+++ b/cost/google/object_storage_optimization/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v3.0.12
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v3.0.11

--- a/cost/google/object_storage_optimization/CHANGELOG.md
+++ b/cost/google/object_storage_optimization/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v3.0.11
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/object_storage_optimization/CHANGELOG.md
+++ b/cost/google/object_storage_optimization/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.0.12
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v3.0.11
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/object_storage_optimization/google_object_storage_optimization.pt
+++ b/cost/google/object_storage_optimization/google_object_storage_optimization.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.0.11",
+  version: "3.0.12",
   provider: "Google",
   service: "Storage",
   policy_set: "Object Store Optimization",
@@ -568,7 +568,7 @@ policy "pol_object_storage_optimization" do
     escalate $esc_email
     escalate $esc_update_objects
     escalate $esc_delete_objects
-    hash_exclude "message", "tags"
+    hash_exclude "tags"
     export do
       resource_level true
       field "accountID" do

--- a/cost/google/old_snapshots/CHANGELOG.md
+++ b/cost/google/old_snapshots/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v5.4.4
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v5.4.3
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/old_snapshots/CHANGELOG.md
+++ b/cost/google/old_snapshots/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v5.4.3
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/old_snapshots/CHANGELOG.md
+++ b/cost/google/old_snapshots/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v5.4.4
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v5.4.3

--- a/cost/google/old_snapshots/google_delete_old_snapshots.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.4.3",
+  version: "5.4.4",
   provider:"Google",
   service: "Storage",
   policy_set: "Old Snapshots",
@@ -1043,7 +1043,7 @@ policy "pol_old_snapshots" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_snapshots
-    hash_exclude "message", "tags", "age", "savings", "savingsCurrency"
+    hash_exclude "tags", "age", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/google/recommender/CHANGELOG.md
+++ b/cost/google/recommender/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.2.5
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v3.2.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/recommender/CHANGELOG.md
+++ b/cost/google/recommender/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v3.2.5
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v3.2.4

--- a/cost/google/recommender/CHANGELOG.md
+++ b/cost/google/recommender/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v3.2.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/recommender/recommender.pt
+++ b/cost/google/recommender/recommender.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.2.4",
+  version: "3.2.5",
   provider: "Google",
   service: "All",
   policy_set: "Native Recommendations",
@@ -638,7 +638,7 @@ policy "pol_recommendations" do
     EOS
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceName"), ""))
     escalate $esc_email
-    hash_exclude "savings", "savingsCurrency", "total_savings", "message"
+    hash_exclude "savings", "savingsCurrency", "total_savings"
     export do
       resource_level true
       field "accountID" do

--- a/cost/google/recommender/recommender.pt
+++ b/cost/google/recommender/recommender.pt
@@ -638,7 +638,7 @@ policy "pol_recommendations" do
     EOS
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceName"), ""))
     escalate $esc_email
-    hash_exclude "savings", "savingsCurrency", "total_savings"
+    hash_exclude "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/google/rightsize_cloudsql_instances/CHANGELOG.md
+++ b/cost/google/rightsize_cloudsql_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.2.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/rightsize_cloudsql_instances/CHANGELOG.md
+++ b/cost/google/rightsize_cloudsql_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.5
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.2.4

--- a/cost/google/rightsize_cloudsql_instances/CHANGELOG.md
+++ b/cost/google/rightsize_cloudsql_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.5
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.2.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/rightsize_cloudsql_instances/google_rightsize_cloudsql_instances.pt
+++ b/cost/google/rightsize_cloudsql_instances/google_rightsize_cloudsql_instances.pt
@@ -1623,7 +1623,7 @@ policy "pol_cloudsql_recommendations" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_downsize_instances
-    hash_exclude "tags", "savings", "savingsCurrency", "total_savings"
+    hash_exclude "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do
@@ -1748,7 +1748,7 @@ policy "pol_cloudsql_recommendations" do
     escalate $esc_email
     escalate $esc_stop_instances
     escalate $esc_delete_instances
-    hash_exclude "tags", "savings", "savingsCurrency", "total_savings"
+    hash_exclude "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/google/rightsize_cloudsql_instances/google_rightsize_cloudsql_instances.pt
+++ b/cost/google/rightsize_cloudsql_instances/google_rightsize_cloudsql_instances.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.4",
+  version: "0.2.5",
   provider: "Google",
   service: "Compute",
   policy_set: "Rightsize Database Instances",
@@ -1623,7 +1623,7 @@ policy "pol_cloudsql_recommendations" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_downsize_instances
-    hash_exclude "tags", "savings", "savingsCurrency", "total_savings", "message"
+    hash_exclude "tags", "savings", "savingsCurrency", "total_savings"
     export do
       resource_level true
       field "accountID" do
@@ -1748,7 +1748,7 @@ policy "pol_cloudsql_recommendations" do
     escalate $esc_email
     escalate $esc_stop_instances
     escalate $esc_delete_instances
-    hash_exclude "tags", "savings", "savingsCurrency", "total_savings", "message"
+    hash_exclude "tags", "savings", "savingsCurrency", "total_savings"
     export do
       resource_level true
       field "accountID" do

--- a/cost/google/rightsize_cloudsql_instances/google_rightsize_cloudsql_instances.pt
+++ b/cost/google/rightsize_cloudsql_instances/google_rightsize_cloudsql_instances.pt
@@ -1623,7 +1623,7 @@ policy "pol_cloudsql_recommendations" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_downsize_instances
-    hash_exclude "tags", "savings", "savingsCurrency"
+    hash_exclude "tags", "savings", "savingsCurrency", "cpuMaximum", "cpuMinimum", "cpuAverage", "cpuP99", "cpuP95", "cpuP90", "memMaximum", "memMinimum", "memAverage", "memP99", "memP95", "memP90"
     export do
       resource_level true
       field "accountID" do
@@ -1748,7 +1748,7 @@ policy "pol_cloudsql_recommendations" do
     escalate $esc_email
     escalate $esc_stop_instances
     escalate $esc_delete_instances
-    hash_exclude "tags", "savings", "savingsCurrency"
+    hash_exclude "tags", "savings", "savingsCurrency", "cpuMaximum", "cpuMinimum", "cpuAverage", "cpuP99", "cpuP95", "cpuP90", "memMaximum", "memMinimum", "memAverage", "memP99", "memP95", "memP90"
     export do
       resource_level true
       field "accountID" do

--- a/cost/google/rightsize_cloudsql_recommendations/CHANGELOG.md
+++ b/cost/google/rightsize_cloudsql_recommendations/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.5
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.4.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/rightsize_cloudsql_recommendations/CHANGELOG.md
+++ b/cost/google/rightsize_cloudsql_recommendations/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.4.5
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.4.4

--- a/cost/google/rightsize_cloudsql_recommendations/CHANGELOG.md
+++ b/cost/google/rightsize_cloudsql_recommendations/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.4.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/rightsize_cloudsql_recommendations/google_rightsize_cloudsql_recommendations.pt
+++ b/cost/google/rightsize_cloudsql_recommendations/google_rightsize_cloudsql_recommendations.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.4",
+  version: "0.4.5",
   provider: "Google",
   service: "Compute",
   policy_set: "Rightsize Database Instances",
@@ -1112,7 +1112,7 @@ policy "pol_cloudsql_recommendations" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_downsize_instances
-    hash_exclude "tags", "savings", "savingsCurrency", "total_savings", "message"
+    hash_exclude "tags", "savings", "savingsCurrency", "total_savings"
     export do
       resource_level true
       field "accountID" do
@@ -1207,7 +1207,7 @@ policy "pol_cloudsql_recommendations" do
     escalate $esc_email
     escalate $esc_stop_instances
     escalate $esc_delete_instances
-    hash_exclude "tags", "savings", "savingsCurrency", "total_savings", "message"
+    hash_exclude "tags", "savings", "savingsCurrency", "total_savings"
     export do
       resource_level true
       field "accountID" do

--- a/cost/google/rightsize_cloudsql_recommendations/google_rightsize_cloudsql_recommendations.pt
+++ b/cost/google/rightsize_cloudsql_recommendations/google_rightsize_cloudsql_recommendations.pt
@@ -1112,7 +1112,7 @@ policy "pol_cloudsql_recommendations" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_downsize_instances
-    hash_exclude "tags", "savings", "savingsCurrency", "total_savings"
+    hash_exclude "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do
@@ -1207,7 +1207,7 @@ policy "pol_cloudsql_recommendations" do
     escalate $esc_email
     escalate $esc_stop_instances
     escalate $esc_delete_instances
-    hash_exclude "tags", "savings", "savingsCurrency", "total_savings"
+    hash_exclude "tags", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/google/rightsize_persistent_disks/CHANGELOG.md
+++ b/cost/google/rightsize_persistent_disks/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.1.1
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.1.0
 
 - Initial release.

--- a/cost/google/rightsize_persistent_disks/CHANGELOG.md
+++ b/cost/google/rightsize_persistent_disks/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.1.1
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.1.0

--- a/cost/google/rightsize_persistent_disks/CHANGELOG.md
+++ b/cost/google/rightsize_persistent_disks/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.1.0
 
 - Initial release.

--- a/cost/google/rightsize_persistent_disks/google_rightsize_persistent_disks.pt
+++ b/cost/google/rightsize_persistent_disks/google_rightsize_persistent_disks.pt
@@ -1410,7 +1410,7 @@ policy "pol_rightsize_persistent_disks" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_disks
-    hash_exclude "total_savings", "tags", "savings", "savingsCurrency", "detachDays"
+    hash_exclude "tags", "savings", "savingsCurrency", "detachDays"
     export do
       resource_level true
       field "accountID" do
@@ -1486,7 +1486,7 @@ policy "pol_rightsize_persistent_disks" do
     EOS
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
-    hash_exclude "total_savings", "tags", "savings", "savingsCurrency", "iopsAverage", "iopsMaximum", "iopsP99", "iopsP95", "iopsP90", "iopsUtilPct", "throughputAverage", "throughputMaximum", "throughputP99", "throughputP95", "throughputP90", "throughputUtilPct"
+    hash_exclude "tags", "savings", "savingsCurrency", "iopsAverage", "iopsMaximum", "iopsP99", "iopsP95", "iopsP90", "iopsUtilPct", "throughputAverage", "throughputMaximum", "throughputP99", "throughputP95", "throughputP90", "throughputUtilPct"
     export do
       resource_level true
       field "accountID" do

--- a/cost/google/rightsize_persistent_disks/google_rightsize_persistent_disks.pt
+++ b/cost/google/rightsize_persistent_disks/google_rightsize_persistent_disks.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.1.0",
+  version: "0.1.1",
   provider: "Google",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -1410,7 +1410,7 @@ policy "pol_rightsize_persistent_disks" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_disks
-    hash_exclude "total_savings", "message", "tags", "savings", "savingsCurrency", "detachDays"
+    hash_exclude "total_savings", "tags", "savings", "savingsCurrency", "detachDays"
     export do
       resource_level true
       field "accountID" do
@@ -1486,7 +1486,7 @@ policy "pol_rightsize_persistent_disks" do
     EOS
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
-    hash_exclude "total_savings", "message", "tags", "savings", "savingsCurrency", "iopsAverage", "iopsMaximum", "iopsP99", "iopsP95", "iopsP90", "iopsUtilPct", "throughputAverage", "throughputMaximum", "throughputP99", "throughputP95", "throughputP90", "throughputUtilPct"
+    hash_exclude "total_savings", "tags", "savings", "savingsCurrency", "iopsAverage", "iopsMaximum", "iopsP99", "iopsP95", "iopsP90", "iopsUtilPct", "throughputAverage", "throughputMaximum", "throughputP99", "throughputP95", "throughputP90", "throughputUtilPct"
     export do
       resource_level true
       field "accountID" do

--- a/cost/google/rightsize_vm_instances/CHANGELOG.md
+++ b/cost/google/rightsize_vm_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.2.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/rightsize_vm_instances/CHANGELOG.md
+++ b/cost/google/rightsize_vm_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.5
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.2.4

--- a/cost/google/rightsize_vm_instances/CHANGELOG.md
+++ b/cost/google/rightsize_vm_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.5
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.2.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/rightsize_vm_instances/google_rightsize_vm_instances.pt
+++ b/cost/google/rightsize_vm_instances/google_rightsize_vm_instances.pt
@@ -1737,7 +1737,7 @@ policy "pol_recommendations" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_downsize_instances
-    hash_exclude "tags", "savings", "savingsCurrency", "total_savings", "cpuMaximum", "cpuMinimum", "cpuAverage", "cpuP99", "cpuP95", "cpuP90", "memMaximum", "memMinimum", "memAverage", "memP99", "memP95", "memP90"
+    hash_exclude "tags", "savings", "savingsCurrency", "cpuMaximum", "cpuMinimum", "cpuAverage", "cpuP99", "cpuP95", "cpuP90", "memMaximum", "memMinimum", "memAverage", "memP99", "memP95", "memP90"
     export do
       resource_level true
       field "accountID" do
@@ -1856,7 +1856,7 @@ policy "pol_recommendations" do
     escalate $esc_email
     escalate $esc_stop_instances
     escalate $esc_delete_instances
-    hash_exclude "tags", "savings", "savingsCurrency", "total_savings", "cpuMaximum", "cpuMinimum", "cpuAverage", "cpuP99", "cpuP95", "cpuP90", "memMaximum", "memMinimum", "memAverage", "memP99", "memP95", "memP90"
+    hash_exclude "tags", "savings", "savingsCurrency", "cpuMaximum", "cpuMinimum", "cpuAverage", "cpuP99", "cpuP95", "cpuP90", "memMaximum", "memMinimum", "memAverage", "memP99", "memP95", "memP90"
     export do
       resource_level true
       field "accountID" do

--- a/cost/google/rightsize_vm_instances/google_rightsize_vm_instances.pt
+++ b/cost/google/rightsize_vm_instances/google_rightsize_vm_instances.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.4",
+  version: "0.2.5",
   provider: "Google",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -1737,7 +1737,7 @@ policy "pol_recommendations" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_downsize_instances
-    hash_exclude "tags", "savings", "savingsCurrency", "total_savings", "message", "cpuMaximum", "cpuMinimum", "cpuAverage", "cpuP99", "cpuP95", "cpuP90", "memMaximum", "memMinimum", "memAverage", "memP99", "memP95", "memP90"
+    hash_exclude "tags", "savings", "savingsCurrency", "total_savings", "cpuMaximum", "cpuMinimum", "cpuAverage", "cpuP99", "cpuP95", "cpuP90", "memMaximum", "memMinimum", "memAverage", "memP99", "memP95", "memP90"
     export do
       resource_level true
       field "accountID" do
@@ -1856,7 +1856,7 @@ policy "pol_recommendations" do
     escalate $esc_email
     escalate $esc_stop_instances
     escalate $esc_delete_instances
-    hash_exclude "tags", "savings", "savingsCurrency", "total_savings", "message", "cpuMaximum", "cpuMinimum", "cpuAverage", "cpuP99", "cpuP95", "cpuP90", "memMaximum", "memMinimum", "memAverage", "memP99", "memP95", "memP90"
+    hash_exclude "tags", "savings", "savingsCurrency", "total_savings", "cpuMaximum", "cpuMinimum", "cpuAverage", "cpuP99", "cpuP95", "cpuP90", "memMaximum", "memMinimum", "memAverage", "memP99", "memP95", "memP90"
     export do
       resource_level true
       field "accountID" do

--- a/cost/google/rightsize_vm_recommendations/CHANGELOG.md
+++ b/cost/google/rightsize_vm_recommendations/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v3.3.5
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v3.3.4

--- a/cost/google/rightsize_vm_recommendations/CHANGELOG.md
+++ b/cost/google/rightsize_vm_recommendations/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v3.3.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/rightsize_vm_recommendations/CHANGELOG.md
+++ b/cost/google/rightsize_vm_recommendations/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.5
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v3.3.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations.pt
+++ b/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "3.3.4",
+  version: "3.3.5",
   provider: "Google",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -1294,7 +1294,7 @@ policy "pol_recommendations" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_downsize_instances
-    hash_exclude "tags", "savings", "savingsCurrency", "total_savings", "message", "cpuMaximum", "cpuMinimum", "cpuAverage"
+    hash_exclude "tags", "savings", "savingsCurrency", "total_savings", "cpuMaximum", "cpuMinimum", "cpuAverage"
     export do
       resource_level true
       field "accountID" do
@@ -1386,7 +1386,7 @@ policy "pol_recommendations" do
     escalate $esc_email
     escalate $esc_stop_instances
     escalate $esc_delete_instances
-    hash_exclude "tags", "savings", "savingsCurrency", "total_savings", "message", "cpuMaximum", "cpuMinimum", "cpuAverage"
+    hash_exclude "tags", "savings", "savingsCurrency", "total_savings", "cpuMaximum", "cpuMinimum", "cpuAverage"
     export do
       resource_level true
       field "accountID" do

--- a/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations.pt
+++ b/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations.pt
@@ -1294,7 +1294,7 @@ policy "pol_recommendations" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_downsize_instances
-    hash_exclude "tags", "savings", "savingsCurrency", "total_savings", "cpuMaximum", "cpuMinimum", "cpuAverage"
+    hash_exclude "tags", "savings", "savingsCurrency", "cpuMaximum", "cpuMinimum", "cpuAverage"
     export do
       resource_level true
       field "accountID" do
@@ -1386,7 +1386,7 @@ policy "pol_recommendations" do
     escalate $esc_email
     escalate $esc_stop_instances
     escalate $esc_delete_instances
-    hash_exclude "tags", "savings", "savingsCurrency", "total_savings", "cpuMaximum", "cpuMinimum", "cpuAverage"
+    hash_exclude "tags", "savings", "savingsCurrency", "cpuMaximum", "cpuMinimum", "cpuAverage"
     export do
       resource_level true
       field "accountID" do

--- a/cost/google/unused_disks/CHANGELOG.md
+++ b/cost/google/unused_disks/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.6
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.2.5
 
 - Policy template deprecated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/cost/google/unused_disks) for more details.

--- a/cost/google/unused_disks/CHANGELOG.md
+++ b/cost/google/unused_disks/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.6
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.2.5

--- a/cost/google/unused_disks/CHANGELOG.md
+++ b/cost/google/unused_disks/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.2.5
 
 - Policy template deprecated. Please see [README](https://github.com/flexera-public/policy_templates/tree/master/cost/google/unused_disks) for more details.

--- a/cost/google/unused_disks/google_unused_disks.pt
+++ b/cost/google/unused_disks/google_unused_disks.pt
@@ -871,7 +871,7 @@ policy "pol_unused_disks" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_ip_address
-    hash_exclude "total_savings", "tags", "savings", "savingsCurrency", "detachDays"
+    hash_exclude "tags", "savings", "savingsCurrency", "detachDays"
     export do
       resource_level true
       field "accountID" do

--- a/cost/google/unused_disks/google_unused_disks.pt
+++ b/cost/google/unused_disks/google_unused_disks.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.5",
+  version: "0.2.6",
   provider: "Google",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -871,7 +871,7 @@ policy "pol_unused_disks" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_ip_address
-    hash_exclude "total_savings", "message", "tags", "savings", "savingsCurrency", "detachDays"
+    hash_exclude "total_savings", "tags", "savings", "savingsCurrency", "detachDays"
     export do
       resource_level true
       field "accountID" do

--- a/cost/oracle/advisor_lifecycle_mgmt/CHANGELOG.md
+++ b/cost/oracle/advisor_lifecycle_mgmt/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/oracle/advisor_lifecycle_mgmt/CHANGELOG.md
+++ b/cost/oracle/advisor_lifecycle_mgmt/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/oracle/advisor_lifecycle_mgmt/CHANGELOG.md
+++ b/cost/oracle/advisor_lifecycle_mgmt/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.2.2

--- a/cost/oracle/advisor_lifecycle_mgmt/oracle_advisor_lifecycle_mgmt.pt
+++ b/cost/oracle/advisor_lifecycle_mgmt/oracle_advisor_lifecycle_mgmt.pt
@@ -500,7 +500,7 @@ policy "pol_oci_volume_recommendations" do
     EOS
     check eq(val(item, "resourceID"), "")
     escalate $esc_email
-    hash_exclude "total_savings", "savings", "savingsCurrency"
+    hash_exclude "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/oracle/advisor_lifecycle_mgmt/oracle_advisor_lifecycle_mgmt.pt
+++ b/cost/oracle/advisor_lifecycle_mgmt/oracle_advisor_lifecycle_mgmt.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.2",
+  version: "0.2.3",
   provider: "Oracle",
   service: "Storage",
   policy_set: "",
@@ -500,7 +500,7 @@ policy "pol_oci_volume_recommendations" do
     EOS
     check eq(val(item, "resourceID"), "")
     escalate $esc_email
-    hash_exclude "message", "total_savings", "savings", "savingsCurrency"
+    hash_exclude "total_savings", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/oracle/advisor_rightsize_autodbs/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_autodbs/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/oracle/advisor_rightsize_autodbs/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_autodbs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/oracle/advisor_rightsize_autodbs/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_autodbs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.2.2

--- a/cost/oracle/advisor_rightsize_autodbs/oracle_advisor_rightsize_autodbs.pt
+++ b/cost/oracle/advisor_rightsize_autodbs/oracle_advisor_rightsize_autodbs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.2",
+  version: "0.2.3",
   provider: "Oracle",
   service: "Database",
   policy_set: "Rightsize Database Instances",
@@ -504,7 +504,7 @@ policy "pol_oci_rightsize_db_recommendations" do
     check eq(val(item, "resourceID"), "")
     escalate $esc_email
     escalate $esc_downsize_instances
-    hash_exclude "message", "total_savings", "savings", "savingsCurrency", "cpuAverage", "cpuP95"
+    hash_exclude "total_savings", "savings", "savingsCurrency", "cpuAverage", "cpuP95"
     export do
       resource_level true
       field "accountID" do

--- a/cost/oracle/advisor_rightsize_autodbs/oracle_advisor_rightsize_autodbs.pt
+++ b/cost/oracle/advisor_rightsize_autodbs/oracle_advisor_rightsize_autodbs.pt
@@ -504,7 +504,7 @@ policy "pol_oci_rightsize_db_recommendations" do
     check eq(val(item, "resourceID"), "")
     escalate $esc_email
     escalate $esc_downsize_instances
-    hash_exclude "total_savings", "savings", "savingsCurrency", "cpuAverage", "cpuP95"
+    hash_exclude "savings", "savingsCurrency", "cpuAverage", "cpuP95"
     export do
       resource_level true
       field "accountID" do

--- a/cost/oracle/advisor_rightsize_basedbs/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_basedbs/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/oracle/advisor_rightsize_basedbs/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_basedbs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/oracle/advisor_rightsize_basedbs/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_basedbs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.2.2

--- a/cost/oracle/advisor_rightsize_basedbs/oracle_advisor_rightsize_basedbs.pt
+++ b/cost/oracle/advisor_rightsize_basedbs/oracle_advisor_rightsize_basedbs.pt
@@ -530,7 +530,7 @@ policy "pol_oci_rightsize_db_recommendations" do
     check eq(val(item, "resourceID"), "")
     escalate $esc_email
     escalate $esc_downsize_instances
-    hash_exclude "total_savings", "savings", "savingsCurrency", "cpuAverage"
+    hash_exclude "savings", "savingsCurrency", "cpuAverage"
     export do
       resource_level true
       field "accountID" do

--- a/cost/oracle/advisor_rightsize_basedbs/oracle_advisor_rightsize_basedbs.pt
+++ b/cost/oracle/advisor_rightsize_basedbs/oracle_advisor_rightsize_basedbs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.2",
+  version: "0.2.3",
   provider: "Oracle",
   service: "Database",
   policy_set: "Rightsize Database Instances",
@@ -530,7 +530,7 @@ policy "pol_oci_rightsize_db_recommendations" do
     check eq(val(item, "resourceID"), "")
     escalate $esc_email
     escalate $esc_downsize_instances
-    hash_exclude "message", "total_savings", "savings", "savingsCurrency", "cpuAverage"
+    hash_exclude "total_savings", "savings", "savingsCurrency", "cpuAverage"
     export do
       resource_level true
       field "accountID" do

--- a/cost/oracle/advisor_rightsize_lbs/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_lbs/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/oracle/advisor_rightsize_lbs/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_lbs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/oracle/advisor_rightsize_lbs/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_lbs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.2.2

--- a/cost/oracle/advisor_rightsize_lbs/oracle_advisor_rightsize_lbs.pt
+++ b/cost/oracle/advisor_rightsize_lbs/oracle_advisor_rightsize_lbs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.2",
+  version: "0.2.3",
   provider: "Oracle",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -544,7 +544,7 @@ policy "pol_oci_lb_recommendations" do
     check eq(val(item, "resourceID"), "")
     escalate $esc_email
     escalate $esc_downsize_lbs
-    hash_exclude "message", "total_savings", "savings", "savingsCurrency"
+    hash_exclude "total_savings", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/oracle/advisor_rightsize_lbs/oracle_advisor_rightsize_lbs.pt
+++ b/cost/oracle/advisor_rightsize_lbs/oracle_advisor_rightsize_lbs.pt
@@ -544,7 +544,7 @@ policy "pol_oci_lb_recommendations" do
     check eq(val(item, "resourceID"), "")
     escalate $esc_email
     escalate $esc_downsize_lbs
-    hash_exclude "total_savings", "savings", "savingsCurrency"
+    hash_exclude "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/oracle/advisor_rightsize_vms/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_vms/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.3.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/oracle/advisor_rightsize_vms/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_vms/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.3.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/oracle/advisor_rightsize_vms/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_vms/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.3.2

--- a/cost/oracle/advisor_rightsize_vms/oracle_advisor_rightsize_vms.pt
+++ b/cost/oracle/advisor_rightsize_vms/oracle_advisor_rightsize_vms.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.2",
+  version: "0.3.3",
   provider: "Oracle",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -749,7 +749,7 @@ policy "pol_oci_rightsize_compute_recommendations" do
     check eq(val(item, "resourceID"), "")
     escalate $esc_email
     escalate $esc_downsize_instances
-    hash_exclude "message", "total_savings", "savings", "savingsCurrency", "cpuAverage", "cpuMaximum", "cpuP95", "memMaximum", "netMaximum"
+    hash_exclude "total_savings", "savings", "savingsCurrency", "cpuAverage", "cpuMaximum", "cpuP95", "memMaximum", "netMaximum"
     export do
       resource_level true
       field "accountID" do
@@ -831,7 +831,7 @@ policy "pol_oci_rightsize_compute_recommendations" do
     check eq(val(item, "resourceID"), "")
     escalate $esc_email
     escalate $esc_terminate_instances
-    hash_exclude "message", "total_savings", "savings", "savingsCurrency", "cpuAverage", "cpuMaximum", "cpuP95", "memMaximum", "netMaximum"
+    hash_exclude "total_savings", "savings", "savingsCurrency", "cpuAverage", "cpuMaximum", "cpuP95", "memMaximum", "netMaximum"
     export do
       resource_level true
       field "accountID" do

--- a/cost/oracle/advisor_rightsize_vms/oracle_advisor_rightsize_vms.pt
+++ b/cost/oracle/advisor_rightsize_vms/oracle_advisor_rightsize_vms.pt
@@ -749,7 +749,7 @@ policy "pol_oci_rightsize_compute_recommendations" do
     check eq(val(item, "resourceID"), "")
     escalate $esc_email
     escalate $esc_downsize_instances
-    hash_exclude "total_savings", "savings", "savingsCurrency", "cpuAverage", "cpuMaximum", "cpuP95", "memMaximum", "netMaximum"
+    hash_exclude "savings", "savingsCurrency", "cpuAverage", "cpuMaximum", "cpuP95", "memMaximum", "netMaximum"
     export do
       resource_level true
       field "accountID" do
@@ -831,7 +831,7 @@ policy "pol_oci_rightsize_compute_recommendations" do
     check eq(val(item, "resourceID"), "")
     escalate $esc_email
     escalate $esc_terminate_instances
-    hash_exclude "total_savings", "savings", "savingsCurrency", "cpuAverage", "cpuMaximum", "cpuP95", "memMaximum", "netMaximum"
+    hash_exclude "savings", "savingsCurrency", "cpuAverage", "cpuMaximum", "cpuP95", "memMaximum", "netMaximum"
     export do
       resource_level true
       field "accountID" do

--- a/cost/oracle/advisor_unattached_volumes/CHANGELOG.md
+++ b/cost/oracle/advisor_unattached_volumes/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/oracle/advisor_unattached_volumes/CHANGELOG.md
+++ b/cost/oracle/advisor_unattached_volumes/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/oracle/advisor_unattached_volumes/CHANGELOG.md
+++ b/cost/oracle/advisor_unattached_volumes/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.2.2

--- a/cost/oracle/advisor_unattached_volumes/oracle_advisor_unattached_volumes.pt
+++ b/cost/oracle/advisor_unattached_volumes/oracle_advisor_unattached_volumes.pt
@@ -493,7 +493,7 @@ policy "pol_oci_volume_recommendations" do
     check eq(val(item, "resourceID"), "")
     escalate $esc_email
     escalate $esc_delete_volumes
-    hash_exclude "total_savings", "savings", "savingsCurrency"
+    hash_exclude "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/cost/oracle/advisor_unattached_volumes/oracle_advisor_unattached_volumes.pt
+++ b/cost/oracle/advisor_unattached_volumes/oracle_advisor_unattached_volumes.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.2",
+  version: "0.2.3",
   provider: "Oracle",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -493,7 +493,7 @@ policy "pol_oci_volume_recommendations" do
     check eq(val(item, "resourceID"), "")
     escalate $esc_email
     escalate $esc_delete_volumes
-    hash_exclude "message", "total_savings", "savings", "savingsCurrency"
+    hash_exclude "total_savings", "savings", "savingsCurrency"
     export do
       resource_level true
       field "accountID" do

--- a/operational/aws/ec2_stopped_report/CHANGELOG.md
+++ b/operational/aws/ec2_stopped_report/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.3.4
 
 - Category of policy template updated to "Operational". Functionality unchanged.

--- a/operational/aws/ec2_stopped_report/CHANGELOG.md
+++ b/operational/aws/ec2_stopped_report/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3.5
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.3.4

--- a/operational/aws/ec2_stopped_report/CHANGELOG.md
+++ b/operational/aws/ec2_stopped_report/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.5
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.3.4
 
 - Category of policy template updated to "Operational". Functionality unchanged.

--- a/operational/aws/ec2_stopped_report/aws_ec2_stopped_report.pt
+++ b/operational/aws/ec2_stopped_report/aws_ec2_stopped_report.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "0.3.4",
+  version: "0.3.5",
   provider: "AWS",
   service: "Compute",
   policy_set: "",
@@ -848,7 +848,7 @@ policy "pol_instances_stopped_report" do
     escalate $esc_email
     escalate $esc_stop_instances
     escalate $esc_terminate_instances
-    hash_exclude "message", "resourceName", "tags", "usage_hours", "hours_stopped", "percentage_stopped", "hourly_cost"
+    hash_exclude "resourceName", "tags", "usage_hours", "hours_stopped", "percentage_stopped", "hourly_cost"
     export do
       resource_level true
       field "accountID" do

--- a/operational/aws/lambda_functions_with_high_error_rate/CHANGELOG.md
+++ b/operational/aws/lambda_functions_with_high_error_rate/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v5.1.6
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v5.1.5
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/operational/aws/lambda_functions_with_high_error_rate/CHANGELOG.md
+++ b/operational/aws/lambda_functions_with_high_error_rate/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v5.1.6
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v5.1.5

--- a/operational/aws/lambda_functions_with_high_error_rate/CHANGELOG.md
+++ b/operational/aws/lambda_functions_with_high_error_rate/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v5.1.5
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate.pt
+++ b/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate.pt
@@ -8,7 +8,7 @@ severity "high"
 category "Operational"
 default_frequency "hourly"
 info(
-  version: "5.1.5",
+  version: "5.1.6",
   provider: "AWS",
   service: "PaaS",
   policy_set: "Lambda",
@@ -817,7 +817,7 @@ policy "pol_functions_in_error" do
     # Policy check fails and incident is created only if data is not empty and the Parent Policy has not been terminated
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
-    hash_exclude "message", "tags", "invocations", "errors", "error_rate"
+    hash_exclude "tags", "invocations", "errors", "error_rate"
     export do
       resource_level true
       field "accountID" do

--- a/operational/aws/long_running_instances/CHANGELOG.md
+++ b/operational/aws/long_running_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v5.2.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/operational/aws/long_running_instances/CHANGELOG.md
+++ b/operational/aws/long_running_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v5.2.5
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v5.2.4

--- a/operational/aws/long_running_instances/CHANGELOG.md
+++ b/operational/aws/long_running_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v5.2.5
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v5.2.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/operational/aws/long_running_instances/long_running_instances.pt
+++ b/operational/aws/long_running_instances/long_running_instances.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.2.4",
+  version: "5.2.5",
   provider: "AWS",
   service: "Compute",
   policy_set: "Long Running Instances",
@@ -899,7 +899,7 @@ policy "pol_utilization" do
     escalate $esc_email
     escalate $esc_stop_instances
     escalate $esc_terminate_instances
-    hash_exclude "tags", "cost", "costCurrency", "resourceName", "age", "billing_center", "hostname", "ipAddress", "ipv6Address", "lookbackPeriod", "policy_name", "message"
+    hash_exclude "tags", "cost", "costCurrency", "resourceName", "age", "billing_center", "hostname", "ipAddress", "ipv6Address", "lookbackPeriod", "policy_name"
     export do
       resource_level true
       field "accountID" do

--- a/operational/aws/marketplace_new_products/CHANGELOG.md
+++ b/operational/aws/marketplace_new_products/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.4
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.4.3
 
 - Category of policy template updated to "Operational". Functionality unchanged.

--- a/operational/aws/marketplace_new_products/CHANGELOG.md
+++ b/operational/aws/marketplace_new_products/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.4.3
 
 - Category of policy template updated to "Operational". Functionality unchanged.

--- a/operational/aws/marketplace_new_products/CHANGELOG.md
+++ b/operational/aws/marketplace_new_products/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.4.4
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.4.3

--- a/operational/aws/marketplace_new_products/aws_marketplace_new_products.pt
+++ b/operational/aws/marketplace_new_products/aws_marketplace_new_products.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "0.4.3",
+  version: "0.4.4",
   provider: "AWS",
   service: "Marketplace",
   policy_set: "New Marketplace Products",
@@ -395,7 +395,7 @@ policy "pol_new_products" do
     EOS
     check eq(val(item, "product"), "")
     escalate $esc_email
-    hash_exclude "message", "total_cost", "cost", "currency"
+    hash_exclude "total_cost", "cost", "currency"
     export do
       resource_level false
       field "product" do

--- a/operational/azure/azure_long_running_instances/CHANGELOG.md
+++ b/operational/azure/azure_long_running_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v6.2.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v6.2.2

--- a/operational/azure/azure_long_running_instances/CHANGELOG.md
+++ b/operational/azure/azure_long_running_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v6.2.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v6.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/operational/azure/azure_long_running_instances/CHANGELOG.md
+++ b/operational/azure/azure_long_running_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v6.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.2.2",
+  version: "6.2.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "Long Running Instances",
@@ -831,7 +831,7 @@ policy "pol_utilization" do
     escalate $esc_email
     escalate $esc_poweroff_instances
     escalate $esc_delete_instances
-    hash_exclude "tags", "cost", "costCurrency", "age", "billing_center", "lookbackPeriod", "policy_name", "message"
+    hash_exclude "tags", "cost", "costCurrency", "age", "billing_center", "lookbackPeriod", "policy_name"
     export do
       resource_level true
       field "accountID" do

--- a/operational/azure/compute_poweredoff_report/CHANGELOG.md
+++ b/operational/azure/compute_poweredoff_report/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.3.3
 
 - Category of policy template updated to "Operational". Functionality unchanged.

--- a/operational/azure/compute_poweredoff_report/CHANGELOG.md
+++ b/operational/azure/compute_poweredoff_report/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.4
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.3.3
 
 - Category of policy template updated to "Operational". Functionality unchanged.

--- a/operational/azure/compute_poweredoff_report/CHANGELOG.md
+++ b/operational/azure/compute_poweredoff_report/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3.4
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.3.3

--- a/operational/azure/compute_poweredoff_report/azure_compute_poweredoff_report.pt
+++ b/operational/azure/compute_poweredoff_report/azure_compute_poweredoff_report.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "0.3.3",
+  version: "0.3.4",
   provider: "Azure",
   service: "Compute",
   policy_set: "",
@@ -883,7 +883,7 @@ policy "pol_instances_poweredoff_report" do
     escalate $esc_email
     escalate $esc_poweroff_instances
     escalate $esc_delete_instances
-    hash_exclude "message", "tags", "usage_hours", "hours_poweredoff", "percentage_poweredoff", "hourly_cost"
+    hash_exclude "tags", "usage_hours", "hours_poweredoff", "percentage_poweredoff", "hourly_cost"
     export do
       resource_level true
       field "accountID" do

--- a/operational/azure/marketplace_new_products/CHANGELOG.md
+++ b/operational/azure/marketplace_new_products/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.6.3
 
 - Category of policy template updated to "Operational". Functionality unchanged.

--- a/operational/azure/marketplace_new_products/CHANGELOG.md
+++ b/operational/azure/marketplace_new_products/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.6.4
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.6.3
 
 - Category of policy template updated to "Operational". Functionality unchanged.

--- a/operational/azure/marketplace_new_products/CHANGELOG.md
+++ b/operational/azure/marketplace_new_products/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.6.4
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.6.3

--- a/operational/azure/marketplace_new_products/azure_marketplace_new_products.pt
+++ b/operational/azure/marketplace_new_products/azure_marketplace_new_products.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "0.6.3",
+  version: "0.6.4",
   provider: "Azure",
   service: "Marketplace",
   policy_set: "New Marketplace Products",
@@ -718,7 +718,7 @@ policy "pol_new_products" do
     EOS
     check eq(val(item, "product"), "")
     escalate $esc_email
-    hash_exclude "message", "total_cost", "cost", "currency"
+    hash_exclude "total_cost", "cost", "currency"
     export do
       resource_level false
       field "product" do

--- a/operational/flexera/automation/applied_policy_error_notification/CHANGELOG.md
+++ b/operational/flexera/automation/applied_policy_error_notification/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v4.1.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/operational/flexera/automation/applied_policy_error_notification/CHANGELOG.md
+++ b/operational/flexera/automation/applied_policy_error_notification/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.1.1
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v4.1.0

--- a/operational/flexera/automation/applied_policy_error_notification/CHANGELOG.md
+++ b/operational/flexera/automation/applied_policy_error_notification/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.1.1
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v4.1.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/operational/flexera/automation/applied_policy_error_notification/applied_policy_error_notification.pt
+++ b/operational/flexera/automation/applied_policy_error_notification/applied_policy_error_notification.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "high"
 default_frequency "hourly"
 info(
-  version: "4.1.0",
+  version: "4.1.1",
   provider: "Flexera",
   service: "Automation",
   policy_set: "Automation",
@@ -322,7 +322,7 @@ policy "pol_bad_applied_policies" do
     detail_template "{{ with index data 0 }}{{ .message }}{{ end }}"
     check eq(val(item, "id"), "")
     escalate $esc_email
-    hash_exclude "updated_at", "errored_at", "message"
+    hash_exclude "updated_at", "errored_at"
     export do
       resource_level true
       field "id" do
@@ -369,7 +369,7 @@ policy "pol_bad_applied_policies" do
     detail_template "{{ with index data 0 }}{{ .message }}{{ end }}"
     check eq(val(item, "id"), "")
     escalate $esc_email
-    hash_exclude "updated_at", "errored_at", "message"
+    hash_exclude "updated_at", "errored_at"
     export do
       resource_level true
       field "parent_id" do

--- a/operational/flexera/cco/bill_processing_errors_notification/CHANGELOG.md
+++ b/operational/flexera/cco/bill_processing_errors_notification/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v2.7.1
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v2.7.0

--- a/operational/flexera/cco/bill_processing_errors_notification/CHANGELOG.md
+++ b/operational/flexera/cco/bill_processing_errors_notification/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.7.1
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v2.7.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/operational/flexera/cco/bill_processing_errors_notification/CHANGELOG.md
+++ b/operational/flexera/cco/bill_processing_errors_notification/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v2.7.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/operational/flexera/cco/bill_processing_errors_notification/bill_processing_errors_notification.pt
+++ b/operational/flexera/cco/bill_processing_errors_notification/bill_processing_errors_notification.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "high"
 default_frequency "daily"
 info(
-  version: "2.7.0",
+  version: "2.7.1",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -433,7 +433,7 @@ policy "pol_bill_processing_errors" do
     detail_template "{{ with index data 0 }}{{ .message }}{{ end }}"
     check eq(val(item, "id"), "")
     escalate $esc_email
-    hash_exclude "created_at", "updated_at", "message"
+    hash_exclude "created_at", "updated_at"
     export do
       resource_level true
       field "id" do

--- a/operational/flexera/itam/asset_report/CHANGELOG.md
+++ b/operational/flexera/itam/asset_report/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.1
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.2.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/operational/flexera/itam/asset_report/CHANGELOG.md
+++ b/operational/flexera/itam/asset_report/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.1
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.2.0

--- a/operational/flexera/itam/asset_report/CHANGELOG.md
+++ b/operational/flexera/itam/asset_report/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.2.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/operational/flexera/itam/asset_report/itam_asset_report.pt
+++ b/operational/flexera/itam/asset_report/itam_asset_report.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.0",
+  version: "0.2.1",
   provider: "Flexera",
   service: "IT Asset Management",
   policy_set: "ITAM Report",
@@ -248,7 +248,6 @@ policy "pol_itam_asset_report" do
     detail_template "{{ with index data 0 }}{{ .message }}{{ end }}"
     check eq(val(item, "id"), "")
     escalate $esc_email
-    hash_exclude "message"
     export do
       resource_level true
       field "id" do

--- a/operational/flexera/itam/installed_app_report/CHANGELOG.md
+++ b/operational/flexera/itam/installed_app_report/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.1
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.2.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/operational/flexera/itam/installed_app_report/CHANGELOG.md
+++ b/operational/flexera/itam/installed_app_report/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.1
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.2.0

--- a/operational/flexera/itam/installed_app_report/CHANGELOG.md
+++ b/operational/flexera/itam/installed_app_report/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.2.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/operational/flexera/itam/installed_app_report/itam_installed_app_report.pt
+++ b/operational/flexera/itam/installed_app_report/itam_installed_app_report.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.0",
+  version: "0.2.1",
   provider: "Flexera",
   service: "IT Asset Management",
   policy_set: "ITAM Report",
@@ -199,7 +199,6 @@ policy "pol_itam_apps_report" do
     detail_template "{{ with index data 0 }}{{ .message }}{{ end }}"
     check eq(val(item, "id"), "")
     escalate $esc_email
-    hash_exclude "message"
     export do
       resource_level true
       field "id" do

--- a/operational/flexera/itam/license_report/CHANGELOG.md
+++ b/operational/flexera/itam/license_report/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.1
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.2.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/operational/flexera/itam/license_report/CHANGELOG.md
+++ b/operational/flexera/itam/license_report/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.1
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.2.0

--- a/operational/flexera/itam/license_report/CHANGELOG.md
+++ b/operational/flexera/itam/license_report/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.2.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/operational/flexera/itam/license_report/itam_license_report.pt
+++ b/operational/flexera/itam/license_report/itam_license_report.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.0",
+  version: "0.2.1",
   provider: "Flexera",
   service: "IT Asset Management",
   policy_set: "ITAM Report",
@@ -205,7 +205,6 @@ policy "pol_itam_licenses_report" do
     detail_template "{{ with index data 0 }}{{ .message }}{{ end }}"
     check eq(val(item, "id"), "")
     escalate $esc_email
-    hash_exclude "message"
     export do
       resource_level true
       field "id" do

--- a/operational/google/long_running_instances/CHANGELOG.md
+++ b/operational/google/long_running_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.1.3
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.1.2

--- a/operational/google/long_running_instances/CHANGELOG.md
+++ b/operational/google/long_running_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.1.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/operational/google/long_running_instances/CHANGELOG.md
+++ b/operational/google/long_running_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.1.3
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.1.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/operational/google/long_running_instances/google_long_running_instances.pt
+++ b/operational/google/long_running_instances/google_long_running_instances.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.1.2",
+  version: "0.1.3",
   provider: "Google",
   service: "Compute",
   policy_set: "Long Running Instances",
@@ -876,7 +876,7 @@ policy "pol_long_running_instances" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_delete_instances
-    hash_exclude "tags", "message", "cost"
+    hash_exclude "tags", "cost"
     export do
       resource_level true
       field "accountID" do

--- a/operational/google/overutilized_vms/CHANGELOG.md
+++ b/operational/google/overutilized_vms/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v0.2.4
 
 - Updated instance type data source from `data/google/instance_types.json` to `data/google/google_compute_instance_types.json`. Upsize recommendations now use a computed lookup based on vCPU count and memory-to-vCPU ratio, matching the approach used by the Google Rightsize VM Instances policy template.

--- a/operational/google/overutilized_vms/CHANGELOG.md
+++ b/operational/google/overutilized_vms/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.5
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v0.2.4

--- a/operational/google/overutilized_vms/CHANGELOG.md
+++ b/operational/google/overutilized_vms/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.5
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v0.2.4
 
 - Updated instance type data source from `data/google/instance_types.json` to `data/google/google_compute_instance_types.json`. Upsize recommendations now use a computed lookup based on vCPU count and memory-to-vCPU ratio, matching the approach used by the Google Rightsize VM Instances policy template.

--- a/operational/google/overutilized_vms/google_overutilized_vms.pt
+++ b/operational/google/overutilized_vms/google_overutilized_vms.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.4",
+  version: "0.2.5",
   provider: "Google",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -941,7 +941,7 @@ policy "pol_recommendations" do
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))
     escalate $esc_email
     escalate $esc_upsize_instances
-    hash_exclude "tags", "message", "cpuMaximum", "cpuMinimum", "cpuAverage"
+    hash_exclude "tags", "cpuMaximum", "cpuMinimum", "cpuAverage"
     export do
       resource_level true
       field "accountID" do

--- a/security/aws/public_buckets/CHANGELOG.md
+++ b/security/aws/public_buckets/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed issue with incident table that cause policy execution to fail
 
-
 ## v3.2.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/aws/public_buckets/CHANGELOG.md
+++ b/security/aws/public_buckets/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.2.1
+
+- Removed non-exported field `message` from `hash_exclude`
+
+
 ## v3.2.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/aws/public_buckets/CHANGELOG.md
+++ b/security/aws/public_buckets/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v3.2.1
 
-- Removed non-exported field `message` from `hash_exclude`
+- Fixed issue with incident table that cause policy execution to fail
 
 
 ## v3.2.0

--- a/security/aws/public_buckets/aws_public_buckets.pt
+++ b/security/aws/public_buckets/aws_public_buckets.pt
@@ -8,7 +8,7 @@ severity "high"
 category "Security"
 default_frequency "daily"
 info(
-  version: "3.2.0",
+  version: "3.2.1",
   provider: "AWS",
   service: "S3",
   policy_set: "Open S3 Buckets",
@@ -513,7 +513,7 @@ policy "pol_public_buckets" do
 EOS
     check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
     escalate $esc_email
-    hash_exclude "message", "owner"
+    hash_exclude "owner"
     export do
       resource_level true
       field "accountID" do


### PR DESCRIPTION
### Description

This fixes an issue introduced when bulk modifying policy templates to add CSV support. Inadvertently, "message" and "total_savings" were added to the export block, which isn't logical since this will cause policy execution to fail due to neither of them being in the export block.

This also fixes a small issue with a Dangerfile test, and adds some necessary entries to hash_exclude for a few policy templates that were missing them.
