### PR TITLE
POL-1788 AWS Tag Cardinality: API Update

### DIFF
--- a/operational/aws/tag_cardinality/CHANGELOG.md
+++ b/operational/aws/tag_cardinality/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.3.1
+
+- Updated AWS Organizations account status field from deprecated `Status` to `State`, with fallback to `Status` during the dual-availability window, to accommodate the AWS Organizations API deprecation on September 9, 2026. Internal field renamed from `account_status` to `account_state`.
+
 ## v3.3.0
 
 - Added graceful error handling for inaccessible AWS regions

--- a/operational/aws/tag_cardinality/CHANGELOG.md
+++ b/operational/aws/tag_cardinality/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v3.3.1
 
-- Updated AWS Organizations account status field from deprecated `Status` to `State`, with fallback to `Status` during the dual-availability window, to accommodate the AWS Organizations API deprecation on September 9, 2026. Internal field renamed from `account_status` to `account_state`.
+- Updated AWS Organizations API calls to ensure compatibility with upcoming changes to AWS APIs. Functionality unchanged.
 
 ## v3.3.0
 

--- a/operational/aws/tag_cardinality/aws_tag_cardinality.pt
+++ b/operational/aws/tag_cardinality/aws_tag_cardinality.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "AWS",
   service: "Tags",
   policy_set: "Tag Cardinality",
@@ -178,7 +178,7 @@ datasource "ds_aws_accounts_without_tags" do
       field "org_arn", jmes_path(col_item, "Arn")
       field "account_id", jmes_path(col_item, "Id")
       field "account_name", jmes_path(col_item, "Name")
-      field "account_status", jmes_path(col_item, "Status")
+      field "account_state", jmes_path(col_item, "State || Status")
     end
   end
 end
@@ -203,7 +203,7 @@ datasource "ds_aws_accounts" do
     field "org_arn", val(iter_item, "org_arn")
     field "account_id", val(iter_item, "account_id")
     field "account_name", val(iter_item, "account_name")
-    field "account_status", val(iter_item, "account_status")
+    field "account_state", val(iter_item, "account_state")
     field "tags_unsorted", jmes_path(response, "Tags")
   end
 end

--- a/operational/aws/tag_cardinality/aws_tag_cardinality.pt
+++ b/operational/aws/tag_cardinality/aws_tag_cardinality.pt
@@ -178,7 +178,6 @@ datasource "ds_aws_accounts_without_tags" do
       field "org_arn", jmes_path(col_item, "Arn")
       field "account_id", jmes_path(col_item, "Id")
       field "account_name", jmes_path(col_item, "Name")
-      field "account_state", jmes_path(col_item, "State || Status")
     end
   end
 end
@@ -203,7 +202,6 @@ datasource "ds_aws_accounts" do
     field "org_arn", val(iter_item, "org_arn")
     field "account_id", val(iter_item, "account_id")
     field "account_name", val(iter_item, "account_name")
-    field "account_state", val(iter_item, "account_state")
     field "tags_unsorted", jmes_path(response, "Tags")
   end
 end


### PR DESCRIPTION
### Description

Removes the "status" field from the API call to list AWS accounts. This field is changing on the AWS side to "state" and is not actually used at all during policy execution.

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=6a45253a620578afd278b996

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
