### PR TITLE
POL-1759 Pi Harness Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,9 @@ __pycache__/
 *.pyc
 *.pyo
 .Python
+
+# Ignore user-created Pi harness assets
+.pi/
+!.pi/
+!.pi/extensions/
+!.pi/extensions/**

--- a/.pi/extensions/CHANGELOG.md
+++ b/.pi/extensions/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+- Initial release

--- a/.pi/extensions/README.md
+++ b/.pi/extensions/README.md
@@ -1,0 +1,67 @@
+# github-agents
+
+A [Pi](https://pi.dev) extension that loads agent instruction files from `.github/agents/` and injects them into the system prompt on every agent turn.
+
+## Why
+
+Pi natively loads `AGENTS.md` files from the current directory and its parents. But if your repo already has agent instructions in `.github/agents/` (for GitHub Copilot or other tools), maintaining a separate `AGENTS.md` is redundant. This extension bridges the gap so Pi picks up those files automatically.
+
+Injecting via `before_agent_start` means the instructions are re-added fresh on every prompt, so they **survive compaction** — unlike `AGENTS.md` content which can be summarized away over a long session.
+
+## Install
+
+**Note: Installation is not needed if running [Pi](https://pi.dev) from the root directory of the [flexera-public/policy_templates](https://github.com/flexera-public/policy_templates) Github repository. It will automatically detect and load the extension.**
+
+Copy the extension into your repo's `.pi/extensions/` directory and commit it:
+
+```sh
+mkdir -p .pi/extensions
+cp github-agents.ts .pi/extensions/
+```
+
+Pi auto-discovers extensions in `.pi/extensions/`, so every contributor gets the agent instructions loaded automatically when they run `pi` from the repo root. No extra configuration needed.
+
+## Usage
+
+The extension loads silently on startup and notifies you which files were found:
+
+```text
+github-agents: loaded 2 files: coding.md, security.md
+```
+
+If `.github/agents/` doesn't exist or contains no `.md` or `.txt` files, you'll see a warning and the extension stays inactive.
+
+### Commands
+
+| Command | Description |
+| --- | --- |
+| `/github-agents-reload` | Reload files from disk without restarting pi. Useful if you edit a file mid-session. |
+| `/github-agents-status` | Show loaded files, character counts, and a content preview. Good for auditing what's actually in the prompt. |
+
+## File support
+
+The extension loads all `.md` and `.txt` files from `.github/agents/`, sorted alphabetically. Empty files are skipped. Files are concatenated in the system prompt, each wrapped in an HTML comment header identifying its source:
+
+```text
+<!-- .github/agents/coding.md -->
+...content...
+
+---
+
+<!-- .github/agents/security.md -->
+...content...
+```
+
+## Notifications
+
+| Situation | Behavior |
+|---|---|
+| Startup | Notifies with loaded file names, or warns if none found |
+| `/new`, `/fork`, session resume | Cache refreshed silently (no toast) |
+| `/github-agents-reload` | Always notifies with result |
+| File read error | Error toast shown at startup and on explicit reload only |
+
+## Requirements
+
+- [Pi coding agent](https://pi.dev) (`@mariozechner/pi-coding-agent`)
+- The extension file must remain `.ts` — Pi loads extensions via [jiti](https://github.com/unjs/jiti) and expects TypeScript. Renaming to `.js` will break it.

--- a/.pi/extensions/github-agents.ts
+++ b/.pi/extensions/github-agents.ts
@@ -1,0 +1,148 @@
+/**
+ * github-agents.ts
+ *
+ * Pi extension that loads agent instruction files from .github/agents/ and
+ * injects them into the system prompt on every agent turn.
+ *
+ * Install (project-local, committed to repo):
+ *   mkdir -p .pi/extensions
+ *   cp github-agents.ts .pi/extensions/
+ *
+ * Pi auto-discovers extensions in .pi/extensions/ so no config needed.
+ * Every contributor who runs `pi` from this repo gets the agents loaded.
+ */
+
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+interface AgentFile {
+  name: string;
+  content: string;
+}
+
+interface LoadResult {
+  agentsDir: string;
+  files: AgentFile[];
+  errors: string[];
+}
+
+export default function (pi: ExtensionAPI) {
+  let cached: LoadResult = { agentsDir: "", files: [], errors: [] };
+
+  function loadAgentFiles(): LoadResult {
+    const agentsDir = path.join(process.cwd(), ".github", "agents");
+
+    if (!fs.existsSync(agentsDir)) {
+      return { agentsDir, files: [], errors: [] };
+    }
+
+    let filenames: string[];
+    try {
+      filenames = fs
+        .readdirSync(agentsDir)
+        .filter((f) => f.endsWith(".md") || f.endsWith(".txt"))
+        .sort();
+    } catch (err) {
+      return { agentsDir, files: [], errors: [`Could not read .github/agents/: ${(err as Error).message}`] };
+    }
+
+    const files: AgentFile[] = [];
+    const errors: string[] = [];
+
+    for (const name of filenames) {
+      try {
+        const content = fs.readFileSync(path.join(agentsDir, name), "utf-8").trim();
+        if (content.length === 0) continue; // skip empty files
+        files.push({ name, content });
+      } catch (err) {
+        errors.push(`Could not read .github/agents/${name}: ${(err as Error).message}`);
+      }
+    }
+
+    return { agentsDir, files, errors };
+  }
+
+  function buildSystemPromptAppendix(files: AgentFile[]): string {
+    const sections = files.map(({ name, content }) => `<!-- .github/agents/${name} -->\n${content}`);
+    return `\n\n---\n<!-- Project agent instructions from .github/agents/ -->\n\n${sections.join("\n\n---\n\n")}`;
+  }
+
+  function reload(ctx: ExtensionContext, notify: boolean) {
+    cached = loadAgentFiles();
+    const { agentsDir, files, errors } = cached;
+
+    // Always surface errors, but only when notifying — avoids surprise
+    // red toasts during silent session switches
+    if (notify) {
+      for (const err of errors) {
+        ctx.ui.notify(`github-agents: ${err}`, "error");
+      }
+
+      if (files.length === 0 && errors.length === 0) {
+        ctx.ui.notify(`github-agents: .github/agents/ not found or empty — extension inactive`, "warning");
+      } else if (files.length > 0) {
+        ctx.ui.notify(
+          `github-agents: loaded ${files.length} file${files.length !== 1 ? "s" : ""}: ${files.map((f) => f.name).join(", ")}`,
+          "info"
+        );
+      }
+    }
+  }
+
+  pi.on("session_start", (event, ctx) => {
+    const shouldNotify = event.reason === "startup" || event.reason === "reload";
+    reload(ctx, shouldNotify);
+  });
+
+  pi.registerCommand("github-agents-reload", {
+    description: "Reload files from .github/agents/ without restarting pi",
+    handler: (_args, ctx) => {
+      reload(ctx, true);
+    },
+  });
+
+  pi.registerCommand("github-agents-status", {
+    description: "Show currently loaded .github/agents/ files and their content preview",
+    handler: (_args, ctx) => {
+      const { agentsDir, files, errors } = cached;
+
+      const lines: string[] = [];
+
+      if (files.length === 0 && errors.length === 0) {
+        lines.push(`No files loaded. Looked in: ${agentsDir}`);
+      } else {
+        lines.push(`${files.length} file${files.length !== 1 ? "s" : ""} loaded from ${agentsDir}`);
+        lines.push("");
+        for (const { name, content } of files) {
+          const previewLines = content.split("\n").slice(0, 3);
+          const preview = previewLines.join(" ↵ ");
+          const truncated = content.split("\n").length > 3 ? " …" : "";
+          lines.push(`• ${name} (${content.length} chars): ${preview}${truncated}`);
+        }
+      }
+
+      if (errors.length > 0) {
+        lines.push("");
+        lines.push("Errors:");
+        for (const err of errors) {
+          lines.push(`• ${err}`);
+        }
+      }
+
+      pi.sendMessage({
+        customType: "github-agents-status",
+        content: lines.join("\n"),
+        display: true,
+      });
+    },
+  });
+
+  pi.on("before_agent_start", (event, _ctx) => {
+    if (cached.files.length === 0) return;
+
+    return {
+      systemPrompt: event.systemPrompt + buildSystemPromptAppendix(cached.files),
+    };
+  });
+}

