### PR TITLE
POL-1806 Markdown Table Option

### DIFF
--- a/.spellignore
+++ b/.spellignore
@@ -744,6 +744,7 @@ GCS
 RHEL
 PowerShell
 CCV
+CVE
 CWAgent
 ENA
 NIC

--- a/cost/flexera/cco/budget_report_alerts/CHANGELOG.md
+++ b/cost/flexera/cco/budget_report_alerts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.7.0
+
+- Added `Include Data Table In Incident` parameter to optionally include a formatted table of the budget data in the body of the incident.
+
 ## v3.6.0
 
 - Added `Incident Table Size` and `Attach Incident CSV` parameters to control email incident table row count and CSV attachment behavior.

--- a/cost/flexera/cco/budget_report_alerts/README.md
+++ b/cost/flexera/cco/budget_report_alerts/README.md
@@ -28,7 +28,7 @@ This policy template utilizes Flexera Budgets to detect if budget expense has ex
 - *Threshold Percentage* - Threshold to raise the alert if reached
 - *Incident Table Rows for Email Body (#)* - The number of results to include in the incident table in the incident email. Set to '0' to not show an incident table at all, and '100000' to include all results. Does not impact attached CSV files or the incident as presented in Flexera One.
 - *Attach CSV To Incident Email* - Whether or not to attach the results as a CSV file to the incident email.
-- *Include Data Table In Incident* - Whether to also include a formatted table of the underlying budget data within the body of the incident, in addition to the summary details. If you enable this option, consider also setting the `Attach CSV To Incident Email` parameter to `true` to avoid rendering redundant tables in the incident email.
+- *Include Data Table In Incident* - Whether to also include a formatted table of the underlying budget data within the body of the incident, in addition to the summary details. If you enable this option, consider also enabling the `Attach CSV To Incident Email` option to avoid rendering redundant tables in the incident email.
 
 ## Policy Actions
 

--- a/cost/flexera/cco/budget_report_alerts/README.md
+++ b/cost/flexera/cco/budget_report_alerts/README.md
@@ -28,6 +28,7 @@ This policy template utilizes Flexera Budgets to detect if budget expense has ex
 - *Threshold Percentage* - Threshold to raise the alert if reached
 - *Incident Table Rows for Email Body (#)* - The number of results to include in the incident table in the incident email. Set to '0' to not show an incident table at all, and '100000' to include all results. Does not impact attached CSV files or the incident as presented in Flexera One.
 - *Attach CSV To Incident Email* - Whether or not to attach the results as a CSV file to the incident email.
+- *Include Data Table In Incident* - Whether to also include a formatted table of the underlying budget data within the body of the incident, in addition to the summary details. If you enable this option, consider also setting the `Attach CSV To Incident Email` parameter to `true` to avoid rendering redundant tables in the incident email.
 
 ## Policy Actions
 

--- a/cost/flexera/cco/budget_report_alerts/budget_report_alerts.pt
+++ b/cost/flexera/cco/budget_report_alerts/budget_report_alerts.pt
@@ -103,7 +103,7 @@ parameter "param_incident_data_table" do
   type "string"
   category "Incident Settings"
   label "Include Data Table In Incident"
-  description "Whether to also include a formatted table of the underlying budget data within the body of the incident, in addition to the summary details. If you enable this option, consider also setting the 'Attach CSV To Incident Email' parameter to 'true' to avoid rendering redundant tables in the incident email."
+  description "Whether to also include a formatted table of the underlying budget data within the body of the incident, in addition to the summary details. If you enable this option, consider also enabling the 'Attach CSV To Incident Email' option to avoid rendering redundant tables in the incident email."
   allowed_values "true", "false"
   default "false"
 end

--- a/cost/flexera/cco/budget_report_alerts/budget_report_alerts.pt
+++ b/cost/flexera/cco/budget_report_alerts/budget_report_alerts.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "3.6.0",
+  version: "3.7.0",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -95,6 +95,15 @@ parameter "param_incident_csv" do
   category "Incident Settings"
   label "Attach CSV To Incident Email"
   description "Whether or not to attach the results as a CSV file to the incident email."
+  allowed_values "true", "false"
+  default "false"
+end
+
+parameter "param_incident_data_table" do
+  type "string"
+  category "Incident Settings"
+  label "Include Data Table In Incident"
+  description "Whether to also include a formatted table of the underlying budget data within the body of the incident, in addition to the summary details. If you enable this option, consider also setting the 'Attach CSV To Incident Email' parameter to 'true' to avoid rendering redundant tables in the incident email."
   allowed_values "true", "false"
   default "false"
 end
@@ -366,15 +375,56 @@ EOS
 end
 
 datasource "ds_aggregated" do
-  run_script $js_aggregated, $ds_filtered_reports, $ds_currency, $ds_dimensions, $ds_billing_center_table, $param_threshold_percentage, $param_type, $param_budget_name_id, $param_filter, $param_incident_csv, f1_app_host
+  run_script $js_aggregated, $ds_filtered_reports, $ds_currency, $ds_dimensions, $ds_billing_center_table, $param_threshold_percentage, $param_type, $param_budget_name_id, $param_filter, $param_incident_csv, $param_incident_data_table, f1_app_host
 end
 
 script "js_aggregated", type: "javascript" do
-  parameters "ds_filtered_reports", "ds_currency", "ds_dimensions", "ds_billing_center_table", "param_threshold_percentage", "param_type", "param_budget_name_id", "param_filter", "param_incident_csv", "f1_app_host"
+  parameters "ds_filtered_reports", "ds_currency", "ds_dimensions", "ds_billing_center_table", "param_threshold_percentage", "param_type", "param_budget_name_id", "param_filter", "param_incident_csv", "param_incident_data_table", "f1_app_host"
   result "result"
   code <<-'EOS'
   function convert_bc_name(id) {
     return ds_billing_center_table[id] ? ds_billing_center_table[id] : id
+  }
+
+  function format_number(number, separator) {
+    formatted_number = "0"
+
+    if (number) {
+      formatted_number = (Math.round(number * 100) / 100).toString().split(".")[0]
+
+      if (separator) {
+        with_separator = ""
+
+        for (var i = 0; i < formatted_number.length; i++) {
+          if (i > 0 && (formatted_number.length - i) % 3 == 0) { with_separator += separator }
+          with_separator += formatted_number[i]
+        }
+
+        formatted_number = with_separator
+      }
+
+      decimal = (Math.round(number * 100) / 100).toString().split(".")[1]
+      if (decimal) { formatted_number += "." + decimal }
+    }
+
+    return formatted_number
+  }
+
+  function build_data_table(items) {
+    header = "| Group | Budget | Actual Spend | Projected (prorated) Spend | Remaining Amount | % of Budget Spent | Details |"
+    divider = "| --- | ---: | ---: | ---: | ---: | ---: | --- |"
+
+    rows = _.map(items, function(item) {
+      return "| " + item['group'] +
+        " | " + ds_currency['symbol'] + format_number(item['budgetAmount'], ds_currency['separator']) +
+        " | " + ds_currency['symbol'] + format_number(item['spendAmount'], ds_currency['separator']) +
+        " | " + ds_currency['symbol'] + format_number(item['forecastedAmount'], ds_currency['separator']) +
+        " | " + ds_currency['symbol'] + format_number(item['remaining'], ds_currency['separator']) +
+        " | " + (item['spentPercent'] || "") +
+        " | " + item['details'] + " |"
+    })
+
+    return [header, divider].concat(rows).join("\n")
   }
 
   function forecasted(curr) {
@@ -517,6 +567,11 @@ script "js_aggregated", type: "javascript" do
 
   if (result['exceeded'].length > 0) { result['exceeded'][0]['message'] = csv_message }
   if (result['forecasted'].length > 0) { result['forecasted'][0]['message'] = csv_message }
+
+  if (param_incident_data_table == "true") {
+    if (result['exceeded'].length > 0) { result['exceeded'][0]['data_table'] = build_data_table(result['exceeded']) }
+    if (result['forecasted'].length > 0) { result['forecasted'][0]['data_table'] = build_data_table(result['forecasted']) }
+  }
 EOS
 end
 
@@ -575,6 +630,12 @@ Target Groups: \n
 [Link to budget report in Flexera One](https://{{with index data 0}}{{ .host }}{{end}}/orgs/{{ rs_org_id }}/optima/budgets/{{with index data 0}}{{ .b_id }}{{end}})
 
 {{ with index data 0 }}{{ .message }}{{ end }}
+
+{{ if eq parameters.param_incident_data_table "true" }}
+## Data Table
+
+{{ with index data 0 }}{{ .data_table }}{{ end }}
+{{ end }}
 EOS
     check eq(size(data), 0)
     escalate $esc_email
@@ -627,6 +688,12 @@ Target Groups: \n
 [Link to budget report in Flexera One](https://{{with index data 0}}{{ .host }}{{end}}/orgs/{{ rs_org_id }}/optima/budgets/{{with index data 0}}{{ .b_id }}{{end}})
 
 {{ with index data 0 }}{{ .message }}{{ end }}
+
+{{ if eq parameters.param_incident_data_table "true" }}
+## Data Table
+
+{{ with index data 0 }}{{ .data_table }}{{ end }}
+{{ end }}
 EOS
     check eq(size(data), 0)
     escalate $esc_email

--- a/cost/flexera/cco/budget_v_actual_spend_report/CHANGELOG.md
+++ b/cost/flexera/cco/budget_v_actual_spend_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.7.0
+
+- Added `Include Data Table In Incident` parameter to optionally include a formatted table of the budget vs actual spend data in the body of the incident.
+
 ## v2.6.0
 
 - Billing Center dimensions now show Billing Center names instead of IDs in the incident table.

--- a/cost/flexera/cco/budget_v_actual_spend_report/CHANGELOG.md
+++ b/cost/flexera/cco/budget_v_actual_spend_report/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.7.0
 
 - Added `Include Data Table In Incident` parameter to optionally include a formatted table of the budget vs actual spend data in the body of the incident.
+- Added `Attach CSV To Incident Email` and `Incident Table Rows for Email Body (#)` parameters to control CSV attachment and inline table size for the incident email.
 
 ## v2.6.0
 

--- a/cost/flexera/cco/budget_v_actual_spend_report/README.md
+++ b/cost/flexera/cco/budget_v_actual_spend_report/README.md
@@ -15,7 +15,9 @@ This policy generates an email report comparing actual spending to budgeted valu
 - _Filter Group By Dimensions_: Filter by dimension=value pairs (e.g., 'Cloud Vendor=AWS'). Multiple values for the same dimension can be supplied as coma-separated list.
 - _Unbudgeted Spend_: Parameter to include or exclude unbudgeted funds in the calculation.
 - _Email Addresses_: A list of email addresses to notify.
-- _Include Data Table In Incident_: Whether to also include a formatted table of the underlying budget vs actual spend data within the body of the incident, in addition to the chart and summary details above.
+- _Attach CSV To Incident Email_: Whether or not to attach the results as a CSV file to the incident email.
+- _Incident Table Rows for Email Body (#)_: The number of results to include in the incident table in the incident email. Set to '0' to not show an incident table at all, and '100000' to include all results. Does not impact attached CSV files or the incident as presented in Flexera One.
+- _Include Data Table In Incident_: Whether to also include a formatted table of the underlying budget vs actual spend data within the body of the incident, in addition to the chart and summary details above. If you enable this option, consider also enabling the 'Attach CSV To Incident Email' option to avoid rendering redundant tables in the incident email.
 
 ## Policy Actions
 

--- a/cost/flexera/cco/budget_v_actual_spend_report/README.md
+++ b/cost/flexera/cco/budget_v_actual_spend_report/README.md
@@ -15,6 +15,7 @@ This policy generates an email report comparing actual spending to budgeted valu
 - _Filter Group By Dimensions_: Filter by dimension=value pairs (e.g., 'Cloud Vendor=AWS'). Multiple values for the same dimension can be supplied as coma-separated list.
 - _Unbudgeted Spend_: Parameter to include or exclude unbudgeted funds in the calculation.
 - _Email Addresses_: A list of email addresses to notify.
+- _Include Data Table In Incident_: Whether to also include a formatted table of the underlying budget vs actual spend data within the body of the incident, in addition to the chart and summary details above.
 
 ## Policy Actions
 

--- a/cost/flexera/cco/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
+++ b/cost/flexera/cco/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
@@ -63,11 +63,29 @@ parameter "param_email" do
   default []
 end
 
+parameter "param_incident_csv" do
+  type "string"
+  category "Incident Settings"
+  label "Attach CSV To Incident Email"
+  description "Whether or not to attach the results as a CSV file to the incident email."
+  allowed_values "true", "false"
+  default "false"
+end
+
+parameter "param_incident_table_size" do
+  type "number"
+  category "Incident Settings"
+  label "Incident Table Rows for Email Body (#)"
+  description "The number of results to include in the incident table in the incident email. Set to '0' to not show an incident table at all, and '100000' to include all results. Does not impact attached CSV files or the incident as presented in Flexera One."
+  allowed_values 0, 10, 50, 100, 200, 500, 1000, 10000, 100000
+  default 100000
+end
+
 parameter "param_incident_data_table" do
   type "string"
   category "Incident Settings"
   label "Include Data Table In Incident"
-  description "Whether to also include a formatted table of the underlying budget vs actual spend data within the body of the incident, in addition to the chart and summary details above."
+  description "Whether to also include a formatted table of the underlying budget vs actual spend data within the body of the incident, in addition to the chart and summary details above. If you enable this option, consider also enabling the 'Attach CSV To Incident Email' option to avoid rendering redundant tables in the incident email."
   allowed_values "true", "false"
   default "false"
 end
@@ -642,5 +660,8 @@ escalation "esc_budget_alert" do
   automatic true
   label "Send Email"
   description "Send incident email"
-  email $param_email
+  email $param_email do
+    attach_export_table $param_incident_csv
+    body_table_max_rows $param_incident_table_size
+  end
 end

--- a/cost/flexera/cco/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
+++ b/cost/flexera/cco/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.6.0",
+  version: "2.7.0",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -61,6 +61,15 @@ parameter "param_email" do
   label "Email Addresses"
   description "A list of email addresses to notify"
   default []
+end
+
+parameter "param_incident_data_table" do
+  type "string"
+  category "Incident Settings"
+  label "Include Data Table In Incident"
+  description "Whether to also include a formatted table of the underlying budget vs actual spend data within the body of the incident, in addition to the chart and summary details above."
+  allowed_values "true", "false"
+  default "false"
 end
 
 ###############################################################################
@@ -323,11 +332,11 @@ EOS
 end
 
 datasource "ds_aggregated_report" do
-  run_script $js_aggregated_report, $ds_reports, $ds_currency_code, $ds_currency_reference, $ds_dimensions, $ds_filters, $ds_billing_center_table, $param_budget_name_id, $param_report_type, f1_app_host
+  run_script $js_aggregated_report, $ds_reports, $ds_currency_code, $ds_currency_reference, $ds_dimensions, $ds_filters, $ds_billing_center_table, $param_budget_name_id, $param_report_type, $param_incident_data_table, f1_app_host
 end
 
 script "js_aggregated_report", type: "javascript" do
-  parameters "reports", "currency_code", "currency_reference", "ds_dimensions", "filters", "ds_billing_center_table", "budget_name_id", "report_type", "f1_app_host"
+  parameters "reports", "currency_code", "currency_reference", "ds_dimensions", "filters", "ds_billing_center_table", "budget_name_id", "report_type", "param_incident_data_table", "f1_app_host"
   result "results"
   code <<-'EOS'
   function convert_bc_name(id) {
@@ -343,8 +352,49 @@ script "js_aggregated_report", type: "javascript" do
   }
   var currency = currency_code.value || '';
   var ref = currency ? currency_reference[currency] : undefined;
+  var separator = ",";
   if (ref) {
     currency = ref.symbol || "";
+    separator = ref.t_separator !== undefined ? ref.t_separator : "";
+  }
+
+  function format_number(number) {
+    formatted_number = "0"
+
+    if (number) {
+      formatted_number = (Math.round(number * 100) / 100).toString().split(".")[0]
+
+      if (separator) {
+        with_separator = ""
+
+        for (var i = 0; i < formatted_number.length; i++) {
+          if (i > 0 && (formatted_number.length - i) % 3 == 0) { with_separator += separator }
+          with_separator += formatted_number[i]
+        }
+
+        formatted_number = with_separator
+      }
+
+      decimal = (Math.round(number * 100) / 100).toString().split(".")[1]
+      if (decimal) { formatted_number += "." + decimal }
+    }
+
+    return formatted_number
+  }
+
+  function build_data_table(items) {
+    header = "| MonthYear | Group | Budget | Actual Spend | Over Budget |"
+    divider = "| --- | --- | ---: | ---: | ---: |"
+
+    rows = _.map(items, function(item) {
+      return "| " + item.monthYear +
+        " | " + item.group +
+        " | " + currency + format_number(item.budget) +
+        " | " + currency + format_number(item.spend) +
+        " | " + currency + format_number(item.overBudget) + " |"
+    })
+
+    return [header, divider].concat(rows).join("\n")
   }
 
   function get_group(dimensions, dimensionsIDs) {
@@ -503,6 +553,10 @@ script "js_aggregated_report", type: "javascript" do
     chartAxis: encodeURI('chxl=0:|' + formatChartDates(yearMonthsArr)),
   }
 
+  if (param_incident_data_table == "true" && reportData.length > 0) {
+    results.dataTable = build_data_table(reportData)
+  }
+
 EOS
 end
 
@@ -551,6 +605,12 @@ EOS
   [Link to budget report in Flexera One](https://{{with index data.reportData 0}}{{ .host }}{{end}}/orgs/{{ rs_org_id }}/optima/budgets/{{with index data.reportData 0}}{{ .b_id }}{{end}})
 
   *Please note: The chart in the incident reflects the selected filters. However, the budget dashboard via hyperlink displays the overall budget without filters applied.*
+
+  {{ if eq parameters.param_incident_data_table "true" }}
+  ## Data Table
+
+  {{ data.dataTable }}
+  {{ end }}
 EOS
     check eq(size(val(data, "reportData")), 0)
     escalate $esc_budget_alert

--- a/cost/flexera/cco/forecasting/straight_line_forecast/CHANGELOG.md
+++ b/cost/flexera/cco/forecasting/straight_line_forecast/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v4.1.0
 
 - Added `Include Data Table In Incident` parameter to optionally include a formatted table of the forecasted cost data in the body of the incident.
+- Added `Attach CSV To Incident Email` and `Incident Table Rows for Email Body (#)` parameters to control CSV attachment and inline table size for the incident email.
 
 ## v4.0.7
 

--- a/cost/flexera/cco/forecasting/straight_line_forecast/CHANGELOG.md
+++ b/cost/flexera/cco/forecasting/straight_line_forecast/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.1.0
+
+- Added `Include Data Table In Incident` parameter to optionally include a formatted table of the forecasted cost data in the body of the incident.
+
 ## v4.0.7
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/flexera/cco/forecasting/straight_line_forecast/README.md
+++ b/cost/flexera/cco/forecasting/straight_line_forecast/README.md
@@ -18,7 +18,9 @@ This policy template produces a forecast for monthly cloud spend based on cost d
 - *Forecast Months (#)* - Number of months in the future to forecast.
 - *Forecast Formula* - Formula to use when projecting costs.
 - *Dimension* - The name or ID of the Flexera dimension you want to split costs by in the chart. Enter `Billing Center` to split costs by Billing Center. Leave blank to not split costs by any dimension.
-- *Include Data Table In Incident* - Whether to also include a formatted table of the underlying forecasted cost data within the body of the incident, in addition to the chart above.
+- *Attach CSV To Incident Email* - Whether or not to attach the results as a CSV file to the incident email.
+- *Incident Table Rows for Email Body (#)* - The number of results to include in the incident table in the incident email. Set to '0' to not show an incident table at all, and '100000' to include all results. Does not impact attached CSV files or the incident as presented in Flexera One.
+- *Include Data Table In Incident* - Whether to also include a formatted table of the underlying forecasted cost data within the body of the incident, in addition to the chart above. If you enable this option, consider also enabling the 'Attach CSV To Incident Email' option to avoid rendering redundant tables in the incident email.
 
 ## Policy Actions
 

--- a/cost/flexera/cco/forecasting/straight_line_forecast/README.md
+++ b/cost/flexera/cco/forecasting/straight_line_forecast/README.md
@@ -18,6 +18,7 @@ This policy template produces a forecast for monthly cloud spend based on cost d
 - *Forecast Months (#)* - Number of months in the future to forecast.
 - *Forecast Formula* - Formula to use when projecting costs.
 - *Dimension* - The name or ID of the Flexera dimension you want to split costs by in the chart. Enter `Billing Center` to split costs by Billing Center. Leave blank to not split costs by any dimension.
+- *Include Data Table In Incident* - Whether to also include a formatted table of the underlying forecasted cost data within the body of the incident, in addition to the chart above.
 
 ## Policy Actions
 

--- a/cost/flexera/cco/forecasting/straight_line_forecast/straight_line_forecast.pt
+++ b/cost/flexera/cco/forecasting/straight_line_forecast/straight_line_forecast.pt
@@ -88,11 +88,29 @@ parameter "param_dimension" do
   default ""
 end
 
+parameter "param_incident_csv" do
+  type "string"
+  category "Incident Settings"
+  label "Attach CSV To Incident Email"
+  description "Whether or not to attach the results as a CSV file to the incident email."
+  allowed_values "true", "false"
+  default "false"
+end
+
+parameter "param_incident_table_size" do
+  type "number"
+  category "Incident Settings"
+  label "Incident Table Rows for Email Body (#)"
+  description "The number of results to include in the incident table in the incident email. Set to '0' to not show an incident table at all, and '100000' to include all results. Does not impact attached CSV files or the incident as presented in Flexera One."
+  allowed_values 0, 10, 50, 100, 200, 500, 1000, 10000, 100000
+  default 100000
+end
+
 parameter "param_incident_data_table" do
   type "string"
   category "Incident Settings"
   label "Include Data Table In Incident"
-  description "Whether to also include a formatted table of the underlying forecasted cost data within the body of the incident, in addition to the chart above."
+  description "Whether to also include a formatted table of the underlying forecasted cost data within the body of the incident, in addition to the chart above. If you enable this option, consider also enabling the 'Attach CSV To Incident Email' option to avoid rendering redundant tables in the incident email."
   allowed_values "true", "false"
   default "false"
 end
@@ -745,5 +763,8 @@ escalation "esc_email" do
   automatic true
   label "Send Email"
   description "Send incident email"
-  email $param_email
+  email $param_email do
+    attach_export_table $param_incident_csv
+    body_table_max_rows $param_incident_table_size
+  end
 end

--- a/cost/flexera/cco/forecasting/straight_line_forecast/straight_line_forecast.pt
+++ b/cost/flexera/cco/forecasting/straight_line_forecast/straight_line_forecast.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "monthly"
 info(
-  version: "4.0.7",
+  version: "4.1.0",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Forecasting",
@@ -86,6 +86,15 @@ parameter "param_dimension" do
   label "Dimension"
   description "The name or ID of the Flexera dimension you want to split costs by in the chart. Enter 'Billing Center' to split costs by Billing Center. Leave blank to not split costs by any dimension."
   default ""
+end
+
+parameter "param_incident_data_table" do
+  type "string"
+  category "Incident Settings"
+  label "Include Data Table In Incident"
+  description "Whether to also include a formatted table of the underlying forecasted cost data within the body of the incident, in addition to the chart above."
+  allowed_values "true", "false"
+  default "false"
 end
 
 ###############################################################################
@@ -594,13 +603,51 @@ EOS
 end
 
 datasource "ds_chart_creation" do
-  run_script $js_chart_creation, $ds_forecasted_costs, $ds_dimension, $ds_applied_policy, $param_formula
+  run_script $js_chart_creation, $ds_forecasted_costs, $ds_dimension, $ds_applied_policy, $ds_currency, $param_formula, $param_incident_data_table
 end
 
 script "js_chart_creation", type: "javascript" do
-  parameters "ds_forecasted_costs", "ds_dimension", "ds_applied_policy", "param_formula"
+  parameters "ds_forecasted_costs", "ds_dimension", "ds_applied_policy", "ds_currency", "param_formula", "param_incident_data_table"
   result "result"
   code <<-'EOS'
+  function format_number(number, separator) {
+    formatted_number = "0"
+
+    if (number) {
+      formatted_number = (Math.round(number * 100) / 100).toString().split(".")[0]
+
+      if (separator) {
+        with_separator = ""
+
+        for (var i = 0; i < formatted_number.length; i++) {
+          if (i > 0 && (formatted_number.length - i) % 3 == 0) { with_separator += separator }
+          with_separator += formatted_number[i]
+        }
+
+        formatted_number = with_separator
+      }
+
+      decimal = (Math.round(number * 100) / 100).toString().split(".")[1]
+      if (decimal) { formatted_number += "." + decimal }
+    }
+
+    return formatted_number
+  }
+
+  function build_data_table(items) {
+    header = "| Month | Dimension | Dimension Value | Forecasted Cost |"
+    divider = "| --- | --- | --- | ---: |"
+
+    rows = _.map(items, function(item) {
+      return "| " + item.month +
+        " | " + item.dimension +
+        " | " + item.value +
+        " | " + ds_currency['symbol'] + format_number(item.cost, ds_currency['separator']) + " |"
+    })
+
+    return [header, divider].concat(rows).join("\n")
+  }
+
   chart_axis_label = 'chxl=0:|' + _.uniq(_.pluck(ds_forecasted_costs, "month")).join('|')
 
   group_by_value = _.groupBy(ds_forecasted_costs, "value")
@@ -646,6 +693,10 @@ script "js_chart_creation", type: "javascript" do
     report_data: ds_forecasted_costs,
     model: param_formula
   }
+
+  if (param_incident_data_table == "true") {
+    result.data_table = build_data_table(ds_forecasted_costs)
+  }
 EOS
 end
 
@@ -660,6 +711,12 @@ policy "pol_straight_line_forecast" do
 # Forecast Report for {{ rs_org_name }} - {{ data.current_month_name }}
 ### Model: {{ data.model }}
 ![Forecast Chart](https://api.image-charts-auth.flexeraeng.com/ic-function?rs_org_id={{ rs_org_id }}&rs_project_id={{ rs_project_id }}&{{ data.chart_options }})
+
+{{ if eq parameters.param_incident_data_table "true" }}
+## Data Table
+
+{{ data.data_table }}
+{{ end }}
 EOS
     check eq(1, 0)
     escalate $esc_email

--- a/cost/flexera/cco/moving_average/CHANGELOG.md
+++ b/cost/flexera/cco/moving_average/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.1.0
+
+- Added `Include Data Table In Incident` parameter to optionally include a formatted table of the moving average cost data in the body of the incident.
+
 ## v4.0.6
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/flexera/cco/moving_average/CHANGELOG.md
+++ b/cost/flexera/cco/moving_average/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v4.1.0
 
 - Added `Include Data Table In Incident` parameter to optionally include a formatted table of the moving average cost data in the body of the incident.
+- Added `Attach CSV To Incident Email` and `Incident Table Rows for Email Body (#)` parameters to control CSV attachment and inline table size for the incident email.
 
 ## v4.0.6
 

--- a/cost/flexera/cco/moving_average/README.md
+++ b/cost/flexera/cco/moving_average/README.md
@@ -25,7 +25,9 @@ This policy template pulls cost data from Flexera Cloud Cost Optimization (CCO) 
 - *Allow/Deny Billing Center List* - A list of allowed or denied Billing Center names/IDs. Leave blank to produce forecast for entire Flexera organization.
 - *Look Back Months (#)* - Number of months into the past to use for generating forecast.
 - *Moving Average Months* - Number of prior months to use to calculate moving average.
-- *Include Data Table In Incident* - Whether to also include a formatted table of the underlying moving average cost data within the body of the incident, in addition to the chart above.
+- *Attach CSV To Incident Email* - Whether or not to attach the results as a CSV file to the incident email.
+- *Incident Table Rows for Email Body (#)* - The number of results to include in the incident table in the incident email. Set to '0' to not show an incident table at all, and '100000' to include all results. Does not impact attached CSV files or the incident as presented in Flexera One.
+- *Include Data Table In Incident* - Whether to also include a formatted table of the underlying moving average cost data within the body of the incident, in addition to the chart above. If you enable this option, consider also enabling the 'Attach CSV To Incident Email' option to avoid rendering redundant tables in the incident email.
 
 ## Policy Actions
 

--- a/cost/flexera/cco/moving_average/README.md
+++ b/cost/flexera/cco/moving_average/README.md
@@ -25,6 +25,7 @@ This policy template pulls cost data from Flexera Cloud Cost Optimization (CCO) 
 - *Allow/Deny Billing Center List* - A list of allowed or denied Billing Center names/IDs. Leave blank to produce forecast for entire Flexera organization.
 - *Look Back Months (#)* - Number of months into the past to use for generating forecast.
 - *Moving Average Months* - Number of prior months to use to calculate moving average.
+- *Include Data Table In Incident* - Whether to also include a formatted table of the underlying moving average cost data within the body of the incident, in addition to the chart above.
 
 ## Policy Actions
 

--- a/cost/flexera/cco/moving_average/moving_average.pt
+++ b/cost/flexera/cco/moving_average/moving_average.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.0.6",
+  version: "4.1.0",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "",
@@ -70,6 +70,15 @@ parameter "param_average_months" do
   min_value 2
   max_value 6
   default 3
+end
+
+parameter "param_incident_data_table" do
+  type "string"
+  category "Incident Settings"
+  label "Include Data Table In Incident"
+  description "Whether to also include a formatted table of the underlying moving average cost data within the body of the incident, in addition to the chart above."
+  allowed_values "true", "false"
+  default "false"
 end
 
 ###############################################################################
@@ -374,13 +383,51 @@ EOS
 end
 
 datasource "ds_moving_average_chart" do
-  run_script $js_moving_average_chart, $ds_costs_calculated, $ds_billing_centers_filtered, $ds_applied_policy, $param_bc_list, $param_average_months, rs_org_name
+  run_script $js_moving_average_chart, $ds_costs_calculated, $ds_billing_centers_filtered, $ds_applied_policy, $ds_currency, $param_bc_list, $param_average_months, $param_incident_data_table, rs_org_name
 end
 
 script "js_moving_average_chart", type: "javascript" do
-  parameters "ds_costs_calculated", "ds_billing_centers_filtered", "ds_applied_policy", "param_bc_list", "param_average_months", "rs_org_name"
+  parameters "ds_costs_calculated", "ds_billing_centers_filtered", "ds_applied_policy", "ds_currency", "param_bc_list", "param_average_months", "param_incident_data_table", "rs_org_name"
   result "result"
   code <<-'EOS'
+  function format_number(number) {
+    formatted_number = "0"
+
+    if (number) {
+      formatted_number = (Math.round(number * 100) / 100).toString().split(".")[0]
+
+      if (ds_currency['separator']) {
+        with_separator = ""
+
+        for (var i = 0; i < formatted_number.length; i++) {
+          if (i > 0 && (formatted_number.length - i) % 3 == 0) { with_separator += ds_currency['separator'] }
+          with_separator += formatted_number[i]
+        }
+
+        formatted_number = with_separator
+      }
+
+      decimal = (Math.round(number * 100) / 100).toString().split(".")[1]
+      if (decimal) { formatted_number += "." + decimal }
+    }
+
+    return formatted_number
+  }
+
+  function build_data_table(items) {
+    header = "| Month | Cloud Cost | Moving Average | Currency |"
+    divider = "| --- | ---: | ---: | --- |"
+
+    rows = _.map(items, function(item) {
+      return "| " + item.month +
+        " | " + format_number(item.cost) +
+        " | " + format_number(item.average) +
+        " | " + item.currency + " |"
+    })
+
+    return [header, divider].concat(rows).join("\n")
+  }
+
   billingCenters = "All"
   if (param_bc_list.length > 0) { billingCenters = _.pluck(ds_billing_centers_filtered, 'name').join(', ') }
 
@@ -404,6 +451,10 @@ script "js_moving_average_chart", type: "javascript" do
     policy_name: ds_applied_policy['name'],
     param_average_months: param_average_months
   }
+
+  if (param_incident_data_table == "true") {
+    result.data_table = build_data_table(ds_costs_calculated)
+  }
 EOS
 end
 
@@ -419,6 +470,12 @@ policy "pol_moving_average_chart" do
 ### Billing Centers: {{ data.billingCenters }}
 #### Average calculated from previous {{ data.param_average_months }} months
 ![Moving Average](https://api.image-charts-auth.flexeraeng.com/ic-function?rs_org_id={{ rs_org_id }}&rs_project_id={{ rs_project_id }}&{{ data.chartType }}&{{ data.chartLabel }}&{{ data.chartSize }}&{{ data.chartTitle }}&{{ data.chartAxis }}&{{ data.chartXAxis }}&{{ data.chartAxisFormat }}&{{ data.chartData }}&{{ data.chartColors }}&{{ data.chartExtension }} "Moving Average Spend Chart")
+
+{{ if eq parameters.param_incident_data_table "true" }}
+## Data Table
+
+{{ data.data_table }}
+{{ end }}
 EOS
     check eq(1, 0)
     escalate $esc_email

--- a/cost/flexera/cco/moving_average/moving_average.pt
+++ b/cost/flexera/cco/moving_average/moving_average.pt
@@ -72,11 +72,29 @@ parameter "param_average_months" do
   default 3
 end
 
+parameter "param_incident_csv" do
+  type "string"
+  category "Incident Settings"
+  label "Attach CSV To Incident Email"
+  description "Whether or not to attach the results as a CSV file to the incident email."
+  allowed_values "true", "false"
+  default "false"
+end
+
+parameter "param_incident_table_size" do
+  type "number"
+  category "Incident Settings"
+  label "Incident Table Rows for Email Body (#)"
+  description "The number of results to include in the incident table in the incident email. Set to '0' to not show an incident table at all, and '100000' to include all results. Does not impact attached CSV files or the incident as presented in Flexera One."
+  allowed_values 0, 10, 50, 100, 200, 500, 1000, 10000, 100000
+  default 100000
+end
+
 parameter "param_incident_data_table" do
   type "string"
   category "Incident Settings"
   label "Include Data Table In Incident"
-  description "Whether to also include a formatted table of the underlying moving average cost data within the body of the incident, in addition to the chart above."
+  description "Whether to also include a formatted table of the underlying moving average cost data within the body of the incident, in addition to the chart above. If you enable this option, consider also enabling the 'Attach CSV To Incident Email' option to avoid rendering redundant tables in the incident email."
   allowed_values "true", "false"
   default "false"
 end
@@ -504,5 +522,8 @@ escalation "esc_email" do
   automatic true
   label "Send Email"
   description "Send incident email"
-  email $param_email
+  email $param_email do
+    attach_export_table $param_incident_csv
+    body_table_max_rows $param_incident_table_size
+  end
 end

--- a/operational/flexera/cco/bc_report/CHANGELOG.md
+++ b/operational/flexera/cco/bc_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.0
+
+- Added `Include Data Table In Incident` parameter to optionally include a formatted table of the Billing Center data in the body of the incident.
+
 ## v0.1.0
 
 - Initial release

--- a/operational/flexera/cco/bc_report/README.md
+++ b/operational/flexera/cco/bc_report/README.md
@@ -9,7 +9,7 @@ This policy template reports on all Billing Centers within the Flexera organizat
 - *Email Addresses* - A list of email addresses to notify.
 - *Attach CSV To Incident Email* - Whether or not to attach the results as a CSV file to the incident email.
 - *Incident Table Rows for Email Body (#)* - The number of results to include in the incident table in the incident email. Set to '0' to not show an incident table at all, and '100000' to include all results. Does not impact attached CSV files or the incident as presented in Flexera One.
-- *Include Data Table In Incident* - Whether to also include a formatted table of the underlying Billing Center data within the body of the incident, in addition to the summary details. If you enable this option, consider also setting the `Attach CSV To Incident Email` parameter to `true` to avoid rendering redundant tables in the incident email.
+- *Include Data Table In Incident* - Whether to also include a formatted table of the underlying Billing Center data within the body of the incident, in addition to the summary details. If you enable this option, consider also enabling the `Attach CSV To Incident Email` option to avoid rendering redundant tables in the incident email.
 
 ## Policy Actions
 

--- a/operational/flexera/cco/bc_report/README.md
+++ b/operational/flexera/cco/bc_report/README.md
@@ -9,6 +9,7 @@ This policy template reports on all Billing Centers within the Flexera organizat
 - *Email Addresses* - A list of email addresses to notify.
 - *Attach CSV To Incident Email* - Whether or not to attach the results as a CSV file to the incident email.
 - *Incident Table Rows for Email Body (#)* - The number of results to include in the incident table in the incident email. Set to '0' to not show an incident table at all, and '100000' to include all results. Does not impact attached CSV files or the incident as presented in Flexera One.
+- *Include Data Table In Incident* - Whether to also include a formatted table of the underlying Billing Center data within the body of the incident, in addition to the summary details. If you enable this option, consider also setting the `Attach CSV To Incident Email` parameter to `true` to avoid rendering redundant tables in the incident email.
 
 ## Policy Actions
 

--- a/operational/flexera/cco/bc_report/flexera_bc_report.pt
+++ b/operational/flexera/cco/bc_report/flexera_bc_report.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.1.0",
+  version: "0.2.0",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -43,6 +43,15 @@ parameter "param_incident_table_size" do
   description "The number of results to include in the incident table in the incident email. Set to '0' to not show an incident table at all, and '100000' to include all results. Does not impact attached CSV files or the incident as presented in Flexera One."
   allowed_values 0, 10, 50, 100, 200, 500, 1000, 10000, 100000
   default 100000
+end
+
+parameter "param_incident_data_table" do
+  type "string"
+  category "Incident Settings"
+  label "Include Data Table In Incident"
+  description "Whether to also include a formatted table of the underlying Billing Center data within the body of the incident, in addition to the summary details. If you enable this option, consider also setting the 'Attach CSV To Incident Email' parameter to 'true' to avoid rendering redundant tables in the incident email."
+  allowed_values "true", "false"
+  default "false"
 end
 
 ###############################################################################
@@ -136,14 +145,31 @@ datasource "ds_billing_centers" do
 end
 
 datasource "ds_report" do
-  run_script $js_report, $ds_billing_centers, $ds_applied_policy, $param_incident_csv
+  run_script $js_report, $ds_billing_centers, $ds_applied_policy, $param_incident_csv, $param_incident_data_table
 end
 
 script "js_report", type: "javascript" do
-  parameters "ds_billing_centers", "ds_applied_policy", "param_incident_csv"
+  parameters "ds_billing_centers", "ds_applied_policy", "param_incident_csv", "param_incident_data_table"
   result "result"
   code <<-'EOS'
   csv_message = param_incident_csv == "false" ? "" : " Incident table CSV file has been attached to emails for this incident."
+
+  function build_data_table(items) {
+    header = "| Billing Center ID | Billing Center Name | Description | Created At | Updated At | Parent Billing Center ID | Parent Billing Center Name |"
+    divider = "| --- | --- | --- | --- | --- | --- | --- |"
+
+    rows = _.map(items, function(item) {
+      return "| " + item['id'] +
+        " | " + item['name'] +
+        " | " + (item['description'] || "") +
+        " | " + (item['createdAt'] || "") +
+        " | " + (item['updatedAt'] || "") +
+        " | " + (item['parentId'] || "") +
+        " | " + (item['parentName'] || "") + " |"
+    })
+
+    return [header, divider].concat(rows).join("\n")
+  }
 
   // Build a lookup table of all Billing Centers (including "unallocated" ones) so parent
   // names can be resolved even though "unallocated" Billing Centers are excluded from the report.
@@ -174,6 +200,10 @@ script "js_report", type: "javascript" do
   if (result.length > 0) {
     result[0]['policy_name'] = ds_applied_policy['name']
     result[0]['message'] = "Total Billing Centers Found: " + result.length + csv_message
+
+    if (param_incident_data_table == "true") {
+      result[0]['data_table'] = build_data_table(result)
+    }
   }
 EOS
 end
@@ -187,6 +217,12 @@ policy "pol_bc_report" do
     summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Billing Centers Found"
     detail_template <<-'EOS'
     **Details:** {{ with index data 0 }}{{ .message }}{{ end }}
+
+    {{ if eq parameters.param_incident_data_table "true" }}
+    ## Data Table
+
+    {{ with index data 0 }}{{ .data_table }}{{ end }}
+    {{ end }}
     EOS
     check eq(val(item, "id"), "")
     escalate $esc_email

--- a/operational/flexera/cco/bc_report/flexera_bc_report.pt
+++ b/operational/flexera/cco/bc_report/flexera_bc_report.pt
@@ -49,7 +49,7 @@ parameter "param_incident_data_table" do
   type "string"
   category "Incident Settings"
   label "Include Data Table In Incident"
-  description "Whether to also include a formatted table of the underlying Billing Center data within the body of the incident, in addition to the summary details. If you enable this option, consider also setting the 'Attach CSV To Incident Email' parameter to 'true' to avoid rendering redundant tables in the incident email."
+  description "Whether to also include a formatted table of the underlying Billing Center data within the body of the incident, in addition to the summary details. If you enable this option, consider also enabling the 'Attach CSV To Incident Email' option to avoid rendering redundant tables in the incident email."
   allowed_values "true", "false"
   default "false"
 end


### PR DESCRIPTION
### Description

Adds an option to render the data table as a nicely formatted markdown table in a handful of policy templates. This is primarily useful for making the table look nice in emails compared to a traditional export table.

Also adds CSV support to some of these policy templates so that the email won't contain redundant tables if desired by the end user.

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=6a636f638c66f274f3a246c1

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
