### PR TITLE
POL-1777 Azure Sentinel Commitment Tier Recommendations Fix

### DIFF
--- a/cost/azure/sentinel_commitment_tiers/CHANGELOG.md
+++ b/cost/azure/sentinel_commitment_tiers/CHANGELOG.md
@@ -1,12 +1,9 @@
 # Changelog
 
-## v0.3.2
+## v0.4.0
 
 - Fixed bug where workspaces using Azure Sentinel Simplified pricing (unified SKU) received no recommendations or incorrect savings estimates. The policy now detects the pricing scheme per workspace via the OperationsManagement Solutions API and applies the correct rate model: Simplified workspaces use the all-inclusive Sentinel unified rate; Classic workspaces continue to use the sum of Log Analytics and Sentinel component rates.
-- Added the 50 GB/day commitment tier to the list of evaluated tiers, which is available under Simplified pricing.
-- Added a guard to skip recommendation calculation for workspaces whose current committed tier rate cannot be determined from pricing data, preventing incorrect baselines.
 - Added `Pricing Scheme` field to the incident table, indicating whether each recommendation was generated using Classic or Simplified pricing.
-- Added `Microsoft.OperationsManagement/solutions/read` permission to the required Azure credential permissions in the README.
 
 ## v0.3.1
 

--- a/cost/azure/sentinel_commitment_tiers/CHANGELOG.md
+++ b/cost/azure/sentinel_commitment_tiers/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.3.2
+
+- Fixed bug where workspaces using Azure Sentinel Simplified pricing (unified SKU) received no recommendations or incorrect savings estimates. The policy now detects the pricing scheme per workspace via the OperationsManagement Solutions API and applies the correct rate model: Simplified workspaces use the all-inclusive Sentinel unified rate; Classic workspaces continue to use the sum of Log Analytics and Sentinel component rates.
+- Added the 50 GB/day commitment tier to the list of evaluated tiers, which is available under Simplified pricing.
+- Added a guard to skip recommendation calculation for workspaces whose current committed tier rate cannot be determined from pricing data, preventing incorrect baselines.
+- Added `Pricing Scheme` field to the incident table, indicating whether each recommendation was generated using Classic or Simplified pricing.
+- Added `Microsoft.OperationsManagement/solutions/read` permission to the required Azure credential permissions in the README.
+
 ## v0.3.1
 
 - Fixed incorrect overage billing calculation: usage exceeding a commitment tier's daily GB level is now billed at the tier's effective per-GB rate (`Tier Daily Rate / Tier GB Level`) rather than the Pay-As-You-Go rate, consistent with Microsoft Sentinel pricing.

--- a/cost/azure/sentinel_commitment_tiers/CHANGELOG.md
+++ b/cost/azure/sentinel_commitment_tiers/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed bug where workspaces using Azure Sentinel Simplified pricing (unified SKU) received no recommendations or incorrect savings estimates. The policy now detects the pricing scheme per workspace via the OperationsManagement Solutions API and applies the correct rate model: Simplified workspaces use the all-inclusive Sentinel unified rate; Classic workspaces continue to use the sum of Log Analytics and Sentinel component rates.
 - Added `Pricing Scheme` field to the incident table, indicating whether each recommendation was generated using Classic or Simplified pricing.
+- Added downgrade and PAYG switch recommendations: the policy now evaluates all commitment tiers in both directions and checks whether switching to Pay-As-You-Go pricing would be cheaper than a workspace's current commitment tier.
 
 ## v0.3.1
 

--- a/cost/azure/sentinel_commitment_tiers/README.md
+++ b/cost/azure/sentinel_commitment_tiers/README.md
@@ -11,8 +11,9 @@ The policy template performs the following steps:
 1. All Azure subscriptions are enumerated and filtered based on the configured allow/deny list.
 1. All Log Analytics workspaces in each subscription are listed.
 1. For each workspace, the Microsoft Sentinel onboarding state is checked via the SecurityInsights API; workspaces without Sentinel enabled are excluded.
