### PR TITLE
POL-1781 Fix Tag Filtering Logic

### DIFF
--- a/compliance/aws/ecs_unused/CHANGELOG.md
+++ b/compliance/aws/ecs_unused/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.2.5
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v4.2.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/compliance/aws/ecs_unused/CHANGELOG.md
+++ b/compliance/aws/ecs_unused/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v4.2.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/compliance/aws/ecs_unused/aws_unused_ecs_clusters.pt
+++ b/compliance/aws/ecs_unused/aws_unused_ecs_clusters.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Compliance"
 default_frequency "weekly"
 info(
-  version: "4.2.4",
+  version: "4.2.5",
   provider: "AWS",
   service: "Compute",
   policy_set: "Unused Containers",
@@ -521,8 +521,7 @@ script "js_aws_ecs_clusters_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/compliance/aws/long_stopped_instances/CHANGELOG.md
+++ b/compliance/aws/long_stopped_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v6.1.5
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v6.1.4
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/compliance/aws/long_stopped_instances/CHANGELOG.md
+++ b/compliance/aws/long_stopped_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v6.1.4
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt
+++ b/compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Compliance"
 default_frequency "weekly"
 info(
-  version: "6.1.4",
+  version: "6.1.5",
   provider: "AWS",
   service: "Compute",
   policy_set: "Long Stopped Instances",
@@ -482,8 +482,7 @@ script "js_instances_tag_filtered", type: "javascript" do
           }
 
           if (comparison == '!~') {
-            if (resource_tag == undefined) { found_tags.push(string) }
-            if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+            if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
           }
         })
 

--- a/compliance/aws/rds_backup/CHANGELOG.md
+++ b/compliance/aws/rds_backup/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.1.4
 
 - Updated instance type data source from `data/aws/instance_types.json` to `data/aws/aws_ec2_instance_types.json`. RDS instance type vCPU lookups continue to work correctly since RDS types share the same underlying hardware as their EC2 counterparts.

--- a/compliance/aws/rds_backup/CHANGELOG.md
+++ b/compliance/aws/rds_backup/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.1.5
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.1.4
 
 - Updated instance type data source from `data/aws/instance_types.json` to `data/aws/aws_ec2_instance_types.json`. RDS instance type vCPU lookups continue to work correctly since RDS types share the same underlying hardware as their EC2 counterparts.

--- a/compliance/aws/rds_backup/aws_rds_backup.pt
+++ b/compliance/aws/rds_backup/aws_rds_backup.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "medium"
 default_frequency "weekly"
 info(
-  version: "3.1.4",
+  version: "3.1.5",
   provider: "AWS",
   service: "RDS",
   policy_set: "",
@@ -568,8 +568,7 @@ script "js_rds_instances", type: "javascript" do
       }
 
       if (comparison == '!~') {
-        if (resource_tag == undefined) { found_tags.push(string) }
-        if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+        if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
       }
     })
 

--- a/compliance/azure/ahub_manual/CHANGELOG.md
+++ b/compliance/azure/ahub_manual/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v4.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/compliance/azure/ahub_manual/CHANGELOG.md
+++ b/compliance/azure/ahub_manual/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v4.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry.pt
+++ b/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Compliance"
 default_frequency "weekly"
 info(
-  version: "4.3.0",
+  version: "4.3.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Hybrid Use Benefit",
@@ -377,8 +377,7 @@ script "js_azure_instances_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/compliance/azure/deprecated_storage_accounts/CHANGELOG.md
+++ b/compliance/azure/deprecated_storage_accounts/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.4.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/compliance/azure/deprecated_storage_accounts/CHANGELOG.md
+++ b/compliance/azure/deprecated_storage_accounts/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.4.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/compliance/azure/deprecated_storage_accounts/azure_deprecated_storage_accounts.pt
+++ b/compliance/azure/deprecated_storage_accounts/azure_deprecated_storage_accounts.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.0",
+  version: "0.4.1",
   provider: "Azure",
   service: "Storage Accounts",
   policy_set: "Deprecated Storage Accounts",
@@ -473,8 +473,7 @@ script "js_storage_accounts_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/aws/burstable_ec2_instances/CHANGELOG.md
+++ b/cost/aws/burstable_ec2_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.5.4
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v4.5.3
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/burstable_ec2_instances/CHANGELOG.md
+++ b/cost/aws/burstable_ec2_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v4.5.3
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/burstable_ec2_instances/aws_burstable_ec2_instances.pt
+++ b/cost/aws/burstable_ec2_instances/aws_burstable_ec2_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "monthly"
 info(
-  version: "4.5.3",
+  version: "4.5.4",
   provider: "AWS",
   service: "Compute",
   policy_set: "Burstable Compute Instances",
@@ -513,8 +513,7 @@ script "js_instances", type: "javascript" do
           }
 
           if (comparison == '!~') {
-            if (resource_tag == undefined) { found_tags.push(string) }
-            if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+            if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
           }
         })
 

--- a/cost/aws/ec2_compute_optimizer/CHANGELOG.md
+++ b/cost/aws/ec2_compute_optimizer/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.6.1
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/ec2_compute_optimizer/CHANGELOG.md
+++ b/cost/aws/ec2_compute_optimizer/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.6.2
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.6.1
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/ec2_compute_optimizer/aws_ec2_compute_optimizer.pt
+++ b/cost/aws/ec2_compute_optimizer/aws_ec2_compute_optimizer.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.6.1",
+  version: "0.6.2",
   provider: "AWS",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -519,8 +519,7 @@ script "js_instances", type: "javascript" do
           }
 
           if (comparison == '!~') {
-            if (resource_tag == undefined) { found_tags.push(string) }
-            if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+            if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
           }
         })
 

--- a/cost/aws/eks_without_spot/CHANGELOG.md
+++ b/cost/aws/eks_without_spot/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.2.5
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/eks_without_spot/CHANGELOG.md
+++ b/cost/aws/eks_without_spot/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.6
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.2.5
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/eks_without_spot/aws_eks_without_spot.pt
+++ b/cost/aws/eks_without_spot/aws_eks_without_spot.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.5",
+  version: "0.2.6",
   provider: "AWS",
   service: "Compute",
   policy_set: "Autoscaling",
@@ -492,8 +492,7 @@ script "js_eks_clusters_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/aws/idle_fsx/CHANGELOG.md
+++ b/cost/aws/idle_fsx/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.2.1
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/idle_fsx/CHANGELOG.md
+++ b/cost/aws/idle_fsx/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.2
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.2.1
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/idle_fsx/aws_idle_fsx.pt
+++ b/cost/aws/idle_fsx/aws_idle_fsx.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.1",
+  version: "0.2.2",
   provider: "AWS",
   service: "Storage",
   policy_set: "Unused Storage",
@@ -618,8 +618,7 @@ script "js_aws_fsx_instances_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/aws/idle_lambda_functions/CHANGELOG.md
+++ b/cost/aws/idle_lambda_functions/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.1.1
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/idle_lambda_functions/CHANGELOG.md
+++ b/cost/aws/idle_lambda_functions/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.1.2
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.1.1
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/idle_lambda_functions/aws_idle_lambda_functions.pt
+++ b/cost/aws/idle_lambda_functions/aws_idle_lambda_functions.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.1.1",
+  version: "0.1.2",
   provider: "AWS",
   service: "PaaS",
   policy_set: "Idle Lambda Functions",
