### PR TITLE
POL-1759 Pi Harness Ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ __pycache__/
 *.pyc
 *.pyo
 .Python
+
+# Ignore pi harness subdirectory to enable user customization
+.pi/
+pi/


### PR DESCRIPTION
### Description

Adds directories related to the pi Harness to the git ignore list to avoid merging these files. This is so users can make use of this harness at their discretion.
