### PR TITLE
POL-1705 Google Project Error Incidents

### DIFF
--- a/automation/google/google_credential/CHANGELOG.md
+++ b/automation/google/google_credential/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v0.1.7
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/automation/google/google_credential/google_credential.pt
+++ b/automation/google/google_credential/google_credential.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "0.1.7",
+  version: "0.2.0",
   provider: "Google",
   service: "Identity & Access Management",
   policy_set: "Authentication",
@@ -137,6 +137,28 @@ datasource "ds_google_projects" do
   end
 end
 
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
+  }
+EOS
+end
+
 datasource "ds_google_credential_status" do
   run_script $js_google_credential_status, $ds_google_projects, $ds_applied_policy
 end
@@ -183,11 +205,36 @@ policy "pol_credentials" do
       end
     end
   end
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email" do
   automatic true

--- a/automation/google/google_credential/google_credential.pt
+++ b/automation/google/google_credential/google_credential.pt
@@ -12,6 +12,7 @@ info(
   provider: "Google",
   service: "Identity & Access Management",
   policy_set: "Authentication",
+  hide_skip_approvals: "true",
   publish: "false"
 )
 

--- a/automation/google/google_missing_projects/CHANGELOG.md
+++ b/automation/google/google_missing_projects/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v0.2.0
 
 - Added `Incident Table Rows for Email Body` and `Attach CSV To Incident Email` parameters to support sending a CSV attachment with incident emails.

--- a/automation/google/google_missing_projects/google_missing_projects.pt
+++ b/automation/google/google_missing_projects/google_missing_projects.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.0",
+  version: "0.3.0",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Automation",
@@ -270,6 +270,28 @@ datasource "ds_google_projects" do
   end
 end
 
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
+  }
+EOS
+end
+
 datasource "ds_missing_projects_api" do
   run_script $js_missing_projects_api, $ds_flexera_cco_data, $ds_google_projects, $ds_applied_policy, $param_projects_list, $param_report_selection, $param_incident_csv
 end
@@ -392,11 +414,36 @@ policy "pol_missing_projects" do
       end
     end
   end
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email" do
   automatic true

--- a/compliance/google/long_stopped_instances/CHANGELOG.md
+++ b/compliance/google/long_stopped_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.3.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v4.2.5
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/compliance/google/long_stopped_instances/google_long_stopped_instances.pt
+++ b/compliance/google/long_stopped_instances/google_long_stopped_instances.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.2.5",
+  version: "4.3.0",
   provider: "Google",
   service: "Compute",
   policy_set: "Long Stopped Instances",
@@ -388,6 +388,28 @@ script "js_google_projects_filtered", type: "javascript" do
 EOS
 end
 
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
+  }
+EOS
+end
+
 datasource "ds_get_instances" do
   iterate $ds_google_projects_filtered
   request do
@@ -755,11 +777,37 @@ policy "pol_long_stopped_instances" do
       end
     end
   end
+
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email" do
   automatic true

--- a/compliance/google/long_stopped_instances/google_long_stopped_instances_meta_parent.pt
+++ b/compliance/google/long_stopped_instances/google_long_stopped_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "4.2.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.3.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/compliance/google/unlabeled_resources/CHANGELOG.md
+++ b/compliance/google/unlabeled_resources/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.4.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v3.3.3
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/compliance/google/unlabeled_resources/unlabeled_resources.pt
+++ b/compliance/google/unlabeled_resources/unlabeled_resources.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "3.3.3",
+  version: "3.4.0",
   provider: "Google",
   service: "Compute",
   policy_set: "Untagged Resources",
@@ -357,6 +357,28 @@ script "js_google_projects_filtered", type: "javascript" do
     })
   } else {
     result = ds_google_projects
+  }
+EOS
+end
+
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
   }
 EOS
 end
@@ -988,11 +1010,37 @@ policy "pol_unlabeled_resources" do
       end
     end
   end
+
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email" do
   automatic true