@@ -634,8 +634,7 @@ script "js_aws_lambda_functions_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/aws/idle_nat_gateways/CHANGELOG.md
+++ b/cost/aws/idle_nat_gateways/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.7
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.3.6
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/idle_nat_gateways/CHANGELOG.md
+++ b/cost/aws/idle_nat_gateways/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.3.6
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/idle_nat_gateways/aws_idle_nat_gateways.pt
+++ b/cost/aws/idle_nat_gateways/aws_idle_nat_gateways.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.6",
+  version: "0.3.7",
   provider: "AWS",
   service: "Network",
   policy_set: "Idle NAT Gateways",
@@ -619,8 +619,7 @@ script "js_gateways_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/aws/old_snapshots/CHANGELOG.md
+++ b/cost/aws/old_snapshots/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v8.6.6
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/old_snapshots/CHANGELOG.md
+++ b/cost/aws/old_snapshots/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v8.6.7
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v8.6.6
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "8.6.6",
+  version: "8.6.7",
   provider: "AWS",
   service: "Storage",
   policy_set: "Old Snapshots",
@@ -791,8 +791,7 @@ script "js_snapshots_combined", type: "javascript" do
       }
 
       if (comparison == '!~') {
-        if (resource_tag == undefined) { found_tags.push(string) }
-        if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+        if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
       }
     })
 

--- a/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.5.6
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.5.7
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.5.6
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/rightsize_ebs_volumes/aws_rightsize_ebs_volumes.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_rightsize_ebs_volumes.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.6",
+  version: "0.5.7",
   provider: "AWS",
   service: "EBS",
   policy_set: "Unused Volumes",
@@ -784,8 +784,7 @@ script "js_volumes_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/aws/rightsize_ec2_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_ec2_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v5.7.2
 
 - Fixed bug which would cause policy to use utilization metrics from the last 1d period instead of the correct full lookback period

--- a/cost/aws/rightsize_ec2_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_ec2_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v5.7.3
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v5.7.2
 
 - Fixed bug which would cause policy to use utilization metrics from the last 1d period instead of the correct full lookback period

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "5.7.2",
+  version: "5.7.3",
   provider: "AWS",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -801,8 +801,7 @@ script "js_instances", type: "javascript" do
           }
 
           if (comparison == '!~') {
-            if (resource_tag == undefined) { found_tags.push(string) }
-            if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+            if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
           }
         })
 

--- a/cost/aws/rightsize_elasticache/CHANGELOG.md
+++ b/cost/aws/rightsize_elasticache/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.5.8
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.5.7
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/rightsize_elasticache/CHANGELOG.md
+++ b/cost/aws/rightsize_elasticache/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.5.7
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/rightsize_elasticache/aws_rightsize_elasticache.pt
+++ b/cost/aws/rightsize_elasticache/aws_rightsize_elasticache.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.7",
+  version: "0.5.8",
   provider: "AWS",
   service: "Database",
   policy_set: "Rightsize Database Instances",
@@ -813,8 +813,7 @@ script "js_elasticache_clusters_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/aws/rightsize_rds_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_rds_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v5.10.6
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/rightsize_rds_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_rds_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v5.10.7
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v5.10.6
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "5.10.6",
+  version: "5.10.7",
   provider: "AWS",
   service: "RDS",
   policy_set: "Rightsize Database Instances",
@@ -960,8 +960,7 @@ script "js_rds_instances", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/aws/rightsize_redshift/CHANGELOG.md
+++ b/cost/aws/rightsize_redshift/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.2
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.3.1
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/rightsize_redshift/CHANGELOG.md
+++ b/cost/aws/rightsize_redshift/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.3.1
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/rightsize_redshift/aws_rightsize_redshift.pt
+++ b/cost/aws/rightsize_redshift/aws_rightsize_redshift.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.1",
+  version: "0.3.2",
   provider: "AWS",
   service: "Database",
   policy_set: "Rightsize Database Instances",
@@ -665,8 +665,7 @@ script "js_redshift_clusters_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/aws/s3_bucket_size/CHANGELOG.md
+++ b/cost/aws/s3_bucket_size/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v4.0.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/s3_bucket_size/CHANGELOG.md
+++ b/cost/aws/s3_bucket_size/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.0.3
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v4.0.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/s3_bucket_size/aws_bucket_size.pt
+++ b/cost/aws/s3_bucket_size/aws_bucket_size.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "medium"
 default_frequency "weekly"
 info(
-  version: "4.0.2",
+  version: "4.0.3",
   provider: "AWS",
   service: "Storage",
   policy_set: "",
@@ -515,8 +515,7 @@ script "js_aws_buckets_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/aws/s3_lifecycle/CHANGELOG.md
+++ b/cost/aws/s3_lifecycle/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.4
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.2.3
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/s3_lifecycle/CHANGELOG.md
+++ b/cost/aws/s3_lifecycle/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.2.3
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/s3_lifecycle/aws_s3_lifecycle.pt
+++ b/cost/aws/s3_lifecycle/aws_s3_lifecycle.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "medium"
 default_frequency "weekly"
 info(
-  version: "0.2.3",
+  version: "0.2.4",
   provider: "AWS",
   service: "Storage",
   policy_set: "",
@@ -507,8 +507,7 @@ script "js_aws_buckets_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/aws/s3_multipart_uploads/CHANGELOG.md
+++ b/cost/aws/s3_multipart_uploads/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.4
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.2.3
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/s3_multipart_uploads/CHANGELOG.md
+++ b/cost/aws/s3_multipart_uploads/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.2.3
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/s3_multipart_uploads/aws_s3_multipart_uploads.pt
+++ b/cost/aws/s3_multipart_uploads/aws_s3_multipart_uploads.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.3",
+  version: "0.2.4",
   provider: "AWS",
   service: "Storage",
   policy_set: "",
@@ -525,8 +525,7 @@ script "js_aws_buckets_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/aws/s3_storage_policy/CHANGELOG.md
+++ b/cost/aws/s3_storage_policy/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.2.5
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v4.2.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/s3_storage_policy/CHANGELOG.md
+++ b/cost/aws/s3_storage_policy/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v4.2.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check.pt
+++ b/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "medium"
 default_frequency "weekly"
 info(
-  version: "4.2.4",
+  version: "4.2.5",
   provider: "AWS",
   service: "Storage",
   policy_set: "Object Store Optimization",
@@ -599,8 +599,7 @@ script "js_aws_buckets_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/aws/schedule_instance/CHANGELOG.md
+++ b/cost/aws/schedule_instance/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v8.0.10
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v8.0.9
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/schedule_instance/CHANGELOG.md
+++ b/cost/aws/schedule_instance/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v8.0.9
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/aws/schedule_instance/aws_schedule_instance.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "15 minutes"
 info(
-  version: "8.0.9",
+  version: "8.0.10",
   provider: "AWS",
   service: "Compute",
   policy_set: "Schedule Instance",
@@ -767,8 +767,7 @@ script "js_instances", type: "javascript" do
           }
 
           if (comparison == '!~') {
-            if (resource_tag == undefined) { found_tags.push(string) }
-            if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+            if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
           }
         })
 

--- a/cost/aws/superseded_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/superseded_ebs_volumes/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v6.6.0
 
 - Updated savings calculation to use the percentage difference between GP2 and GP3 list prices applied to the actual cost of the resource in Flexera CCO, rather than the raw list price difference. This ensures that savings estimates reflect Flexera adjustment rules and cloud provider discounts.

--- a/cost/aws/superseded_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/superseded_ebs_volumes/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v6.6.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v6.6.0
 
 - Updated savings calculation to use the percentage difference between GP2 and GP3 list prices applied to the actual cost of the resource in Flexera CCO, rather than the raw list price difference. This ensures that savings estimates reflect Flexera adjustment rules and cloud provider discounts.

--- a/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
+++ b/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "6.6.0",
+  version: "6.6.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Inefficient Disk Usage",
@@ -694,8 +694,7 @@ script "js_volumes_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/aws/superseded_instances/CHANGELOG.md
+++ b/cost/aws/superseded_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.2.6
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/superseded_instances/CHANGELOG.md
+++ b/cost/aws/superseded_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.2.7
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.2.6
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/superseded_instances/aws_superseded_instances.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.2.6",
+  version: "3.2.7",
   provider: "AWS",
   service: "Compute",
   policy_set: "Superseded Compute Instances",
@@ -697,8 +697,7 @@ script "js_instances", type: "javascript" do
           }
 
           if (comparison == '!~') {
-            if (resource_tag == undefined) { found_tags.push(string) }
-            if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+            if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
           }
         })
 

