### PR TITLE
POL-1785 Untagged Resources Bug Fix

### DIFF
--- a/compliance/aws/untagged_resources/CHANGELOG.md
+++ b/compliance/aws/untagged_resources/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.6.3
+
+- Fixed bug where resources whose missing tags were fully covered by Tag Dimension equivalents were still included in the incident with a blank `Missing Tags` field instead of being correctly excluded.
+
 ## v5.6.2
 
 - Fixed bug with `Consider Tag Dimensions` feature that would sometimes cause it to not work correctly.

--- a/compliance/aws/untagged_resources/aws_untagged_resources.pt
+++ b/compliance/aws/untagged_resources/aws_untagged_resources.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.6.2",
+  version: "5.6.3",
   provider: "AWS",
   service: "Compute",
   policy_set: "Untagged Resources",
@@ -769,7 +769,7 @@ script "js_aws_resources_missing_tags", type:"javascript" do
         })
       }
 
-      if (missing_tags.length == comparators.length || (missing_tags.length > 0 && param_tags_boolean == 'Any')) {
+      if (missing_tags_result.length == comparators.length || (missing_tags_result.length > 0 && param_tags_boolean == 'Any')) {
         new_resource = resource
         new_resource['tags'] = resource_tags
         new_resource['missing_tags'] = missing_tags_result

--- a/compliance/azure/azure_untagged_resources/CHANGELOG.md
+++ b/compliance/azure/azure_untagged_resources/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.0.1
+
+- Fixed bug where resources whose missing tags were fully covered by Tag Dimension equivalents were still included in the incident with a blank `Missing Tags` field instead of being correctly excluded.
+
 ## v4.0.0
 
 - Added `Consider Tag Dimensions` parameter to allow Flexera Tag Dimensions to be considered when reporting on untagged resources.

--- a/compliance/azure/azure_untagged_resources/untagged_resources.pt
+++ b/compliance/azure/azure_untagged_resources/untagged_resources.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.0.0",
+  version: "4.0.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Untagged Resources",
@@ -584,7 +584,7 @@ script "js_azure_resources_missing_tags", type: "javascript" do
         })
       }
 
-      if (missing_tags.length == comparators.length || (missing_tags.length > 0 && param_tags_boolean == 'Any')) {
+      if (missing_tags_result.length == comparators.length || (missing_tags_result.length > 0 && param_tags_boolean == 'Any')) {
         new_resource = resource
         new_resource['missing_tags'] = missing_tags_result
         result.push(new_resource)

--- a/compliance/azure/azure_untagged_vms/CHANGELOG.md
+++ b/compliance/azure/azure_untagged_vms/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.0.1
+
+- Fixed bug where resources whose missing tags were fully covered by Tag Dimension equivalents were still included in the incident with a blank `Missing Tags` field instead of being correctly excluded.
+
 ## v2.0.0
 
 - Added `Consider Tag Dimensions` parameter to allow Flexera Tag Dimensions to be considered when reporting on untagged resources.

--- a/compliance/azure/azure_untagged_vms/untagged_vms.pt
+++ b/compliance/azure/azure_untagged_vms/untagged_vms.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "2.0.0",
+  version: "2.0.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Untagged Resources",
@@ -490,7 +490,7 @@ script "js_azure_instances_missing_tags", type: "javascript" do
         })
       }
 
-      if (missing_tags.length == comparators.length || (missing_tags.length > 0 && param_tags_boolean == 'Any')) {
+      if (missing_tags_result.length == comparators.length || (missing_tags_result.length > 0 && param_tags_boolean == 'Any')) {
         new_vm = vm
         new_vm['missing_tags'] = missing_tags_result
         result.push(new_vm)

--- a/compliance/google/unlabeled_resources/CHANGELOG.md
+++ b/compliance/google/unlabeled_resources/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.0.1
+
+- Fixed bug where resources whose missing labels were fully covered by Tag Dimension equivalents were still included in the incident with a blank `Missing Labels` field instead of being correctly excluded.
+
 ## v4.0.0
 
 - Added `Consider Tag Dimensions` parameter to allow Flexera Tag Dimensions to be considered when reporting on unlabeled resources.

--- a/compliance/google/unlabeled_resources/unlabeled_resources.pt
+++ b/compliance/google/unlabeled_resources/unlabeled_resources.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.0.0",
+  version: "4.0.1",
   provider: "Google",
   service: "Compute",
   policy_set: "Untagged Resources",
@@ -912,7 +912,7 @@ script "js_google_resources_missing_labels", type: "javascript" do
         })
       }
 
-      if (missing_labels.length == comparators.length || (missing_labels.length > 0 && param_labels_boolean == 'Any')) {
+      if (missing_labels_result.length == comparators.length || (missing_labels_result.length > 0 && param_labels_boolean == 'Any')) {
         new_resource = resource
         new_resource['missing_labels'] = missing_labels_result
         result.push(new_resource)


### PR DESCRIPTION
### Description

Fixed bug in the various "Untagged Resources" policy templates where resources whose missing tags were fully covered by Tag Dimension equivalents were still included in the incident with a blank `Missing Tags` field instead of being correctly excluded.

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=6a2af844d4f6397e66bb3b95

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
