### PR TITLE
FOPTS-27963 Fix overlapping X-axis date labels in scheduled report chart

### DIFF
--- a/cost/flexera/cco/scheduled_reports/CHANGELOG.md
+++ b/cost/flexera/cco/scheduled_reports/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.1.2
+
+- Fixed X-axis date labels overlapping in the report chart when `Billing Term` is set to `Day` over a multi-month date range.
+
 ## v4.1.1
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/flexera/cco/scheduled_reports/scheduled_report.pt
+++ b/cost/flexera/cco/scheduled_reports/scheduled_report.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "monthly"
 info(
-  version: "4.1.1",
+  version: "4.1.2",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -1094,9 +1094,13 @@ script "js_generated_report", type: "javascript" do
   if (encodedCategories.length < 1)  { chartCategories = "chdl=Unknown" }
   if (encodedCategories.length >= 1) { chartCategories = "chdl=" + encodedCategories }
 
-  if (param_billing_term == "Month") { chartXAxis = "chxl=0:|" + stringMonths.join('|') }
-  if (param_billing_term == "Day")   { chartXAxis = "chxl=0:|" + stringDays.join('|')   }
-  if (param_billing_term == "Week")  { chartXAxis = "chxl=0:|" + stringWeeks.join('|')  }
+  function padAxisLabels(labels) {
+    return _.map(labels, function(label) { return "++" + label + "++" })
+  }
+
+  if (param_billing_term == "Month") { chartXAxis = "chxl=0:|" + padAxisLabels(stringMonths).join('|') }
+  if (param_billing_term == "Day")   { chartXAxis = "chxl=0:|" + padAxisLabels(stringDays).join('|')   }
+  if (param_billing_term == "Week")  { chartXAxis = "chxl=0:|" + padAxisLabels(stringWeeks).join('|')  }
 
   if (param_billing_centers.length == 0) { billingCenters = "All" }
   if (param_billing_centers.length != 0) { billingCenters = param_billing_centers.join(', ') }
@@ -1131,7 +1135,7 @@ script "js_generated_report", type: "javascript" do
     chartTitle: encodeURI('chtt=Spending+Overview'),
     chartAxis: encodeURI('chxt=x,y'),
     chartXAxis: encodeURI(chartXAxis),
-    chartAxisFormat: encodeURI('chxs=1N*c' + ds_currency['code'] + 's*'),
+    chartAxisFormat: encodeURI('chxs=1N*c' + ds_currency['code'] + 's*|0,s'),
     chartData: encodeURI(chartData),
     chartCategories: chartCategories,
     chartColors: encodeURI(chartColors),


### PR DESCRIPTION
### Description

Fixes SQ-26519: X-axis date labels in the scheduled reports spending chart were rendering as an overlapping, unreadable block for customers over multi-month date ranges. The chxs axis style parameter only configured the Y-axis (currency formatting), the X-axis had no label-skipping or rotation, so every daily label was drawn with no thinning.

Added opt_skip_labels (s) to the X-axis entry in chxs, so Image-Charts automatically thins out labels when there are too many for the available width, instead of rendering all of them.

### Link to Example Applied Policy

[6a6a0aeb7c9b4608965b31de](https://app.flexeratest.com/orgs/1105/automation/applied-policies/projects/107982?policyId=6a6a0aeb7c9b4608965b31de)

### Example chart:

<img width="400" height="250" alt="before" src="https://github.com/user-attachments/assets/6550a297-a28f-4930-999b-3a425bdda295" />
<img width="400" height="250" alt="after" src="https://github.com/user-attachments/assets/767f7848-b806-4d53-bec4-a1e5f02f18e4" />


<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD