### PR TITLE
AWS Resources Under or Approaching Extended Support Updates

### DIFF
--- a/cost/aws/extended_support/README.md
+++ b/cost/aws/extended_support/README.md
@@ -4,6 +4,10 @@
 
 This policy template uses the AWS APIs (RDS, EKS, and ElastiCache) to identify all resources running versions covered by AWS Extended Support. Extended support start and end dates are determined using the static reference data file at `data/aws/aws_extended_support_dates.json`. Resource-level billing data from the Flexera CCO platform is used to obtain actual extended support costs for resources already incurring those charges. These resources are outdated and AWS charges an extended support fee for continued use. A report is produced containing a list of these resources, and optionally, an email is sent with this report.
 
+**NOTE: This policy template is scoped to extended support *costs*, not maintenance or security posture. It should not be used to determine when a resource stops receiving security updates and bug fixes. Extended support includes critical CVE patches, but individual minor and patch versions reach end of support on their own schedules (often earlier than the major version) so a resource may stop receiving patches well before the dates listed here. For RDS, Aurora, and ElastiCache the template keys on major versions, because AWS offers extended support only at the major version level and bills accordingly. EKS is keyed on Kubernetes minor versions (e.g. 1.31), which is the granularity at which AWS defines the EKS support lifecycle.**
+
+**NOTE: AWS does not maintain a single authoritative source for extended support dates. They are published across per-service release calendars, pricing pages, and What's New announcements, and these sources can disagree; an announcement may change a date weeks before the corresponding calendar is updated. AWS also revises published dates, sometimes extending them by years. The dates in this template are a best-effort consolidation of first-party AWS sources as of the last update and may lag changes on AWS's side.**
+
 ## How It Works
 
 - The policy queries the AWS APIs (RDS, EKS, and ElastiCache) across all opted-in regions to enumerate all running resources.

--- a/data/aws/aws_extended_support_dates.json
+++ b/data/aws/aws_extended_support_dates.json
@@ -9,7 +9,7 @@
     "hourly_rate_year_1_2": 0.1,
     "hourly_rate_year_3": 0.2,
     "rate_unit": "vCPU-hour",