--- a/cost/aws/unused_albs/CHANGELOG.md
+++ b/cost/aws/unused_albs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.7
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.4.6
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/unused_albs/CHANGELOG.md
+++ b/cost/aws/unused_albs/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.4.6
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/unused_albs/aws_unused_albs.pt
+++ b/cost/aws/unused_albs/aws_unused_albs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.6",
+  version: "0.4.7",
   provider: "AWS",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -674,8 +674,7 @@ script "js_albs_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/aws/unused_clbs/CHANGELOG.md
+++ b/cost/aws/unused_clbs/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v6.6.1
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/unused_clbs/CHANGELOG.md
+++ b/cost/aws/unused_clbs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v6.6.2
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v6.6.1
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/unused_clbs/aws_unused_clbs.pt
+++ b/cost/aws/unused_clbs/aws_unused_clbs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.6.1",
+  version: "6.6.2",
   provider: "AWS",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -621,8 +621,7 @@ script "js_clbs_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/aws/unused_ip_addresses/CHANGELOG.md
+++ b/cost/aws/unused_ip_addresses/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v9.5.2
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v9.5.1
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/unused_ip_addresses/CHANGELOG.md
+++ b/cost/aws/unused_ip_addresses/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v9.5.1
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "9.5.1",
+  version: "9.5.2",
   provider: "AWS",
   service: "Compute",
   policy_set: "Unused IP Addresses",
@@ -616,8 +616,7 @@ script "js_ip_addresses_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/aws/unused_nlbs/CHANGELOG.md
+++ b/cost/aws/unused_nlbs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.7
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.4.6
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/unused_nlbs/CHANGELOG.md
+++ b/cost/aws/unused_nlbs/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.4.6
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/unused_nlbs/aws_unused_nlbs.pt
+++ b/cost/aws/unused_nlbs/aws_unused_nlbs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.6",
+  version: "0.4.7",
   provider: "AWS",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -674,8 +674,7 @@ script "js_nlbs_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/advisor_compute/CHANGELOG.md
+++ b/cost/azure/advisor_compute/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.4.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/advisor_compute/CHANGELOG.md
+++ b/cost/azure/advisor_compute/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.4.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/advisor_compute/azure_advisor_compute.pt
+++ b/cost/azure/advisor_compute/azure_advisor_compute.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.0",
+  version: "0.4.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -502,8 +502,7 @@ script "js_azure_instances_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/blob_storage_optimization/CHANGELOG.md
+++ b/cost/azure/blob_storage_optimization/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.2.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v4.2.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/blob_storage_optimization/CHANGELOG.md
+++ b/cost/azure/blob_storage_optimization/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v4.2.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/blob_storage_optimization/azure_blob_storage_optimization.pt
+++ b/cost/azure/blob_storage_optimization/azure_blob_storage_optimization.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.2.0",
+  version: "4.2.1",
   provider: "Azure",
   service: "Storage",
   policy_set: "Object Store Optimization",
@@ -405,8 +405,7 @@ script "js_azure_storage_accounts_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/data_lake_optimization/CHANGELOG.md
+++ b/cost/azure/data_lake_optimization/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.4.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/data_lake_optimization/CHANGELOG.md
+++ b/cost/azure/data_lake_optimization/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.4.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/data_lake_optimization/data_lake_optimization.pt
+++ b/cost/azure/data_lake_optimization/data_lake_optimization.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "0.4.0",
+  version: "0.4.1",
   provider: "Azure",
   service: "Storage Accounts",
   policy_set: "Data Lake Optimization",
@@ -496,8 +496,7 @@ script "js_azure_storage_accounts_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/hybrid_use_benefit/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v5.6.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/hybrid_use_benefit/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v5.6.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v5.6.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "5.6.0",
+  version: "5.6.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Hybrid Use Benefit",
@@ -577,8 +577,7 @@ script "js_azure_instances_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/hybrid_use_benefit_linux/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit_linux/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v5.5.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v5.5.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/hybrid_use_benefit_linux/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit_linux/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v5.5.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "5.5.0",
+  version: "5.5.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Hybrid Use Benefit",
@@ -494,8 +494,7 @@ script "js_azure_instances_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/hybrid_use_benefit_sql/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit_sql/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v4.8.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/hybrid_use_benefit_sql/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit_sql/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.8.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v4.8.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "4.8.0",
+  version: "4.8.1",
   provider: "Azure",
   service: "SQL",
   policy_set: "Hybrid Use Benefit",
@@ -712,8 +712,7 @@ script "js_resources_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/long_stopped_instances/CHANGELOG.md
+++ b/cost/azure/long_stopped_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v6.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v6.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/long_stopped_instances/CHANGELOG.md
+++ b/cost/azure/long_stopped_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v6.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/long_stopped_instances/long_stopped_instances_azure.pt
+++ b/cost/azure/long_stopped_instances/long_stopped_instances_azure.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.3.0",
+  version: "6.3.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Long Stopped Instances",
@@ -496,8 +496,7 @@ script "js_azure_instances_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/old_snapshots/CHANGELOG.md
+++ b/cost/azure/old_snapshots/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Changelog
 
-## v7.5.2
-
-- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
-
-
 ## v7.5.1
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of excluding those that did not match

--- a/cost/azure/old_snapshots/CHANGELOG.md
+++ b/cost/azure/old_snapshots/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v7.5.2
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
+## v7.5.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of excluding those that did not match
+
 ## v7.5.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "7.5.0",
+  version: "7.5.2",
   provider: "Azure",
   service: "Storage",
   policy_set: "Old Snapshots",
@@ -482,8 +482,7 @@ script "js_azure_snapshots_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "7.5.2",
+  version: "7.5.1",
   provider: "Azure",
   service: "Storage",
   policy_set: "Old Snapshots",

