### PR TITLE
POL-1796 Untagged Resources: Improved Filtering

### DIFF
--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -24,10 +24,10 @@ def policy_missing_github_labels?(github, file, file_parsed, file_metadata, is_n
     current_major_version = file_metadata["version"].split('.')[0]
     current_minor_version = file_metadata["version"].split('.')[0] + "." + file_metadata["version"].split('.')[1]
 
-    if major_version != current_major_version && !github.pr_labels.include?("MAJOR UPDATE")
-      fail_message += "[[Info](https://github.com/flexera-public/policy_templates/blob/master/CONTRIBUTING.md#4-make-a-pull-request)] Policy Template has changed major versions but Pull Request is missing `MAJOR UPDATE` label. Please add this label to the Pull Request.\n\n"
-    elsif minor_version != current_minor_version && !github.pr_labels.include?("MINOR UPDATE")
-      fail_message += "[[Info](https://github.com/flexera-public/policy_templates/blob/master/CONTRIBUTING.md#4-make-a-pull-request)] Policy Template has changed minor versions but Pull Request is missing `MINOR UPDATE` label. Please add this label to the Pull Request.\n\n"
+    if major_version != current_major_version
+      fail_message += "[[Info](https://github.com/flexera-public/policy_templates/blob/master/CONTRIBUTING.md#4-make-a-pull-request)] Policy Template has changed major versions but Pull Request is missing `MAJOR UPDATE` label. Please add this label to the Pull Request.\n\n" if !github.pr_labels.include?("MAJOR UPDATE")
+    elsif minor_version != current_minor_version
+      fail_message += "[[Info](https://github.com/flexera-public/policy_templates/blob/master/CONTRIBUTING.md#4-make-a-pull-request)] Policy Template has changed minor versions but Pull Request is missing `MINOR UPDATE` label. Please add this label to the Pull Request.\n\n" if !github.pr_labels.include?("MINOR UPDATE")
     end
   end
 

--- a/.spellignore
+++ b/.spellignore
@@ -764,3 +764,4 @@ Serverless
 serverless
 DevTest
 ROI
+labelable

--- a/compliance/aws/untagged_resources/CHANGELOG.md
+++ b/compliance/aws/untagged_resources/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v6.0.0
+
+- Replaced `Include Account Tags` parameter with new `Report Types` list parameter that allows selecting `Accounts` and/or `Resources` individually
+- Default behavior now includes both Accounts and Resources in the report (previously the default excluded the account)
+
 ## v5.6.3
 
 - Fixed bug where resources whose missing tags were fully covered by Tag Dimension equivalents were still included in the incident with a blank `Missing Tags` field instead of being correctly excluded.

--- a/compliance/aws/untagged_resources/README.md
+++ b/compliance/aws/untagged_resources/README.md
@@ -25,7 +25,7 @@ This policy template checks for AWS resources missing the user-specified tags. A
   - s3
   - rds:db
   - dynamodb:table
-- *Include Account Tags* - Whether or not to include the AWS account itself as a resource whose tags are checked and reported on.
+- *Report Types* - The types of resources to include in the report. Select 'Accounts' to include the AWS account itself, and 'Resources' to include individual taggable resources.
 - *Tags* - The policy will report resources missing the specified tags. The following formats are supported:
   - `Key` - Find all resources missing the specified tag key.
   - `Key==Value` - Find all resources missing the specified tag key:value pair and all resources missing the specified tag key.

--- a/compliance/aws/untagged_resources/aws_untagged_resources.pt
+++ b/compliance/aws/untagged_resources/aws_untagged_resources.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.6.3",
+  version: "6.0.0",
   provider: "AWS",
   service: "Compute",
   policy_set: "Untagged Resources",
@@ -96,13 +96,13 @@ parameter "param_consider_tag_dimensions" do
   default "Consider Tag Dimensions"
 end
 
-parameter "param_include_account" do
-  type "string"
+parameter "param_report_types" do
+  type "list"
   category "Filters"
-  label "Include Account Tags"
-  description "Whether or not to include the AWS account itself as a resource whose tags are checked and reported on."
-  allowed_values "Include Account", "Do Not Include Account"
-  default "Do Not Include Account"
+  label "Report Types"
+  description "The types of resources to include in the report. Select 'Accounts' to include the AWS account itself, and 'Resources' to include individual taggable resources."
+  allowed_values "Accounts", "Resources"
+  default ["Accounts", "Resources"]
 end
 
 parameter "param_incident_csv" do
@@ -655,11 +655,11 @@ EOS
 end
 
 datasource "ds_aws_resources_missing_tags" do
-  run_script $js_aws_resources_missing_tags, $ds_aws_resources, $ds_aws_account, $ds_tag_dimensions, $param_tags, $param_tags_boolean, $param_consider_tag_dimensions, $param_include_account
+  run_script $js_aws_resources_missing_tags, $ds_aws_resources, $ds_aws_account, $ds_tag_dimensions, $param_tags, $param_tags_boolean, $param_consider_tag_dimensions, $param_report_types
 end
 
 script "js_aws_resources_missing_tags", type:"javascript" do
-  parameters "ds_aws_resources", "ds_aws_account", "ds_tag_dimensions", "param_tags", "param_tags_boolean", "param_consider_tag_dimensions", "param_include_account"
+  parameters "ds_aws_resources", "ds_aws_account", "ds_tag_dimensions", "param_tags", "param_tags_boolean", "param_consider_tag_dimensions", "param_report_types"
   result "result"
   code <<-'EOS'
   result = []
@@ -695,9 +695,9 @@ script "js_aws_resources_missing_tags", type:"javascript" do
   })
 
   if (comparators.length > 0) {
-    // Check each resource for missing tags. Include account when appropriate.
-    resources = [].concat(ds_aws_resources)
-    if (param_include_account == "Include Account") { resources.push(ds_aws_account) }
+    // Check each resource for missing tags based on selected report types
+    resources = _.contains(param_report_types, "Resources") ? [].concat(ds_aws_resources) : []
+    if (_.contains(param_report_types, "Accounts")) { resources.push(ds_aws_account) }
 
     _.each(resources, function(resource) {
       resource_tags = {}

--- a/compliance/aws/untagged_resources/aws_untagged_resources_meta_parent.pt
+++ b/compliance/aws/untagged_resources/aws_untagged_resources_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "5.6.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.0.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/compliance/aws/untagged_resources/aws_untagged_resources_meta_parent.pt
+++ b/compliance/aws/untagged_resources/aws_untagged_resources_meta_parent.pt
@@ -159,13 +159,13 @@ parameter "param_consider_tag_dimensions" do
   default "Consider Tag Dimensions"
 end
 
-parameter "param_include_account" do
-  type "string"
+parameter "param_report_types" do
+  type "list"
   category "Filters"
-  label "Include Account Tags"
-  description "Whether or not to include the AWS account itself as a resource whose tags are checked and reported on."
-  allowed_values "Include Account", "Do Not Include Account"
-  default "Do Not Include Account"
+  label "Report Types"
+  description "The types of resources to include in the report. Select 'Accounts' to include the AWS account itself, and 'Resources' to include individual taggable resources."
+  allowed_values "Accounts", "Resources"
+  default ["Accounts", "Resources"]
 end
 
 ###############################################################################

--- a/compliance/azure/azure_untagged_resources/CHANGELOG.md
+++ b/compliance/azure/azure_untagged_resources/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v5.0.0
+
+- Replaced `Include Subscription/Resource Group Tags` parameter with new `Report Types` list parameter that allows selecting `Subscriptions`, `Resource Groups`, and/or `Resources` individually
+- Default behavior now includes Subscriptions, Resource Groups, and Resources in the report (previously the default excluded Subscriptions and Resource Groups)
+
 ## v4.0.1
 
 - Fixed bug where resources whose missing tags were fully covered by Tag Dimension equivalents were still included in the incident with a blank `Missing Tags` field instead of being correctly excluded.

--- a/compliance/azure/azure_untagged_resources/README.md
+++ b/compliance/azure/azure_untagged_resources/README.md
@@ -26,7 +26,7 @@ This policy template has the following input parameters required when launching 
 - *Allow/Deny Regions List* - Filter results by region, either only allowing this list or denying it depending on how the above parameter is set. Leave blank to consider all the regions.
 - *Allow/Deny Resource Groups* - Whether to treat Allow/Deny Resource Groups List parameter as allow or deny list. Has no effect if Allow/Deny Resource Groups List is left empty.
 - *Allow/Deny Resource Groups List* - A list of allowed or denied Resource Group names to filter the results by. Entries can be in the format `resource_group_name` to filter all resource groups with that name regardless of subscription, or `subscription_id/resource_group_name` to filter a resource group within a specific subscription. Leave blank to consider all resource groups.
-- *Include Subscription/Resource Group Tags* - Whether or not to include Azure Subscriptions and Resource Groups as resources whose tags are checked and reported on.
+- *Report Types* - The types of resources to include in the report. Select 'Subscriptions' to include Azure Subscriptions, 'Resource Groups' to include Resource Groups, and 'Resources' to include individual taggable resources.
 - *Tags* - The policy will report resources missing the specified tags. The following formats are supported:
   - `Key` - Find all resources missing the specified tag key.
   - `Key==Value` - Find all resources missing the specified tag key:value pair and all resources missing the specified tag key.

--- a/compliance/azure/azure_untagged_resources/untagged_resources.pt
+++ b/compliance/azure/azure_untagged_resources/untagged_resources.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.0.1",
+  version: "5.0.0",
   provider: "Azure",
   service: "Compute",
   policy_set: "Untagged Resources",
@@ -121,13 +121,13 @@ parameter "param_resource_groups_list" do
   default []
 end
 
-parameter "param_include_account" do
-  type "string"
+parameter "param_report_types" do
+  type "list"
   category "Filters"
-  label "Include Subscription/Resource Group Tags"
-  description "Whether or not to include Azure Subscriptions and Resource Groups as resources whose tags are checked and reported on."
-  allowed_values "Include Subscription/Resource Group", "Do Not Include Subscription/Resource Group"
-  default "Do Not Include Subscription/Resource Group"
+  label "Report Types"
+  description "The types of resources to include in the report. Select 'Subscriptions' to include Azure Subscriptions, 'Resource Groups' to include Resource Groups, and 'Resources' to include individual taggable resources."
+  allowed_values "Subscriptions", "Resource Groups", "Resources"
+  default ["Subscriptions", "Resource Groups", "Resources"]
 end
 
 parameter "param_consider_tag_dimensions" do
@@ -491,11 +491,11 @@ EOS
 end
 
 datasource "ds_azure_resources_missing_tags" do
-  run_script $js_azure_resources_missing_tags, $ds_azure_subscriptions_with_tags, $ds_azure_resource_groups, $ds_azure_resources_rg_filtered, $ds_tag_dimensions, $param_tags, $param_tags_boolean, $param_include_account, $param_consider_tag_dimensions
+  run_script $js_azure_resources_missing_tags, $ds_azure_subscriptions_with_tags, $ds_azure_resource_groups, $ds_azure_resources_rg_filtered, $ds_tag_dimensions, $param_tags, $param_tags_boolean, $param_report_types, $param_consider_tag_dimensions
 end
 
 script "js_azure_resources_missing_tags", type: "javascript" do
-  parameters "ds_azure_subscriptions_with_tags", "ds_azure_resource_groups", "ds_azure_resources_rg_filtered", "ds_tag_dimensions", "param_tags", "param_tags_boolean", "param_include_account", "param_consider_tag_dimensions"
+  parameters "ds_azure_subscriptions_with_tags", "ds_azure_resource_groups", "ds_azure_resources_rg_filtered", "ds_tag_dimensions", "param_tags", "param_tags_boolean", "param_report_types", "param_consider_tag_dimensions"
   result "result"
   code <<-'EOS'
   result = []
@@ -531,11 +531,10 @@ script "js_azure_resources_missing_tags", type: "javascript" do
   })
 
   if (comparators.length > 0) {
-    if (param_include_account == "Include Subscription/Resource Group") {
-      resources = ds_azure_resources_rg_filtered.concat(ds_azure_subscriptions_with_tags, ds_azure_resource_groups)
-    } else {
-      resources = [].concat(ds_azure_resources_rg_filtered)
-    }
+    resources = []
+    if (_.contains(param_report_types, "Resources")) { resources = resources.concat(ds_azure_resources_rg_filtered) }
+    if (_.contains(param_report_types, "Subscriptions")) { resources = resources.concat(ds_azure_subscriptions_with_tags) }
+    if (_.contains(param_report_types, "Resource Groups")) { resources = resources.concat(ds_azure_resource_groups) }
 
     // Check each VM for missing tags
     _.each(resources, function(resource) {

--- a/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent.pt
+++ b/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "4.0.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.0.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent.pt
+++ b/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent.pt
@@ -158,13 +158,13 @@ parameter "param_regions_list" do
   default []
 end
 
-parameter "param_include_account" do
-  type "string"
+parameter "param_report_types" do
+  type "list"
   category "Filters"
-  label "Include Subscription/Resource Group Tags"
-  description "Whether or not to include Azure Subscriptions and Resource Groups as resources whose tags are checked and reported on."
-  allowed_values "Include Subscription/Resource Group", "Do Not Include Subscription/Resource Group"
-  default "Do Not Include Subscription/Resource Group"
+  label "Report Types"
+  description "The types of resources to include in the report. Select 'Subscriptions' to include Azure Subscriptions, 'Resource Groups' to include Resource Groups, and 'Resources' to include individual taggable resources."
+  allowed_values "Subscriptions", "Resource Groups", "Resources"
+  default ["Subscriptions", "Resource Groups", "Resources"]
 end
 
 parameter "param_consider_tag_dimensions" do

--- a/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent_rg.pt
+++ b/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent_rg.pt
@@ -149,13 +149,13 @@ parameter "param_regions_list" do
   default []
 end
 
-parameter "param_include_account" do
-  type "string"
+parameter "param_report_types" do
+  type "list"
   category "Filters"
-  label "Include Subscription/Resource Group Tags"
-  description "Whether or not to include Azure Subscriptions and Resource Groups as resources whose tags are checked and reported on."
-  allowed_values "Include Subscription/Resource Group", "Do Not Include Subscription/Resource Group"
-  default "Do Not Include Subscription/Resource Group"
+  label "Report Types"
+  description "The types of resources to include in the report. Select 'Subscriptions' to include Azure Subscriptions, 'Resource Groups' to include Resource Groups, and 'Resources' to include individual taggable resources."
+  allowed_values "Subscriptions", "Resource Groups", "Resources"
+  default ["Subscriptions", "Resource Groups", "Resources"]
 end
 
 parameter "param_consider_tag_dimensions" do

--- a/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent_rg.pt
+++ b/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "4.0.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.0.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/compliance/google/unlabeled_resources/CHANGELOG.md
+++ b/compliance/google/unlabeled_resources/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v5.0.0
+
+- Added new `Report Types` list parameter that allows selecting `Projects` and/or `Resources` individually
+- Removed `Projects` as an option from the `Resource Types` parameter; project inclusion is now controlled via the `Report Types` parameter
+- Default behavior now includes both Projects and Resources in the report (previously the default excluded Projects)
+
 ## v4.0.1
 
 - Fixed bug where resources whose missing labels were fully covered by Tag Dimension equivalents were still included in the incident with a blank `Missing Labels` field instead of being correctly excluded.

--- a/compliance/google/unlabeled_resources/README.md
+++ b/compliance/google/unlabeled_resources/README.md
@@ -17,7 +17,8 @@ This policy template checks for Google Cloud resources missing the user-specifie
 - *Allow/Deny Projects List* - Filter results by project ID/name, either only allowing this list or denying it depending on how the above parameter is set. Leave blank to consider all projects.
 - *Ignore System Projects* - Whether or not to automatically ignore system projects e.g. projects whose id begins with `sys-`
 - *Ignore Google Apps Script Projects* - Whether or not to automatically ignore Google Apps Script projects e.g. projects whose id begins with `app-`
-- *Resource Types* - The types of resources to check labels for. Any options not selected will not be reported on.
+- *Report Types* - The types of resources to include in the report. Select 'Projects' to include Google Projects themselves, and 'Resources' to include individual labelable resources.
+- *Resource Types* - The specific resource types to check labels for when 'Resources' is selected in the 'Report Types' parameter. Any options not selected will not be reported on.
 - *Labels* - The policy will report resources missing the specified labels. The following formats are supported:
   - `Key` - Find all resources missing the specified label key.
   - `Key==Value` - Find all resources missing the specified label key:value pair and all resources missing the specified label key.

--- a/compliance/google/unlabeled_resources/unlabeled_resources.pt
+++ b/compliance/google/unlabeled_resources/unlabeled_resources.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.0.1",
+  version: "5.0.0",
   provider: "Google",
   service: "Compute",
   policy_set: "Untagged Resources",
@@ -79,12 +79,21 @@ parameter "param_projects_ignore_app" do
   default "No"
 end
 
+parameter "param_report_types" do
+  type "list"
+  category "Filters"
+  label "Report Types"
+  description "The types of resources to include in the report. Select 'Projects' to include Google Projects themselves, and 'Resources' to include individual labelable resources."
+  allowed_values "Projects", "Resources"
+  default ["Projects", "Resources"]
+end
+
 parameter "param_resource_types" do
   type "list"
   category "Filters"
   label "Resource Types"
-  description "The types of resources to check labels for. Any options not selected will not be reported on."
-  allowed_values ["Projects", "Persistent Disks", "VPN Gateways (Internal)", "VPN Gateways (External)", "Images", "Virtual Machines", "Snapshots", "Storage Buckets"]
+  description "The specific resource types to check labels for when 'Resources' is selected in the 'Report Types' parameter. Any options not selected will not be reported on."
+  allowed_values ["Persistent Disks", "VPN Gateways (Internal)", "VPN Gateways (External)", "Images", "Virtual Machines", "Snapshots", "Storage Buckets"]
   default ["Persistent Disks", "VPN Gateways (Internal)", "VPN Gateways (External)", "Images", "Virtual Machines", "Snapshots", "Storage Buckets"]
 end
 
@@ -795,16 +804,16 @@ datasource "ds_storage_buckets" do
 end
 
 datasource "ds_google_resources" do
-  run_script $js_google_resources, $ds_google_projects_filtered, $ds_disks, $ds_vpn_gateways, $ds_external_vpn_gateways, $ds_images, $ds_instances, $ds_snapshots, $ds_storage_buckets, $param_resource_types
+  run_script $js_google_resources, $ds_google_projects_filtered, $ds_disks, $ds_vpn_gateways, $ds_external_vpn_gateways, $ds_images, $ds_instances, $ds_snapshots, $ds_storage_buckets, $param_resource_types, $param_report_types
 end
 
 script "js_google_resources", type: "javascript" do
-  parameters "ds_google_projects_filtered", "ds_disks", "ds_vpn_gateways", "ds_external_vpn_gateways", "ds_images", "ds_instances", "ds_snapshots", "ds_storage_buckets", "param_resource_types"
+  parameters "ds_google_projects_filtered", "ds_disks", "ds_vpn_gateways", "ds_external_vpn_gateways", "ds_images", "ds_instances", "ds_snapshots", "ds_storage_buckets", "param_resource_types", "param_report_types"
   result "result"
   code <<-'EOS'
   projects = []
 
-  if (_.contains(param_resource_types, "Projects")) {
+  if (_.contains(param_report_types, "Projects")) {
     projects = _.map(ds_google_projects_filtered, function(project) {
       return {
         id: project['id'],
@@ -820,7 +829,12 @@ script "js_google_resources", type: "javascript" do
     })
   }
 
-  result = projects.concat(ds_disks, ds_vpn_gateways, ds_external_vpn_gateways, ds_images, ds_instances, ds_snapshots, ds_storage_buckets)
+  resources = []
+  if (_.contains(param_report_types, "Resources")) {
+    resources = [].concat(ds_disks, ds_vpn_gateways, ds_external_vpn_gateways, ds_images, ds_instances, ds_snapshots, ds_storage_buckets)
+  }
+
+  result = projects.concat(resources)
 EOS
 end
 

--- a/compliance/google/unlabeled_resources/unlabeled_resources_meta_parent.pt
+++ b/compliance/google/unlabeled_resources/unlabeled_resources_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "4.0.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.0.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -135,12 +135,21 @@ parameter "param_projects_ignore_app" do
 end
 
 
+parameter "param_report_types" do
+  type "list"
+  category "Filters"
+  label "Report Types"
+  description "The types of resources to include in the report. Select 'Projects' to include Google Projects themselves, and 'Resources' to include individual labelable resources."
+  allowed_values "Projects", "Resources"
+  default ["Projects", "Resources"]
+end
+
 parameter "param_resource_types" do
   type "list"
   category "Filters"
   label "Resource Types"
-  description "The types of resources to check labels for. Any options not selected will not be reported on."
-  allowed_values ["Projects", "Persistent Disks", "VPN Gateways (Internal)", "VPN Gateways (External)", "Images", "Virtual Machines", "Snapshots", "Storage Buckets"]
+  description "The specific resource types to check labels for when 'Resources' is selected in the 'Report Types' parameter. Any options not selected will not be reported on."
+  allowed_values ["Persistent Disks", "VPN Gateways (Internal)", "VPN Gateways (External)", "Images", "Virtual Machines", "Snapshots", "Storage Buckets"]
   default ["Persistent Disks", "VPN Gateways (Internal)", "VPN Gateways (External)", "Images", "Virtual Machines", "Snapshots", "Storage Buckets"]
 end
 


### PR DESCRIPTION
### Description

Updates the 3 Untagged Resources policy templates to allow the user to select various resource types (Account, Resource, Subscription, etc.) from a list. This allows the user to report only Subscriptions, only Resources, etc. as desired. 

Also fixes a Dangerfile issue where a change to a policy template's MAJOR version would trigger an error if the MINOR UPDATE label wasn't applied to the PR, and adds "labelable" to the .spellignore since [this is a valid English word](https://en.wiktionary.org/wiki/labelable).

### Link to Example Applied Policy

AWS https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=6a4d5372620578afd278fb26

Azure https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=6a4d5352620578afd278fb24

Google https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=6a4d5393d4f6397e66bcd076

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
