### PR TITLE
POL-000 - Fix AWS Rightsize EC2 to use deep clone instead of shallow clone for timeseries queries

### DIFF
--- a/cost/aws/rightsize_ec2_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_ec2_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.7.2
+
+- Fixed bug which would cause policy to use utilization metrics from the last 1d period instead of the correct full lookback period
+
 ## v5.7.1
 
 - Updated instance type data source from `data/aws/instance_types.json` to `data/aws/aws_ec2_instance_types.json`. Functionality unchanged.

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "5.7.1",
+  version: "5.7.2",
   provider: "AWS",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -969,7 +969,7 @@ script "js_cloudwatch_queries", type: "javascript" do
 
         result[instance['region']].push(query)
 
-        query_timeseries = _.clone(query)
+        query_timeseries = JSON.parse(JSON.stringify(query)) // Deep copy so we can modify without affecting original
         query_timeseries.Id = query.Id + "_timeseries"
         query_timeseries.MetricStat.Period = lookback_1d
         result[instance['region']].push(query_timeseries)
@@ -1038,7 +1038,7 @@ script "js_cloudwatch_queries", type: "javascript" do
 
         result[instance['region']].push(query)
 
-        query_timeseries = _.clone(query)
+        query_timeseries = JSON.parse(JSON.stringify(query))  // Deep copy so we can modify without affecting original
         query_timeseries.Id = query.Id + "_timeseries"
         query_timeseries.MetricStat.Period = lookback_1d
         result[instance['region']].push(query_timeseries)


### PR DESCRIPTION
### Description

Fixed bug which would cause policy to use utilization metrics from the last 1d period instead of the correct full lookback period

### Link to Example Applied Policy

https://app.flexera.au/orgs/48199/automation/applied-policies/projects/150385?noIndex=1&policyId=69e159f87f3946b18fb7247e

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