--- a/cost/azure/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v6.6.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v6.6.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v6.6.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.6.0",
+  version: "6.6.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -687,8 +687,7 @@ script "js_azure_instances_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/rightsize_managed_disks/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_disks/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.9.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v2.9.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/rightsize_managed_disks/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_disks/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v2.9.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "monthly"
 info(
-  version: "2.9.0",
+  version: "2.9.1",
   provider: "Azure",
   service: "Managed Disks",
   policy_set: "Rightsize Storage",
@@ -587,8 +587,7 @@ script "js_azure_disks_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/rightsize_managed_sql/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_sql/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.6.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.6.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/rightsize_managed_sql/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_sql/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.6.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql.pt
+++ b/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.6.0",
+  version: "0.6.1",
   provider: "Azure",
   service: "SQL",
   policy_set: "Rightsize Database Instances",
@@ -568,8 +568,7 @@ script "js_azure_sql_instances_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/rightsize_managed_sql_storage/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_sql_storage/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.5.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/rightsize_managed_sql_storage/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_sql_storage/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.5.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.5.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/rightsize_managed_sql_storage/azure_rightsize_managed_sql_storage.pt
+++ b/cost/azure/rightsize_managed_sql_storage/azure_rightsize_managed_sql_storage.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.0",
+  version: "0.5.1",
   provider: "Azure",
   service: "SQL",
   policy_set: "Rightsize Database Instances",
@@ -521,8 +521,7 @@ script "js_azure_sql_instances_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/rightsize_mysql_flexible/CHANGELOG.md
+++ b/cost/azure/rightsize_mysql_flexible/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.5.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/rightsize_mysql_flexible/CHANGELOG.md
+++ b/cost/azure/rightsize_mysql_flexible/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.5.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.5.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible.pt
+++ b/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.0",
+  version: "0.5.1",
   provider: "Azure",
   service: "MySQL",
   policy_set: "Rightsize Database Instances",
@@ -577,8 +577,7 @@ script "js_azure_mysql_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/rightsize_mysql_single/CHANGELOG.md
+++ b/cost/azure/rightsize_mysql_single/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.5.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/rightsize_mysql_single/CHANGELOG.md
+++ b/cost/azure/rightsize_mysql_single/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.5.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.5.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single.pt
+++ b/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.0",
+  version: "0.5.1",
   provider: "Azure",
   service: "MySQL",
   policy_set: "Rightsize Database Instances",
@@ -577,8 +577,7 @@ script "js_azure_mysql_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/rightsize_netapp/CHANGELOG.md
+++ b/cost/azure/rightsize_netapp/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v2.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/rightsize_netapp/CHANGELOG.md
+++ b/cost/azure/rightsize_netapp/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v2.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/rightsize_netapp/azure_rightsize_netapp.pt
+++ b/cost/azure/rightsize_netapp/azure_rightsize_netapp.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "2.3.0",
+  version: "2.3.1",
   provider: "Azure",
   service: "NetApp Files",
   policy_set: "Rightsize Storage",
@@ -518,8 +518,7 @@ script "js_objects_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/rightsize_sql_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_sql_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v6.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v6.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/rightsize_sql_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_sql_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v6.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.3.0",
+  version: "6.3.1",
   provider: "Azure",
   service: "SQL",
   policy_set: "Rightsize Database Instances",
@@ -659,8 +659,7 @@ script "js_azure_sql_databases_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/rightsize_sql_storage/CHANGELOG.md
+++ b/cost/azure/rightsize_sql_storage/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.4.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/rightsize_sql_storage/CHANGELOG.md
+++ b/cost/azure/rightsize_sql_storage/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.4.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/rightsize_sql_storage/azure_rightsize_sql_storage.pt
+++ b/cost/azure/rightsize_sql_storage/azure_rightsize_sql_storage.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.0",
+  version: "0.4.1",
   provider: "Azure",
   service: "SQL",
   policy_set: "Rightsize Database Instances",
@@ -601,8 +601,7 @@ script "js_azure_sql_databases_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/rightsize_synapse_sql_pools/CHANGELOG.md
+++ b/cost/azure/rightsize_synapse_sql_pools/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.4.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/rightsize_synapse_sql_pools/CHANGELOG.md
+++ b/cost/azure/rightsize_synapse_sql_pools/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.4.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/rightsize_synapse_sql_pools/azure_rightsize_synapse_sql_pools.pt
+++ b/cost/azure/rightsize_synapse_sql_pools/azure_rightsize_synapse_sql_pools.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.0",
+  version: "0.4.1",
   provider: "Azure",
   service: "SQL",
   policy_set: "Rightsize Synapse SQL Pools",
@@ -552,8 +552,7 @@ script "js_azure_synapse_sql_pools_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/schedule_instance/CHANGELOG.md
+++ b/cost/azure/schedule_instance/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v7.2.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/schedule_instance/CHANGELOG.md
+++ b/cost/azure/schedule_instance/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v7.2.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v7.2.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/schedule_instance/azure_schedule_instance.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "15 minutes"
 info(
-  version: "7.2.0",
+  version: "7.2.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Schedule Instance",
@@ -588,8 +588,7 @@ script "js_azure_instances_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/sql_servers_without_elastic_pool/CHANGELOG.md
+++ b/cost/azure/sql_servers_without_elastic_pool/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/sql_servers_without_elastic_pool/CHANGELOG.md
+++ b/cost/azure/sql_servers_without_elastic_pool/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/sql_servers_without_elastic_pool/azure_sql_servers_without_elastic_pool.pt
+++ b/cost/azure/sql_servers_without_elastic_pool/azure_sql_servers_without_elastic_pool.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "SQL",
   policy_set: "Database Services",
@@ -364,8 +364,7 @@ script "js_azure_sql_servers_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/storage_account_lifecycle_management/CHANGELOG.md
+++ b/cost/azure/storage_account_lifecycle_management/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v4.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/storage_account_lifecycle_management/CHANGELOG.md
+++ b/cost/azure/storage_account_lifecycle_management/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v4.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management.pt
+++ b/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.3.0",
+  version: "4.3.1",
   provider: "Azure",
   service: "Storage Accounts",
   policy_set: "Lifecycle Management",
@@ -374,8 +374,7 @@ script "js_storage_accounts_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/superseded_instances/CHANGELOG.md
+++ b/cost/azure/superseded_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v4.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/superseded_instances/CHANGELOG.md
+++ b/cost/azure/superseded_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v4.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/superseded_instances/azure_superseded_instances.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.3.0",
+  version: "4.3.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Superseded Compute Instances",
@@ -623,8 +623,7 @@ script "js_azure_instances_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/unused_app_service_plans/CHANGELOG.md
+++ b/cost/azure/unused_app_service_plans/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.4.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/unused_app_service_plans/CHANGELOG.md
+++ b/cost/azure/unused_app_service_plans/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.4.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/unused_app_service_plans/azure_unused_app_service_plans.pt
+++ b/cost/azure/unused_app_service_plans/azure_unused_app_service_plans.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.0",
+  version: "0.4.1",
   provider: "Azure",
   service: "PaaS",
   policy_set: "PaaS Optimization",
@@ -483,8 +483,7 @@ script "js_azure_app_service_plans_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/unused_firewalls/CHANGELOG.md
+++ b/cost/azure/unused_firewalls/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.5.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/unused_firewalls/CHANGELOG.md
+++ b/cost/azure/unused_firewalls/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.5.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.5.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/unused_firewalls/azure_unused_firewalls.pt
+++ b/cost/azure/unused_firewalls/azure_unused_firewalls.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.0",
+  version: "0.5.1",
   provider: "Azure",
   service: "Network",
   policy_set: "Unused Firewalls",
@@ -483,8 +483,7 @@ script "js_azure_firewalls_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/unused_ip_addresses/CHANGELOG.md
+++ b/cost/azure/unused_ip_addresses/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v7.6.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/unused_ip_addresses/CHANGELOG.md
+++ b/cost/azure/unused_ip_addresses/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v7.6.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v7.6.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "7.6.0",
+  version: "7.6.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Unused IP Addresses",
@@ -508,8 +508,7 @@ script "js_ip_addresses_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/unused_load_balancers/CHANGELOG.md
+++ b/cost/azure/unused_load_balancers/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.4.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/unused_load_balancers/CHANGELOG.md
+++ b/cost/azure/unused_load_balancers/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.4.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/unused_load_balancers/azure_unused_load_balancers.pt
+++ b/cost/azure/unused_load_balancers/azure_unused_load_balancers.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.0",
+  version: "0.4.1",
   provider: "Azure",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -489,8 +489,7 @@ script "js_azure_loadbalancers_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/unused_storage_accounts/CHANGELOG.md
+++ b/cost/azure/unused_storage_accounts/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.4.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/unused_storage_accounts/CHANGELOG.md
+++ b/cost/azure/unused_storage_accounts/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.4.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/unused_storage_accounts/azure_unused_storage_accounts.pt
+++ b/cost/azure/unused_storage_accounts/azure_unused_storage_accounts.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "0.4.0",
+  version: "0.4.1",
   provider: "Azure",
   service: "Storage",
   policy_set: "Unused Storage Accounts",
@@ -491,8 +491,7 @@ script "js_azure_storage_accounts_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/unused_vngs/CHANGELOG.md
+++ b/cost/azure/unused_vngs/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.4.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/unused_vngs/CHANGELOG.md
+++ b/cost/azure/unused_vngs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.4.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/unused_vngs/azure_unused_vngs.pt
+++ b/cost/azure/unused_vngs/azure_unused_vngs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.0",
+  version: "0.4.1",
   provider: "Azure",
   service: "Network",
   policy_set: "Unused Virtual Networks",
@@ -377,8 +377,7 @@ script "js_azure_vngs_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/cost/azure/unused_volumes/CHANGELOG.md
+++ b/cost/azure/unused_volumes/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v8.5.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/unused_volumes/CHANGELOG.md
+++ b/cost/azure/unused_volumes/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v8.5.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v8.5.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/cost/azure/unused_volumes/azure_unused_volumes.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "8.5.0",
+  version: "8.5.1",
   provider: "Azure",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -543,8 +543,7 @@ script "js_azure_disks_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/operational/aws/ec2_stopped_report/CHANGELOG.md
+++ b/operational/aws/ec2_stopped_report/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.6
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.3.5
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/operational/aws/ec2_stopped_report/CHANGELOG.md
+++ b/operational/aws/ec2_stopped_report/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.3.5
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/operational/aws/ec2_stopped_report/aws_ec2_stopped_report.pt
+++ b/operational/aws/ec2_stopped_report/aws_ec2_stopped_report.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "0.3.5",
+  version: "0.3.6",
   provider: "AWS",
   service: "Compute",
   policy_set: "",
@@ -554,8 +554,7 @@ script "js_instances", type: "javascript" do
           }
 
           if (comparison == '!~') {
-            if (resource_tag == undefined) { found_tags.push(string) }
-            if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+            if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
           }
         })
 

