### PR TITLE
SQ-23518 Azure Storage Accounts Allowing Default Network Access Improvement

### DIFF
--- a/.dangerfile/github_tests.rb
+++ b/.dangerfile/github_tests.rb
@@ -13,13 +13,15 @@ def github_pr_bad_title?(github)
   pol_matcher = /^POL-\d{1,4} .+$/
   fopts_matcher = /^FOPTS-\d{1,4} .+$/
   foaa_matcher = /^FOAA-\d{1,4} .+$/
+  sq_matcher = /^SQ-\d{1,4} .+$/
 
-  return false if github.pr_title.match?(pol_matcher) || github.pr_title.match?(fopts_matcher) || github.pr_title.match?(foaa_matcher)
+  return false if github.pr_title.match?(pol_matcher) || github.pr_title.match?(fopts_matcher) || github.pr_title.match?(foaa_matcher) || github.pr_title.match?(sq_matcher)
 
   fail_message = "### **Github Pull Request**\n[[Info](https://github.com/flexera-public/policy_templates/blob/master/CONTRIBUTING.md#4-make-a-pull-request)] Pull Request has improper title. Title should always begin with the JIRA ticket id, followed by a description, like in the following examples:\n\n"
   fail_message += "POL-123 Add New Feature\n"
   fail_message += "FOPTS-1000 Fixed Bug\n\n"
   fail_message += "FOAA-710 New Policy Template\n\n"
+  fail_message += "SQ-123 Add New Feature\n\n"
   fail_message.strip
 end
 

--- a/security/azure/storage_network_deny/CHANGELOG.md
+++ b/security/azure/storage_network_deny/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.4.0
+
+- Added "Treat Disabled Public Network Access as Compliant" parameter to optionally exclude storage accounts with public network access disabled from results. Default value preserves existing behavior.
+
 ## v3.3.1
 
 - Fixed bug where the `!~` exclusion tag operator incorrectly excluded resources whose tag value matched the regex instead of those that did not match

--- a/security/azure/storage_network_deny/README.md
+++ b/security/azure/storage_network_deny/README.md
@@ -22,6 +22,7 @@ This policy template reports any Azure Storage Accounts that do not have their d
   - `Key=~/Regex/` - Filter all resources where the value for the specified key matches the specified regex string.
   - `Key!~/Regex/` - Filter all resources where the value for the specified key does not match the specified regex string. This will also filter all resources missing the specified tag key.
 - *Exclusion Tags: Any / All* - Whether to filter instances containing any of the specified tags or only those that contain all of them. Only applicable if more than one value is entered in the `Exclusion Tags` field.
+- *Treat Disabled Public Network Access as Compliant* - If set to `true`, storage accounts with public network access explicitly disabled are treated as compliant and excluded from results, even if their default network access rule is `Allow`. When public network access is disabled, the storage firewall has no effect because the account is only reachable via private endpoints. Default is `false`, which preserves strict CIS 3.6 behavior of reporting any account whose default network action is `Allow`.
 - *Attach CSV To Incident Email* - Whether or not to attach the results as a CSV file to the incident email.
 - *Incident Table Rows for Email Body (#)* - The number of results to include in the incident table in the incident email. Set to '0' to not show an incident table at all, and '100000' to include all results. Does not impact attached CSV files or the incident as presented in Flexera One.
 

--- a/security/azure/storage_network_deny/storage_network_deny.pt
+++ b/security/azure/storage_network_deny/storage_network_deny.pt
@@ -522,7 +522,7 @@ script "js_bad_storage_accounts", type: "javascript" do
       networkAcls: resource['networkAcls'],
       primaryEndpoints: resource['primaryEndpoints'],
       networkDefaultAction: resource['networkDefaultAction'],
-      publicNetworkAccess: resource['publicNetworkAccess'],
+      publicNetworkAccess: resource['publicNetworkAccess'] || "Enabled (Implicit)",
       tags: tags.join(', '),
       policy_name: ds_applied_policy['name']
     }

--- a/security/azure/storage_network_deny/storage_network_deny.pt
+++ b/security/azure/storage_network_deny/storage_network_deny.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.1",
+  version: "3.4.0",
   provider: "Azure",
   service: "Storage",
   policy_set: "CIS",
