### PR TITLE
POL-1774 AWS RI/SP - Fixes for Multiple Options

### DIFF
--- a/cost/aws/reserved_instances/recommendations/CHANGELOG.md
+++ b/cost/aws/reserved_instances/recommendations/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.8.0
+
+- When `Everything` is selected for the `Payment Option` parameter, the policy now makes a separate API call for each of the three payment options (No Upfront, Partial Upfront, All Upfront) and combines the results, ensuring all recommendations are captured.
+- When `Any` is selected for the `Reservation Term` parameter, the policy now makes a separate API call for each term (1 Year, 3 Year) and combines the results, ensuring all recommendations are captured.
+
 ## v3.7.4
 
 - Fixed issue where policy execution would sometimes fail if "Everything" was selected for the `Payment Option` parameter.

--- a/cost/aws/reserved_instances/recommendations/README.md
+++ b/cost/aws/reserved_instances/recommendations/README.md
@@ -27,8 +27,8 @@ This policy template has the following input parameters:
 - *Service* - AWS Services to scan for recommendations. Items can be removed by clicking X to the right of the name.
 - *EC2 Reservation Type* - The type of reservation recommendations to produce for EC2. Standard reservations are less flexible than convertible ones but provide a higher discount. Has no effect on recommendations for services other than `Elastic Compute Cloud (EC2)`
 - *Account Scope* - The account scope that you want your recommendations for. Select `Payer` to produce results aggregated across the entire AWS Organization (Master Payer and Linked accounts), or `Linked` to produce results for each linked account individually.
-- *Reservation Term* - Length of reservation term to provide recommendations for.
-- *Payment Option* - Reservation purchase option to provide recommendations for. Select `Everything` to produce recommendations for all three.
+- *Reservation Term* - Length of reservation term to provide recommendations for. Select `Any` to produce recommendations for both 1-year and 3-year terms; the policy will make a separate API call for each term and combine the results.
+- *Payment Option* - Reservation purchase option to provide recommendations for. Select `Everything` to produce recommendations for all three payment options (No Upfront, Partial Upfront, All Upfront); the policy will make a separate API call for each option and combine the results.
 - *Attach CSV To Incident Email* - Whether or not to attach the results as a CSV file to the incident email.
 - *Incident Table Rows for Email Body (#)* - The number of results to include in the incident table in the incident email. Set to '0' to not show an incident table at all, and '100000' to include all results. Does not impact attached CSV files or the incident as presented in Flexera One.
 

--- a/cost/aws/reserved_instances/recommendations/aws_reserved_instance_recommendations.pt
+++ b/cost/aws/reserved_instances/recommendations/aws_reserved_instance_recommendations.pt
@@ -94,7 +94,7 @@ parameter "param_payment_option" do
   type "string"
   category "Reservation Settings"
   label "Payment Option"
-  description "Reservation purchase option to provide recommendations for. Select 'Everything' to produce recommendations for all three."
+  description "Reservation purchase option to provide recommendations for. Select 'Everything' to return combined results for all three options."
   allowed_values "No Upfront", "Partial Upfront", "All Upfront", "Everything"
   default "No Upfront"
 end

--- a/cost/aws/reserved_instances/recommendations/aws_reserved_instance_recommendations.pt
+++ b/cost/aws/reserved_instances/recommendations/aws_reserved_instance_recommendations.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.7.4",
+  version: "3.8.0",
   provider: "AWS",
   service: "Compute",
   policy_set: "Reserved Instances",
@@ -372,11 +372,11 @@ EOS
 end
 
 datasource "ds_ri_types" do
-  run_script $js_ri_types, $param_service
+  run_script $js_ri_types, $param_service, $param_payment_option, $param_term
 end
 
 script "js_ri_types", type: "javascript" do
-  parameters "param_service"
+  parameters "param_service", "param_payment_option", "param_term"
   result "result"
   code <<-'EOS'
   if (param_service.length == 0) {
@@ -401,8 +401,38 @@ script "js_ri_types", type: "javascript" do
     })
   }
 