--- a/operational/aws/lambda_functions_with_high_error_rate/CHANGELOG.md
+++ b/operational/aws/lambda_functions_with_high_error_rate/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v5.1.6
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/operational/aws/lambda_functions_with_high_error_rate/CHANGELOG.md
+++ b/operational/aws/lambda_functions_with_high_error_rate/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v5.1.7
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v5.1.6
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate.pt
+++ b/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate.pt
@@ -8,7 +8,7 @@ severity "high"
 category "Operational"
 default_frequency "hourly"
 info(
-  version: "5.1.6",
+  version: "5.1.7",
   provider: "AWS",
   service: "PaaS",
   policy_set: "Lambda",
@@ -493,8 +493,7 @@ script "js_aws_lambda_functions_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/operational/aws/lambda_provisioned_concurrency/CHANGELOG.md
+++ b/operational/aws/lambda_provisioned_concurrency/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.5
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.2.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/operational/aws/lambda_provisioned_concurrency/CHANGELOG.md
+++ b/operational/aws/lambda_provisioned_concurrency/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.2.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/operational/aws/lambda_provisioned_concurrency/aws_lambda_provisioned_concurrency.pt
+++ b/operational/aws/lambda_provisioned_concurrency/aws_lambda_provisioned_concurrency.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.4",
+  version: "0.2.5",
   provider: "AWS",
   service: "PaaS",
   policy_set: "Lambda",
@@ -471,8 +471,7 @@ script "js_functions_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/operational/aws/long_running_instances/CHANGELOG.md
+++ b/operational/aws/long_running_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v5.2.5
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/operational/aws/long_running_instances/CHANGELOG.md
+++ b/operational/aws/long_running_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v5.2.6
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v5.2.5
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/operational/aws/long_running_instances/long_running_instances.pt
+++ b/operational/aws/long_running_instances/long_running_instances.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.2.5",
+  version: "5.2.6",
   provider: "AWS",
   service: "Compute",
   policy_set: "Long Running Instances",
@@ -599,8 +599,7 @@ script "js_instances", type: "javascript" do
           }
 
           if (comparison == '!~') {
-            if (resource_tag == undefined) { found_tags.push(string) }
-            if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+            if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
           }
         })
 

--- a/operational/aws/overutilized_ec2_instances/CHANGELOG.md
+++ b/operational/aws/overutilized_ec2_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.6
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.2.5
 
 - Updated instance type data source from `data/aws/instance_types.json` to `data/aws/aws_ec2_instance_types.json`. Functionality unchanged.

--- a/operational/aws/overutilized_ec2_instances/CHANGELOG.md
+++ b/operational/aws/overutilized_ec2_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.2.5
 
 - Updated instance type data source from `data/aws/instance_types.json` to `data/aws/aws_ec2_instance_types.json`. Functionality unchanged.

--- a/operational/aws/overutilized_ec2_instances/aws_overutilized_ec2.pt
+++ b/operational/aws/overutilized_ec2_instances/aws_overutilized_ec2.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "0.2.5",
+  version: "0.2.6",
   provider: "AWS",
   service: "Compute",
   policy_set: "Overutilized Compute Instances",
@@ -723,8 +723,7 @@ script "js_instances", type: "javascript" do
           }
 
           if (comparison == '!~') {
-            if (resource_tag == undefined) { found_tags.push(string) }
-            if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+            if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
           }
         })
 

--- a/operational/aws/scheduled_ec2_events/CHANGELOG.md
+++ b/operational/aws/scheduled_ec2_events/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v4.1.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/operational/aws/scheduled_ec2_events/CHANGELOG.md
+++ b/operational/aws/scheduled_ec2_events/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.1.5
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v4.1.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/operational/aws/scheduled_ec2_events/aws_scheduled_ec2_events.pt
+++ b/operational/aws/scheduled_ec2_events/aws_scheduled_ec2_events.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "medium"
 default_frequency "weekly"
 info(
-  version: "4.1.4",
+  version: "4.1.5",
   provider: "AWS",
   service: "Compute",
   policy_set: "",
@@ -479,8 +479,7 @@ script "js_instances", type: "javascript" do
           }
 
           if (comparison == '!~') {
-            if (resource_tag == undefined) { found_tags.push(string) }
-            if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+            if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
           }
         })
 

--- a/operational/azure/aks_nodepools_without_autoscaling/CHANGELOG.md
+++ b/operational/azure/aks_nodepools_without_autoscaling/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/operational/azure/aks_nodepools_without_autoscaling/CHANGELOG.md
+++ b/operational/azure/aks_nodepools_without_autoscaling/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/operational/azure/aks_nodepools_without_autoscaling/aks_nodepools_without_autoscaling.pt
+++ b/operational/azure/aks_nodepools_without_autoscaling/aks_nodepools_without_autoscaling.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "AKS",
   policy_set: "",