-    "pricing_notes": "Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas."
+    "pricing_notes": "Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. End of Extended Support was extended from 2027-02-28 to 2029-06-30 (AWS announcement, June 2026); the RDS for MySQL major version calendar reflects this. Year 3 pricing continues through 2029-06-30 rather than escalating again."
   },
   {
     "service": "RDS",
@@ -21,7 +21,7 @@
     "hourly_rate_year_1_2": 0.1,
     "hourly_rate_year_3": 0.2,
     "rate_unit": "vCPU-hour",
-    "pricing_notes": "Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas."
+    "pricing_notes": "Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. End of standard support 2026-07-31."
   },
   {
     "service": "RDS",
@@ -33,7 +33,7 @@
     "hourly_rate_year_1_2": 0.1,
     "hourly_rate_year_3": 0.2,
     "rate_unit": "vCPU-hour",
-    "pricing_notes": "Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas."
+    "pricing_notes": "Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. End of standard support 2029-07-31."
   },
   {
     "service": "RDS",
@@ -45,7 +45,7 @@
     "hourly_rate_year_1_2": 0.1,
     "hourly_rate_year_3": 0.2,
     "rate_unit": "vCPU-hour",
-    "pricing_notes": "Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas."
+    "pricing_notes": "Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. End of standard support 2024-02-29; Extended Support coverage began 2024-03-01 but year 1 pricing began 2024-04-01. Dates here follow AWS's 'start of Extended Support year 1 pricing' column."
   },
   {
     "service": "RDS",
@@ -57,7 +57,7 @@
     "hourly_rate_year_1_2": 0.1,
     "hourly_rate_year_3": 0.2,
     "rate_unit": "vCPU-hour",
-    "pricing_notes": "Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas."
+    "pricing_notes": "Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. End of standard support 2025-02-28."
   },
   {
     "service": "RDS",
@@ -69,7 +69,7 @@
     "hourly_rate_year_1_2": 0.1,
     "hourly_rate_year_3": 0.2,
     "rate_unit": "vCPU-hour",
-    "pricing_notes": "Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas."
+    "pricing_notes": "Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. End of standard support 2026-02-28."
   },
   {
     "service": "RDS",
@@ -81,7 +81,7 @@
     "hourly_rate_year_1_2": 0.1,
     "hourly_rate_year_3": 0.2,
     "rate_unit": "vCPU-hour",
-    "pricing_notes": "Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas."
+    "pricing_notes": "Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. End of standard support 2027-02-28. Note the RDS calendar lists end of Extended Support as 28 February 2030 while the Aurora PostgreSQL calendar lists 29 February 2030 for the same major version; 2030 is not a leap year."
   },
   {
     "service": "RDS",
@@ -93,7 +93,7 @@
     "hourly_rate_year_1_2": 0.1,
     "hourly_rate_year_3": 0.2,
     "rate_unit": "vCPU-hour",
-    "pricing_notes": "Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas."
+    "pricing_notes": "Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. End of standard support 2028-02-29."
   },
   {
     "service": "RDS",
@@ -105,7 +105,7 @@
     "hourly_rate_year_1_2": 0.1,
     "hourly_rate_year_3": 0.2,
     "rate_unit": "vCPU-hour",
-    "pricing_notes": "Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas."
+    "pricing_notes": "Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. End of standard support 2029-02-28. The RDS calendar lists end of Extended Support as 29 February 2032, which is valid (2032 is a leap year); the Aurora calendar lists 28 February 2032 for the same major version."
   },
   {
     "service": "RDS",
@@ -117,7 +117,19 @@
     "hourly_rate_year_1_2": 0.1,
     "hourly_rate_year_3": 0.2,
     "rate_unit": "vCPU-hour",
-    "pricing_notes": "Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas."
+    "pricing_notes": "Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. End of standard support 2030-02-28."
+  },
+  {
+    "service": "RDS",
+    "engine": "postgres",
+    "version": "18",
+    "extended_support_start": "2031-03-01",
+    "extended_support_year3_start": "2033-03-01",
+    "extended_support_end": "2034-02-28",
+    "hourly_rate_year_1_2": 0.1,
+    "hourly_rate_year_3": 0.2,
+    "rate_unit": "vCPU-hour",
+    "pricing_notes": "Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. End of standard support 2031-02-28. Rates assumed to follow the existing 0.10/0.20 structure; AWS has not published version-specific pricing this far out."
   },
   {
     "service": "RDS",
@@ -125,11 +137,11 @@
     "version": "5.7",
     "aurora_major": "Aurora MySQL v2",
     "extended_support_start": "2024-12-01",
-    "extended_support_end": "2027-02-28",
+    "extended_support_end": "2029-06-30",
     "hourly_rate_year_1_2": 0.1,
     "hourly_rate_year_3": 0.1,
     "rate_unit": "vCPU-hour",
-    "pricing_notes": "Aurora MySQL v2 (MySQL 5.7-compatible). Aurora MySQL Extended Support does NOT escalate in year 3; year 1 rate applies for the full duration. Eligible minor versions: 2.11 and 2.12. Rates are US East (N. Virginia); vary by region. For Aurora Serverless v2, charges are per ACU-hour, not vCPU-hour. Not available on Aurora Serverless v1."
+    "pricing_notes": "Aurora MySQL v2 (MySQL 5.7-compatible). SOURCE CONFLICT: the AWS June 2026 announcement extends Extended Support for MySQL 5.7 to 2029-06-30 and states it applies to Aurora MySQL version 2, but as of 2026-07-23 the Aurora MySQL release calendar still lists 28 February 2027. This file follows the announcement; revisit when the calendar is updated. End of standard support 2024-10-31; coverage began 2024-11-01, year 1 pricing began 2024-12-01. Aurora MySQL Extended Support does NOT escalate in year 3 (AWS Aurora pricing page: Year 3 pricing does not apply to Aurora MySQL-Compatible Edition; the release calendar lists year 3 pricing as Not applicable). Eligible minor versions: 2.11 and 2.12. Rates are US East (N. Virginia); vary by region. For Aurora Serverless v2, charges are per ACU-hour, not vCPU-hour. Not available on Aurora Serverless v1."
   },
   {
     "service": "RDS",
@@ -141,7 +153,7 @@
     "hourly_rate_year_1_2": 0.1,
     "hourly_rate_year_3": 0.1,
     "rate_unit": "vCPU-hour",
-    "pricing_notes": "Aurora MySQL v3 (MySQL 8.0-compatible). Aurora MySQL Extended Support does NOT escalate in year 3; year 1 rate applies for the full duration. Rates are US East (N. Virginia); vary by region. For Aurora Serverless v2, charges are per ACU-hour, not vCPU-hour. Not available on Aurora Serverless v1."
+    "pricing_notes": "Aurora MySQL v3 (MySQL 8.0-compatible). End of standard support 2028-04-30. Aurora MySQL Extended Support does NOT escalate in year 3; year 1 rate applies for the full duration. Eligible minor versions not yet published by AWS. Rates are US East (N. Virginia); vary by region. For Aurora Serverless v2, charges are per ACU-hour, not vCPU-hour. Not available on Aurora Serverless v1."
   },
   {
     "service": "RDS",
@@ -153,7 +165,7 @@
     "hourly_rate_year_1_2": 0.1,
     "hourly_rate_year_3": 0.2,
     "rate_unit": "vCPU-hour",
-    "pricing_notes": "Aurora PostgreSQL. Eligible minor versions: 11.9 and 11.21. Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. For Aurora Serverless v2, charges are per ACU-hour, not vCPU-hour. Not available on Aurora Serverless v1."
+    "pricing_notes": "Aurora PostgreSQL. End of standard support 2024-02-29; Extended Support coverage began 2024-03-01 but year 1 pricing began 2024-04-01. Eligible minor versions: 11.9 and 11.21. Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. For Aurora Serverless v2, charges are per ACU-hour, not vCPU-hour. Not available on Aurora Serverless v1."
   },
   {
     "service": "RDS",
@@ -165,7 +177,7 @@
     "hourly_rate_year_1_2": 0.1,
     "hourly_rate_year_3": 0.2,
     "rate_unit": "vCPU-hour",
-    "pricing_notes": "Aurora PostgreSQL. Eligible minor versions: 12.9 and 12.22. Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. For Aurora Serverless v2, charges are per ACU-hour, not vCPU-hour. Not available on Aurora Serverless v1."
+    "pricing_notes": "Aurora PostgreSQL. End of standard support 2025-02-28. Eligible minor versions: 12.9 and 12.22. Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. For Aurora Serverless v2, charges are per ACU-hour, not vCPU-hour. Not available on Aurora Serverless v1."
   },
   {
     "service": "RDS",
@@ -177,7 +189,7 @@
     "hourly_rate_year_1_2": 0.1,
     "hourly_rate_year_3": 0.2,
     "rate_unit": "vCPU-hour",
-    "pricing_notes": "Aurora PostgreSQL. Eligible minor versions: 13.9 and 13.23. Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. For Aurora Serverless v2, charges are per ACU-hour, not vCPU-hour. Not available on Aurora Serverless v1."
+    "pricing_notes": "Aurora PostgreSQL. End of standard support 2026-02-28. Eligible minor versions: 13.9 and 13.23. Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. For Aurora Serverless v2, charges are per ACU-hour, not vCPU-hour. Not available on Aurora Serverless v1."
   },
   {
     "service": "RDS",
@@ -189,7 +201,7 @@
     "hourly_rate_year_1_2": 0.1,
     "hourly_rate_year_3": 0.2,
     "rate_unit": "vCPU-hour",
-    "pricing_notes": "Aurora PostgreSQL. AWS calendar lists end date as 29 February 2030, which is not a valid date (2030 is not a leap year); using 28 February 2030. Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. For Aurora Serverless v2, charges are per ACU-hour, not vCPU-hour. Not available on Aurora Serverless v1."
+    "pricing_notes": "Aurora PostgreSQL. End of standard support 2027-02-28. The Aurora calendar lists end of Extended Support as 29 February 2030, which is not a valid date (2030 is not a leap year); the RDS for PostgreSQL calendar lists 28 February 2030 for the same major version, which is used here. Eligible minor versions not yet published by AWS. Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. For Aurora Serverless v2, charges are per ACU-hour, not vCPU-hour. Not available on Aurora Serverless v1."
   },
   {
     "service": "RDS",
@@ -201,7 +213,7 @@
     "hourly_rate_year_1_2": 0.1,
     "hourly_rate_year_3": 0.2,
     "rate_unit": "vCPU-hour",
-    "pricing_notes": "Aurora PostgreSQL. Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. For Aurora Serverless v2, charges are per ACU-hour, not vCPU-hour. Not available on Aurora Serverless v1."
+    "pricing_notes": "Aurora PostgreSQL. End of standard support 2028-02-29. Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. For Aurora Serverless v2, charges are per ACU-hour, not vCPU-hour. Not available on Aurora Serverless v1."
   },
   {
     "service": "RDS",
@@ -213,7 +225,7 @@
     "hourly_rate_year_1_2": 0.1,
     "hourly_rate_year_3": 0.2,
     "rate_unit": "vCPU-hour",
-    "pricing_notes": "Aurora PostgreSQL. Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. For Aurora Serverless v2, charges are per ACU-hour, not vCPU-hour. Not available on Aurora Serverless v1."
+    "pricing_notes": "Aurora PostgreSQL. End of standard support 2029-02-28. The Aurora calendar lists 28 February 2032; the RDS for PostgreSQL calendar lists 29 February 2032 for the same major version. Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. For Aurora Serverless v2, charges are per ACU-hour, not vCPU-hour. Not available on Aurora Serverless v1."
   },
   {
     "service": "RDS",
@@ -225,7 +237,7 @@
     "hourly_rate_year_1_2": 0.1,
     "hourly_rate_year_3": 0.2,
     "rate_unit": "vCPU-hour",
-    "pricing_notes": "Aurora PostgreSQL. Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. For Aurora Serverless v2, charges are per ACU-hour, not vCPU-hour. Not available on Aurora Serverless v1."
+    "pricing_notes": "Aurora PostgreSQL. End of standard support 2030-02-28. Rates are US East (N. Virginia); vary by region. Charged per vCPU on primary, Multi-AZ standby, and read replicas. For Aurora Serverless v2, charges are per ACU-hour, not vCPU-hour. Not available on Aurora Serverless v1."
   },
   {
     "service": "EKS",
@@ -235,7 +247,8 @@
     "extended_support_end": "2024-10-11",
     "hourly_rate": 0.6,
     "rate_unit": "cluster-hour",
-    "pricing_notes": "Total cluster price in extended support (standard is 0.10). EKS extended support billing began 2024-04-01 when the feature went GA; no charges before that date for any version."
+    "estimated": true,
+    "pricing_notes": "Total cluster price in extended support (standard is 0.10). EKS extended support billing began 2024-04-01 when the feature went GA; no charges before that date for any version. This version has aged off the EKS release calendar and can no longer be verified against a first-party source; month-level window matches the EKS extended support pricing blog (Oct 2023 - Oct 2024) but the exact days are unverified."
   },
   {
     "service": "EKS",
@@ -245,7 +258,8 @@
     "extended_support_end": "2025-01-31",
     "hourly_rate": 0.6,
     "rate_unit": "cluster-hour",
-    "pricing_notes": "Total cluster price in extended support (standard is 0.10). Billing for this version effectively began 2024-04-01 (extended support GA)."
+    "estimated": true,
+    "pricing_notes": "Total cluster price in extended support (standard is 0.10). Billing for this version effectively began 2024-04-01 (extended support GA). Aged off the EKS release calendar; month-level window matches the pricing blog (Jan 2024 - Jan 2025) but exact days are unverified."
   },
   {
     "service": "EKS",
@@ -255,7 +269,8 @@
     "extended_support_end": "2025-05-01",
     "hourly_rate": 0.6,
     "rate_unit": "cluster-hour",
-    "pricing_notes": "Total cluster price in extended support (standard is 0.10)."
+    "estimated": true,
+    "pricing_notes": "Total cluster price in extended support (standard is 0.10). Aged off the EKS release calendar; month-level window matches the pricing blog (May 2024 - May 2025) but exact days are unverified."
   },
   {
     "service": "EKS",
@@ -265,7 +280,8 @@
     "extended_support_end": "2025-06-11",
     "hourly_rate": 0.6,
     "rate_unit": "cluster-hour",
-    "pricing_notes": "Total cluster price in extended support (standard is 0.10)."
+    "estimated": true,
+    "pricing_notes": "Total cluster price in extended support (standard is 0.10). Aged off the EKS release calendar; month-level window matches the pricing blog (June 2024 - June 2025) but exact days are unverified."
   },
   {
     "service": "EKS",
@@ -275,7 +291,8 @@
     "extended_support_end": "2025-07-24",
     "hourly_rate": 0.6,
     "rate_unit": "cluster-hour",
-    "pricing_notes": "Total cluster price in extended support (standard is 0.10)."
+    "estimated": true,
+    "pricing_notes": "Total cluster price in extended support (standard is 0.10). Aged off the EKS release calendar; month-level window matches the pricing blog (July 2024 - July 2025) but exact days are unverified."
   },
   {
     "service": "EKS",
@@ -355,7 +372,8 @@
     "extended_support_end": "2028-03-27",
     "hourly_rate": 0.6,
     "rate_unit": "cluster-hour",
-    "pricing_notes": "Total cluster price in extended support (standard is 0.10)."
+    "estimated": true,
+    "pricing_notes": "Total cluster price in extended support (standard is 0.10). PROJECTED: AWS has not yet published support dates for this version. Derived from the standard EKS lifecycle (14 months standard support from EKS release, then 12 months extended). Replace with published dates when they appear on the EKS release calendar."
   },
   {
     "service": "EKS",
@@ -365,7 +383,8 @@
     "extended_support_end": "2028-08-02",
     "hourly_rate": 0.6,
     "rate_unit": "cluster-hour",
-    "pricing_notes": "Total cluster price in extended support (standard is 0.10)."
+    "estimated": true,
+    "pricing_notes": "Total cluster price in extended support (standard is 0.10). PROJECTED: AWS has not yet published support dates for this version. Derived from the standard EKS lifecycle (14 months standard support from EKS release, then 12 months extended). Replace with published dates when they appear on the EKS release calendar."
   },
   {
     "service": "ElastiCache",
@@ -377,7 +396,7 @@
     "premium_percent_year_1_2": 80,
     "premium_percent_year_3": 160,
     "rate_unit": "percent-of-on-demand-node-rate",
-    "pricing_notes": "Extended Support is a percentage premium on the node's on-demand hourly rate, not a flat node-hour fee. Verify exact per-year premiums against the ElastiCache pricing page."
+    "pricing_notes": "End of standard support 2026-01-31. Year 2 premium starts 2027-02-01 at the same rate as year 1. Extended Support is offered only for the latest supported patch version; clusters not already on 4.0.10 were automatically upgraded to it before enrollment. Extended Support is a percentage premium on the node's on-demand hourly rate, not a flat node-hour fee, and applies on top of any reserved node rate. The 80/160 premiums are corroborated by multiple secondary sources but not confirmed against a first-party AWS pricing table."
   },
   {
     "service": "ElastiCache",
@@ -389,7 +408,7 @@
     "premium_percent_year_1_2": 80,
     "premium_percent_year_3": 160,
     "rate_unit": "percent-of-on-demand-node-rate",
-    "pricing_notes": "Extended Support is a percentage premium on the node's on-demand hourly rate, not a flat node-hour fee. Verify exact per-year premiums against the ElastiCache pricing page."
+    "pricing_notes": "End of standard support 2026-01-31. Year 2 premium starts 2027-02-01 at the same rate as year 1. Extended Support is offered only for the latest supported patch version; clusters not already on 5.0.6 were automatically upgraded to it before enrollment. Extended Support is a percentage premium on the node's on-demand hourly rate, not a flat node-hour fee, and applies on top of any reserved node rate. The 80/160 premiums are corroborated by multiple secondary sources but not confirmed against a first-party AWS pricing table."
   },
   {
     "service": "ElastiCache",
@@ -401,6 +420,6 @@
     "premium_percent_year_1_2": 80,
     "premium_percent_year_3": 160,
     "rate_unit": "percent-of-on-demand-node-rate",
-    "pricing_notes": "Covers all v6.x including 6.2; Extended Support is offered per major version, only for the latest supported patch. Percentage premium on the node's on-demand hourly rate."
+    "pricing_notes": "End of standard support 2027-01-31. Year 2 premium starts 2028-02-01. Covers all v6.x including 6.2; Extended Support is offered per major version, only for the latest supported patch. Percentage premium on the node's on-demand hourly rate, applied on top of any reserved node rate. The 80/160 premiums are corroborated by multiple secondary sources but not confirmed against a first-party AWS pricing table."
   }
 ]


### PR DESCRIPTION
### Description

`AWS Resources Under or Approaching Extended Support`
- A small number of corrections to the JSON file tracking extended support versions.
- Commentary added to the README to inform the user of some caveats:
  - This policy only tracks major versions because it is for tracking costs and should not be used for maintenance/security purposes.
  - The dates are a best effort amalgamation of various sources because AWS does not provide a single consistent source of truth for these dates and often changes them ad hoc via blog posts without updating their alleged authoritative sources of truth.