+1. For each Sentinel-enabled workspace, the Sentinel pricing scheme is determined by checking the `Microsoft.OperationsManagement/solutions/SecurityInsights({workspaceName})` resource. If the solution SKU is `Unified`, the workspace uses **Simplified pricing** — a single all-inclusive Microsoft Sentinel rate that covers both log analytics ingestion and Sentinel analysis. All other workspaces use **Classic pricing** — two separate, additive cost components: Log Analytics data ingestion and Microsoft Sentinel analysis.
 1. For each Sentinel-enabled workspace, the Log Analytics Query API is used to retrieve daily billable data ingestion volumes (in GB) over the configured lookback period.
-1. The Azure Retail Prices API is queried for the current pricing for each workspace's Azure region. Because a Sentinel-enabled workspace incurs two separate, additive cost components — Log Analytics data ingestion (sourced from the `Log Analytics` and `Azure Monitor` service listings) and Microsoft Sentinel analysis (sourced from the `Sentinel` service listing) — pricing is fetched from all three service names and combined.
+1. The Azure Retail Prices API is queried for the current pricing for each workspace's Azure region. For **Classic** workspaces, pricing is fetched from the `Log Analytics`, `Azure Monitor`, and `Sentinel` service listings and the two components are summed. For **Simplified** workspaces, only the `Sentinel` service listing is used, as that rate is all-inclusive.
 1. For each workspace, the estimated daily cost is calculated at the current tier and at each available higher tier.
 1. The tier with the lowest estimated cost that is higher than the current tier is identified as the recommended tier.
 1. An incident is raised if the recommended tier saves more than the configured minimum savings threshold.
@@ -21,9 +22,11 @@ The policy template performs the following steps:
 
 The policy includes the estimated monthly savings. The estimated monthly savings is recognized if the workspace's pricing tier is upgraded to the recommended Commitment Tier.
 