--- a/compliance/google/unlabeled_resources/unlabeled_resources_meta_parent.pt
+++ b/compliance/google/unlabeled_resources/unlabeled_resources_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "3.3.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/cloud_run_anomaly_detection/CHANGELOG.md
+++ b/cost/google/cloud_run_anomaly_detection/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v0.3.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/cloud_run_anomaly_detection/google_cloud_run_anomaly_detection.pt
+++ b/cost/google/cloud_run_anomaly_detection/google_cloud_run_anomaly_detection.pt
@@ -12,7 +12,8 @@ info(
   version: "0.4.0",
   provider: "Google",
   service: "Cloud Run",
-  policy_set: "Anomaly Detection"
+  policy_set: "Anomaly Detection",
+  hide_skip_approvals: "true"
 )
 
 ###############################################################################

--- a/cost/google/cloud_run_anomaly_detection/google_cloud_run_anomaly_detection.pt
+++ b/cost/google/cloud_run_anomaly_detection/google_cloud_run_anomaly_detection.pt
@@ -9,7 +9,7 @@ category "Cost"
 default_frequency "daily"
 info(
   publish: "false",
-  version: "0.3.2",
+  version: "0.4.0",
   provider: "Google",
   service: "Cloud Run",
   policy_set: "Anomaly Detection"
@@ -307,6 +307,25 @@ script "js_google_projects_filtered", type: "javascript" do
 EOS
 end
 
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: "Google Cloud Run Anomaly Detection"
+    }]
+  }
+EOS
+end
+
 datasource "ds_google_regions" do
   iterate $ds_google_projects_filtered
   request do
@@ -530,11 +549,37 @@ policy "pol_utilization" do
       end
     end
   end
+
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email" do
   automatic true

--- a/cost/google/cloud_storage_lifecycle/CHANGELOG.md
+++ b/cost/google/cloud_storage_lifecycle/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v0.3.3
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/cloud_storage_lifecycle/google_cloud_storage_lifecycle.pt
+++ b/cost/google/cloud_storage_lifecycle/google_cloud_storage_lifecycle.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.3",
+  version: "0.4.0",
   provider: "Google",
   service: "Storage",
   policy_set: "",
@@ -242,6 +242,28 @@ script "js_google_projects_filtered", type: "javascript" do
 EOS
 end
 
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
+  }
+EOS
+end
+
 datasource "ds_google_buckets" do
   iterate $ds_google_projects_filtered
   request do
@@ -428,11 +450,37 @@ policy "pol_google_bad_buckets" do
       end
     end
   end
+
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email" do
   automatic true

--- a/cost/google/cloud_storage_lifecycle/google_cloud_storage_lifecycle_meta_parent.pt
+++ b/cost/google/cloud_storage_lifecycle/google_cloud_storage_lifecycle_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "0.3.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/cud_expiration/CHANGELOG.md
+++ b/cost/google/cud_expiration/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.3.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v3.2.3
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/cud_expiration/google_cud_expiration_report.pt
+++ b/cost/google/cud_expiration/google_cud_expiration_report.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "3.2.3",
+  version: "3.3.0",
   provider: "Google",
   service: "Compute",
   policy_set: "Committed Use Discount",
@@ -251,6 +251,28 @@ script "js_google_projects_filtered", type: "javascript" do
 EOS
 end
 
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
+  }
+EOS
+end
+
 datasource "ds_google_cuds" do
   iterate $ds_google_projects_filtered
   request do
@@ -397,11 +419,37 @@ policy "pol_expiring_google_cuds" do
       end
     end
   end
+
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email" do
   automatic true

--- a/cost/google/cud_expiration/google_cud_expiration_report_meta_parent.pt
+++ b/cost/google/cud_expiration/google_cud_expiration_report_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "3.2.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.3.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/cud_recommendations/CHANGELOG.md
+++ b/cost/google/cud_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.6.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v4.5.5
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/google/cud_recommendations/google_committed_use_discount_recommendations.pt
+++ b/cost/google/cud_recommendations/google_committed_use_discount_recommendations.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.5.5",
+  version: "4.6.0",
   provider: "Google",
   service: "Compute",
   recommendation_type: "Rate Reduction",