@@ -361,8 +361,7 @@ script "js_aks_clusters_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/operational/azure/aks_nodepools_without_zero_autoscaling/CHANGELOG.md
+++ b/operational/azure/aks_nodepools_without_zero_autoscaling/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.4.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/operational/azure/aks_nodepools_without_zero_autoscaling/CHANGELOG.md
+++ b/operational/azure/aks_nodepools_without_zero_autoscaling/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.4.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.4.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/operational/azure/aks_nodepools_without_zero_autoscaling/aks_nodepools_without_zero_autoscaling.pt
+++ b/operational/azure/aks_nodepools_without_zero_autoscaling/aks_nodepools_without_zero_autoscaling.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "daily"
 info(
-  version: "3.4.0",
+  version: "3.4.1",
   provider: "Azure",
   service: "AKS",
   policy_set: "",
@@ -361,8 +361,7 @@ script "js_aks_clusters_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/operational/azure/azure_certificates/CHANGELOG.md
+++ b/operational/azure/azure_certificates/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v4.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/operational/azure/azure_certificates/CHANGELOG.md
+++ b/operational/azure/azure_certificates/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v4.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/operational/azure/azure_certificates/azure_certificates.pt
+++ b/operational/azure/azure_certificates/azure_certificates.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "daily"
 info(
-  version: "4.3.0",
+  version: "4.3.1",
   provider: "Azure",
   service: "PaaS",
   policy_set: "Expiring Certificates",
@@ -387,8 +387,7 @@ script "js_azure_certificates_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/operational/azure/azure_long_running_instances/CHANGELOG.md
+++ b/operational/azure/azure_long_running_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v6.4.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/operational/azure/azure_long_running_instances/CHANGELOG.md
+++ b/operational/azure/azure_long_running_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v6.4.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v6.4.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.4.0",
+  version: "6.4.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Long Running Instances",
@@ -533,8 +533,7 @@ script "js_azure_instances_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/operational/azure/compute_poweredoff_report/CHANGELOG.md
+++ b/operational/azure/compute_poweredoff_report/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.5.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/operational/azure/compute_poweredoff_report/CHANGELOG.md
+++ b/operational/azure/compute_poweredoff_report/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.5.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.5.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/operational/azure/compute_poweredoff_report/azure_compute_poweredoff_report.pt
+++ b/operational/azure/compute_poweredoff_report/azure_compute_poweredoff_report.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "0.5.0",
+  version: "0.5.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "",
@@ -543,8 +543,7 @@ script "js_azure_instances_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/operational/azure/overutilized_compute_instances/CHANGELOG.md
+++ b/operational/azure/overutilized_compute_instances/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v0.4.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/operational/azure/overutilized_compute_instances/CHANGELOG.md
+++ b/operational/azure/overutilized_compute_instances/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v0.4.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/operational/azure/overutilized_compute_instances/azure_compute_overutilized.pt
+++ b/operational/azure/overutilized_compute_instances/azure_compute_overutilized.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.0",
+  version: "0.4.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Overutilized Compute Instances",
@@ -630,8 +630,7 @@ script "js_azure_instances_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/operational/azure/vms_without_managed_disks/CHANGELOG.md
+++ b/operational/azure/vms_without_managed_disks/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v4.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/operational/azure/vms_without_managed_disks/CHANGELOG.md
+++ b/operational/azure/vms_without_managed_disks/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v4.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks.pt
+++ b/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.3.0",
+  version: "4.3.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "",
@@ -364,8 +364,7 @@ script "js_azure_instances_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/aws/ebs_unencrypted_volumes/CHANGELOG.md
+++ b/security/aws/ebs_unencrypted_volumes/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v5.1.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v5.1.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/aws/ebs_unencrypted_volumes/CHANGELOG.md
+++ b/security/aws/ebs_unencrypted_volumes/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v5.1.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes.pt
+++ b/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.1.0",
+  version: "5.1.1",
   provider: "AWS",
   service: "EBS",
   policy_set: "",
@@ -479,8 +479,7 @@ script "js_volumes_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/aws/elb_unencrypted/CHANGELOG.md
+++ b/security/aws/elb_unencrypted/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v4.1.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/aws/elb_unencrypted/CHANGELOG.md
+++ b/security/aws/elb_unencrypted/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.1.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v4.1.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/aws/elb_unencrypted/aws_elb_encryption.pt
+++ b/security/aws/elb_unencrypted/aws_elb_encryption.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "medium"
 default_frequency "daily"
 info(
-  version: "4.1.0",
+  version: "4.1.1",
   provider: "AWS",
   service: "Network",
   policy_set: "",
@@ -607,8 +607,7 @@ script "js_lbs_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/aws/loadbalancer_internet_facing/CHANGELOG.md
+++ b/security/aws/loadbalancer_internet_facing/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v4.1.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/aws/loadbalancer_internet_facing/CHANGELOG.md
+++ b/security/aws/loadbalancer_internet_facing/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.1.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v4.1.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/aws/loadbalancer_internet_facing/aws_internet_facing_elbs.pt
+++ b/security/aws/loadbalancer_internet_facing/aws_internet_facing_elbs.pt
@@ -8,7 +8,7 @@ severity "high"
 category "Security"
 default_frequency "daily"
 info(
-  version: "4.1.0",
+  version: "4.1.1",
   provider: "AWS",
   service: "Network",
   policy_set: "",
@@ -595,8 +595,7 @@ script "js_lbs_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/aws/rds_publicly_accessible/CHANGELOG.md
+++ b/security/aws/rds_publicly_accessible/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v5.2.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v5.2.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/aws/rds_publicly_accessible/CHANGELOG.md
+++ b/security/aws/rds_publicly_accessible/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v5.2.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances.pt
+++ b/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "hourly"
 info(
-  version: "5.2.0",
+  version: "5.2.1",
   provider: "AWS",
   service: "RDS",
   policy_set: "",
@@ -570,8 +570,7 @@ script "js_rds_instances", type: "javascript" do
       }
 
       if (comparison == '!~') {
-        if (resource_tag == undefined) { found_tags.push(string) }
-        if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+        if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
       }
     })
 

--- a/security/aws/rds_unencrypted/CHANGELOG.md
+++ b/security/aws/rds_unencrypted/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.2.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v4.2.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/aws/rds_unencrypted/CHANGELOG.md
+++ b/security/aws/rds_unencrypted/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v4.2.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/aws/rds_unencrypted/aws_unencrypted_rds_instances.pt
+++ b/security/aws/rds_unencrypted/aws_unencrypted_rds_instances.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "medium"
 default_frequency "daily"
 info(
-  version: "4.2.0",
+  version: "4.2.1",
   provider: "AWS",
   service: "RDS",
   policy_set: "CIS",
@@ -576,8 +576,7 @@ script "js_rds_instances", type: "javascript" do
       }
 
       if (comparison == '!~') {
-        if (resource_tag == undefined) { found_tags.push(string) }
-        if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+        if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
       }
     })
 

--- a/security/aws/s3_buckets_deny_http/CHANGELOG.md
+++ b/security/aws/s3_buckets_deny_http/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.1.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.1.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/aws/s3_buckets_deny_http/CHANGELOG.md
+++ b/security/aws/s3_buckets_deny_http/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.1.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/aws/s3_buckets_deny_http/s3_buckets_deny_http.pt
+++ b/security/aws/s3_buckets_deny_http/s3_buckets_deny_http.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.0",
+  version: "3.1.1",
   provider: "AWS",
   service: "Storage",
   policy_set: "CIS",
@@ -518,8 +518,7 @@ script "js_aws_buckets_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/aws/s3_buckets_without_server_access_logging/CHANGELOG.md
+++ b/security/aws/s3_buckets_without_server_access_logging/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.1.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.1.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/aws/s3_buckets_without_server_access_logging/CHANGELOG.md
+++ b/security/aws/s3_buckets_without_server_access_logging/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.1.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/aws/s3_buckets_without_server_access_logging/aws_s3_buckets_without_server_access_logging.pt
+++ b/security/aws/s3_buckets_without_server_access_logging/aws_s3_buckets_without_server_access_logging.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.0",
+  version: "3.1.1",
   provider: "AWS",
   service: "Storage",
   policy_set: "",