--- a/.pi/extensions/github-agents.ts
+++ b/.pi/extensions/github-agents.ts
@@ -4,6 +4,10 @@
  * Pi extension that loads agent instruction files from .github/agents/ and
  * injects them into the system prompt on every agent turn.
  *
+ * Commands:
+ *   /github-agents-reload  — reload files from disk without restarting pi
+ *   /github-agents-status  — show loaded files and content preview
+ *
  * Install (project-local, committed to repo):
  *   mkdir -p .pi/extensions
  *   cp github-agents.ts .pi/extensions/
@@ -13,8 +17,11 @@
  */
 
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
 import * as fs from "node:fs";
 import * as path from "node:path";
+
+const STATUS_MESSAGE_TYPE = "github-agents-status";
 
 interface AgentFile {
   name: string;
@@ -25,6 +32,11 @@ interface LoadResult {
   agentsDir: string;
   files: AgentFile[];
   errors: string[];
+}
+
+interface StatusLine {
+  text: string;
+  style: "header" | "file" | "error-heading" | "error" | "inactive";
 }
 
 export default function (pi: ExtensionAPI) {
@@ -44,7 +56,11 @@ export default function (pi: ExtensionAPI) {
         .filter((f) => f.endsWith(".md") || f.endsWith(".txt"))
         .sort();
     } catch (err) {
-      return { agentsDir, files: [], errors: [`Could not read .github/agents/: ${(err as Error).message}`] };
+      return {
+        agentsDir,
+        files: [],
+        errors: [`Could not read .github/agents/: ${(err as Error).message}`],
+      };
     }
 
     const files: AgentFile[] = [];
@@ -53,7 +69,7 @@ export default function (pi: ExtensionAPI) {
     for (const name of filenames) {
       try {
         const content = fs.readFileSync(path.join(agentsDir, name), "utf-8").trim();
-        if (content.length === 0) continue; // skip empty files
+        if (content.length === 0) continue;
         files.push({ name, content });
       } catch (err) {
         errors.push(`Could not read .github/agents/${name}: ${(err as Error).message}`);
@@ -64,23 +80,63 @@ export default function (pi: ExtensionAPI) {
   }
 
   function buildSystemPromptAppendix(files: AgentFile[]): string {
-    const sections = files.map(({ name, content }) => `<!-- .github/agents/${name} -->\n${content}`);
+    const sections = files.map(
+      ({ name, content }) => `<!-- .github/agents/${name} -->\n${content}`
+    );
     return `\n\n---\n<!-- Project agent instructions from .github/agents/ -->\n\n${sections.join("\n\n---\n\n")}`;
+  }
+
+  function buildStatusLines(): StatusLine[] {
+    const { agentsDir, files, errors } = cached;
+    const lines: StatusLine[] = [];
+
+    if (files.length === 0 && errors.length === 0) {
+      lines.push({
+        text: `No files loaded. Looked in: ${agentsDir}`,
+        style: "inactive",
+      });
+    } else {
+      lines.push({
+        text: `${files.length} file${files.length !== 1 ? "s" : ""} loaded from ${agentsDir}`,
+        style: "header",
+      });
+      lines.push({ text: "", style: "file" });
+      for (const { name, content } of files) {
+        const contentLines = content.split("\n");
+        const preview = contentLines.slice(0, 3).join(" ↵ ");
+        const truncated = contentLines.length > 3 ? " …" : "";
+        lines.push({
+          text: `• ${name} (${content.length} chars): ${preview}${truncated}`,
+          style: "file",
+        });
+      }
+    }
+
+    if (errors.length > 0) {
+      lines.push({ text: "", style: "error" });
+      lines.push({ text: "Errors:", style: "error-heading" });
+      for (const err of errors) {
+        lines.push({ text: `• ${err}`, style: "error" });
+      }
+    }
+
+    return lines;
   }
 
   function reload(ctx: ExtensionContext, notify: boolean) {
     cached = loadAgentFiles();
-    const { agentsDir, files, errors } = cached;
+    const { files, errors } = cached;
 
-    // Always surface errors, but only when notifying — avoids surprise
-    // red toasts during silent session switches
     if (notify) {
       for (const err of errors) {
         ctx.ui.notify(`github-agents: ${err}`, "error");
       }
 
       if (files.length === 0 && errors.length === 0) {
-        ctx.ui.notify(`github-agents: .github/agents/ not found or empty — extension inactive`, "warning");
+        ctx.ui.notify(
+          "github-agents: .github/agents/ not found or empty — extension inactive",
+          "warning"
+        );
       } else if (files.length > 0) {
         ctx.ui.notify(
           `github-agents: loaded ${files.length} file${files.length !== 1 ? "s" : ""}: ${files.map((f) => f.name).join(", ")}`,
@@ -89,6 +145,30 @@ export default function (pi: ExtensionAPI) {
       }
     }
   }
+
+  pi.registerMessageRenderer(STATUS_MESSAGE_TYPE, (message, _options, theme) => {
+    const statusLines = message.details?.lines as StatusLine[] | undefined;
+
+    // Fall back to raw content if details are missing (e.g. old session replay)
+    if (!statusLines) {
+      return new Text(String(message.content), 0, 0);
+    }
+
+    const rendered = statusLines
+      .map(({ text, style }) => {
+        switch (style) {
+          case "header":  return theme.fg("accent", text);
+          case "file":    return theme.fg("muted", text);
+          case "error-heading": return theme.fg("error", text);
+          case "error":   return theme.fg("error", text);
+          case "inactive": return theme.fg("warning", text);
+          default:        return text;
+        }
+      })
+      .join("\n");
+
+    return new Text(rendered, 0, 0);
+  });
 
   pi.on("session_start", (event, ctx) => {
     const shouldNotify = event.reason === "startup" || event.reason === "reload";
@@ -104,36 +184,13 @@ export default function (pi: ExtensionAPI) {
 
   pi.registerCommand("github-agents-status", {
     description: "Show currently loaded .github/agents/ files and their content preview",
-    handler: (_args, ctx) => {
-      const { agentsDir, files, errors } = cached;
-
-      const lines: string[] = [];
-
-      if (files.length === 0 && errors.length === 0) {
-        lines.push(`No files loaded. Looked in: ${agentsDir}`);
-      } else {
-        lines.push(`${files.length} file${files.length !== 1 ? "s" : ""} loaded from ${agentsDir}`);
-        lines.push("");
-        for (const { name, content } of files) {
-          const previewLines = content.split("\n").slice(0, 3);
-          const preview = previewLines.join(" ↵ ");
-          const truncated = content.split("\n").length > 3 ? " …" : "";
-          lines.push(`• ${name} (${content.length} chars): ${preview}${truncated}`);
-        }
-      }
-
-      if (errors.length > 0) {
-        lines.push("");
-        lines.push("Errors:");
-        for (const err of errors) {
-          lines.push(`• ${err}`);
-        }
-      }
-
+    handler: (_args, _ctx) => {
+      const lines = buildStatusLines();
       pi.sendMessage({
-        customType: "github-agents-status",
-        content: lines.join("\n"),
+        customType: STATUS_MESSAGE_TYPE,
+        content: lines.map((l) => l.text).join("\n"),
         display: true,
+        details: { lines },
       });
     },
   });


### PR DESCRIPTION
### Description

Adds a [Pi](https://pi.dev) extension to enable the Pi harness to automatically load the GitHub agent for policy template development. This eliminates the need to maintain a separate agent file for Pi.

This is for users that prefer to use Pi for interfacing with GitHub Copilot instead of the official Copilot CLI.