@@ -308,6 +308,28 @@ script "js_google_projects_filtered", type: "javascript" do
     })
   } else {
     result = ds_google_projects
+  }
+EOS
+end
+
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
   }
 EOS
 end
@@ -757,11 +779,37 @@ policy "pol_recommendations" do
       end
     end
   end
+
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email" do
   automatic true

--- a/cost/google/cud_recommendations/google_committed_use_discount_recommendations_meta_parent.pt
+++ b/cost/google/cud_recommendations/google_committed_use_discount_recommendations_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "4.5.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.6.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/cud_report/CHANGELOG.md
+++ b/cost/google/cud_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.3.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v3.2.3
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/cud_report/google_committed_use_discount_report.pt
+++ b/cost/google/cud_report/google_committed_use_discount_report.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "3.2.3",
+  version: "3.3.0",
   provider: "Google",
   service: "Compute",
   policy_set: "Committed Use Discount",
@@ -251,6 +251,28 @@ script "js_google_projects_filtered", type: "javascript" do
 EOS
 end
 
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
+  }
+EOS
+end
+
 datasource "ds_google_cuds" do
   iterate $ds_google_projects_filtered
   request do
@@ -386,11 +408,37 @@ policy "pol_google_cuds_report" do
       end
     end
   end
+
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email" do
   automatic true

--- a/cost/google/cud_report/google_committed_use_discount_report_meta_parent.pt
+++ b/cost/google/cud_report/google_committed_use_discount_report_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "3.2.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.3.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/idle_ip_address_recommendations/CHANGELOG.md
+++ b/cost/google/idle_ip_address_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.5.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v4.4.5
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.4.5",
+  version: "4.5.0",
   provider: "Google",
   service: "Compute",
   policy_set: "Unused IP Addresses",
@@ -316,6 +316,28 @@ script "js_google_projects_filtered", type: "javascript" do
     })
   } else {
     result = ds_google_projects
+  }
+EOS
+end
+
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
   }
 EOS
 end
@@ -853,11 +875,37 @@ policy "pol_recommendations" do
       end
     end
   end
+
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email" do
   automatic true

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "4.4.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/idle_persistent_disk_recommendations/CHANGELOG.md
+++ b/cost/google/idle_persistent_disk_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.5.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v4.4.5
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.4.5",
+  version: "4.5.0",
   provider: "Google",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -445,6 +445,28 @@ script "js_google_projects_filtered", type: "javascript" do
     })
   } else {
     result = ds_google_projects
+  }
+EOS
+end
+
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
   }
 EOS
 end
@@ -1132,11 +1154,37 @@ policy "pol_recommendations" do
       end
     end
   end
+
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email" do
   automatic true

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "4.4.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/object_storage_optimization/CHANGELOG.md
+++ b/cost/google/object_storage_optimization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v3.0.12
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/google/object_storage_optimization/google_object_storage_optimization.pt
+++ b/cost/google/object_storage_optimization/google_object_storage_optimization.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.0.12",
+  version: "3.1.0",
   provider: "Google",
   service: "Storage",
   policy_set: "Object Store Optimization",
@@ -232,6 +232,28 @@ script "js_google_projects_filtered", type: "javascript" do
     })
   } else {
     result = ds_google_projects
+  }
+EOS
+end
+
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
   }
 EOS
 end
@@ -616,11 +638,37 @@ policy "pol_object_storage_optimization" do
       end
     end
   end
+
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email" do
   automatic true

--- a/cost/google/object_storage_optimization/google_object_storage_optimization_meta_parent.pt
+++ b/cost/google/object_storage_optimization/google_object_storage_optimization_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "3.0.12", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.1.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "true",
   hide_skip_approvals: "true"

--- a/cost/google/old_snapshots/CHANGELOG.md
+++ b/cost/google/old_snapshots/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.5.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v5.4.4
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/google/old_snapshots/google_delete_old_snapshots.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.4.4",
+  version: "5.5.0",
   provider:"Google",
   service: "Storage",
   policy_set: "Old Snapshots",