@@ -512,8 +512,7 @@ script "js_aws_buckets_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/aws/s3_ensure_buckets_block_public_access/CHANGELOG.md
+++ b/security/aws/s3_ensure_buckets_block_public_access/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.1.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.1.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/aws/s3_ensure_buckets_block_public_access/CHANGELOG.md
+++ b/security/aws/s3_ensure_buckets_block_public_access/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.1.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/aws/s3_ensure_buckets_block_public_access/s3_ensure_buckets_block_public_access.pt
+++ b/security/aws/s3_ensure_buckets_block_public_access/s3_ensure_buckets_block_public_access.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.0",
+  version: "3.1.1",
   provider: "AWS",
   service: "Storage",
   policy_set: "CIS",
@@ -518,8 +518,7 @@ script "js_aws_buckets_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/aws/s3_ensure_mfa_delete_enabled/CHANGELOG.md
+++ b/security/aws/s3_ensure_mfa_delete_enabled/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.1.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.1.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/aws/s3_ensure_mfa_delete_enabled/CHANGELOG.md
+++ b/security/aws/s3_ensure_mfa_delete_enabled/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.1.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/aws/s3_ensure_mfa_delete_enabled/s3_ensure_mfa_delete_enabled.pt
+++ b/security/aws/s3_ensure_mfa_delete_enabled/s3_ensure_mfa_delete_enabled.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.0",
+  version: "3.1.1",
   provider: "AWS",
   service: "Storage",
   policy_set: "CIS",
