### PR TITLE
FOPTS-22112 Fixed a string concatenation bug in Dynamic Dashboards Policy.

### DIFF
--- a/operational/flexera/cco/dynamic_dashboards/CHANGELOG.md
+++ b/operational/flexera/cco/dynamic_dashboards/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.3
+
+- Fixed a bug introduced in v0.2.0 which causes Cloud Workflow to fail.
+
 ## v0.2.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/operational/flexera/cco/dynamic_dashboards/dynamic_dashboards.pt
+++ b/operational/flexera/cco/dynamic_dashboards/dynamic_dashboards.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "daily"
 info(
-  version: "0.2.2",
+  version: "0.2.3",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -950,7 +950,7 @@ define upsert_dashboards($data, $rs_org_id, $rs_optima_host) do
 
   foreach $dashboard in $data do
     sub on_error: handle_error() do
-      log_error("Processing dashboard: " + $dashboard["name"] + " with verb: " + $dashboard["verb"])
+      log_error("Processing dashboard: " + to_s($dashboard["name"]))
       call modify_dashboard($dashboard, $rs_org_id, $rs_optima_host, false)
     end
   end


### PR DESCRIPTION
### Description

Fixed a string concatenation bug in Dynamic Dashboards Policy.

The error raises because `$dashboard["verb"]` results to `null`, and `+` operator does not support "string" plus "null".
> "+ operator cannot be applied between a string and a null"

1. Removed `$dashboard["verb"]`. `verb` is not exported by the Policy, and thus `$dashboard` does not contain field `verb`.
2. The addition of `to_s()` is redundant but just to be safe.

### Link to Example Applied Policy

Link to Policy:
https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/60073?policyId=69e274c0494645276290469f

Link to Cloud Workflow action:
https://app.flexeratest.com/orgs/1105/automation/incidents/projects/60073?incidentId=69e274d392d7f73f07b286a3&tab=action_log

### Contribution Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