@@ -467,6 +467,28 @@ script "js_google_projects_filtered", type: "javascript" do
     })
   } else {
     result = ds_google_projects
+  }
+EOS
+end
+
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Old Snapshots"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
   }
 EOS
 end
@@ -1103,11 +1125,37 @@ policy "pol_old_snapshots" do
       end
     end
   end
+
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email" do
   automatic true

--- a/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "5.4.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/recommender/CHANGELOG.md
+++ b/cost/google/recommender/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.3.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v3.2.5
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/google/recommender/recommender.pt
+++ b/cost/google/recommender/recommender.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.2.5",
+  version: "3.3.0",
   provider: "Google",
   service: "All",
   policy_set: "Native Recommendations",
@@ -298,6 +298,28 @@ script "js_google_projects_filtered", type: "javascript" do
     })
   } else {
     result = ds_google_projects
+  }
+EOS
+end
+
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
   }
 EOS
 end
@@ -682,11 +704,37 @@ policy "pol_recommendations" do
       end
     end
   end
+
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email" do
   automatic true

--- a/cost/google/recommender/recommender_meta_parent.pt
+++ b/cost/google/recommender/recommender_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "3.2.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.3.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/rightsize_cloudsql_instances/CHANGELOG.md
+++ b/cost/google/rightsize_cloudsql_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v0.2.5
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/google/rightsize_cloudsql_instances/google_rightsize_cloudsql_instances.pt
+++ b/cost/google/rightsize_cloudsql_instances/google_rightsize_cloudsql_instances.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.5",
+  version: "0.3.0",
   provider: "Google",
   service: "Compute",
   policy_set: "Rightsize Database Instances",
@@ -442,6 +442,28 @@ script "js_google_projects_filtered", type: "javascript" do
     })
   } else {
     result = ds_google_projects
+  }
+EOS
+end
+
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
   }
 EOS
 end
@@ -1862,11 +1884,37 @@ policy "pol_cloudsql_recommendations" do
       end
     end
   end
+
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email" do
   automatic true

--- a/cost/google/rightsize_cloudsql_instances/google_rightsize_cloudsql_instances_meta_parent.pt
+++ b/cost/google/rightsize_cloudsql_instances/google_rightsize_cloudsql_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "0.2.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.3.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/rightsize_cloudsql_recommendations/CHANGELOG.md
+++ b/cost/google/rightsize_cloudsql_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v0.4.5
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/google/rightsize_cloudsql_recommendations/google_rightsize_cloudsql_recommendations.pt
+++ b/cost/google/rightsize_cloudsql_recommendations/google_rightsize_cloudsql_recommendations.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.5",
+  version: "0.5.0",
   provider: "Google",
   service: "Compute",
   policy_set: "Rightsize Database Instances",
@@ -325,6 +325,28 @@ script "js_google_projects_filtered", type: "javascript" do
     })
   } else {
     result = ds_google_projects
+  }
+EOS
+end
+
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
   }
 EOS
 end
@@ -1291,11 +1313,37 @@ policy "pol_cloudsql_recommendations" do
       end
     end
   end
+
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email" do
   automatic true

--- a/cost/google/rightsize_cloudsql_recommendations/google_rightsize_cloudsql_recommendations_meta_parent.pt
+++ b/cost/google/rightsize_cloudsql_recommendations/google_rightsize_cloudsql_recommendations_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "0.4.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/rightsize_persistent_disks/CHANGELOG.md
+++ b/cost/google/rightsize_persistent_disks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v0.1.1
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/google/rightsize_persistent_disks/google_rightsize_persistent_disks.pt
+++ b/cost/google/rightsize_persistent_disks/google_rightsize_persistent_disks.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.1.1",
+  version: "0.2.0",
   provider: "Google",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -422,6 +422,28 @@ script "js_google_projects_filtered", type: "javascript" do
     })
   } else {
     result = ds_google_projects
+  }
+EOS
+end
+
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
   }
 EOS
 end