@@ -518,8 +518,7 @@ script "js_aws_buckets_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/aws/unencrypted_s3_buckets/CHANGELOG.md
+++ b/security/aws/unencrypted_s3_buckets/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.1.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.1.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/aws/unencrypted_s3_buckets/CHANGELOG.md
+++ b/security/aws/unencrypted_s3_buckets/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.1.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/aws/unencrypted_s3_buckets/aws_unencrypted_s3_buckets.pt
+++ b/security/aws/unencrypted_s3_buckets/aws_unencrypted_s3_buckets.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "low"
 default_frequency "daily"
 info(
-  version: "3.1.0",
+  version: "3.1.1",
   provider: "AWS",
   service: "Storage",
   policy_set: "CIS",
@@ -525,8 +525,7 @@ script "js_aws_buckets_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/aws/vpcs_without_flow_logs_enabled/CHANGELOG.md
+++ b/security/aws/vpcs_without_flow_logs_enabled/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v4.1.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/aws/vpcs_without_flow_logs_enabled/CHANGELOG.md
+++ b/security/aws/vpcs_without_flow_logs_enabled/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.1.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v4.1.0
 
 - Added support for attaching CSV files to incident emails.

--- a/security/aws/vpcs_without_flow_logs_enabled/aws_vpcs_without_flow_logs_enabled.pt
+++ b/security/aws/vpcs_without_flow_logs_enabled/aws_vpcs_without_flow_logs_enabled.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "medium"
 default_frequency "daily"
 info(
-  version: "4.1.0",
+  version: "4.1.1",
   provider: "AWS",
   service: "Network",
   policy_set: "",
@@ -465,8 +465,7 @@ script "js_vpcs_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/blob_storage_logging/CHANGELOG.md
+++ b/security/azure/blob_storage_logging/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/blob_storage_logging/CHANGELOG.md
+++ b/security/azure/blob_storage_logging/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/blob_storage_logging/blob_storage_logging.pt
+++ b/security/azure/blob_storage_logging/blob_storage_logging.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "Storage",
   policy_set: "CIS",
@@ -391,8 +391,7 @@ script "js_azure_storage_accounts_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/mysql_ssl/CHANGELOG.md
+++ b/security/azure/mysql_ssl/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/mysql_ssl/CHANGELOG.md
+++ b/security/azure/mysql_ssl/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/mysql_ssl/mysql_ssl.pt
+++ b/security/azure/mysql_ssl/mysql_ssl.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "MySQL",
   policy_set: "CIS",
@@ -371,8 +371,7 @@ script "js_mysql_servers_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/mysql_tls_version/CHANGELOG.md
+++ b/security/azure/mysql_tls_version/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/mysql_tls_version/CHANGELOG.md
+++ b/security/azure/mysql_tls_version/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/mysql_tls_version/mysql_tls_version.pt
+++ b/security/azure/mysql_tls_version/mysql_tls_version.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "MySQL",
   policy_set: "CIS",
@@ -368,8 +368,7 @@ script "js_mysql_servers_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/pg_conn_throttling/CHANGELOG.md
+++ b/security/azure/pg_conn_throttling/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/pg_conn_throttling/CHANGELOG.md
+++ b/security/azure/pg_conn_throttling/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/pg_conn_throttling/pg_conn_throttling.pt
+++ b/security/azure/pg_conn_throttling/pg_conn_throttling.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "PostgreSQL",
   policy_set: "CIS",
@@ -373,8 +373,7 @@ script "js_pg_servers_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/pg_infra_encryption/CHANGELOG.md
+++ b/security/azure/pg_infra_encryption/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/pg_infra_encryption/CHANGELOG.md
+++ b/security/azure/pg_infra_encryption/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/pg_infra_encryption/pg_infra_encryption.pt
+++ b/security/azure/pg_infra_encryption/pg_infra_encryption.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "PostgreSQL",
   policy_set: "CIS",
@@ -373,8 +373,7 @@ script "js_pg_servers_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/pg_log_retention/CHANGELOG.md
+++ b/security/azure/pg_log_retention/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/pg_log_retention/CHANGELOG.md
+++ b/security/azure/pg_log_retention/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/pg_log_retention/pg_log_retention.pt
+++ b/security/azure/pg_log_retention/pg_log_retention.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "PostgreSQL",
   policy_set: "CIS",
@@ -382,8 +382,7 @@ script "js_pg_servers_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/pg_log_settings/CHANGELOG.md
+++ b/security/azure/pg_log_settings/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/pg_log_settings/CHANGELOG.md
+++ b/security/azure/pg_log_settings/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/pg_log_settings/pg_log_settings.pt
+++ b/security/azure/pg_log_settings/pg_log_settings.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "PostgreSQL",
   policy_set: "CIS",
@@ -382,8 +382,7 @@ script "js_pg_servers_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/private_blob_containers/CHANGELOG.md
+++ b/security/azure/private_blob_containers/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/private_blob_containers/CHANGELOG.md
+++ b/security/azure/private_blob_containers/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/private_blob_containers/private_blob_containers.pt
+++ b/security/azure/private_blob_containers/private_blob_containers.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "Storage",
   policy_set: "CIS",
@@ -391,8 +391,7 @@ script "js_azure_storage_accounts_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/queue_storage_logging/CHANGELOG.md
+++ b/security/azure/queue_storage_logging/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/queue_storage_logging/CHANGELOG.md
+++ b/security/azure/queue_storage_logging/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/queue_storage_logging/queue_storage_logging.pt
+++ b/security/azure/queue_storage_logging/queue_storage_logging.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "Storage",
   policy_set: "CIS",
@@ -391,8 +391,7 @@ script "js_azure_storage_accounts_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/secure_transfer_required/CHANGELOG.md
+++ b/security/azure/secure_transfer_required/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/secure_transfer_required/CHANGELOG.md
+++ b/security/azure/secure_transfer_required/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/secure_transfer_required/secure_transfer_required.pt
+++ b/security/azure/secure_transfer_required/secure_transfer_required.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "Storage",
   policy_set: "CIS",
@@ -384,8 +384,7 @@ script "js_azure_storage_accounts_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/sql_ad_admin/CHANGELOG.md
+++ b/security/azure/sql_ad_admin/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/sql_ad_admin/CHANGELOG.md
+++ b/security/azure/sql_ad_admin/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/sql_ad_admin/sql_ad_admin.pt
+++ b/security/azure/sql_ad_admin/sql_ad_admin.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "SQL",
   policy_set: "CIS",
@@ -368,8 +368,7 @@ script "js_azure_sql_servers_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/sql_auditing_retention/CHANGELOG.md
+++ b/security/azure/sql_auditing_retention/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/sql_auditing_retention/CHANGELOG.md
+++ b/security/azure/sql_auditing_retention/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/sql_auditing_retention/sql_auditing_retention.pt
+++ b/security/azure/sql_auditing_retention/sql_auditing_retention.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "SQL",
   policy_set: "CIS",
@@ -377,8 +377,7 @@ script "js_azure_sql_servers_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/sql_db_encryption/CHANGELOG.md
+++ b/security/azure/sql_db_encryption/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/sql_db_encryption/CHANGELOG.md
+++ b/security/azure/sql_db_encryption/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/sql_db_encryption/sql_db_encryption.pt
+++ b/security/azure/sql_db_encryption/sql_db_encryption.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "SQL",
   policy_set: "CIS",
@@ -405,8 +405,7 @@ script "js_azure_sql_databases_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/sql_publicly_accessible_managed_instance/CHANGELOG.md
+++ b/security/azure/sql_publicly_accessible_managed_instance/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/sql_publicly_accessible_managed_instance/CHANGELOG.md
+++ b/security/azure/sql_publicly_accessible_managed_instance/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/sql_publicly_accessible_managed_instance/sql_publicly_accessible_managed_instance.pt
+++ b/security/azure/sql_publicly_accessible_managed_instance/sql_publicly_accessible_managed_instance.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "SQL",
   policy_set: "",
@@ -374,8 +374,7 @@ script "js_azure_sql_managed_instances_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/sql_server_atp/CHANGELOG.md
+++ b/security/azure/sql_server_atp/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/sql_server_atp/CHANGELOG.md
+++ b/security/azure/sql_server_atp/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/sql_server_atp/sql_server_atp.pt
+++ b/security/azure/sql_server_atp/sql_server_atp.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "SQL",
   policy_set: "CIS",
@@ -368,8 +368,7 @@ script "js_azure_sql_servers_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/sql_server_auditing/CHANGELOG.md
+++ b/security/azure/sql_server_auditing/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/sql_server_auditing/CHANGELOG.md
+++ b/security/azure/sql_server_auditing/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/sql_server_auditing/sql_server_auditing.pt
+++ b/security/azure/sql_server_auditing/sql_server_auditing.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "SQL",
   policy_set: "CIS",
@@ -368,8 +368,7 @@ script "js_azure_sql_servers_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/sql_server_va/CHANGELOG.md
+++ b/security/azure/sql_server_va/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/sql_server_va/CHANGELOG.md
+++ b/security/azure/sql_server_va/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/sql_server_va/sql_server_va.pt
+++ b/security/azure/sql_server_va/sql_server_va.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "SQL",
   policy_set: "CIS",
@@ -368,8 +368,7 @@ script "js_azure_sql_servers_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/sql_server_va_admins/CHANGELOG.md
+++ b/security/azure/sql_server_va_admins/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/sql_server_va_admins/CHANGELOG.md
+++ b/security/azure/sql_server_va_admins/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/sql_server_va_admins/sql_server_va_admins.pt
+++ b/security/azure/sql_server_va_admins/sql_server_va_admins.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "SQL",
   policy_set: "CIS",
@@ -368,8 +368,7 @@ script "js_azure_sql_servers_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/sql_server_va_emails/CHANGELOG.md
+++ b/security/azure/sql_server_va_emails/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/sql_server_va_emails/CHANGELOG.md
+++ b/security/azure/sql_server_va_emails/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/sql_server_va_emails/sql_server_va_emails.pt
+++ b/security/azure/sql_server_va_emails/sql_server_va_emails.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "SQL",
   policy_set: "CIS",
@@ -368,8 +368,7 @@ script "js_azure_sql_servers_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/sql_server_va_scans/CHANGELOG.md
+++ b/security/azure/sql_server_va_scans/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/sql_server_va_scans/CHANGELOG.md
+++ b/security/azure/sql_server_va_scans/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/sql_server_va_scans/sql_server_va_scans.pt
+++ b/security/azure/sql_server_va_scans/sql_server_va_scans.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "SQL",
   policy_set: "CIS",
@@ -368,8 +368,7 @@ script "js_azure_sql_servers_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/storage_network_deny/CHANGELOG.md
+++ b/security/azure/storage_network_deny/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/storage_network_deny/CHANGELOG.md
+++ b/security/azure/storage_network_deny/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/storage_network_deny/storage_network_deny.pt
+++ b/security/azure/storage_network_deny/storage_network_deny.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "Storage",
   policy_set: "CIS",
@@ -384,8 +384,7 @@ script "js_azure_storage_accounts_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/storage_soft_delete/CHANGELOG.md
+++ b/security/azure/storage_soft_delete/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/storage_soft_delete/CHANGELOG.md
+++ b/security/azure/storage_soft_delete/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/storage_soft_delete/storage_soft_delete.pt
+++ b/security/azure/storage_soft_delete/storage_soft_delete.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "Storage",
   policy_set: "CIS",
@@ -384,8 +384,7 @@ script "js_azure_storage_accounts_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/storage_tls_version/CHANGELOG.md
+++ b/security/azure/storage_tls_version/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/storage_tls_version/CHANGELOG.md
+++ b/security/azure/storage_tls_version/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/storage_tls_version/storage_tls_version.pt
+++ b/security/azure/storage_tls_version/storage_tls_version.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "Storage",
   policy_set: "CIS",
@@ -384,8 +384,7 @@ script "js_azure_storage_accounts_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/storage_trusted_services/CHANGELOG.md
+++ b/security/azure/storage_trusted_services/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/storage_trusted_services/CHANGELOG.md
+++ b/security/azure/storage_trusted_services/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/storage_trusted_services/storage_trusted_services.pt
+++ b/security/azure/storage_trusted_services/storage_trusted_services.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "Storage",
   policy_set: "CIS",
@@ -385,8 +385,7 @@ script "js_azure_storage_accounts_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/table_storage_logging/CHANGELOG.md
+++ b/security/azure/table_storage_logging/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/table_storage_logging/CHANGELOG.md
+++ b/security/azure/table_storage_logging/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/table_storage_logging/table_storage_logging.pt
+++ b/security/azure/table_storage_logging/table_storage_logging.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "Storage",
   policy_set: "CIS",
@@ -393,8 +393,7 @@ script "js_azure_storage_accounts_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 

--- a/security/azure/webapp_tls_version_support/CHANGELOG.md
+++ b/security/azure/webapp_tls_version_support/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.1
+
+- Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
+
+
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/webapp_tls_version_support/CHANGELOG.md
+++ b/security/azure/webapp_tls_version_support/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match
 
-
 ## v3.3.0
 
 - Added `Allow/Deny Resource Groups` and `Allow/Deny Resource Groups List` filter parameters to allow filtering resources by resource group

--- a/security/azure/webapp_tls_version_support/azure_webapp_min_tls_version.pt
+++ b/security/azure/webapp_tls_version_support/azure_webapp_min_tls_version.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "low"
 default_frequency "daily"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "Azure",
   service: "App Service",
   policy_set: "",
@@ -377,8 +377,7 @@ script "js_azure_web_apps_tag_filtered", type: "javascript" do
         }
 
         if (comparison == '!~') {
-          if (resource_tag == undefined) { found_tags.push(string) }
-          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
         }
       })
 


### PR DESCRIPTION
### Description

Fixed bug in many policy templates where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of excluding those that did not match

(Dangerfile warnings/errors not related to the above change)
