### PR TITLE
POL-1784 - Align region values to API identifier used in other AWS Policy Sets

### DIFF
--- a/cost/aws/extended_support/CHANGELOG.md
+++ b/cost/aws/extended_support/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.1.0
+
+- Updated incident/export region reporting to use AWS API region identifiers (for example, `us-east-1`) for consistency with other AWS optimization policy sets.
+
 ## v1.0.1
 
 - Fixed issue with incident table that cause policy execution to fail

--- a/cost/aws/extended_support/README.md
+++ b/cost/aws/extended_support/README.md
@@ -7,6 +7,7 @@ This policy template uses the AWS APIs (RDS, EKS, and ElastiCache) to identify a
 ## How It Works
 
 - The policy queries the AWS APIs (RDS, EKS, and ElastiCache) across all opted-in regions to enumerate all running resources.
+- Region values shown in incidents and exports are reported using AWS API region identifiers (for example, `us-east-1`) for consistency with other AWS optimization policy sets.
 - Each discovered resource's version is matched against the reference data file at `data/aws/aws_extended_support_dates.json` to determine if it is currently under extended support or will enter extended support within the number of days specified by the `Days Until Extended Support` parameter.
 - The policy also pulls resource-level billing data from the Flexera CCO platform from 3 days ago, filtered to resources with a `Usage Type` that contains `ExtendedSupport`. This data is used only for obtaining actual costs for resources already incurring extended support charges. Data from 3 days ago is used to ensure that we have available, processed billing data to search through.
 

--- a/cost/aws/extended_support/aws_extended_support.pt
+++ b/cost/aws/extended_support/aws_extended_support.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "1.0.1",
+  version: "1.1.0",
   provider: "AWS",
   service: "All",
   policy_set: "Deprecated Resources",
@@ -879,11 +879,11 @@ EOS
 end
 
 datasource "ds_all_extended_support_resources" do
-  run_script $js_all_extended_support_resources, $ds_rds_instances_filtered, $ds_rds_tags, $ds_eks_clusters, $ds_elasticache_clusters_filtered, $ds_elasticache_tags, $ds_aws_extended_support_dates, $ds_flexera_cco_data_filtered, $ds_cloud_vendor_accounts, $ds_currency, $param_upcoming_days, $param_exclusion_tags, $param_exclusion_tags_boolean
+  run_script $js_all_extended_support_resources, $ds_rds_instances_filtered, $ds_rds_tags, $ds_eks_clusters, $ds_elasticache_clusters_filtered, $ds_elasticache_tags, $ds_aws_extended_support_dates, $ds_flexera_cco_data_filtered, $ds_cloud_vendor_accounts, $ds_currency, $ds_regions_table, $param_upcoming_days, $param_exclusion_tags, $param_exclusion_tags_boolean
 end
 
 script "js_all_extended_support_resources", type: "javascript" do
-  parameters "ds_rds_instances", "ds_rds_tags", "ds_eks_clusters", "ds_elasticache_clusters", "ds_elasticache_tags", "ds_aws_extended_support_dates", "ds_flexera_cco_data_filtered", "ds_cloud_vendor_accounts", "ds_currency", "param_upcoming_days", "param_exclusion_tags", "param_exclusion_tags_boolean"
+  parameters "ds_rds_instances", "ds_rds_tags", "ds_eks_clusters", "ds_elasticache_clusters", "ds_elasticache_tags", "ds_aws_extended_support_dates", "ds_flexera_cco_data_filtered", "ds_cloud_vendor_accounts", "ds_currency", "ds_regions_table", "param_upcoming_days", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
   result = []
@@ -925,6 +925,11 @@ script "js_all_extended_support_resources", type: "javascript" do
   function getResourceName(tag_map, fallback) {
     if (tag_map && tag_map['Name']) { return tag_map['Name'] }
     return fallback
+  }
+
+  function normalizeRegion(region) {
+    if (!region) { return '' }
+    return ds_regions_table[region] || region
   }
 
   var rds_tag_lookup = buildTagLookup(ds_rds_tags)
@@ -1098,7 +1103,7 @@ script "js_all_extended_support_resources", type: "javascript" do
       resourceName: resourceName,
       tags: tagsString,
       service: 'RDS',
-      region: instance['region'],
+      region: normalizeRegion(instance['region']),
       resourceType: instance['instanceClass'] || 'N/A',
       engineVersion: instance['engine'] + ' ' + instance['engineVersion'],
       extendedSupportStart: entry['extended_support_start'],
@@ -1140,7 +1145,7 @@ script "js_all_extended_support_resources", type: "javascript" do
       resourceName: resourceName,
       tags: tagsString,
       service: 'EKS',
-      region: cluster['region'],
+      region: normalizeRegion(cluster['region']),
       resourceType: 'EKS Cluster',
       engineVersion: 'Kubernetes ' + cluster['version'],
       extendedSupportStart: entry['extended_support_start'],
@@ -1182,7 +1187,7 @@ script "js_all_extended_support_resources", type: "javascript" do
       resourceName: resourceName,
       tags: tagsString,
       service: 'ElastiCache',
-      region: cluster['region'],
+      region: normalizeRegion(cluster['region']),
       resourceType: cluster['cacheNodeType'] || 'N/A',
       engineVersion: cluster['engine'] + ' ' + cluster['engineVersion'],
       extendedSupportStart: entry['extended_support_start'],
@@ -1312,7 +1317,7 @@ policy "pol_extended_support_resources" do
         label "Service"
       end
       field "region" do
-        label "Region"
+        label "Region ID"
       end
       field "resourceType" do
         label "Resource Type"


### PR DESCRIPTION
### Description

We noticed that the AWS Resources Under Extended Support recommendations are using display names, instead of the identifier used when interacting with APIs. This release updates the region values to use the API identifier, which aligns with other AWS Policy Sets.

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/policy/projects/7954/applied-policies/6a2c5ad0620578afd2778e1c

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
