### PR TITLE
POL-1794 Google Cloud Resources Under or Approaching Extended Support: sys- and app- Project Filtering

### DIFF
--- a/cost/google/extended_support/CHANGELOG.md
+++ b/cost/google/extended_support/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.0
+
+- Added `Ignore System Projects` parameter to automatically exclude projects whose ID begins with `sys-`
+- Added `Ignore Google Apps Script Projects` parameter to automatically exclude projects whose ID begins with `app-`
+
 ## v0.1.0
 
 - Initial release

--- a/cost/google/extended_support/README.md
+++ b/cost/google/extended_support/README.md
@@ -24,6 +24,8 @@ The policy includes an estimated monthly extended-support surcharge for each res
 - *Days Until Extended Support* - Report resources that will enter extended support within this many days. Set to 0 to only report resources currently under extended support.
 - *Allow/Deny Projects* - Whether to allow or deny the projects listed in the *Allow/Deny Projects List* parameter.
 - *Allow/Deny Projects List* - A list of allowed or denied Google Cloud project IDs/names. Leave blank to check all projects.
+- *Ignore System Projects* - Whether or not to automatically ignore system projects (projects whose ID begins with `sys-`).
+- *Ignore Google Apps Script Projects* - Whether or not to automatically ignore Google Apps Script projects (projects whose ID begins with `app-`).
 - *Allow/Deny Regions* - Whether to allow or deny the regions listed in the *Allow/Deny Regions List* parameter.
 - *Allow/Deny Regions List* - A list of allowed or denied Google region names (e.g. `us-central1`). Leave blank to check all regions.
 - *Exclusion Labels* - Cloud native labels to ignore resources. Enter the Key name to filter resources with a specific Key regardless of Value, or `Key==Value` to filter a specific pair. Regex operators `=~` and `!~` are also supported.