-- Pricing data is retrieved in real time from the [Azure Retail Prices API](https://learn.microsoft.com/en-us/rest/api/cost-management/retail-prices/azure-retail-prices) for each workspace's Azure region. Costs for a Sentinel-enabled workspace are the sum of two additive components: the Log Analytics data ingestion cost (fetched from the `Log Analytics` and `Azure Monitor` service listings) and the Microsoft Sentinel analysis cost (fetched from the `Sentinel` service listing). The combined Pay-As-You-Go per-GB rate and each combined Commitment Tier daily rate are used for all cost calculations.
+- Pricing data is retrieved in real time from the [Azure Retail Prices API](https://learn.microsoft.com/en-us/rest/api/cost-management/retail-prices/azure-retail-prices) for each workspace's Azure region. How pricing is computed depends on the workspace's pricing scheme, shown in the **Pricing Scheme** column of the incident table:
+  - **Classic**: Costs are the sum of two additive components — the Log Analytics data ingestion cost (fetched from the `Log Analytics` and `Azure Monitor` service listings) and the Microsoft Sentinel analysis cost (fetched from the `Sentinel` service listing).
+  - **Simplified**: A single unified Sentinel rate covers both log analytics ingestion and Sentinel analysis (available for workspaces created after July 2023). Only the `Sentinel` service listing is used; no Log Analytics component is added.
 - The `Estimated Monthly Savings` is calculated as the difference between the current estimated monthly cost and the estimated monthly cost at the recommended tier, multiplied by 30.44 (average days per month).
-- The estimated monthly cost at a given tier is: `(Tier Daily Rate + max(0, Average Daily Ingestion − Tier GB Level) × (Tier Daily Rate / Tier GB Level)) × 30.44`. For Pay-As-You-Go: `Average Daily Ingestion × Pay-as-you-go Rate per GB × 30.44`. The overage rate for a commitment tier is the tier's own effective per-GB rate (`Tier Daily Rate / Tier GB Level`), not the Pay-as-you-go rate, consistent with [Microsoft Sentinel pricing](https://www.microsoft.com/en-us/security/pricing/microsoft-sentinel/). `Tier Daily Rate` and `Pay-as-you-go Rate per GB` are composite values equal to the sum of the Log Analytics component and the Microsoft Sentinel component for the given tier and region.
+- The estimated monthly cost at a given tier is: `(Tier Daily Rate + max(0, Average Daily Ingestion − Tier GB Level) × (Tier Daily Rate / Tier GB Level)) × 30.44`. For Pay-As-You-Go: `Average Daily Ingestion × Pay-as-you-go Rate per GB × 30.44`. The overage rate for a commitment tier is the tier's own effective per-GB rate (`Tier Daily Rate / Tier GB Level`), not the Pay-as-you-go rate, consistent with [Microsoft Sentinel pricing](https://www.microsoft.com/en-us/security/pricing/microsoft-sentinel/). For Classic workspaces, `Tier Daily Rate` and `Pay-as-you-go Rate per GB` are composite values equal to the sum of the Log Analytics and Sentinel components. For Simplified workspaces, these rates come directly from the unified Sentinel pricing.
 - `Average Daily Ingestion` is computed from the Log Analytics `Usage` table over the configured lookback period using only billable data (`IsBillable == true`).
 - If no pricing data is available for the workspace's region, the workspace is excluded from recommendations.
 - The incident message detail includes the sum of each workspace's `Estimated Monthly Savings` as `Potential Monthly Savings`.
@@ -53,8 +56,9 @@ This Policy Template uses [Credentials](https://docs.flexera.com/flexera-one/aut
 - [**Azure Resource Manager Credential**](https://docs.flexera.com/flexera-one/automation/automation-administration/managing-credentials-for-policy-access-to-external-systems/provider-specific-credentials#azure-resource-manager) (*provider=azure_rm*) which has the following permissions:
   - `Microsoft.Resources/subscriptions/read`
   - `Microsoft.OperationalInsights/workspaces/read`
-  - `Microsoft.SecurityInsights/onboardingStates/read`
   - `Microsoft.OperationalInsights/workspaces/query/action`
+  - `Microsoft.OperationsManagement/solutions/read`
+  - `Microsoft.SecurityInsights/onboardingStates/read`
 
 - [**Flexera Credential**](https://docs.flexera.com/flexera-one/automation/automation-administration/managing-credentials-for-policy-access-to-external-systems/provider-specific-credentials#flexera) (*provider=flexera*) which has the following roles:
   - `billing_center_viewer`

--- a/cost/azure/sentinel_commitment_tiers/azure_sentinel_commitment_tiers.pt
+++ b/cost/azure/sentinel_commitment_tiers/azure_sentinel_commitment_tiers.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "0.3.1",
+  version: "0.3.2",
   provider: "Azure",
   service: "Sentinel",
   policy_set: "Commitment Tiers",
@@ -472,8 +472,49 @@ script "js_sentinel_workspaces", type: "javascript" do
 EOS
 end
 
-datasource "ds_workspace_ingestion_raw" do
+datasource "ds_sentinel_pricing_scheme" do
   iterate $ds_sentinel_workspaces
+  request do
+    auth $auth_azure
+    host $param_azure_endpoint
+    path join(["/subscriptions/", val(iter_item, "subscriptionId"), "/resourceGroups/", val(iter_item, "resourceGroup"), "/providers/Microsoft.OperationsManagement/solutions/SecurityInsights(", val(iter_item, "name"), ")"])
+    query "api-version", "2015-11-01-preview"
+    header "User-Agent", "RS Policies"
+    ignore_status [400, 403, 404]
+  end
+  result do
+    encoding "json"
+    field "workspaceId", val(iter_item, "workspaceId")
+    field "skuName", jmes_path(response, "properties.sku.name")
+  end
+end
+
+datasource "ds_sentinel_workspaces_with_scheme" do
+  run_script $js_sentinel_workspaces_with_scheme, $ds_sentinel_workspaces, $ds_sentinel_pricing_scheme
+end
+
+script "js_sentinel_workspaces_with_scheme", type: "javascript" do
+  parameters "ds_sentinel_workspaces", "ds_sentinel_pricing_scheme"
+  result "result"
+  code <<-'EOS'
+    var scheme_map = {}
+    _.each(ds_sentinel_pricing_scheme, function(item) {
+      if (item["workspaceId"] && item["skuName"] != null && item["skuName"] != undefined) {
+        var sku = item["skuName"].toLowerCase().trim()
+        scheme_map[item["workspaceId"]] = (sku === "unified") ? "Simplified" : "Classic"
+      }
+    })
+    result = _.map(ds_sentinel_workspaces, function(ws) {
+      var new_ws = {}
+      _.each(ws, function(v, k) { new_ws[k] = v })
+      new_ws["pricingScheme"] = scheme_map[ws["workspaceId"]] || "Unknown"
+      return new_ws
+    })
+EOS
+end
+
+datasource "ds_workspace_ingestion_raw" do
+  iterate $ds_sentinel_workspaces_with_scheme
   request do
     run_script $js_workspace_ingestion_raw, iter_item, $param_lookback_days, $param_azure_endpoint
   end
@@ -489,6 +530,7 @@ datasource "ds_workspace_ingestion_raw" do
     field "capacityReservationLevel", val(iter_item, "capacityReservationLevel")
     field "tags", val(iter_item, "tags")
     field "resourceID", val(iter_item, "id")
+    field "pricingScheme", val(iter_item, "pricingScheme")
     field "columns", jmes_path(response, "tables[0].columns")
     field "rows", jmes_path(response, "tables[0].rows")
   end
@@ -565,6 +607,7 @@ script "js_workspace_ingestion", type: "javascript" do
         capacityReservationLevel: ws["capacityReservationLevel"],
         tags: ws["tags"],
         resourceID: ws["resourceID"],
+        pricingScheme: ws["pricingScheme"] || "Unknown",
         avgDailyGB: avg_daily_gb,
         peakDailyGB: peak_daily_gb,
         totalGB: total_gb,
@@ -670,13 +713,13 @@ script "js_sentinel_incident", type: "javascript" do
       return formatted_number
     }
 
-    var commitment_tiers = [100, 200, 300, 400, 500, 1000, 2000, 5000]
+    var commitment_tiers = [50, 100, 200, 300, 400, 500, 1000, 2000, 5000]
 
     var pricing_by_region = {}
     _.each(ds_pricing, function(item) {
       var region = item["region"]
       if (!pricing_by_region[region]) {
-        pricing_by_region[region] = { la_payg: 0, sentinel_payg: 0, la_tiers: {}, sentinel_tiers: {} }
+        pricing_by_region[region] = { la_payg: 0, sentinel_payg: 0, la_tiers: {}, sentinel_tiers: {}, unified_payg: 0, unified_tiers: {} }
       }
 
       var service = (item["serviceName"] || "").toLowerCase()
@@ -697,6 +740,9 @@ script "js_sentinel_incident", type: "javascript" do
         if (pricing_by_region[region]["sentinel_payg"] == 0 || price < pricing_by_region[region]["sentinel_payg"]) {
           pricing_by_region[region]["sentinel_payg"] = price
         }
+        if (pricing_by_region[region]["unified_payg"] == 0 || price < pricing_by_region[region]["unified_payg"]) {
+          pricing_by_region[region]["unified_payg"] = price
+        }
       }
 
       if (unit.indexOf("day") >= 0) {
@@ -715,6 +761,9 @@ script "js_sentinel_incident", type: "javascript" do
           if (service.indexOf("sentinel") >= 0) {
             if (!pricing_by_region[region]["sentinel_tiers"][tier_gb] || price < pricing_by_region[region]["sentinel_tiers"][tier_gb]) {
               pricing_by_region[region]["sentinel_tiers"][tier_gb] = price
+            }
+            if (!pricing_by_region[region]["unified_tiers"][tier_gb] || price < pricing_by_region[region]["unified_tiers"][tier_gb]) {
+              pricing_by_region[region]["unified_tiers"][tier_gb] = price
             }
           }
         }
@@ -749,10 +798,21 @@ script "js_sentinel_incident", type: "javascript" do
     _.each(ds_workspace_ingestion_rg_filtered, function(ws) {
       var region = ws["location"]
       var pricing = pricing_by_region[region]
+      var scheme = ws["pricingScheme"] || "Unknown"
 
-      if (!pricing || pricing["la_payg"] <= 0 || pricing["sentinel_payg"] <= 0) { return }
+      if (!pricing || scheme === "Unknown") { return }
 
-      var payg_rate = pricing["payg_rate"] * exchange_rate
+      var payg_rate, active_tier_rates
+      if (scheme === "Simplified") {
+        if (pricing["unified_payg"] <= 0) { return }
+        payg_rate = pricing["unified_payg"] * exchange_rate
+        active_tier_rates = pricing["unified_tiers"]
+      } else {
+        if (pricing["la_payg"] <= 0 || pricing["sentinel_payg"] <= 0) { return }
+        payg_rate = pricing["payg_rate"] * exchange_rate
+        active_tier_rates = pricing["tier_rates"]
+      }
+
       var avg_daily_gb = ws["avgDailyGB"] || 0
 
       if (avg_daily_gb <= 0) { return }
@@ -764,7 +824,8 @@ script "js_sentinel_incident", type: "javascript" do
 
       var current_tier_rate = 0
       if (current_tier_gb > 0) {
-        current_tier_rate = (pricing["tier_rates"][current_tier_gb] || 0) * exchange_rate
+        current_tier_rate = (active_tier_rates[current_tier_gb] || 0) * exchange_rate
+        if (current_tier_rate <= 0) { return }
       }
 
       var current_daily_cost = calculateDailyCost(avg_daily_gb, current_tier_gb, current_tier_rate, payg_rate)
@@ -775,7 +836,7 @@ script "js_sentinel_incident", type: "javascript" do
 
       _.each(commitment_tiers, function(tier_gb) {
         if (tier_gb > current_tier_gb) {
-          var tier_rate = (pricing["tier_rates"][tier_gb] || 0) * exchange_rate
+          var tier_rate = (active_tier_rates[tier_gb] || 0) * exchange_rate
           if (tier_rate > 0) {
             var tier_cost = calculateDailyCost(avg_daily_gb, tier_gb, tier_rate, payg_rate)
             if (tier_cost < best_daily_cost) {
@@ -818,6 +879,7 @@ script "js_sentinel_incident", type: "javascript" do
         recommendationDetails: recommendation_details,
         region: ws["location"],
         resourceGroup: ws["resourceGroup"],
+        pricingScheme: scheme,
         currentTier: current_tier_label,
         recommendedTier: recommended_tier_label,
         avgDailyGB: Math.round(avg_daily_gb * 100) / 100,
@@ -894,6 +956,9 @@ policy "pol_sentinel_commitment_tier_recommendations" do
       end
       field "region" do
         label "Region"
+      end
+      field "pricingScheme" do
+        label "Pricing Scheme"
       end
       field "currentTier" do
         label "Current Pricing Tier"

--- a/cost/azure/sentinel_commitment_tiers/azure_sentinel_commitment_tiers.pt
+++ b/cost/azure/sentinel_commitment_tiers/azure_sentinel_commitment_tiers.pt
@@ -338,8 +338,12 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+    var enabled_subscriptions = _.filter(ds_azure_subscriptions, function(sub) {
+      return sub["state"] === "Enabled"
+    })
+
     if (param_subscriptions_list.length > 0) {
-      result = _.filter(ds_azure_subscriptions, function(subscription) {
+      result = _.filter(enabled_subscriptions, function(subscription) {
         include_subscription = _.contains(param_subscriptions_list, subscription["id"]) ||
                                _.contains(param_subscriptions_list, subscription["name"])
         if (param_subscriptions_allow_or_deny == "Deny") {
@@ -348,7 +352,7 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
         return include_subscription
       })
     } else {
-      result = ds_azure_subscriptions
+      result = enabled_subscriptions
     }
 EOS
 end
@@ -648,14 +652,14 @@ EOS
 end
 
 datasource "ds_pricing_regions" do
-  run_script $js_pricing_regions, $ds_workspace_ingestion
+  run_script $js_pricing_regions, $ds_workspace_ingestion_rg_filtered
 end
 
 script "js_pricing_regions", type: "javascript" do
-  parameters "ds_workspace_ingestion"
+  parameters "ds_workspace_ingestion_rg_filtered"
   result "result"
   code <<-'EOS'
-    var regions = _.uniq(_.pluck(ds_workspace_ingestion, "location"))
+    var regions = _.uniq(_.pluck(ds_workspace_ingestion_rg_filtered, "location"))
     result = _.map(regions, function(r) { return { region: r } })
 EOS
 end
@@ -713,8 +717,6 @@ script "js_sentinel_incident", type: "javascript" do
       return formatted_number
     }
 
-    var commitment_tiers = [50, 100, 200, 300, 400, 500, 1000, 2000, 5000]
-
     var pricing_by_region = {}
     _.each(ds_pricing, function(item) {
       var region = item["region"]
@@ -737,11 +739,15 @@ script "js_sentinel_incident", type: "javascript" do
       }
 
       if (service.indexOf("sentinel") >= 0 && unit.indexOf("gb") >= 0 && (sku.indexOf("pay") >= 0 || meter.indexOf("pay") >= 0)) {
-        if (pricing_by_region[region]["sentinel_payg"] == 0 || price < pricing_by_region[region]["sentinel_payg"]) {
-          pricing_by_region[region]["sentinel_payg"] = price
-        }
-        if (pricing_by_region[region]["unified_payg"] == 0 || price < pricing_by_region[region]["unified_payg"]) {
-          pricing_by_region[region]["unified_payg"] = price
+        // Items with "unified" in the SKU name are Simplified pricing; all others are Classic
+        if (sku.indexOf("unified") >= 0) {
+          if (pricing_by_region[region]["unified_payg"] == 0 || price < pricing_by_region[region]["unified_payg"]) {
+            pricing_by_region[region]["unified_payg"] = price
+          }
+        } else {
+          if (pricing_by_region[region]["sentinel_payg"] == 0 || price < pricing_by_region[region]["sentinel_payg"]) {
+            pricing_by_region[region]["sentinel_payg"] = price
+          }
         }
       }
 
@@ -752,23 +758,37 @@ script "js_sentinel_incident", type: "javascript" do
         if (gb_match) { tier_gb = parseInt(gb_match[1]) }
         else if (tb_match) { tier_gb = parseInt(tb_match[1]) * 1000 }
 
-        if (tier_gb > 0 && _.contains(commitment_tiers, tier_gb)) {
+        if (tier_gb > 0) {
           if (service.indexOf("azure monitor") >= 0) {
             if (!pricing_by_region[region]["la_tiers"][tier_gb] || price < pricing_by_region[region]["la_tiers"][tier_gb]) {
               pricing_by_region[region]["la_tiers"][tier_gb] = price
             }
           }
           if (service.indexOf("sentinel") >= 0) {
-            if (!pricing_by_region[region]["sentinel_tiers"][tier_gb] || price < pricing_by_region[region]["sentinel_tiers"][tier_gb]) {
-              pricing_by_region[region]["sentinel_tiers"][tier_gb] = price
-            }
-            if (!pricing_by_region[region]["unified_tiers"][tier_gb] || price < pricing_by_region[region]["unified_tiers"][tier_gb]) {
-              pricing_by_region[region]["unified_tiers"][tier_gb] = price
+            // Items with "unified" in the SKU name are Simplified pricing; all others are Classic
+            if (sku.indexOf("unified") >= 0) {
+              if (!pricing_by_region[region]["unified_tiers"][tier_gb] || price < pricing_by_region[region]["unified_tiers"][tier_gb]) {
+                pricing_by_region[region]["unified_tiers"][tier_gb] = price
+              }
+            } else {
+              if (!pricing_by_region[region]["sentinel_tiers"][tier_gb] || price < pricing_by_region[region]["sentinel_tiers"][tier_gb]) {
+                pricing_by_region[region]["sentinel_tiers"][tier_gb] = price
+              }
             }
           }
         }
       }
     })
+
+    // Derive commitment tier levels dynamically from all observed tier prices in the pricing API
+    // response. New tiers published by Microsoft will be picked up automatically.
+    var all_tier_gbs = {}
+    _.each(pricing_by_region, function(pricing) {
+      _.each(pricing["la_tiers"], function(rate, tier_gb) { all_tier_gbs[tier_gb] = true })
+      _.each(pricing["sentinel_tiers"], function(rate, tier_gb) { all_tier_gbs[tier_gb] = true })
+      _.each(pricing["unified_tiers"], function(rate, tier_gb) { all_tier_gbs[tier_gb] = true })
+    })
+    var commitment_tiers = _.sortBy(_.map(_.keys(all_tier_gbs), function(t) { return parseInt(t) }), function(t) { return t })
 
     _.each(pricing_by_region, function(pricing, region) {
       pricing["payg_rate"] = pricing["la_payg"] + pricing["sentinel_payg"]
@@ -778,6 +798,17 @@ script "js_sentinel_incident", type: "javascript" do
         var sentinel_rate = pricing["sentinel_tiers"][tier_gb] || 0
         if (la_rate > 0 && sentinel_rate > 0) {
           pricing["tier_rates"][tier_gb] = la_rate + sentinel_rate
+        }
+      })
+      // If no dedicated Simplified (Unified) pricing items were found, fall back to Classic
+      // Sentinel rates. This preserves correct behavior when the Azure pricing API publishes
+      // a single shared Sentinel SKU for both pricing models.
+      if (pricing["unified_payg"] == 0 && pricing["sentinel_payg"] > 0) {
+        pricing["unified_payg"] = pricing["sentinel_payg"]
+      }
+      _.each(commitment_tiers, function(tier_gb) {
+        if (!pricing["unified_tiers"][tier_gb] && pricing["sentinel_tiers"][tier_gb]) {
+          pricing["unified_tiers"][tier_gb] = pricing["sentinel_tiers"][tier_gb]
         }
       })
     })
@@ -834,8 +865,9 @@ script "js_sentinel_incident", type: "javascript" do
       var best_tier_rate = current_tier_rate
       var best_daily_cost = current_daily_cost
 
+      // Evaluate all commitment tiers regardless of direction to surface both upgrades and downgrades
       _.each(commitment_tiers, function(tier_gb) {
-        if (tier_gb > current_tier_gb) {
+        if (tier_gb !== current_tier_gb) {
           var tier_rate = (active_tier_rates[tier_gb] || 0) * exchange_rate
           if (tier_rate > 0) {
             var tier_cost = calculateDailyCost(avg_daily_gb, tier_gb, tier_rate, payg_rate)
@@ -848,7 +880,17 @@ script "js_sentinel_incident", type: "javascript" do
         }
       })
 
-      if (best_tier_gb <= current_tier_gb) { return }
+      // If currently on a commitment tier, also check whether switching to PAYG would be cheaper
+      if (current_tier_gb > 0 && payg_rate > 0) {
+        var payg_daily_cost = calculateDailyCost(avg_daily_gb, 0, 0, payg_rate)
+        if (payg_daily_cost < best_daily_cost) {
+          best_tier_gb = 0
+          best_tier_rate = 0
+          best_daily_cost = payg_daily_cost
+        }
+      }
+
+      if (best_tier_gb === current_tier_gb) { return }
 
       var monthly_savings = (current_daily_cost - best_daily_cost) * 30.44
 
@@ -858,12 +900,23 @@ script "js_sentinel_incident", type: "javascript" do
 
       var current_monthly_cost = Math.round(current_daily_cost * 30.44 * 100) / 100
       var new_monthly_cost = Math.round(best_daily_cost * 30.44 * 100) / 100
-      var savings_rounded = Math.round(monthly_savings * 100) / 100
 
       var current_tier_label = current_tier_gb === 0 ? "Pay-As-You-Go" : (current_tier_gb + " GB/day")
-      var recommended_tier_label = best_tier_gb + " GB/day"
+      var recommended_tier_label = best_tier_gb === 0 ? "Pay-As-You-Go" : (best_tier_gb + " GB/day")
 
-      var recommendation_details = "Upgrade Sentinel workspace '" + ws["workspaceName"] + "' from " + current_tier_label + " to the " + recommended_tier_label + " Commitment Tier. Based on an average of " + (Math.round(avg_daily_gb * 100) / 100) + " GB/day over the lookback period, this change is estimated to save " + ds_currency["symbol"] + (Math.round(monthly_savings * 100) / 100) + " per month."
+      var action_verb, target_phrase
+      if (best_tier_gb === 0) {
+        action_verb = "Switch"
+        target_phrase = "Pay-As-You-Go pricing"
+      } else if (best_tier_gb > current_tier_gb) {
+        action_verb = "Upgrade"
+        target_phrase = "the " + best_tier_gb + " GB/day Commitment Tier"
+      } else {
+        action_verb = "Downgrade"
+        target_phrase = "the " + best_tier_gb + " GB/day Commitment Tier"
+      }
+
+      var recommendation_details = action_verb + " Sentinel workspace '" + ws["workspaceName"] + "' from " + current_tier_label + " to " + target_phrase + ". Based on an average of " + (Math.round(avg_daily_gb * 100) / 100) + " GB/day over the lookback period, this change is estimated to save " + ds_currency["symbol"] + (Math.round(monthly_savings * 100) / 100) + " per month."
 
       var tags = []
       if (ws["tags"] && typeof(ws["tags"]) == "object") {
@@ -887,7 +940,7 @@ script "js_sentinel_incident", type: "javascript" do
         daysObserved: ws["daysObserved"],
         currentMonthlyCost: current_monthly_cost,
         newMonthlyCost: new_monthly_cost,
-        savings: savings_rounded,
+        savings: parseFloat(monthly_savings.toFixed(3)),
         savingsCurrency: ds_currency["symbol"],
         lookbackPeriod: param_lookback_days,
         service: "Microsoft.SentinelPlatformServices",
@@ -930,6 +983,8 @@ policy "pol_sentinel_commitment_tier_recommendations" do
     EOS
     check logic_or($ds_parent_policy_terminated, lt(val(item, "savings"), 0))
     escalate $esc_email
+    # pricingScheme is intentionally absent: a workspace migrating between Classic and
+    # Simplified pricing is a meaningful state change and should re-trigger incident evaluation.
     hash_exclude "tags", "savings", "savingsCurrency"
     export do
       resource_level false

--- a/cost/azure/sentinel_commitment_tiers/azure_sentinel_commitment_tiers.pt
+++ b/cost/azure/sentinel_commitment_tiers/azure_sentinel_commitment_tiers.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "0.3.2",
+  version: "0.4.0",
   provider: "Azure",
   service: "Sentinel",
   policy_set: "Commitment Tiers",

--- a/tools/policy_api_list_generation/policy_api_list_generator.py
+++ b/tools/policy_api_list_generation/policy_api_list_generator.py
@@ -718,13 +718,26 @@ class PolicyTemplateParser:
                 join_content = path_match.group(1)
 
                 # Parse the join array to maintain proper order of strings and val() calls
-                # Split by comma but be careful with nested function calls
+                # Split by comma but be careful with nested function calls and string literals.
+                # String-literal awareness is required because some paths contain parentheses
+                # inside quoted strings (e.g. "SecurityInsights(" in OperationsManagement paths),
+                # which would otherwise corrupt the depth counter and cause parts to merge.
                 parts = []
                 current_part = ''
                 depth = 0
+                in_string = False
+                string_char = None
 
                 for char in join_content + ',':
-                    if char in '([':
+                    if in_string:
+                        current_part += char
+                        if char == string_char:
+                            in_string = False
+                    elif char in ('"', "'"):
+                        in_string = True
+                        string_char = char
+                        current_part += char
+                    elif char in '([':
                         depth += 1
                         current_part += char
                     elif char in ')]':


### PR DESCRIPTION
### Description

`Azure Sentinel Commitment Tier Recommendations`
- Fixed bug where workspaces using Azure Sentinel Simplified pricing (unified SKU) received no recommendations or incorrect savings estimates. The policy now detects the pricing scheme per workspace via the OperationsManagement Solutions API and applies the correct rate model: Simplified workspaces use the all-inclusive Sentinel unified rate; Classic workspaces continue to use the sum of Log Analytics and Sentinel component rates.
- Added `Pricing Scheme` field to the incident table, indicating whether each recommendation was generated using Classic or Simplified pricing.
- Added downgrade and PAYG switch recommendations: the policy now evaluates all commitment tiers in both directions and checks whether switching to Pay-As-You-Go pricing would be cheaper than a workspace's current commitment tier.

Also fixes a bug in the Policy API script that was generating a false positive for this policy template.

### Link to Example Applied Policy

https://app.flexera.com/orgs/27018/automation/applied-policies/projects/113453?policyId=6a26d145620578afd2770c0f
(Also tested in client environment where calculation is verified to work as expected)

### Contribution Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
