### PR TITLE
POL-1795 New Policy Template: Flexera Create Service Account

### DIFF
--- a/automation/flexera/create_service_account/CHANGELOG.md
+++ b/automation/flexera/create_service_account/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+- Initial release

--- a/automation/flexera/create_service_account/README.md
+++ b/automation/flexera/create_service_account/README.md
@@ -1,0 +1,53 @@
+# Flexera Create Service Account
+
+## What It Does
+
+This policy template creates a Flexera service account via the IAM API, assigns the specified org-level roles to it, generates a client secret, and then registers an OAuth2 credential in Flexera Automation using that client ID and secret. If all steps succeed, an incident is raised containing the credential details and confirmation of role assignments.
+
+## How It Works
+
+The policy template performs the following steps in sequence:
+
+1. Creates the service account by calling `POST /iam/v1/orgs/{org_id}/service-accounts` with the specified name and description.
+1. Since the creation response returns an empty body, lists all service accounts via `GET /iam/v1/orgs/{org_id}/service-accounts` and identifies the newly created one by name to obtain its ID.
+1. Assigns each selected role to the service account by calling `PUT /iam/v1/orgs/{org_id}/access-rules/grant` once per role.
+1. Generates a client secret for the service account by calling `POST /iam/v1/orgs/{org_id}/service-accounts/{id}/clients`.
+1. Registers an OAuth2 credential in Flexera Automation by calling `PUT /cred/v2/projects/{project_id}/credentials/oauth2/{cred_id}` using the client ID and secret from the previous step.
+1. Since the credential creation response returns an empty body, lists credentials via `GET /cred/v2/orgs/{org_id}/credentials` filtered by name and identifies the newly created one to obtain its ID.
+1. Raises an incident containing the credential details and role assignment summary.
+
+If any step fails, the policy execution fails immediately and no further steps are taken.
+
+## Input Parameters
+
+- *Email Addresses* - A list of email addresses to notify.
+- *Service Account Name* - The name to give the new Flexera service account and its corresponding Flexera Automation credential.
+- *Service Account Description* - The description to give the new Flexera service account and its corresponding Flexera Automation credential. Defaults to empty.
+- *Roles* - The roles to assign to the service account. Select role(s) by display name.
+
+> **Important:** This policy template creates Flexera resources each time it runs. It is intended to be applied once, used to create the service account and credential, then terminated. See the Next Steps section in the incident for termination instructions.
+
+## Policy Actions
+
+The following actions may be taken by this policy template:
+
+- Raises an incident containing the new credential details upon successful creation.
+- Sends an email notification to the specified addresses.
+
+## Prerequisites
+
+This Policy Template uses [Credentials](https://docs.flexera.com/flexera-one/automation/automation-administration/managing-credentials-for-policy-access-to-external-systems/) for authenticating to datasources -- in order to apply this policy template you must have a Credential registered in the system that is compatible with this policy template. If there are no Credentials listed when you apply the policy template, please contact your Flexera Org Admin and ask them to register a Credential that is compatible with this policy template. The information below should be consulted when creating the credential(s).
+
+- [**Flexera Credential**](https://docs.flexera.com/flexera-one/automation/automation-administration/managing-credentials-for-policy-access-to-external-systems/provider-specific-credentials#flexera) (*provider=flexera*) which has the following roles:
+  - `iam_admin`
+  - `enterprise_manager`
+
+The [Provider-Specific Credentials](https://docs.flexera.com/flexera-one/automation/automation-administration/managing-credentials-for-policy-access-to-external-systems/provider-specific-credentials) page in the docs has detailed instructions for setting up Credentials for the most common providers.
+
+## Supported Clouds
+
+- Flexera
+
+## Cost
+
+This policy template does not incur any additional costs.

--- a/automation/flexera/create_service_account/create_service_account.pt
+++ b/automation/flexera/create_service_account/create_service_account.pt
@@ -1,0 +1,492 @@
+name "Flexera Create Service Account"
+rs_pt_ver 20180301
+type "policy"
+short_description "Creates a Flexera service account, assigns roles to it, generates a client credential, and adds it to Flexera Automation as an OAuth2 credential. See the [README](https://github.com/flexera-public/policy_templates/tree/master/automation/flexera/create_service_account) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera-one/automation/) to learn more."
+long_description ""
+doc_link "https://github.com/flexera-public/policy_templates/tree/master/automation/flexera/create_service_account"
+severity "low"
+category "Automation"
+default_frequency "monthly"
+info(
+  version: "0.1.0",
+  provider: "Flexera",
+  service: "Identity & Access Management",
+  policy_set: "Automation",
+  hide_skip_approvals: "true",
+  publish: "false"
+)
+
+###############################################################################
+# Parameters
+###############################################################################
+
+parameter "param_email" do
+  type "list"
+  category "Policy Settings"
+  label "Email Addresses"
+  description "A list of email addresses to notify."
+  default []
+end
+
+parameter "param_sa_name" do
+  type "string"
+  category "Policy Settings"
+  label "Service Account Name"
+  description "The name to give the new Flexera service account and its corresponding Flexera Automation credential."
+  min_length 1
+  # No default value, user input required
+end
+
+parameter "param_sa_description" do
+  type "string"
+  category "Policy Settings"
+  label "Service Account Description"
+  description "The description to give the new Flexera service account and its corresponding Flexera Automation credential."
+  default ""
+end
+
+parameter "param_roles" do
+  type "list"
+  category "Policy Settings"
+  label "Roles"
+  description "The roles to assign to the service account. Select role(s) by display name."
+  allowed_values [
+    "Automation: Approve policies",
+    "Automation: Create policies",
+    "Automation: Manage policies",
+    "Automation: Publish policies",
+    "Automation: View policies",
+    "Cloud: Administer cloud",
+    "Cloud: CA User",
+    "Cloud: Manage bill adjustments",
+    "Cloud: Manage bill ingestion",
+    "Cloud: Manage billing centers",
+    "Cloud: Manage budgets",
+    "Cloud: Manage cloud",
+    "Cloud: Manage cloud components",
+    "Cloud: Manage cloud dashboard",
+    "Cloud: Manage cloud infrastructure",
+    "Cloud: Manage cloud security",
+    "Cloud: Manage groups & share objects",
+    "Cloud: Manage Linux servers",
+    "Cloud: Manage marketplace imports",
+    "Cloud: Manage rule-based dimensions",
+    "Cloud: Manage running servers",
+    "Cloud: Manage tag dimensions",
+    "Cloud: View bill adjustments",
+    "Cloud: View budgets",
+    "Cloud: View cloud",
+    "Cloud: View cloud costs",
+    "Cloud: View Commitments",
+    "Cloud: View credentials",
+    "Data and Analytics: Manage custom reports",
+    "Data and Analytics: Query Graphql",
+    "Data and Analytics: View custom reports",
+    "Discovery and Inventory: Delete external inventory connections",
+    "Discovery and Inventory: Manage discovery & inventory",
+    "Discovery and Inventory: View discovery & inventory",
+    "IT Visibility: Export data",
+    "IT Visibility: Manage connections",
+    "IT Visibility: Manage Dashboards",
+    "IT Visibility: Schedule & export data",
+    "IT Visibility: View & Create Insights",
+    "IT Visibility: View IT Visibility",
+    "Other: Read Technopedia Data",
+    "Other: View Vendor Workspaces",
+    "Platform Administration: Administer organization",
+    "Platform Administration: Manage organization",
+    "SCA Data Library: Retrieve Data from Revenera Data Library",
+    "SCA Data Library: Retrieve License Texts from Revenera Data Library",
+    "Self-service CloudApps: Launch & manage cloud apps",
+    "Self-service CloudApps: Manage self-service",
+    "Self-service CloudApps: View self-service",
+    "Software Bill Of Materials: SBOM Manager",
+    "Software Bill Of Materials: SBOM Viewer",
+    "Technology Spend: Manage Technology Spend",
+    "Technology Spend: View & Create Insights",
+    "Technology Spend: View Technology Spend"
+  ]
+  default [
+    "Cloud: View budgets",
+    "Cloud: Manage budgets",
+    "Data and Analytics: Query Graphql",
+    "Cloud: View bill adjustments",
+    "Cloud: Manage bill adjustments",
+    "Cloud: View Commitments",
+    "Cloud: Manage tag dimensions",
+    "Cloud: Manage rule-based dimensions",
+    "Automation: View policies",
+    "Cloud: View credentials",
+    "Cloud: View cloud",
+    "Self-service CloudApps: View self-service",
+    "Automation: Approve policies",
+    "Cloud: Manage billing centers",
+    "Automation: Manage policies",
+    "Cloud: Administer cloud",
+    "Cloud: Manage bill ingestion",
+    "Cloud: Manage cloud components",
+    "Cloud: Manage cloud",
+    "Automation: Create policies",
+    "Cloud: View cloud costs"
+  ]
+end
+
+###############################################################################
+# Authentication
+###############################################################################
+
+credentials "auth_flexera" do
+  schemes "oauth2"
+  label "Flexera"
+  description "Select Flexera One OAuth2 credentials"
+  tags "provider=flexera"
+end
+
+###############################################################################
+# Datasources & Scripts
+###############################################################################
+
+datasource "ds_flexera_api_hosts" do
+  run_script $js_flexera_api_hosts, rs_optima_host
+end
+
+script "js_flexera_api_hosts", type: "javascript" do
+  parameters "rs_optima_host"
+  result "result"
+  code <<-'EOS'
+  var host_table = {
+    "api.optima.flexeraeng.com": {
+      flexera: "api.flexera.com",
+      login: "login.flexera.com"
+    },
+    "api.optima-eu.flexeraeng.com": {
+      flexera: "api.flexera.eu",
+      login: "login.flexera.eu"
+    },
+    "api.optima-apac.flexeraeng.com": {
+      flexera: "api.flexera.au",
+      login: "login.flexera.au"
+    }
+  }
+  result = host_table[rs_optima_host]
+EOS
+end
+
+datasource "ds_applied_policy" do
+  request do
+    auth $auth_flexera
+    host val($ds_flexera_api_hosts, "flexera")
+    path join(["/policy/v1/orgs/", rs_org_id, "/projects/", rs_project_id, "/applied-policies", switch(policy_id, join(["/", policy_id]), "")])
+  end
+end
+
+datasource "ds_create_service_account" do
+  request do
+    auth $auth_flexera
+    verb "POST"
+    host val($ds_flexera_api_hosts, "flexera")
+    path join(["/iam/v1/orgs/", rs_org_id, "/service-accounts"])
+    header "User-Agent", "RS Policies"
+    body_field "name", $param_sa_name
+    body_field "description", $param_sa_description
+  end
+end
+
+datasource "ds_list_service_accounts" do
+  request do
+    run_script $js_list_service_accounts, $ds_create_service_account, $ds_flexera_api_hosts, rs_org_id
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "id", jmes_path(col_item, "id")
+      field "name", jmes_path(col_item, "name")
+      field "kind", jmes_path(col_item, "kind")
+      field "createdBy", jmes_path(col_item, "createdBy")
+      field "ref", jmes_path(col_item, "ref")
+    end
+  end
+end
+
+script "js_list_service_accounts", type: "javascript" do
+  parameters "ds_create_service_account", "ds_flexera_api_hosts", "rs_org_id"
+  result "request"
+  code <<-'EOS'
+  var request = {
+    auth: "auth_flexera",
+    host: ds_flexera_api_hosts["flexera"],
+    path: "/iam/v1/orgs/" + rs_org_id + "/service-accounts",
+    headers: { "User-Agent": "RS Policies" }
+  }
+EOS
+end
+
+datasource "ds_service_account" do
+  run_script $js_service_account, $ds_list_service_accounts, $param_sa_name
+end
+
+script "js_service_account", type: "javascript" do
+  parameters "ds_list_service_accounts", "param_sa_name"
+  result "result"
+  code <<-'EOS'
+  result = {}
+  var match = _.find(ds_list_service_accounts, function(sa) { return sa["name"] == param_sa_name })
+  if (match) { result = match }
+EOS
+end
+
+datasource "ds_roles_to_assign" do
+  run_script $js_roles_to_assign, $ds_service_account, $param_roles
+end
+
+script "js_roles_to_assign", type: "javascript" do
+  parameters "ds_service_account", "param_roles"
+  result "result"
+  code <<-'EOS'
+  var role_map = {
+    "Automation: Approve policies": "policy_approver",
+    "Automation: Create policies": "policy_designer",
+    "Automation: Manage policies": "policy_manager",
+    "Automation: Publish policies": "policy_publisher",
+    "Automation: View policies": "policy_viewer",
+    "Cloud: Administer cloud": "admin",
+    "Cloud: CA User": "ca_user",
+    "Cloud: Manage bill adjustments": "bill_adjustments_manager",
+    "Cloud: Manage bill ingestion": "csm_bill_upload_admin",
+    "Cloud: Manage billing centers": "billing_center_admin",
+    "Cloud: Manage budgets": "budget_manager",
+    "Cloud: Manage cloud": "enterprise_manager",
+    "Cloud: Manage cloud components": "designer",
+    "Cloud: Manage cloud dashboard": "csm_dashboard_admin",
+    "Cloud: Manage cloud infrastructure": "actor",
+    "Cloud: Manage cloud security": "security_manager",
+    "Cloud: Manage groups & share objects": "publisher",
+    "Cloud: Manage Linux servers": "server_superuser",
+    "Cloud: Manage marketplace imports": "library",
+    "Cloud: Manage rule-based dimensions": "rule_based_dimensions_manager",
+    "Cloud: Manage running servers": "server_login",
+    "Cloud: Manage tag dimensions": "custom_dimensions_manager",
+    "Cloud: View bill adjustments": "bill_adjustments_viewer",
+    "Cloud: View budgets": "budget_viewer",
+    "Cloud: View cloud": "observer",
+    "Cloud: View cloud costs": "billing_center_viewer",
+    "Cloud: View Commitments": "reserved_instances_viewer",
+    "Cloud: View credentials": "credential_viewer",
+    "Data and Analytics: Manage custom reports": "uom_report_manager",
+    "Data and Analytics: Query Graphql": "uom_graphql_admin",
+    "Data and Analytics: View custom reports": "uom_report_viewer",
+    "Discovery and Inventory: Delete external inventory connections": "di_connection_deleter",
+    "Discovery and Inventory: Manage discovery & inventory": "di_admin",
+    "Discovery and Inventory: View discovery & inventory": "di_viewer",
+    "IT Visibility: Export data": "vis_exports_viewer",
+    "IT Visibility: Manage connections": "vis_admin",
+    "IT Visibility: Manage Dashboards": "vis_dashboards_manager",
+    "IT Visibility: Schedule & export data": "vis_exports_admin",
+    "IT Visibility: View & Create Insights": "vis_insights_manager",
+    "IT Visibility: View IT Visibility": "vis_viewer",
+    "Other: Read Technopedia Data": "content_user",
+    "Other: View Vendor Workspaces": "vendor_workspace_viewer",
+    "Platform Administration: Administer organization": "iam_admin",
+    "Platform Administration: Manage organization": "org_owner",
+    "SCA Data Library: Retrieve Data from Revenera Data Library": "sdl_viewer",
+    "SCA Data Library: Retrieve License Texts from Revenera Data Library": "sdl_license_text_viewer",
+    "Self-service CloudApps: Launch & manage cloud apps": "ss_end_user",
+    "Self-service CloudApps: Manage self-service": "ss_designer",
+    "Self-service CloudApps: View self-service": "ss_observer",
+    "Software Bill Of Materials: SBOM Manager": "sbom_admin",
+    "Software Bill Of Materials: SBOM Viewer": "sbom_viewer",
+    "Technology Spend: Manage Technology Spend": "sa_admin",
+    "Technology Spend: View & Create Insights": "sa_insights_manager",
+    "Technology Spend: View Technology Spend": "sa_viewer"
+  }
+
+  var id = ds_service_account["id"]
+
+  result = []
+
+  if (id) {
+    result = _.map(param_roles, function(display_name) {
+      return {
+        sa_id: id,
+        roleName: role_map[display_name] || display_name,
+        roleDisplayName: display_name
+      }
+    })
+  }
+EOS
+end
+
+datasource "ds_assign_roles" do
+  iterate $ds_roles_to_assign
+  request do
+    run_script $js_assign_role_request, val(iter_item, "sa_id"), val(iter_item, "roleName"), $ds_flexera_api_hosts, rs_org_id
+  end
+  result do
+    encoding "json"
+    field "roleName", val(iter_item, "roleName")
+    field "roleDisplayName", val(iter_item, "roleDisplayName")
+  end
+end
+
+script "js_assign_role_request", type: "javascript" do
+  parameters "sa_id", "role_name", "ds_flexera_api_hosts", "rs_org_id"
+  result "request"
+  code <<-'EOS'
+  var request = {
+    auth: "auth_flexera",
+    verb: "PUT",
+    host: ds_flexera_api_hosts["flexera"],
+    path: "/iam/v1/orgs/" + rs_org_id + "/access-rules/grant",
+    headers: { "User-Agent": "RS Policies" },
+    body_fields: {
+      "subject": { "ref": "ref::::iam:service-account:" + sa_id },
+      "role": { "name": role_name }
+    }
+  }
+EOS
+end
+
+datasource "ds_create_client" do
+  request do
+    run_script $js_create_client_request, $ds_service_account, $ds_assign_roles, $ds_flexera_api_hosts, rs_org_id
+  end
+  result do
+    encoding "json"
+    field "clientId", jmes_path(response, "clientId")
+    field "clientSecret", jmes_path(response, "clientSecret")
+  end
+end
+
+script "js_create_client_request", type: "javascript" do
+  parameters "ds_service_account", "ds_assign_roles", "ds_flexera_api_hosts", "rs_org_id"
+  result "request"
+  code <<-'EOS'
+  var request = {
+    auth: "auth_flexera",
+    verb: "POST",
+    host: ds_flexera_api_hosts["flexera"],
+    path: "/iam/v1/orgs/" + rs_org_id + "/service-accounts/" + ds_service_account["id"] + "/clients",
+    headers: { "User-Agent": "RS Policies" }
+  }
+EOS
+end
+
+datasource "ds_create_credential" do
+  request do
+    run_script $js_create_credential, $ds_create_client, $ds_flexera_api_hosts, $param_sa_name, $param_sa_description, rs_project_id
+  end
+end
+
+script "js_create_credential", type: "javascript" do
+  parameters "ds_create_client", "ds_flexera_api_hosts", "param_sa_name", "param_sa_description", "rs_project_id"
+  result "request"
+  code <<-'EOS'
+  var cred_id = param_sa_name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '')
+
+  var request = {
+    auth: "auth_flexera",
+    verb: "PUT",
+    host: ds_flexera_api_hosts["flexera"],
+    path: "/cred/v2/projects/" + rs_project_id + "/credentials/oauth2/" + cred_id,
+    headers: { "Api-Version": "1.0", "User-Agent": "RS Policies" },
+    body_fields: {
+      "name": param_sa_name,
+      "description": param_sa_description,
+      "grantType": "client_credentials",
+      "tokenUrl": "https://" + ds_flexera_api_hosts["login"] + "/oidc/token",
+      "tags": [
+        { "key": "provider", "value": "flexera" }
+      ],
+      "clientCredentialsParams": {
+        "clientId": ds_create_client["clientId"],
+        "clientSecret": ds_create_client["clientSecret"]
+      }
+    }
+  }
+EOS
+end
+
+datasource "ds_credential" do
+  request do
+    run_script $js_credential, $ds_create_credential, $ds_flexera_api_hosts, $param_sa_name, rs_project_id
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+    field "name", jmes_path(response, "name")
+    field "kind", jmes_path(response, "kind")
+    field "scheme", jmes_path(response, "scheme")
+  end
+end
+
+script "js_credential", type: "javascript" do
+  parameters "ds_create_credential", "ds_flexera_api_hosts", "param_sa_name", "rs_project_id"
+  result "request"
+  code <<-'EOS'
+  var cred_id = param_sa_name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '')
+
+  var request = {
+    auth: "auth_flexera",
+    host: ds_flexera_api_hosts["flexera"],
+    path: "/cred/v2/projects/" + rs_project_id + "/credentials/oauth2/" + cred_id,
+    headers: { "Api-Version": "1.0", "User-Agent": "RS Policies" }
+  }
+EOS
+end
+
+datasource "ds_incident" do
+  run_script $js_incident, $ds_service_account, $ds_assign_roles, $ds_credential, $param_sa_description, $ds_applied_policy
+end
+
+script "js_incident", type: "javascript" do
+  parameters "ds_service_account", "ds_assign_roles", "ds_credential", "param_sa_description", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  var sa = ds_service_account
+  var cred = ds_credential
+  var roles_text = ""
+  _.each(ds_assign_roles, function(role) {
+    roles_text += "- **" + role["roleDisplayName"] + "** (`" + role["roleName"] + "`)\n"
+  })
+  var detail = "## Service Account and Credential Created Successfully\n\n" +
+    "The service account **" + sa["name"] + "** has been created and the Flexera Automation credential has been registered.\n\n" +
+    "### Flexera Automation Credential\n\n" +
+    "- **Credential ID:** " + cred["id"] + "\n" +
+    "- **Credential Name:** " + cred["name"] + "\n" +
+    "- **Credential Description:** " + (param_sa_description || "(none)") + "\n\n" +
+    "### Roles Assigned to Service Account\n\n" +
+    roles_text +
+    "\n### Next Steps\n\n" +
+    "The service account and credential have been created. Please verify the credential works as expected.\n\n" +
+    "To terminate this policy template after verification:\n\n" +
+    "1. Navigate to **Automation** > **Applied Policies** in Flexera One.\n" +
+    "1. Locate this applied policy by name.\n" +
+    "1. Select **Terminate** to remove it.\n\n" +
+    "This policy template is intended to be applied once, used to create the service account and credential, then terminated.\n"
+  result = [{ policy_name: ds_applied_policy["name"], detail: detail }]
+EOS
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "pol_create_service_account" do
+  validate $ds_incident do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: Service Account and Credential Created Successfully"
+    detail_template "{{ with index data 0 }}{{ .detail }}{{ end }}"
+    check eq(size(data), 0)
+    escalate $esc_email
+  end
+end
+
+###############################################################################
+# Escalations
+###############################################################################
+
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end

--- a/automation/flexera/create_service_account/create_service_account.pt
+++ b/automation/flexera/create_service_account/create_service_account.pt
@@ -5,7 +5,7 @@ short_description "Creates a Flexera service account, assigns roles to it, gener
 long_description ""
 doc_link "https://github.com/flexera-public/policy_templates/tree/master/automation/flexera/create_service_account"
 severity "low"
-category "Automation"
+category "Operational"
 default_frequency "monthly"
 info(
   version: "0.1.0",
@@ -319,7 +319,7 @@ end
 datasource "ds_assign_roles" do
   iterate $ds_roles_to_assign
   request do
-    run_script $js_assign_role_request, val(iter_item, "sa_id"), val(iter_item, "roleName"), $ds_flexera_api_hosts, rs_org_id
+    run_script $js_assign_roles, val(iter_item, "sa_id"), val(iter_item, "roleName"), $ds_flexera_api_hosts, rs_org_id
   end
   result do
     encoding "json"
@@ -328,7 +328,7 @@ datasource "ds_assign_roles" do
   end
 end
 
-script "js_assign_role_request", type: "javascript" do
+script "js_assign_roles", type: "javascript" do
   parameters "sa_id", "role_name", "ds_flexera_api_hosts", "rs_org_id"
   result "request"
   code <<-'EOS'
@@ -348,7 +348,7 @@ end
 
 datasource "ds_create_client" do
   request do
-    run_script $js_create_client_request, $ds_service_account, $ds_assign_roles, $ds_flexera_api_hosts, rs_org_id
+    run_script $js_create_client, $ds_service_account, $ds_assign_roles, $ds_flexera_api_hosts, rs_org_id
   end
   result do
     encoding "json"
@@ -357,7 +357,7 @@ datasource "ds_create_client" do
   end
 end
 
-script "js_create_client_request", type: "javascript" do
+script "js_create_client", type: "javascript" do
   parameters "ds_service_account", "ds_assign_roles", "ds_flexera_api_hosts", "rs_org_id"
   result "request"
   code <<-'EOS'
@@ -435,11 +435,11 @@ EOS
 end
 
 datasource "ds_incident" do
-  run_script $js_incident, $ds_service_account, $ds_assign_roles, $ds_credential, $param_sa_description, $ds_applied_policy
+  run_script $js_incident, $ds_service_account, $ds_assign_roles, $ds_credential, $ds_applied_policy, $param_sa_description
 end
 
 script "js_incident", type: "javascript" do
-  parameters "ds_service_account", "ds_assign_roles", "ds_credential", "param_sa_description", "ds_applied_policy"
+  parameters "ds_service_account", "ds_assign_roles", "ds_credential", "ds_applied_policy", "param_sa_description"
   result "result"
   code <<-'EOS'
   var sa = ds_service_account

--- a/tools/policy_master_permission_generation/validated_policy_templates.yaml
+++ b/tools/policy_master_permission_generation/validated_policy_templates.yaml
@@ -262,6 +262,7 @@ validated_policy_templates:
 # Flexera
 -  "./automation/flexera/delete_all_billing_centers/delete_all_billing_centers.pt"
 -  "./automation/flexera/disallowed_credentials/disallowed_credentials.pt"
+-  "./automation/flexera/create_service_account/create_service_account.pt"
 -  "./automation/flexera/expiring_credentials/expiring_credentials.pt"
 -  "./automation/flexera/outdated_applied_policies/outdated_applied_policies.pt"
 -  "./automation/flexera/rbd_from_custom_tag/rbd_from_custom_tag.pt"


### PR DESCRIPTION
### Description

`Flexera Create Service Account`

This policy template creates a Flexera service account via the IAM API, assigns the specified org-level roles to it, generates a client secret, and then registers an OAuth2 credential in Flexera Automation using that client ID and secret. If all steps succeed, an incident is raised containing the credential details and confirmation of role assignments.

Template is unpublished because it is more intended for internal Flexera use. A Flexeran can add their own token to a new org as a credential, run this to quickly create a service account, and then delete their credential from the Flexera Org, leaving behind a functioning service account that does not require that the client maintain a token associated with someone at their organization to execute policy templates.

(Ignore the dangerfile warning. This is a special case where readability requires something off-spec)

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=6a4cfd41620578afd278f826

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