--- a/cost/google/extended_support/README.md
+++ b/cost/google/extended_support/README.md
@@ -43,7 +43,7 @@ This Policy Template uses [Credentials](https://docs.flexera.com/flexera-one/aut
 
 - [**Google Cloud Credential**](https://docs.flexera.com/flexera-one/automation/automation-administration/managing-credentials-for-policy-access-to-external-systems/provider-specific-credentials#google) (*provider=gce*) which has the following:
   - `container.clusters.list`
-  - `resourcemanager.projects.get`
+  - `resourcemanager.projects.search`
   - `cloudsql.instances.list`
 
 - [**Flexera Credential**](https://docs.flexera.com/flexera-one/automation/automation-administration/managing-credentials-for-policy-access-to-external-systems/provider-specific-credentials#flexera) (*provider=flexera*) which has the following roles:

--- a/cost/google/extended_support/google_extended_support.pt
+++ b/cost/google/extended_support/google_extended_support.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.1.0",
+  version: "0.2.0",
   provider: "Google",
   service: "All",
   policy_set: "Deprecated Resources",
@@ -61,6 +61,24 @@ parameter "param_projects_list" do
   label "Allow/Deny Projects List"
   description "A list of allowed or denied project IDs/names. Leave blank to check all Google Cloud Projects."
   default []
+end
+
+parameter "param_projects_ignore_sys" do
+  type "string"
+  category "Filters"
+  label "Ignore System Projects"
+  description "Whether or not to automatically ignore system projects e.g. projects whose id begins with 'sys-'"
+  allowed_values "Yes", "No"
+  default "No"
+end
+
+parameter "param_projects_ignore_app" do
+  type "string"
+  category "Filters"
+  label "Ignore Google Apps Script Projects"
+  description "Whether or not to automatically ignore Google Apps Script projects e.g. projects whose id begins with 'app-'"
+  allowed_values "Yes", "No"
+  default "No"
 end
 
 parameter "param_regions_allow_or_deny" do
@@ -285,7 +303,7 @@ end
 
 datasource "ds_google_projects" do
   request do
-    run_script $js_google_projects, $ds_is_deleted
+    run_script $js_google_projects, $ds_is_deleted, $param_projects_ignore_sys, $param_projects_ignore_app
   end
   result do
     encoding "json"
@@ -297,15 +315,19 @@ datasource "ds_google_projects" do
 end
 
 script "js_google_projects", type: "javascript" do
-  parameters "ds_is_deleted"
+  parameters "ds_is_deleted", "param_projects_ignore_sys", "param_projects_ignore_app"
   result "request"
   code <<-'EOS'
+  var query = ["state:ACTIVE"]
+  if (param_projects_ignore_sys == "Yes") { query.push("-projectId:sys-") }
+  if (param_projects_ignore_app == "Yes") { query.push("-projectId:app-") }
+
   var request = {
     auth: "auth_google",
     pagination: "pagination_google",
     host: "cloudresourcemanager.googleapis.com",
     path: "/v3/projects:search",
-    query_params: { "query": "state:ACTIVE" },
+    query_params: { "query": query.join(" ") },
     headers: { "Meta-Flexera": ds_is_deleted["path"] }
   }
 EOS

--- a/cost/google/extended_support/google_extended_support_meta_parent.pt
+++ b/cost/google/extended_support/google_extended_support_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "0.1.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -115,6 +115,26 @@ parameter "param_upcoming_days" do
   min_value 0
   default 0
 end
+
+parameter "param_projects_ignore_sys" do
+  type "string"
+  category "Filters"
+  label "Ignore System Projects"
+  description "Whether or not to automatically ignore system projects in child policies e.g. projects whose id begins with 'sys-'. Default value of 'Yes' is recommended."
+  allowed_values "Yes", "No"
+  default "Yes"
+end
+
+
+parameter "param_projects_ignore_app" do
+  type "string"
+  category "Filters"
+  label "Ignore Google Apps Script Projects"
+  description "Whether or not to automatically ignore Google Apps Script projects in child policies e.g. projects whose id begins with 'app-'. Default value of 'Yes' is recommended."
+  allowed_values "Yes", "No"
+  default "Yes"
+end
+
 
 parameter "param_regions_allow_or_deny" do
   type "string"

--- a/tools/policy_api_list_generation/policy_api_list_generator.py
+++ b/tools/policy_api_list_generation/policy_api_list_generator.py
@@ -2360,7 +2360,37 @@ class PolicyTemplateParser:
 
             return None
 
-        return None
+        # Kubernetes Engine (GKE) — container.googleapis.com
+        # Path structure (v1 and v1beta1):
+        #   /v1/projects/{id}/locations/{loc}/{resource}          → list
+        #   /v1/projects/{id}/locations/{loc}/{resource}/{name}   → get/update/delete
+        #   /v1/projects/{id}/zones/{zone}/{resource}             → list (legacy)
+        #   /v1/projects/{id}/zones/{zone}/{resource}/{name}      → get (legacy)
+        if service == 'container':
+            method_upper = method.upper()
+            path_parts = [p for p in path.rstrip('/').split('/') if p]
+            if not path_parts:
+                return None
+            last = path_parts[-1]
+            if last.startswith('{'):
+                # Last segment is a resource ID — find the preceding resource type
+                non_placeholder = [p for p in path_parts if not p.startswith('{')]
+                if not non_placeholder:
+                    return None
+                resource = non_placeholder[-1]
+                if method_upper == 'DELETE':
+                    return f'container.{resource}.delete'
+                if method_upper in ('PUT', 'PATCH', 'POST'):
+                    return f'container.{resource}.update'
+                return f'container.{resource}.get'
+            else:
+                # Last segment is the resource type name — it's a list or create
+                resource = last
+                if method_upper == 'POST':
+                    return f'container.{resource}.create'
+                return f'container.{resource}.list'
+
+
 
     def _format_operation_from_method(self, method, resource):
         """Format an operation name from HTTP method and resource type.


### PR DESCRIPTION
### Description

Adds the following parameters to the `Google Cloud Resources Under or Approaching Extended Support` policy template:

- *Ignore System Projects* - Whether or not to automatically ignore system projects (projects whose ID begins with `sys-`).
- *Ignore Google Apps Script Projects* - Whether or not to automatically ignore Google Apps Script projects (projects whose ID begins with `app-`).

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=6a45492fb752a7ca3bb10948

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