-  result = _.map(services, function(service) {
-    return { service: service }
+  var payment_option_table = {
+    "No Upfront": "NO_UPFRONT",
+    "Partial Upfront": "PARTIAL_UPFRONT",
+    "All Upfront": "ALL_UPFRONT"
+  }
+
+  var payment_options = []
+  if (param_payment_option == "Everything") {
+    payment_options = ["NO_UPFRONT", "PARTIAL_UPFRONT", "ALL_UPFRONT"]
+  } else {
+    payment_options = [payment_option_table[param_payment_option]]
+  }
+
+  var term_table = {
+    "1 Year": "ONE_YEAR",
+    "3 Year": "THREE_YEARS"
+  }
+
+  var terms = []
+  if (param_term == "Any") {
+    terms = ["ONE_YEAR", "THREE_YEARS"]
+  } else {
+    terms = [term_table[param_term]]
+  }
+
+  result = []
+  _.each(services, function(service) {
+    _.each(payment_options, function(payment_option) {
+      _.each(terms, function(term) {
+        result.push({ service: service, payment_option: payment_option, term: term })
+      })
+    })
   })
 EOS
 end
@@ -410,7 +440,7 @@ end
 datasource "ds_ri_recommendations" do
   iterate $ds_ri_types
   request do
-    run_script $js_ri_recommendations, val(iter_item, 'service'), $param_days, $param_payment_option, $param_service_spec, $param_term, $param_scope
+    run_script $js_ri_recommendations, val(iter_item, 'service'), val(iter_item, 'payment_option'), val(iter_item, 'term'), $param_days, $param_service_spec, $param_scope
   end
   result do
     encoding "json"
@@ -463,7 +493,7 @@ datasource "ds_ri_recommendations" do
 end
 
 script "js_ri_recommendations", type: "javascript" do
-  parameters "service", "param_days", "param_payment_option", "param_service_spec", "param_term", "param_scope"
+  parameters "service", "payment_option", "term", "param_days", "param_service_spec", "param_scope"
   result "request"
   code <<-'EOS'
   // Tables to convert human-readable parameter values to their API equivalents
@@ -483,30 +513,20 @@ script "js_ri_recommendations", type: "javascript" do
     "MemoryDB": "Amazon MemoryDB Service"
   }
 
-  term_table = {
-    "1 Year": "ONE_YEAR",
-    "3 Year": "THREE_YEARS"
-  }
-
-  // Build out the body of the request based on parameters
-  body_fields = {
+  // Build out the body of the request based on parameters.
+  // payment_option and term are pre-converted to API format by js_ri_types.
+  var body_fields = {
     LookbackPeriodInDays: period_table[param_days],
     AccountScope: param_scope.toUpperCase(),
-    Service: service_table[service]
-  }
-
-  if (param_payment_option != "Everything") {
-    body_fields['PaymentOption'] = param_payment_option.replace(' ', '_').toUpperCase()
+    Service: service_table[service],
+    PaymentOption: payment_option,
+    TermInYears: term
   }
 
   if (service == "Elastic Compute Cloud (EC2)") {
     body_fields['ServiceSpecification'] = {
       EC2Specification: { OfferingClass: param_service_spec.toUpperCase() }
     }
-  }
-
-  if (param_term != "Any") {
-    body_fields['TermInYears'] = term_table[param_term]
   }
 
   var request = {

--- a/cost/aws/reserved_instances/recommendations/aws_reserved_instance_recommendations.pt
+++ b/cost/aws/reserved_instances/recommendations/aws_reserved_instance_recommendations.pt
@@ -822,6 +822,7 @@ policy "pol_aws_ri_recommendations" do
     EOS
     check lt(val(item, "savings"), 0)
     escalate $esc_email
+    hash_exclude "savings", "savingsCurrency"
     export do
       resource_level false
       field "accountID" do

--- a/cost/aws/savings_plan/recommendations/CHANGELOG.md
+++ b/cost/aws/savings_plan/recommendations/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v4.0.0
+
+- The `Savings Plan Type` parameter now accepts multiple selections (list) instead of a single value. Leave it blank to return results for all Savings Plan types.
+- Added `Everything` option to the `Payment Option` parameter. When selected, the policy makes separate API requests for each payment option and combines the results.
+- Added `Any` option to the `Savings Plan Term` parameter. When selected, the policy makes separate API requests for each term length and combines the results.
+- Selecting both `Any` for term and `Everything` for payment option will result in up to 6 API requests per selected Savings Plan type.
+
 ## v3.4.6
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/savings_plan/recommendations/CHANGELOG.md
+++ b/cost/aws/savings_plan/recommendations/CHANGELOG.md
@@ -5,7 +5,6 @@
 - The `Savings Plan Type` parameter now accepts multiple selections (list) instead of a single value. Leave it blank to return results for all Savings Plan types.
 - Added `Everything` option to the `Payment Option` parameter. When selected, the policy makes separate API requests for each payment option and combines the results.
 - Added `Any` option to the `Savings Plan Term` parameter. When selected, the policy makes separate API requests for each term length and combines the results.
-- Selecting both `Any` for term and `Everything` for payment option will result in up to 6 API requests per selected Savings Plan type.
 
 ## v3.4.6
 

--- a/cost/aws/savings_plan/recommendations/README.md
+++ b/cost/aws/savings_plan/recommendations/README.md
@@ -25,9 +25,9 @@ This policy template has the following input parameters:
 - *Minimum Savings Threshold* - Minimum potential savings required to generate a recommendation.
 - *Look Back Period* - Number of days of prior usage to analyze
 - *Account Scope* - The account scope that you want your recommendations for. Select Payer to produce results for the Master Payer account and all linked accounts, or Linked to produce results for an individual linked member account.
-- *Savings Plan Term* - Length of savings plan term to provide recommendations for.
-- *Savings Plan Type* - Type of Savings Plan to provide recommendations for.
-- *Payment Option* - Savings Plan purchase option to provide recommendations for.
+- *Savings Plan Term* - Length of savings plan term to provide recommendations for. Select `Any` to return results for both term lengths; the policy will make a separate API request for each term and combine the results.
+- *Savings Plan Type* - Type(s) of Savings Plan to provide recommendations for. Multiple selections are allowed. Leave blank to return results for all Savings Plan types.
+- *Payment Option* - Savings Plan purchase option to provide recommendations for. Select `Everything` to return results for all payment options; the policy will make a separate API request for each option and combine the results. Selecting both `Any` for Savings Plan Term and `Everything` for Payment Option will result in up to 6 API requests per selected Savings Plan type.
 - *Attach CSV To Incident Email* - Whether or not to attach the results as a CSV file to the incident email.
 - *Incident Table Rows for Email Body (#)* - The number of results to include in the incident table in the incident email. Set to '0' to not show an incident table at all, and '100000' to include all results. Does not impact attached CSV files or the incident as presented in Flexera One.
 

--- a/cost/aws/savings_plan/recommendations/README.md
+++ b/cost/aws/savings_plan/recommendations/README.md
@@ -26,7 +26,7 @@ This policy template has the following input parameters:
 - *Look Back Period* - Number of days of prior usage to analyze
 - *Account Scope* - The account scope that you want your recommendations for. Select Payer to produce results for the Master Payer account and all linked accounts, or Linked to produce results for an individual linked member account.
 - *Savings Plan Term* - Length of savings plan term to provide recommendations for. Select `Any` to return results for both term lengths; the policy will make a separate API request for each term and combine the results.
-- *Savings Plan Type* - Type(s) of Savings Plan to provide recommendations for. Multiple selections are allowed. Leave blank to return results for all Savings Plan types.
+- *Savings Plan Type* - Type(s) of Savings Plan to provide recommendations for. Multiple selections are allowed.
 - *Payment Option* - Savings Plan purchase option to provide recommendations for. Select `Everything` to return results for all payment options; the policy will make a separate API request for each option and combine the results. Selecting both `Any` for Savings Plan Term and `Everything` for Payment Option will result in up to 6 API requests per selected Savings Plan type.
 - *Attach CSV To Incident Email* - Whether or not to attach the results as a CSV file to the incident email.
 - *Incident Table Rows for Email Body (#)* - The number of results to include in the incident table in the incident email. Set to '0' to not show an incident table at all, and '100000' to include all results. Does not impact attached CSV files or the incident as presented in Flexera One.

--- a/cost/aws/savings_plan/recommendations/aws_savings_plan_recommendations.pt
+++ b/cost/aws/savings_plan/recommendations/aws_savings_plan_recommendations.pt
@@ -78,7 +78,7 @@ parameter "param_savings_plan_type" do
   label "Savings Plan Type"
   description "Type(s) of Savings Plan to provide recommendations for. Leave blank to return results for all Savings Plan types."
   allowed_values "Compute Savings Plan", "EC2 Instance Savings Plan", "SageMaker Savings Plan", "Database Savings Plan"
-  default []
+  default ["Compute Savings Plan"]
 end
 
 parameter "param_payment_option" do
@@ -789,6 +789,7 @@ policy "pol_aws_sp_recommendations" do
     EOS
     check lt(val(item, "savings"), 0)
     escalate $esc_email
+    hash_exclude "savings", "savingsCurrency"
     export do
       resource_level false
       field "accountID" do

--- a/cost/aws/savings_plan/recommendations/aws_savings_plan_recommendations.pt
+++ b/cost/aws/savings_plan/recommendations/aws_savings_plan_recommendations.pt
@@ -67,7 +67,7 @@ parameter "param_term" do
   type "string"
   category "Savings Plan Settings"
   label "Savings Plan Term"
-  description "Length of savings plan term to provide recommendations for. Select 'Any' to return results for both term lengths by making a separate API request for each term."
+  description "Length of savings plan term to provide recommendations for. Select 'Any' to return combined results for both term lengths."
   allowed_values "1 Year", "3 Year", "Any"
   default "1 Year"
 end
@@ -85,7 +85,7 @@ parameter "param_payment_option" do
   type "string"
   category "Savings Plan Settings"
   label "Payment Option"
-  description "Savings Plan purchase option to provide recommendations for. Select 'Everything' to return results for all payment options by making a separate API request for each option. Selecting both 'Any' for Savings Plan Term and 'Everything' for Payment Option will result in up to 6 API requests per Savings Plan type."
+  description "Savings Plan purchase option to provide recommendations for. Select 'Everything' to return combined results for all payment options."
   allowed_values "No Upfront", "Partial Upfront", "All Upfront", "Everything"
   default "No Upfront"
 end

--- a/cost/aws/savings_plan/recommendations/aws_savings_plan_recommendations.pt
+++ b/cost/aws/savings_plan/recommendations/aws_savings_plan_recommendations.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.4.6",
+  version: "4.0.0",
   provider: "AWS",
   service: "Compute",
   policy_set: "Savings Plans",
@@ -67,26 +67,26 @@ parameter "param_term" do
   type "string"
   category "Savings Plan Settings"
   label "Savings Plan Term"
-  description "Length of savings plan term to provide recommendations for."
-  allowed_values "1 Year", "3 Year"
+  description "Length of savings plan term to provide recommendations for. Select 'Any' to return results for both term lengths by making a separate API request for each term."
+  allowed_values "1 Year", "3 Year", "Any"
   default "1 Year"
 end
 
 parameter "param_savings_plan_type" do
-  type "string"
+  type "list"
   category "Savings Plan Settings"
   label "Savings Plan Type"
-  description "Type of Savings Plan to provide recommendations for."
+  description "Type(s) of Savings Plan to provide recommendations for. Leave blank to return results for all Savings Plan types."
   allowed_values "Compute Savings Plan", "EC2 Instance Savings Plan", "SageMaker Savings Plan", "Database Savings Plan"
-  default "Compute Savings Plan"
+  default []
 end
 
 parameter "param_payment_option" do
   type "string"
   category "Savings Plan Settings"
   label "Payment Option"
-  description "Savings Plan purchase option to provide recommendations for."
-  allowed_values "No Upfront", "Partial Upfront", "All Upfront"
+  description "Savings Plan purchase option to provide recommendations for. Select 'Everything' to return results for all payment options by making a separate API request for each option. Selecting both 'Any' for Savings Plan Term and 'Everything' for Payment Option will result in up to 6 API requests per Savings Plan type."
+  allowed_values "No Upfront", "Partial Upfront", "All Upfront", "Everything"
   default "No Upfront"
 end
 
@@ -362,9 +362,101 @@ script "js_vendor_account_table", type:"javascript" do
 EOS
 end
 
+datasource "ds_sp_types" do
+  run_script $js_sp_types, $param_savings_plan_type, $param_payment_option, $param_term
+end
+
+script "js_sp_types", type: "javascript" do
+  parameters "param_savings_plan_type", "param_payment_option", "param_term"
+  result "result"
+  code <<-'EOS'
+  var plan_options = [
+    "Compute Savings Plan",
+    "EC2 Instance Savings Plan",
+    "SageMaker Savings Plan",
+    "Database Savings Plan"
+  ]
+
+  var plan_table = {
+    "Compute Savings Plan": "COMPUTE_SP",
+    "EC2 Instance Savings Plan": "EC2_INSTANCE_SP",
+    "SageMaker Savings Plan": "SAGEMAKER_SP",
+    "Database Savings Plan": "DATABASE_SP"
+  }
+
+  var plans = []
+
+  if (param_savings_plan_type.length == 0) {
+    _.each(plan_options, function(plan) {
+      plans.push({ label: plan, value: plan_table[plan] })
+    })
+  } else {
+    _.each(param_savings_plan_type, function(plan) {
+      plans.push({ label: plan, value: plan_table[plan] })
+    })
+  }
+
+  var payment_option_table = {
+    "No Upfront": "NO_UPFRONT",
+    "Partial Upfront": "PARTIAL_UPFRONT",
+    "All Upfront": "ALL_UPFRONT"
+  }
+
+  var payment_option_label_table = {
+    "NO_UPFRONT": "No Upfront",
+    "PARTIAL_UPFRONT": "Partial Upfront",
+    "ALL_UPFRONT": "All Upfront"
+  }
+
+  var payment_options = []
+
+  if (param_payment_option == "Everything") {
+    payment_options = ["NO_UPFRONT", "PARTIAL_UPFRONT", "ALL_UPFRONT"]
+  } else {
+    payment_options = [payment_option_table[param_payment_option]]
+  }
+
+  var term_table = {
+    "1 Year": "ONE_YEAR",
+    "3 Year": "THREE_YEARS"
+  }
+
+  var term_label_table = {
+    "ONE_YEAR": "1 Year",
+    "THREE_YEARS": "3 Year"
+  }
+
+  var terms = []
+
+  if (param_term == "Any") {
+    terms = ["ONE_YEAR", "THREE_YEARS"]
+  } else {
+    terms = [term_table[param_term]]
+  }
+
+  result = []
+
+  _.each(plans, function(plan) {
+    _.each(payment_options, function(payment_option) {
+      _.each(terms, function(term) {
+        result.push({
+          plan_label: plan.label,
+          plan_value: plan.value,
+          payment_option: payment_option,
+          payment_option_label: payment_option_label_table[payment_option],
+          term: term,
+          term_label: term_label_table[term]
+        })
+      })
+    })
+  })
+EOS
+end
+
 datasource "ds_sp_recommendations" do
+  iterate $ds_sp_types
   request do
-    run_script $js_sp_recommendations, $param_days, $param_payment_option, $param_term, $param_savings_plan_type, $param_scope
+    run_script $js_sp_recommendations, val(iter_item, 'plan_value'), val(iter_item, 'payment_option'), val(iter_item, 'term'), $param_days, $param_scope
   end
   result do
     encoding "json"
@@ -386,40 +478,32 @@ datasource "ds_sp_recommendations" do
       field "offeringId", jmes_path(col_item, "SavingsPlansDetails.OfferingId")
       field "region", jmes_path(col_item, "SavingsPlansDetails.Region")
       field "upfrontCost", jmes_path(col_item, "UpfrontCost")
+      field "plan_label", val(iter_item, "plan_label")
+      field "payment_option_label", val(iter_item, "payment_option_label")
+      field "term_label", val(iter_item, "term_label")
     end
   end
 end
 
 script "js_sp_recommendations", type: "javascript" do
-  parameters "param_days", "param_payment_option", "param_term", "param_savings_plan_type", "param_scope"
+  parameters "plan_value", "payment_option", "term", "param_days", "param_scope"
   result "request"
   code <<-'EOS'
-  // Tables to convert human-readable parameter values to their API equivalents
+  // Table to convert human-readable parameter values to their API equivalents
   period_table = {
     "Last 7 Days": "SEVEN_DAYS",
     "Last 30 Days": "THIRTY_DAYS",
     "Last 60 Days": "SIXTY_DAYS"
   }
 
-  term_table = {
-    "1 Year": "ONE_YEAR",
-    "3 Year": "THREE_YEARS"
-  }
-
-  plan_table = {
-    "Compute Savings Plan": "COMPUTE_SP",
-    "EC2 Instance Savings Plan": "EC2_INSTANCE_SP",
-    "SageMaker Savings Plan": "SAGEMAKER_SP",
-    "Database Savings Plan": "DATABASE_SP"
-  }
-
-  // Build out the body of the request based on parameters
-  body_fields = {
+  // Build out the body of the request based on parameters.
+  // plan_value, payment_option, and term are pre-converted to API format by js_sp_types.
+  var body_fields = {
     AccountScope: param_scope.toUpperCase(),
     LookbackPeriodInDays: period_table[param_days],
-    PaymentOption: param_payment_option.replace(' ', '_').toUpperCase()
-    SavingsPlansType: plan_table[param_savings_plan_type],
-    TermInYears: term_table[param_term]
+    PaymentOption: payment_option,
+    SavingsPlansType: plan_value,
+    TermInYears: term
   }
 
   var request = {
@@ -432,7 +516,7 @@ script "js_sp_recommendations", type: "javascript" do
     headers: {
       "User-Agent": "RS Policies",
       "X-Amz-Target": "AWSInsightsIndexService.GetSavingsPlansPurchaseRecommendation",
-      "Content-Type": "application/x-amz-json-1.1",
+      "Content-Type": "application/x-amz-json-1.1"
     }
   }
 EOS
@@ -563,7 +647,7 @@ script "js_sp_normalization", type: "javascript" do
     resourceType = recommendation["instanceFamily"]
 
     if (resourceType == "" || resourceType == null) {
-      resourceType = param_savings_plan_type
+      resourceType = recommendation["plan_label"]
     }
 
     currentAverageHourlyOnDemandSpend = recommendation["currentAverageHourlyOnDemandSpend"] * exchange_rate
@@ -628,11 +712,12 @@ script "js_sp_normalization", type: "javascript" do
         offeringId: recommendation["offeringId"],
         region: recommendation["region"],
         upfrontCost: upfrontCost,
-        term: param_term,
-        paymentOption: param_payment_option,
+        term: recommendation["term_label"],
+        paymentOption: recommendation["payment_option_label"],
         resourceType: resourceType,
         lookbackPeriod: param_days,
-        service: service_table[param_savings_plan_type],
+        service: service_table[recommendation["plan_label"]],
+        savingsPlanType: recommendation["plan_label"],
         policy_name: ds_applied_policy['name'],
         total_savings: "",
         message: ""
@@ -657,12 +742,14 @@ script "js_sp_normalization", type: "javascript" do
   }
 
   if (ds_currency['code'] != currency && ds_currency_conversion.length == 0) {
-    conversion_message = "Savings values are in ", currency, " due to a malfunction with Flexera's internal currency conversion API. Please contact Flexera support to report this issue."
+    conversion_message = ["Savings values are in ", currency, " due to a malfunction with Flexera's internal currency conversion API. Please contact Flexera support to report this issue."].join('')
   }
+
+  var plan_type_msg = (param_savings_plan_type.length == 0) ? "All" : param_savings_plan_type.join(', ')
 
   message = [
     "The following settings were used when generating recommendations:\n",
-    "- Savings Plan Type: ", param_savings_plan_type, "\n",
+    "- Savings Plan Type: ", plan_type_msg, "\n",
     "- Account Scope: ", param_scope, "\n",
     "- Term: ", param_term, "\n",
     "- Look Back Period: ", param_days, "\n",
@@ -715,6 +802,9 @@ policy "pol_aws_sp_recommendations" do
       end
       field "service" do
         label "Service"
+      end
+      field "savingsPlanType" do
+        label "Savings Plan Type"
       end
       field "savingsCurrency" do
         label "Currency"

--- a/cost/aws/savings_plan/recommendations/aws_savings_plan_recommendations.pt
+++ b/cost/aws/savings_plan/recommendations/aws_savings_plan_recommendations.pt
@@ -76,7 +76,7 @@ parameter "param_savings_plan_type" do
   type "list"
   category "Savings Plan Settings"
   label "Savings Plan Type"
-  description "Type(s) of Savings Plan to provide recommendations for. Leave blank to return results for all Savings Plan types."
+  description "Type(s) of Savings Plan to provide recommendations for."
   allowed_values "Compute Savings Plan", "EC2 Instance Savings Plan", "SageMaker Savings Plan", "Database Savings Plan"
   default ["Compute Savings Plan"]
 end
@@ -370,13 +370,6 @@ script "js_sp_types", type: "javascript" do
   parameters "param_savings_plan_type", "param_payment_option", "param_term"
   result "result"
   code <<-'EOS'
-  var plan_options = [
-    "Compute Savings Plan",
-    "EC2 Instance Savings Plan",
-    "SageMaker Savings Plan",
-    "Database Savings Plan"
-  ]
-
   var plan_table = {
     "Compute Savings Plan": "COMPUTE_SP",
     "EC2 Instance Savings Plan": "EC2_INSTANCE_SP",
@@ -386,15 +379,9 @@ script "js_sp_types", type: "javascript" do
 
   var plans = []
 
-  if (param_savings_plan_type.length == 0) {
-    _.each(plan_options, function(plan) {
-      plans.push({ label: plan, value: plan_table[plan] })
-    })
-  } else {
-    _.each(param_savings_plan_type, function(plan) {
-      plans.push({ label: plan, value: plan_table[plan] })
-    })
-  }
+  _.each(param_savings_plan_type, function(plan) {
+    plans.push({ label: plan, value: plan_table[plan] })
+  })
 
   var payment_option_table = {
     "No Upfront": "NO_UPFRONT",
@@ -745,7 +732,7 @@ script "js_sp_normalization", type: "javascript" do
     conversion_message = ["Savings values are in ", currency, " due to a malfunction with Flexera's internal currency conversion API. Please contact Flexera support to report this issue."].join('')
   }
 
-  var plan_type_msg = (param_savings_plan_type.length == 0) ? "All" : param_savings_plan_type.join(', ')
+  var plan_type_msg = param_savings_plan_type.join(', ')
 
   message = [
     "The following settings were used when generating recommendations:\n",


### PR DESCRIPTION
### Description

Updates the `AWS Reserved Instances Recommendations` policy template so that, when a user selects multiple terms or payment types, multiple API calls are made and the results genuinely contain all of the recommendations. This functionality has also been added to the `AWS Savings Plan Recommendations` policy template.

### Link to Example Applied Policy

https://app.flexera.com/orgs/27018/automation/applied-policies/projects/113453?policyId=6a217979d4f6397e66ba5ed8
https://app.flexera.com/orgs/27018/automation/applied-policies/projects/113453?policyId=6a217a6898e17776c7720f98

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