@@ -115,6 +115,15 @@ parameter "param_exclusion_tags_boolean" do
   description "Whether to filter storage accounts containing any of the specified tags or only those that contain all of them. Only applicable if more than one value is entered in the 'Exclusion Tags' field."
   allowed_values "Any", "All"
   default "Any"
+end
+
+parameter "param_public_network_access_compliant" do
+  type "string"
+  category "Filters"
+  label "Treat Disabled Public Network Access as Compliant"
+  description "If set to 'true', Azure Storage Accounts with public network access disabled are treated as compliant and not reported, even if their default network access rule is set to 'Allow'. When disabled, the storage firewall has no effect because the account is only reachable via private endpoints. Default is 'false', which preserves strict CIS 3.6 behavior of reporting any account whose default network action is 'Allow'."
+  allowed_values "true", "false"
+  default "false"
 end
 
 parameter "param_incident_csv" do
@@ -316,6 +325,7 @@ datasource "ds_azure_storage_accounts" do
       field "networkAcls", jmes_path(col_item, "properties.networkAcls")
       field "primaryEndpoints", jmes_path(col_item, "properties.primaryEndpoints")
       field "networkDefaultAction", jmes_path(col_item, "properties.networkAcls.defaultAction")
+      field "publicNetworkAccess", jmes_path(col_item, "properties.publicNetworkAccess")
       field "resourceGroup", get(4, split(jmes_path(col_item, "id"), '/'))
       field "subscriptionID", val(iter_item, "id")
       field "subscriptionName", val(iter_item, "name")
@@ -468,16 +478,21 @@ EOS
 end
 
 datasource "ds_bad_storage_accounts" do
-  run_script $js_bad_storage_accounts, $ds_azure_storage_accounts_rg_filtered, $ds_applied_policy, $param_incident_csv
+  run_script $js_bad_storage_accounts, $ds_azure_storage_accounts_rg_filtered, $ds_applied_policy, $param_incident_csv, $param_public_network_access_compliant
 end
 
 script "js_bad_storage_accounts", type: "javascript" do
-  parameters "ds_azure_storage_accounts_rg_filtered", "ds_applied_policy", "param_incident_csv"
+  parameters "ds_azure_storage_accounts_rg_filtered", "ds_applied_policy", "param_incident_csv", "param_public_network_access_compliant"
   result "result"
   code <<-'EOS'
   csv_message = param_incident_csv == "false" ? "" : "Incident table CSV file has been attached to emails for this incident."
 
   bad_accounts = _.filter(ds_azure_storage_accounts_rg_filtered, function(resource) {
+    // Opt-in: when public network access is disabled, the account is only
+    // reachable via private endpoints, so treat it as compliant.
+    if (param_public_network_access_compliant == "true" && resource['publicNetworkAccess'] == "Disabled") {
+      return false
+    }
     return resource['networkDefaultAction'] == "Allow"
   })
 
@@ -507,6 +522,7 @@ script "js_bad_storage_accounts", type: "javascript" do
       networkAcls: resource['networkAcls'],
       primaryEndpoints: resource['primaryEndpoints'],
       networkDefaultAction: resource['networkDefaultAction'],
+      publicNetworkAccess: resource['publicNetworkAccess'],
       tags: tags.join(', '),
       policy_name: ds_applied_policy['name']
     }
@@ -532,6 +548,7 @@ script "js_bad_storage_accounts", type: "javascript" do
     networkAcls: '',
     primaryEndpoints: '',
     networkDefaultAction: '',
+    publicNetworkAccess: '',
     tags: '',
     policy_name: ''
   })
@@ -581,6 +598,9 @@ policy "pol_bad_storage_accounts" do
       end
       field "networkDefaultAction" do
         label "Network Default Action"
+      end
+      field "publicNetworkAccess" do
+        label "Public Network Access"
       end
       field "id" do
         label "ID"


### PR DESCRIPTION
### Description

`Azure Storage Accounts Allowing Default Network Access`
- Added "Treat Disabled Public Network Access as Compliant" parameter to optionally exclude storage accounts with public network access disabled from results. Default value preserves existing behavior.

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=6a3d7381620578afd278522c

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