@@ -1600,11 +1622,37 @@ policy "pol_rightsize_persistent_disks" do
       end
     end
   end
+
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email" do
   automatic true

--- a/cost/google/rightsize_persistent_disks/google_rightsize_persistent_disks_meta_parent.pt
+++ b/cost/google/rightsize_persistent_disks/google_rightsize_persistent_disks_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "0.1.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/rightsize_vm_instances/CHANGELOG.md
+++ b/cost/google/rightsize_vm_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v0.2.5
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/google/rightsize_vm_instances/google_rightsize_vm_instances.pt
+++ b/cost/google/rightsize_vm_instances/google_rightsize_vm_instances.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.5",
+  version: "0.3.0",
   provider: "Google",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -552,6 +552,28 @@ script "js_google_projects_filtered", type: "javascript" do
     })
   } else {
     result = ds_google_projects
+  }
+EOS
+end
+
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
   }
 EOS
 end
@@ -1964,11 +1986,37 @@ policy "pol_recommendations" do
       end
     end
   end
+
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email" do
   automatic true

--- a/cost/google/rightsize_vm_instances/google_rightsize_vm_instances_meta_parent.pt
+++ b/cost/google/rightsize_vm_instances/google_rightsize_vm_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "0.2.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.3.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/rightsize_vm_recommendations/CHANGELOG.md
+++ b/cost/google/rightsize_vm_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.4.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v3.3.5
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations.pt
+++ b/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "3.3.5",
+  version: "3.4.0",
   provider: "Google",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -435,6 +435,28 @@ script "js_google_projects_filtered", type: "javascript" do
     })
   } else {
     result = ds_google_projects
+  }
+EOS
+end
+
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
   }
 EOS
 end
@@ -1467,11 +1489,36 @@ policy "pol_recommendations" do
       end
     end
   end
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email" do
   automatic true

--- a/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
+++ b/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "3.3.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/schedule_instance/CHANGELOG.md
+++ b/cost/google/schedule_instance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.1.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v6.0.8
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/google/schedule_instance/google_schedule_instance.pt
+++ b/cost/google/schedule_instance/google_schedule_instance.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "15 minutes"
 info(
-  version: "6.0.8",
+  version: "6.1.0",
   provider: "Google",
   service: "Compute",
   policy_set: "Schedule Instance",
@@ -276,6 +276,28 @@ script "js_google_projects_filtered", type: "javascript" do
     })
   } else {
     result = ds_google_projects
+  }
+EOS
+end
+
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
   }
 EOS
 end
@@ -1369,11 +1391,37 @@ The following Google VM Instances have label `{{ parameters.param_label_schedule
       end
     end
   end
+
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email_start" do
   automatic contains($param_automatic_action, "Start Notification")

--- a/cost/google/schedule_instance/google_schedule_instance_meta_parent.pt
+++ b/cost/google/schedule_instance/google_schedule_instance_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "6.0.8", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.1.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/unused_disks/CHANGELOG.md
+++ b/cost/google/unused_disks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v0.2.6
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/google/unused_disks/google_unused_disks.pt
+++ b/cost/google/unused_disks/google_unused_disks.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.6",
+  version: "0.3.0",
   provider: "Google",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -384,6 +384,28 @@ script "js_google_projects_filtered", type: "javascript" do
     })
   } else {
     result = ds_google_projects
+  }
+EOS
+end
+
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
   }
 EOS
 end
@@ -934,11 +956,37 @@ policy "pol_unused_disks" do
       end
     end
   end
+
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email" do
   automatic true

--- a/cost/google/unused_disks/google_unused_disks_meta_parent.pt
+++ b/cost/google/unused_disks/google_unused_disks_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "0.2.6", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.3.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "true",
   hide_skip_approvals: "true"

--- a/operational/google/label_cardinality/CHANGELOG.md
+++ b/operational/google/label_cardinality/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v0.3.3
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/operational/google/label_cardinality/google_label_cardinality.pt
+++ b/operational/google/label_cardinality/google_label_cardinality.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.3",
+  version: "0.4.0",
   provider: "Google",
   service: "Tags",
   policy_set: "Tag Cardinality",
@@ -221,6 +221,28 @@ script "js_google_projects_filtered", type: "javascript" do
     })
   } else {
     result = ds_google_projects
+  }
+EOS
+end
+
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
   }
 EOS
 end
@@ -544,11 +566,36 @@ policy "pol_google_label_cardinality_report" do
       end
     end
   end
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email" do
   automatic true

--- a/operational/google/label_cardinality/google_label_cardinality_meta_parent.pt
+++ b/operational/google/label_cardinality/google_label_cardinality_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "0.3.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/operational/google/long_running_instances/CHANGELOG.md
+++ b/operational/google/long_running_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v0.1.3
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/operational/google/long_running_instances/google_long_running_instances.pt
+++ b/operational/google/long_running_instances/google_long_running_instances.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.1.3",
+  version: "0.2.0",
   provider: "Google",
   service: "Compute",
   policy_set: "Long Running Instances",
@@ -479,6 +479,28 @@ script "js_google_projects_filtered", type: "javascript" do
 EOS
 end
 
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
+  }
+EOS
+end
+
 datasource "ds_get_instances" do
   iterate $ds_google_projects_filtered
   request do
@@ -927,11 +949,36 @@ policy "pol_long_running_instances" do
       end
     end
   end
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email" do
   automatic true

--- a/operational/google/long_running_instances/google_long_running_instances_meta_parent.pt
+++ b/operational/google/long_running_instances/google_long_running_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "0.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/operational/google/overutilized_vms/CHANGELOG.md
+++ b/operational/google/overutilized_vms/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v0.2.5
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/operational/google/overutilized_vms/google_overutilized_vms.pt
+++ b/operational/google/overutilized_vms/google_overutilized_vms.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.5",
+  version: "0.3.0",
   provider: "Google",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -403,6 +403,28 @@ script "js_google_projects_filtered", type: "javascript" do
     })
   } else {
     result = ds_google_projects
+  }
+EOS
+end
+
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
   }
 EOS
 end
@@ -1010,11 +1032,36 @@ policy "pol_recommendations" do
       end
     end
   end
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email" do
   automatic true

--- a/operational/google/overutilized_vms/google_overutilized_vms_meta_parent.pt
+++ b/operational/google/overutilized_vms/google_overutilized_vms_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "0.2.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.3.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/security/google/public_buckets/CHANGELOG.md
+++ b/security/google/public_buckets/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.4.0
+
+- Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.
+
 ## v3.3.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/google/public_buckets/google_public_buckets.pt
+++ b/security/google/public_buckets/google_public_buckets.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.4.0",
   provider: "Google",
   service: "Storage",
   policy_set: "Open Buckets",
@@ -255,6 +255,28 @@ script "js_google_projects_filtered", type: "javascript" do
     })
   } else {
     result = ds_google_projects
+  }
+EOS
+end
+
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
   }
 EOS
 end
@@ -542,11 +564,36 @@ policy "pol_open_storage_buckets" do
       end
     end
   end
+  validate $ds_no_projects_error do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to retrieve any Google projects. This typically indicates a permissions issue with the Google credential.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify that the Google credential has the 'resourcemanager.projects.get' permission.
+    1. Ensure that the credential has access to at least one Google project.
+    1. If using project filtering parameters, verify that the filtered list includes accessible projects.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
 end
 
 ###############################################################################
 # Escalations
 ###############################################################################
+
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
 
 escalation "esc_email" do
   automatic true

--- a/security/google/public_buckets/google_public_buckets_meta_parent.pt
+++ b/security/google/public_buckets/google_public_buckets_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "3.3.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"


### PR DESCRIPTION
### Description

Adds a new error incident to all relevant Google policy templates to report if the credential is not able to access any Google Projects. This way, the lack of results in this scenario is not incorrectly interpreted as a legitimate lack of optimization opportunities.

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=69e8d444a9aee47adaf87150

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
