### PR TITLE
POL-1808 Azure Meta Parent Fix

### DIFF
--- a/compliance/azure/advisor_carbon/azure_advisor_carbon_meta_parent.pt
+++ b/compliance/azure/advisor_carbon/azure_advisor_carbon_meta_parent.pt
@@ -754,7 +754,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/compliance/azure/advisor_carbon/azure_advisor_carbon_meta_parent_rg.pt
+++ b/compliance/azure/advisor_carbon/azure_advisor_carbon_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -213,7 +222,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/compliance/azure/advisor_carbon/azure_advisor_carbon_meta_parent_rg.pt
+++ b/compliance/azure/advisor_carbon/azure_advisor_carbon_meta_parent_rg.pt
@@ -374,6 +374,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -651,7 +670,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -664,7 +683,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -753,7 +772,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry_meta_parent.pt
+++ b/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry_meta_parent.pt
@@ -780,7 +780,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry_meta_parent_rg.pt
+++ b/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry_meta_parent_rg.pt
@@ -400,6 +400,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -677,7 +696,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -690,7 +709,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -779,7 +798,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry_meta_parent_rg.pt
+++ b/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -239,7 +248,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent.pt
+++ b/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent.pt
@@ -781,7 +781,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent_rg.pt
+++ b/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -240,7 +249,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent_rg.pt
+++ b/compliance/azure/azure_disallowed_regions/azure_disallowed_regions_meta_parent_rg.pt
@@ -401,6 +401,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -678,7 +697,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -691,7 +710,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -780,7 +799,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/compliance/azure/azure_policy_audit/azure_policy_audit_meta_parent.pt
+++ b/compliance/azure/azure_policy_audit/azure_policy_audit_meta_parent.pt
@@ -745,7 +745,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent.pt
+++ b/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent.pt
@@ -806,7 +806,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent_rg.pt
+++ b/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent_rg.pt
@@ -426,6 +426,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -703,7 +722,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -716,7 +735,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -805,7 +824,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent_rg.pt
+++ b/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -265,7 +274,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/compliance/azure/azure_untagged_vms/untagged_vms_meta_parent.pt
+++ b/compliance/azure/azure_untagged_vms/untagged_vms_meta_parent.pt
@@ -798,7 +798,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/compliance/azure/azure_untagged_vms/untagged_vms_meta_parent_rg.pt
+++ b/compliance/azure/azure_untagged_vms/untagged_vms_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -257,7 +266,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/compliance/azure/azure_untagged_vms/untagged_vms_meta_parent_rg.pt
+++ b/compliance/azure/azure_untagged_vms/untagged_vms_meta_parent_rg.pt
@@ -418,6 +418,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -695,7 +714,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -708,7 +727,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -797,7 +816,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/compliance/azure/compliance_score/azure_regulatory_compliance_report_meta_parent.pt
+++ b/compliance/azure/compliance_score/azure_regulatory_compliance_report_meta_parent.pt
@@ -737,7 +737,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/compliance/azure/deprecated_storage_accounts/azure_deprecated_storage_accounts_meta_parent.pt
+++ b/compliance/azure/deprecated_storage_accounts/azure_deprecated_storage_accounts_meta_parent.pt
@@ -771,7 +771,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/compliance/azure/deprecated_storage_accounts/azure_deprecated_storage_accounts_meta_parent_rg.pt
+++ b/compliance/azure/deprecated_storage_accounts/azure_deprecated_storage_accounts_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -230,7 +239,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/compliance/azure/deprecated_storage_accounts/azure_deprecated_storage_accounts_meta_parent_rg.pt
+++ b/compliance/azure/deprecated_storage_accounts/azure_deprecated_storage_accounts_meta_parent_rg.pt
@@ -391,6 +391,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -668,7 +687,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -681,7 +700,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -770,7 +789,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
+++ b/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent_meta_parent.pt
@@ -762,7 +762,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/advisor_compute/azure_advisor_compute_meta_parent.pt
+++ b/cost/azure/advisor_compute/azure_advisor_compute_meta_parent.pt
@@ -807,7 +807,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/advisor_compute/azure_advisor_compute_meta_parent_rg.pt
+++ b/cost/azure/advisor_compute/azure_advisor_compute_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -266,7 +275,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/advisor_compute/azure_advisor_compute_meta_parent_rg.pt
+++ b/cost/azure/advisor_compute/azure_advisor_compute_meta_parent_rg.pt
@@ -427,6 +427,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -704,7 +723,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -717,7 +736,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -806,7 +825,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/blob_storage_optimization/azure_blob_storage_optimization_meta_parent.pt
+++ b/cost/azure/blob_storage_optimization/azure_blob_storage_optimization_meta_parent.pt
@@ -822,7 +822,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/blob_storage_optimization/azure_blob_storage_optimization_meta_parent_rg.pt
+++ b/cost/azure/blob_storage_optimization/azure_blob_storage_optimization_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -281,7 +290,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/blob_storage_optimization/azure_blob_storage_optimization_meta_parent_rg.pt
+++ b/cost/azure/blob_storage_optimization/azure_blob_storage_optimization_meta_parent_rg.pt
@@ -442,6 +442,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -719,7 +738,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -732,7 +751,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -821,7 +840,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/data_lake_optimization/data_lake_optimization_meta_parent.pt
+++ b/cost/azure/data_lake_optimization/data_lake_optimization_meta_parent.pt
@@ -831,7 +831,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/data_lake_optimization/data_lake_optimization_meta_parent_rg.pt
+++ b/cost/azure/data_lake_optimization/data_lake_optimization_meta_parent_rg.pt
@@ -451,6 +451,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -728,7 +747,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -741,7 +760,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -830,7 +849,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/data_lake_optimization/data_lake_optimization_meta_parent_rg.pt
+++ b/cost/azure/data_lake_optimization/data_lake_optimization_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -290,7 +299,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/databricks/rightsize_compute/azure_databricks_rightsize_compute_meta_parent.pt
+++ b/cost/azure/databricks/rightsize_compute/azure_databricks_rightsize_compute_meta_parent.pt
@@ -854,7 +854,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/databricks/rightsize_compute/azure_databricks_rightsize_compute_meta_parent_rg.pt
+++ b/cost/azure/databricks/rightsize_compute/azure_databricks_rightsize_compute_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -313,7 +322,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/databricks/rightsize_compute/azure_databricks_rightsize_compute_meta_parent_rg.pt
+++ b/cost/azure/databricks/rightsize_compute/azure_databricks_rightsize_compute_meta_parent_rg.pt
@@ -474,6 +474,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -751,7 +770,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -764,7 +783,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -853,7 +872,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
@@ -789,7 +789,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent_rg.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -248,7 +257,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent_rg.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent_rg.pt
@@ -409,6 +409,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -686,7 +705,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -699,7 +718,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -788,7 +807,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
@@ -789,7 +789,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent_rg.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -248,7 +257,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent_rg.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent_rg.pt
@@ -409,6 +409,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -686,7 +705,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -699,7 +718,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -788,7 +807,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
@@ -807,7 +807,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent_rg.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -266,7 +275,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent_rg.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent_rg.pt
@@ -427,6 +427,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -704,7 +723,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -717,7 +736,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -806,7 +825,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/idle_ml_online_endpoints/azure_idle_ml_online_endpoints_meta_parent.pt
+++ b/cost/azure/idle_ml_online_endpoints/azure_idle_ml_online_endpoints_meta_parent.pt
@@ -816,7 +816,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/idle_ml_online_endpoints/azure_idle_ml_online_endpoints_meta_parent_rg.pt
+++ b/cost/azure/idle_ml_online_endpoints/azure_idle_ml_online_endpoints_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -275,7 +284,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/idle_ml_online_endpoints/azure_idle_ml_online_endpoints_meta_parent_rg.pt
+++ b/cost/azure/idle_ml_online_endpoints/azure_idle_ml_online_endpoints_meta_parent_rg.pt
@@ -436,6 +436,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -713,7 +732,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -726,7 +745,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -815,7 +834,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/long_stopped_instances/long_stopped_instances_azure_meta_parent.pt
+++ b/cost/azure/long_stopped_instances/long_stopped_instances_azure_meta_parent.pt
@@ -808,7 +808,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/long_stopped_instances/long_stopped_instances_azure_meta_parent_rg.pt
+++ b/cost/azure/long_stopped_instances/long_stopped_instances_azure_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -267,7 +276,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/long_stopped_instances/long_stopped_instances_azure_meta_parent_rg.pt
+++ b/cost/azure/long_stopped_instances/long_stopped_instances_azure_meta_parent_rg.pt
@@ -428,6 +428,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -705,7 +724,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -718,7 +737,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -807,7 +826,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
@@ -798,7 +798,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent_rg.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -257,7 +266,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent_rg.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent_rg.pt
@@ -418,6 +418,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -695,7 +714,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -708,7 +727,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -797,7 +816,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/reserved_instances/recommendations/azure_reserved_instance_recommendations_meta_parent.pt
+++ b/cost/azure/reserved_instances/recommendations/azure_reserved_instance_recommendations_meta_parent.pt
@@ -817,7 +817,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/reserved_instances/recommendations/azure_reserved_instance_recommendations_meta_parent_rg.pt
+++ b/cost/azure/reserved_instances/recommendations/azure_reserved_instance_recommendations_meta_parent_rg.pt
@@ -437,6 +437,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -714,7 +733,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -727,7 +746,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -816,7 +835,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/reserved_instances/recommendations/azure_reserved_instance_recommendations_meta_parent_rg.pt
+++ b/cost/azure/reserved_instances/recommendations/azure_reserved_instance_recommendations_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -276,7 +285,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
@@ -911,7 +911,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent_rg.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -370,7 +379,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent_rg.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent_rg.pt
@@ -531,6 +531,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -808,7 +827,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -821,7 +840,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -910,7 +929,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/rightsize_compute_instances_cross_family/azure_rightsize_compute_instances_cross_family_meta_parent.pt
+++ b/cost/azure/rightsize_compute_instances_cross_family/azure_rightsize_compute_instances_cross_family_meta_parent.pt
@@ -835,7 +835,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/rightsize_compute_instances_cross_family/azure_rightsize_compute_instances_cross_family_meta_parent_rg.pt
+++ b/cost/azure/rightsize_compute_instances_cross_family/azure_rightsize_compute_instances_cross_family_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -294,7 +303,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/rightsize_compute_instances_cross_family/azure_rightsize_compute_instances_cross_family_meta_parent_rg.pt
+++ b/cost/azure/rightsize_compute_instances_cross_family/azure_rightsize_compute_instances_cross_family_meta_parent_rg.pt
@@ -455,6 +455,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -732,7 +751,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -745,7 +764,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -834,7 +853,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks_meta_parent.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks_meta_parent.pt
@@ -854,7 +854,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks_meta_parent_rg.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -313,7 +322,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks_meta_parent_rg.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks_meta_parent_rg.pt
@@ -474,6 +474,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -751,7 +770,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -764,7 +783,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -853,7 +872,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql_meta_parent.pt
+++ b/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql_meta_parent.pt
@@ -836,7 +836,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql_meta_parent_rg.pt
+++ b/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -295,7 +304,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql_meta_parent_rg.pt
+++ b/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql_meta_parent_rg.pt
@@ -456,6 +456,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -733,7 +752,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -746,7 +765,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -835,7 +854,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/rightsize_managed_sql_storage/azure_rightsize_managed_sql_storage_meta_parent.pt
+++ b/cost/azure/rightsize_managed_sql_storage/azure_rightsize_managed_sql_storage_meta_parent.pt
@@ -799,7 +799,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/rightsize_managed_sql_storage/azure_rightsize_managed_sql_storage_meta_parent_rg.pt
+++ b/cost/azure/rightsize_managed_sql_storage/azure_rightsize_managed_sql_storage_meta_parent_rg.pt
@@ -419,6 +419,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -696,7 +715,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -709,7 +728,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -798,7 +817,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/rightsize_managed_sql_storage/azure_rightsize_managed_sql_storage_meta_parent_rg.pt
+++ b/cost/azure/rightsize_managed_sql_storage/azure_rightsize_managed_sql_storage_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -258,7 +267,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible_meta_parent.pt
+++ b/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible_meta_parent.pt
@@ -845,7 +845,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible_meta_parent_rg.pt
+++ b/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible_meta_parent_rg.pt
@@ -465,6 +465,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -742,7 +761,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -755,7 +774,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -844,7 +863,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible_meta_parent_rg.pt
+++ b/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -304,7 +313,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single_meta_parent.pt
+++ b/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single_meta_parent.pt
@@ -845,7 +845,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single_meta_parent_rg.pt
+++ b/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single_meta_parent_rg.pt
@@ -465,6 +465,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -742,7 +761,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -755,7 +774,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -844,7 +863,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single_meta_parent_rg.pt
+++ b/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -304,7 +313,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/rightsize_netapp/azure_rightsize_netapp_meta_parent.pt
+++ b/cost/azure/rightsize_netapp/azure_rightsize_netapp_meta_parent.pt
@@ -827,7 +827,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/rightsize_netapp/azure_rightsize_netapp_meta_parent_rg.pt
+++ b/cost/azure/rightsize_netapp/azure_rightsize_netapp_meta_parent_rg.pt
@@ -447,6 +447,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -724,7 +743,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -737,7 +756,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -826,7 +845,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/rightsize_netapp/azure_rightsize_netapp_meta_parent_rg.pt
+++ b/cost/azure/rightsize_netapp/azure_rightsize_netapp_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -286,7 +295,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/rightsize_postgresql_flexible/azure_rightsize_postgresql_flexible_meta_parent.pt
+++ b/cost/azure/rightsize_postgresql_flexible/azure_rightsize_postgresql_flexible_meta_parent.pt
@@ -854,7 +854,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/rightsize_postgresql_flexible/azure_rightsize_postgresql_flexible_meta_parent_rg.pt
+++ b/cost/azure/rightsize_postgresql_flexible/azure_rightsize_postgresql_flexible_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -313,7 +322,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/rightsize_postgresql_flexible/azure_rightsize_postgresql_flexible_meta_parent_rg.pt
+++ b/cost/azure/rightsize_postgresql_flexible/azure_rightsize_postgresql_flexible_meta_parent_rg.pt
@@ -474,6 +474,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -751,7 +770,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -764,7 +783,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -853,7 +872,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/rightsize_postgresql_single/azure_rightsize_postgresql_single_meta_parent.pt
+++ b/cost/azure/rightsize_postgresql_single/azure_rightsize_postgresql_single_meta_parent.pt
@@ -854,7 +854,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/rightsize_postgresql_single/azure_rightsize_postgresql_single_meta_parent_rg.pt
+++ b/cost/azure/rightsize_postgresql_single/azure_rightsize_postgresql_single_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -313,7 +322,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/rightsize_postgresql_single/azure_rightsize_postgresql_single_meta_parent_rg.pt
+++ b/cost/azure/rightsize_postgresql_single/azure_rightsize_postgresql_single_meta_parent_rg.pt
@@ -474,6 +474,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -751,7 +770,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -764,7 +783,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -853,7 +872,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
@@ -864,7 +864,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent_rg.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent_rg.pt
@@ -484,6 +484,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -761,7 +780,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -774,7 +793,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -863,7 +882,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent_rg.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -323,7 +332,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/rightsize_sql_storage/azure_rightsize_sql_storage_meta_parent.pt
+++ b/cost/azure/rightsize_sql_storage/azure_rightsize_sql_storage_meta_parent.pt
@@ -809,7 +809,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/rightsize_sql_storage/azure_rightsize_sql_storage_meta_parent_rg.pt
+++ b/cost/azure/rightsize_sql_storage/azure_rightsize_sql_storage_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -268,7 +277,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/rightsize_sql_storage/azure_rightsize_sql_storage_meta_parent_rg.pt
+++ b/cost/azure/rightsize_sql_storage/azure_rightsize_sql_storage_meta_parent_rg.pt
@@ -429,6 +429,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -706,7 +725,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -719,7 +738,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -808,7 +827,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/savings_plan/recommendations/azure_savings_plan_recommendations_meta_parent.pt
+++ b/cost/azure/savings_plan/recommendations/azure_savings_plan_recommendations_meta_parent.pt
@@ -782,7 +782,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/savings_plan/recommendations/azure_savings_plan_recommendations_meta_parent_rg.pt
+++ b/cost/azure/savings_plan/recommendations/azure_savings_plan_recommendations_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -241,7 +250,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/savings_plan/recommendations/azure_savings_plan_recommendations_meta_parent_rg.pt
+++ b/cost/azure/savings_plan/recommendations/azure_savings_plan_recommendations_meta_parent_rg.pt
@@ -402,6 +402,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -679,7 +698,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -692,7 +711,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -781,7 +800,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
@@ -814,7 +814,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/schedule_instance/azure_schedule_instance_meta_parent_rg.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance_meta_parent_rg.pt
@@ -434,6 +434,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -711,7 +730,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -724,7 +743,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -813,7 +832,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/schedule_instance/azure_schedule_instance_meta_parent_rg.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -273,7 +282,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/sentinel_commitment_tiers/azure_sentinel_commitment_tiers_meta_parent.pt
+++ b/cost/azure/sentinel_commitment_tiers/azure_sentinel_commitment_tiers_meta_parent.pt
@@ -756,7 +756,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/sentinel_commitment_tiers/azure_sentinel_commitment_tiers_meta_parent_rg.pt
+++ b/cost/azure/sentinel_commitment_tiers/azure_sentinel_commitment_tiers_meta_parent_rg.pt
@@ -376,6 +376,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -653,7 +672,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -666,7 +685,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -755,7 +774,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/sentinel_commitment_tiers/azure_sentinel_commitment_tiers_meta_parent_rg.pt
+++ b/cost/azure/sentinel_commitment_tiers/azure_sentinel_commitment_tiers_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -215,7 +224,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/sql_servers_without_elastic_pool/azure_sql_servers_without_elastic_pool_meta_parent.pt
+++ b/cost/azure/sql_servers_without_elastic_pool/azure_sql_servers_without_elastic_pool_meta_parent.pt
@@ -771,7 +771,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/sql_servers_without_elastic_pool/azure_sql_servers_without_elastic_pool_meta_parent_rg.pt
+++ b/cost/azure/sql_servers_without_elastic_pool/azure_sql_servers_without_elastic_pool_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -230,7 +239,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/sql_servers_without_elastic_pool/azure_sql_servers_without_elastic_pool_meta_parent_rg.pt
+++ b/cost/azure/sql_servers_without_elastic_pool/azure_sql_servers_without_elastic_pool_meta_parent_rg.pt
@@ -391,6 +391,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -668,7 +687,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -681,7 +700,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -770,7 +789,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent.pt
+++ b/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent.pt
@@ -771,7 +771,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent_rg.pt
+++ b/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -230,7 +239,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent_rg.pt
+++ b/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management_meta_parent_rg.pt
@@ -391,6 +391,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -668,7 +687,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -681,7 +700,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -770,7 +789,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
@@ -789,7 +789,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/superseded_instances/azure_superseded_instances_meta_parent_rg.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -248,7 +257,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/superseded_instances/azure_superseded_instances_meta_parent_rg.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances_meta_parent_rg.pt
@@ -409,6 +409,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -686,7 +705,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -699,7 +718,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -788,7 +807,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/unoptimized_web_app_scaling/azure_unoptimized_web_app_scaling_meta_parent.pt
+++ b/cost/azure/unoptimized_web_app_scaling/azure_unoptimized_web_app_scaling_meta_parent.pt
@@ -772,7 +772,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/unoptimized_web_app_scaling/azure_unoptimized_web_app_scaling_meta_parent_rg.pt
+++ b/cost/azure/unoptimized_web_app_scaling/azure_unoptimized_web_app_scaling_meta_parent_rg.pt
@@ -392,6 +392,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -669,7 +688,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -682,7 +701,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -771,7 +790,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/unoptimized_web_app_scaling/azure_unoptimized_web_app_scaling_meta_parent_rg.pt
+++ b/cost/azure/unoptimized_web_app_scaling/azure_unoptimized_web_app_scaling_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -231,7 +240,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/unused_app_service_plans/azure_unused_app_service_plans_meta_parent.pt
+++ b/cost/azure/unused_app_service_plans/azure_unused_app_service_plans_meta_parent.pt
@@ -789,7 +789,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/unused_app_service_plans/azure_unused_app_service_plans_meta_parent_rg.pt
+++ b/cost/azure/unused_app_service_plans/azure_unused_app_service_plans_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -248,7 +257,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/unused_app_service_plans/azure_unused_app_service_plans_meta_parent_rg.pt
+++ b/cost/azure/unused_app_service_plans/azure_unused_app_service_plans_meta_parent_rg.pt
@@ -409,6 +409,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -686,7 +705,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -699,7 +718,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -788,7 +807,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/unused_firewalls/azure_unused_firewalls_meta_parent.pt
+++ b/cost/azure/unused_firewalls/azure_unused_firewalls_meta_parent.pt
@@ -799,7 +799,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/unused_firewalls/azure_unused_firewalls_meta_parent_rg.pt
+++ b/cost/azure/unused_firewalls/azure_unused_firewalls_meta_parent_rg.pt
@@ -419,6 +419,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -696,7 +715,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -709,7 +728,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -798,7 +817,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/unused_firewalls/azure_unused_firewalls_meta_parent_rg.pt
+++ b/cost/azure/unused_firewalls/azure_unused_firewalls_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -258,7 +267,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
@@ -808,7 +808,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent_rg.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -267,7 +276,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent_rg.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent_rg.pt
@@ -428,6 +428,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -705,7 +724,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -718,7 +737,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -807,7 +826,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/unused_load_balancers/azure_unused_load_balancers_meta_parent.pt
+++ b/cost/azure/unused_load_balancers/azure_unused_load_balancers_meta_parent.pt
@@ -799,7 +799,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/unused_load_balancers/azure_unused_load_balancers_meta_parent_rg.pt
+++ b/cost/azure/unused_load_balancers/azure_unused_load_balancers_meta_parent_rg.pt
@@ -419,6 +419,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -696,7 +715,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -709,7 +728,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -798,7 +817,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/unused_load_balancers/azure_unused_load_balancers_meta_parent_rg.pt
+++ b/cost/azure/unused_load_balancers/azure_unused_load_balancers_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -258,7 +267,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/unused_storage_accounts/azure_unused_storage_accounts_meta_parent.pt
+++ b/cost/azure/unused_storage_accounts/azure_unused_storage_accounts_meta_parent.pt
@@ -808,7 +808,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/unused_storage_accounts/azure_unused_storage_accounts_meta_parent_rg.pt
+++ b/cost/azure/unused_storage_accounts/azure_unused_storage_accounts_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -267,7 +276,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/unused_storage_accounts/azure_unused_storage_accounts_meta_parent_rg.pt
+++ b/cost/azure/unused_storage_accounts/azure_unused_storage_accounts_meta_parent_rg.pt
@@ -428,6 +428,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -705,7 +724,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -718,7 +737,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -807,7 +826,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/unused_vngs/azure_unused_vngs_meta_parent.pt
+++ b/cost/azure/unused_vngs/azure_unused_vngs_meta_parent.pt
@@ -780,7 +780,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/unused_vngs/azure_unused_vngs_meta_parent_rg.pt
+++ b/cost/azure/unused_vngs/azure_unused_vngs_meta_parent_rg.pt
@@ -400,6 +400,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -677,7 +696,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -690,7 +709,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -779,7 +798,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/cost/azure/unused_vngs/azure_unused_vngs_meta_parent_rg.pt
+++ b/cost/azure/unused_vngs/azure_unused_vngs_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -239,7 +248,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
@@ -826,7 +826,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/cost/azure/unused_volumes/azure_unused_volumes_meta_parent_rg.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -285,7 +294,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/cost/azure/unused_volumes/azure_unused_volumes_meta_parent_rg.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes_meta_parent_rg.pt
@@ -446,6 +446,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -723,7 +742,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -736,7 +755,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -825,7 +844,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/operational/azure/aks_nodepools_without_autoscaling/aks_nodepools_without_autoscaling_meta_parent.pt
+++ b/operational/azure/aks_nodepools_without_autoscaling/aks_nodepools_without_autoscaling_meta_parent.pt
@@ -771,7 +771,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/operational/azure/aks_nodepools_without_autoscaling/aks_nodepools_without_autoscaling_meta_parent_rg.pt
+++ b/operational/azure/aks_nodepools_without_autoscaling/aks_nodepools_without_autoscaling_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -230,7 +239,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/operational/azure/aks_nodepools_without_autoscaling/aks_nodepools_without_autoscaling_meta_parent_rg.pt
+++ b/operational/azure/aks_nodepools_without_autoscaling/aks_nodepools_without_autoscaling_meta_parent_rg.pt
@@ -391,6 +391,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -668,7 +687,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -681,7 +700,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -770,7 +789,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/operational/azure/aks_nodepools_without_zero_autoscaling/aks_nodepools_without_zero_autoscaling_meta_parent.pt
+++ b/operational/azure/aks_nodepools_without_zero_autoscaling/aks_nodepools_without_zero_autoscaling_meta_parent.pt
@@ -771,7 +771,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/operational/azure/aks_nodepools_without_zero_autoscaling/aks_nodepools_without_zero_autoscaling_meta_parent_rg.pt
+++ b/operational/azure/aks_nodepools_without_zero_autoscaling/aks_nodepools_without_zero_autoscaling_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -230,7 +239,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/operational/azure/aks_nodepools_without_zero_autoscaling/aks_nodepools_without_zero_autoscaling_meta_parent_rg.pt
+++ b/operational/azure/aks_nodepools_without_zero_autoscaling/aks_nodepools_without_zero_autoscaling_meta_parent_rg.pt
@@ -391,6 +391,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -668,7 +687,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -681,7 +700,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -770,7 +789,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
+++ b/operational/azure/azure_certificates/azure_certificates_meta_parent.pt
@@ -789,7 +789,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/operational/azure/azure_certificates/azure_certificates_meta_parent_rg.pt
+++ b/operational/azure/azure_certificates/azure_certificates_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -248,7 +257,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/operational/azure/azure_certificates/azure_certificates_meta_parent_rg.pt
+++ b/operational/azure/azure_certificates/azure_certificates_meta_parent_rg.pt
@@ -409,6 +409,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -686,7 +705,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -699,7 +718,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -788,7 +807,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
@@ -798,7 +798,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent_rg.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -257,7 +266,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent_rg.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent_rg.pt
@@ -418,6 +418,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -695,7 +714,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -708,7 +727,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -797,7 +816,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/operational/azure/compute_poweredoff_report/azure_compute_poweredoff_report_meta_parent.pt
+++ b/operational/azure/compute_poweredoff_report/azure_compute_poweredoff_report_meta_parent.pt
@@ -837,7 +837,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/operational/azure/compute_poweredoff_report/azure_compute_poweredoff_report_meta_parent_rg.pt
+++ b/operational/azure/compute_poweredoff_report/azure_compute_poweredoff_report_meta_parent_rg.pt
@@ -457,6 +457,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -734,7 +753,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -747,7 +766,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -836,7 +855,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/operational/azure/compute_poweredoff_report/azure_compute_poweredoff_report_meta_parent_rg.pt
+++ b/operational/azure/compute_poweredoff_report/azure_compute_poweredoff_report_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -296,7 +305,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/operational/azure/overutilized_compute_instances/azure_compute_overutilized_meta_parent.pt
+++ b/operational/azure/overutilized_compute_instances/azure_compute_overutilized_meta_parent.pt
@@ -855,7 +855,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/operational/azure/overutilized_compute_instances/azure_compute_overutilized_meta_parent_rg.pt
+++ b/operational/azure/overutilized_compute_instances/azure_compute_overutilized_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -314,7 +323,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/operational/azure/overutilized_compute_instances/azure_compute_overutilized_meta_parent_rg.pt
+++ b/operational/azure/overutilized_compute_instances/azure_compute_overutilized_meta_parent_rg.pt
@@ -475,6 +475,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -752,7 +771,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -765,7 +784,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -854,7 +873,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
+++ b/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
@@ -745,7 +745,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent.pt
+++ b/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent.pt
@@ -771,7 +771,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent_rg.pt
+++ b/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -230,7 +239,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent_rg.pt
+++ b/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks_meta_parent_rg.pt
@@ -391,6 +391,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -668,7 +687,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -681,7 +700,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -770,7 +789,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/blob_storage_logging/blob_storage_logging_meta_parent.pt
+++ b/security/azure/blob_storage_logging/blob_storage_logging_meta_parent.pt
@@ -786,7 +786,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/blob_storage_logging/blob_storage_logging_meta_parent_rg.pt
+++ b/security/azure/blob_storage_logging/blob_storage_logging_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -245,7 +254,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/blob_storage_logging/blob_storage_logging_meta_parent_rg.pt
+++ b/security/azure/blob_storage_logging/blob_storage_logging_meta_parent_rg.pt
@@ -406,6 +406,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -683,7 +702,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -696,7 +715,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -785,7 +804,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/eol_resources/azure_eol_resources_meta_parent.pt
+++ b/security/azure/eol_resources/azure_eol_resources_meta_parent.pt
@@ -780,7 +780,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/mysql_ssl/mysql_ssl_meta_parent.pt
+++ b/security/azure/mysql_ssl/mysql_ssl_meta_parent.pt
@@ -771,7 +771,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/mysql_ssl/mysql_ssl_meta_parent_rg.pt
+++ b/security/azure/mysql_ssl/mysql_ssl_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -230,7 +239,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/mysql_ssl/mysql_ssl_meta_parent_rg.pt
+++ b/security/azure/mysql_ssl/mysql_ssl_meta_parent_rg.pt
@@ -391,6 +391,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -668,7 +687,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -681,7 +700,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -770,7 +789,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/mysql_tls_version/mysql_tls_version_meta_parent.pt
+++ b/security/azure/mysql_tls_version/mysql_tls_version_meta_parent.pt
@@ -771,7 +771,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/mysql_tls_version/mysql_tls_version_meta_parent_rg.pt
+++ b/security/azure/mysql_tls_version/mysql_tls_version_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -230,7 +239,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/mysql_tls_version/mysql_tls_version_meta_parent_rg.pt
+++ b/security/azure/mysql_tls_version/mysql_tls_version_meta_parent_rg.pt
@@ -391,6 +391,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -668,7 +687,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -681,7 +700,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -770,7 +789,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/pg_conn_throttling/pg_conn_throttling_meta_parent.pt
+++ b/security/azure/pg_conn_throttling/pg_conn_throttling_meta_parent.pt
@@ -771,7 +771,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/pg_conn_throttling/pg_conn_throttling_meta_parent_rg.pt
+++ b/security/azure/pg_conn_throttling/pg_conn_throttling_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -230,7 +239,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/pg_conn_throttling/pg_conn_throttling_meta_parent_rg.pt
+++ b/security/azure/pg_conn_throttling/pg_conn_throttling_meta_parent_rg.pt
@@ -391,6 +391,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -668,7 +687,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -681,7 +700,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -770,7 +789,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/pg_infra_encryption/pg_infra_encryption_meta_parent.pt
+++ b/security/azure/pg_infra_encryption/pg_infra_encryption_meta_parent.pt
@@ -771,7 +771,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/pg_infra_encryption/pg_infra_encryption_meta_parent_rg.pt
+++ b/security/azure/pg_infra_encryption/pg_infra_encryption_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -230,7 +239,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/pg_infra_encryption/pg_infra_encryption_meta_parent_rg.pt
+++ b/security/azure/pg_infra_encryption/pg_infra_encryption_meta_parent_rg.pt
@@ -391,6 +391,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -668,7 +687,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -681,7 +700,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -770,7 +789,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/pg_log_retention/pg_log_retention_meta_parent.pt
+++ b/security/azure/pg_log_retention/pg_log_retention_meta_parent.pt
@@ -780,7 +780,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/pg_log_retention/pg_log_retention_meta_parent_rg.pt
+++ b/security/azure/pg_log_retention/pg_log_retention_meta_parent_rg.pt
@@ -400,6 +400,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -677,7 +696,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -690,7 +709,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -779,7 +798,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/pg_log_retention/pg_log_retention_meta_parent_rg.pt
+++ b/security/azure/pg_log_retention/pg_log_retention_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -239,7 +248,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/pg_log_settings/pg_log_settings_meta_parent.pt
+++ b/security/azure/pg_log_settings/pg_log_settings_meta_parent.pt
@@ -780,7 +780,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/pg_log_settings/pg_log_settings_meta_parent_rg.pt
+++ b/security/azure/pg_log_settings/pg_log_settings_meta_parent_rg.pt
@@ -400,6 +400,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -677,7 +696,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -690,7 +709,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -779,7 +798,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/pg_log_settings/pg_log_settings_meta_parent_rg.pt
+++ b/security/azure/pg_log_settings/pg_log_settings_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -239,7 +248,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/private_blob_containers/private_blob_containers_meta_parent.pt
+++ b/security/azure/private_blob_containers/private_blob_containers_meta_parent.pt
@@ -786,7 +786,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/private_blob_containers/private_blob_containers_meta_parent_rg.pt
+++ b/security/azure/private_blob_containers/private_blob_containers_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -245,7 +254,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/private_blob_containers/private_blob_containers_meta_parent_rg.pt
+++ b/security/azure/private_blob_containers/private_blob_containers_meta_parent_rg.pt
@@ -406,6 +406,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -683,7 +702,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -696,7 +715,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -785,7 +804,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/queue_storage_logging/queue_storage_logging_meta_parent.pt
+++ b/security/azure/queue_storage_logging/queue_storage_logging_meta_parent.pt
@@ -786,7 +786,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/queue_storage_logging/queue_storage_logging_meta_parent_rg.pt
+++ b/security/azure/queue_storage_logging/queue_storage_logging_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -245,7 +254,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/queue_storage_logging/queue_storage_logging_meta_parent_rg.pt
+++ b/security/azure/queue_storage_logging/queue_storage_logging_meta_parent_rg.pt
@@ -406,6 +406,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -683,7 +702,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -696,7 +715,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -785,7 +804,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/restrict_rdp_internet/azure_restrict_rdp_inet_meta_parent.pt
+++ b/security/azure/restrict_rdp_internet/azure_restrict_rdp_inet_meta_parent.pt
@@ -754,7 +754,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/restrict_rdp_internet/azure_restrict_rdp_inet_meta_parent_rg.pt
+++ b/security/azure/restrict_rdp_internet/azure_restrict_rdp_inet_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -213,7 +222,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/restrict_rdp_internet/azure_restrict_rdp_inet_meta_parent_rg.pt
+++ b/security/azure/restrict_rdp_internet/azure_restrict_rdp_inet_meta_parent_rg.pt
@@ -374,6 +374,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -651,7 +670,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -664,7 +683,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -753,7 +772,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/restrict_ssh_internet/azure_restrict_ssh_inet_meta_parent.pt
+++ b/security/azure/restrict_ssh_internet/azure_restrict_ssh_inet_meta_parent.pt
@@ -754,7 +754,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/restrict_ssh_internet/azure_restrict_ssh_inet_meta_parent_rg.pt
+++ b/security/azure/restrict_ssh_internet/azure_restrict_ssh_inet_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -213,7 +222,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/restrict_ssh_internet/azure_restrict_ssh_inet_meta_parent_rg.pt
+++ b/security/azure/restrict_ssh_internet/azure_restrict_ssh_inet_meta_parent_rg.pt
@@ -374,6 +374,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -651,7 +670,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -664,7 +683,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -753,7 +772,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/secure_transfer_required/secure_transfer_required_meta_parent.pt
+++ b/security/azure/secure_transfer_required/secure_transfer_required_meta_parent.pt
@@ -779,7 +779,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/secure_transfer_required/secure_transfer_required_meta_parent_rg.pt
+++ b/security/azure/secure_transfer_required/secure_transfer_required_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -238,7 +247,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/secure_transfer_required/secure_transfer_required_meta_parent_rg.pt
+++ b/security/azure/secure_transfer_required/secure_transfer_required_meta_parent_rg.pt
@@ -399,6 +399,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -676,7 +695,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -689,7 +708,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -778,7 +797,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/security_alert_owners/security_alert_owners_meta_parent.pt
+++ b/security/azure/security_alert_owners/security_alert_owners_meta_parent.pt
@@ -737,7 +737,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/security_contact_email/security_contact_email_meta_parent.pt
+++ b/security/azure/security_contact_email/security_contact_email_meta_parent.pt
@@ -737,7 +737,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/sql_ad_admin/sql_ad_admin_meta_parent.pt
+++ b/security/azure/sql_ad_admin/sql_ad_admin_meta_parent.pt
@@ -771,7 +771,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/sql_ad_admin/sql_ad_admin_meta_parent_rg.pt
+++ b/security/azure/sql_ad_admin/sql_ad_admin_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -230,7 +239,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/sql_ad_admin/sql_ad_admin_meta_parent_rg.pt
+++ b/security/azure/sql_ad_admin/sql_ad_admin_meta_parent_rg.pt
@@ -391,6 +391,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -668,7 +687,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -681,7 +700,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -770,7 +789,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/sql_auditing_retention/sql_auditing_retention_meta_parent.pt
+++ b/security/azure/sql_auditing_retention/sql_auditing_retention_meta_parent.pt
@@ -780,7 +780,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/sql_auditing_retention/sql_auditing_retention_meta_parent_rg.pt
+++ b/security/azure/sql_auditing_retention/sql_auditing_retention_meta_parent_rg.pt
@@ -400,6 +400,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -677,7 +696,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -690,7 +709,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -779,7 +798,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/sql_auditing_retention/sql_auditing_retention_meta_parent_rg.pt
+++ b/security/azure/sql_auditing_retention/sql_auditing_retention_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -239,7 +248,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/sql_db_encryption/sql_db_encryption_meta_parent.pt
+++ b/security/azure/sql_db_encryption/sql_db_encryption_meta_parent.pt
@@ -771,7 +771,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/sql_db_encryption/sql_db_encryption_meta_parent_rg.pt
+++ b/security/azure/sql_db_encryption/sql_db_encryption_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -230,7 +239,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/sql_db_encryption/sql_db_encryption_meta_parent_rg.pt
+++ b/security/azure/sql_db_encryption/sql_db_encryption_meta_parent_rg.pt
@@ -391,6 +391,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -668,7 +687,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -681,7 +700,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -770,7 +789,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/sql_publicly_accessible_managed_instance/sql_publicly_accessible_managed_instance_meta_parent.pt
+++ b/security/azure/sql_publicly_accessible_managed_instance/sql_publicly_accessible_managed_instance_meta_parent.pt
@@ -780,7 +780,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/sql_publicly_accessible_managed_instance/sql_publicly_accessible_managed_instance_meta_parent_rg.pt
+++ b/security/azure/sql_publicly_accessible_managed_instance/sql_publicly_accessible_managed_instance_meta_parent_rg.pt
@@ -400,6 +400,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -677,7 +696,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -690,7 +709,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -779,7 +798,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/sql_publicly_accessible_managed_instance/sql_publicly_accessible_managed_instance_meta_parent_rg.pt
+++ b/security/azure/sql_publicly_accessible_managed_instance/sql_publicly_accessible_managed_instance_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -239,7 +248,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/sql_server_atp/sql_server_atp_meta_parent.pt
+++ b/security/azure/sql_server_atp/sql_server_atp_meta_parent.pt
@@ -771,7 +771,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/sql_server_atp/sql_server_atp_meta_parent_rg.pt
+++ b/security/azure/sql_server_atp/sql_server_atp_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -230,7 +239,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/sql_server_atp/sql_server_atp_meta_parent_rg.pt
+++ b/security/azure/sql_server_atp/sql_server_atp_meta_parent_rg.pt
@@ -391,6 +391,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -668,7 +687,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -681,7 +700,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -770,7 +789,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/sql_server_auditing/sql_server_auditing_meta_parent.pt
+++ b/security/azure/sql_server_auditing/sql_server_auditing_meta_parent.pt
@@ -771,7 +771,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/sql_server_auditing/sql_server_auditing_meta_parent_rg.pt
+++ b/security/azure/sql_server_auditing/sql_server_auditing_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -230,7 +239,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/sql_server_auditing/sql_server_auditing_meta_parent_rg.pt
+++ b/security/azure/sql_server_auditing/sql_server_auditing_meta_parent_rg.pt
@@ -391,6 +391,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -668,7 +687,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -681,7 +700,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -770,7 +789,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/sql_server_va/sql_server_va_meta_parent.pt
+++ b/security/azure/sql_server_va/sql_server_va_meta_parent.pt
@@ -771,7 +771,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/sql_server_va/sql_server_va_meta_parent_rg.pt
+++ b/security/azure/sql_server_va/sql_server_va_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -230,7 +239,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/sql_server_va/sql_server_va_meta_parent_rg.pt
+++ b/security/azure/sql_server_va/sql_server_va_meta_parent_rg.pt
@@ -391,6 +391,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -668,7 +687,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -681,7 +700,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -770,7 +789,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/sql_server_va_admins/sql_server_va_admins_meta_parent.pt
+++ b/security/azure/sql_server_va_admins/sql_server_va_admins_meta_parent.pt
@@ -771,7 +771,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/sql_server_va_admins/sql_server_va_admins_meta_parent_rg.pt
+++ b/security/azure/sql_server_va_admins/sql_server_va_admins_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -230,7 +239,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/sql_server_va_admins/sql_server_va_admins_meta_parent_rg.pt
+++ b/security/azure/sql_server_va_admins/sql_server_va_admins_meta_parent_rg.pt
@@ -391,6 +391,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -668,7 +687,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -681,7 +700,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -770,7 +789,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/sql_server_va_emails/sql_server_va_emails_meta_parent.pt
+++ b/security/azure/sql_server_va_emails/sql_server_va_emails_meta_parent.pt
@@ -771,7 +771,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/sql_server_va_emails/sql_server_va_emails_meta_parent_rg.pt
+++ b/security/azure/sql_server_va_emails/sql_server_va_emails_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -230,7 +239,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/sql_server_va_emails/sql_server_va_emails_meta_parent_rg.pt
+++ b/security/azure/sql_server_va_emails/sql_server_va_emails_meta_parent_rg.pt
@@ -391,6 +391,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -668,7 +687,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -681,7 +700,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -770,7 +789,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/sql_server_va_scans/sql_server_va_scans_meta_parent.pt
+++ b/security/azure/sql_server_va_scans/sql_server_va_scans_meta_parent.pt
@@ -771,7 +771,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/sql_server_va_scans/sql_server_va_scans_meta_parent_rg.pt
+++ b/security/azure/sql_server_va_scans/sql_server_va_scans_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -230,7 +239,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/sql_server_va_scans/sql_server_va_scans_meta_parent_rg.pt
+++ b/security/azure/sql_server_va_scans/sql_server_va_scans_meta_parent_rg.pt
@@ -391,6 +391,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -668,7 +687,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -681,7 +700,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -770,7 +789,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/storage_network_deny/storage_network_deny_meta_parent.pt
+++ b/security/azure/storage_network_deny/storage_network_deny_meta_parent.pt
@@ -788,7 +788,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/storage_network_deny/storage_network_deny_meta_parent_rg.pt
+++ b/security/azure/storage_network_deny/storage_network_deny_meta_parent_rg.pt
@@ -408,6 +408,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -685,7 +704,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -698,7 +717,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -787,7 +806,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/storage_network_deny/storage_network_deny_meta_parent_rg.pt
+++ b/security/azure/storage_network_deny/storage_network_deny_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -247,7 +256,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/storage_soft_delete/storage_soft_delete_meta_parent.pt
+++ b/security/azure/storage_soft_delete/storage_soft_delete_meta_parent.pt
@@ -779,7 +779,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/storage_soft_delete/storage_soft_delete_meta_parent_rg.pt
+++ b/security/azure/storage_soft_delete/storage_soft_delete_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -238,7 +247,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/storage_soft_delete/storage_soft_delete_meta_parent_rg.pt
+++ b/security/azure/storage_soft_delete/storage_soft_delete_meta_parent_rg.pt
@@ -399,6 +399,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -676,7 +695,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -689,7 +708,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -778,7 +797,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/storage_tls_version/storage_tls_version_meta_parent.pt
+++ b/security/azure/storage_tls_version/storage_tls_version_meta_parent.pt
@@ -779,7 +779,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/storage_tls_version/storage_tls_version_meta_parent_rg.pt
+++ b/security/azure/storage_tls_version/storage_tls_version_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -238,7 +247,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/storage_tls_version/storage_tls_version_meta_parent_rg.pt
+++ b/security/azure/storage_tls_version/storage_tls_version_meta_parent_rg.pt
@@ -399,6 +399,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -676,7 +695,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -689,7 +708,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -778,7 +797,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/storage_trusted_services/storage_trusted_services_meta_parent.pt
+++ b/security/azure/storage_trusted_services/storage_trusted_services_meta_parent.pt
@@ -779,7 +779,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/storage_trusted_services/storage_trusted_services_meta_parent_rg.pt
+++ b/security/azure/storage_trusted_services/storage_trusted_services_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -238,7 +247,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/storage_trusted_services/storage_trusted_services_meta_parent_rg.pt
+++ b/security/azure/storage_trusted_services/storage_trusted_services_meta_parent_rg.pt
@@ -399,6 +399,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -676,7 +695,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -689,7 +708,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -778,7 +797,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/table_storage_logging/table_storage_logging_meta_parent.pt
+++ b/security/azure/table_storage_logging/table_storage_logging_meta_parent.pt
@@ -786,7 +786,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/table_storage_logging/table_storage_logging_meta_parent_rg.pt
+++ b/security/azure/table_storage_logging/table_storage_logging_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -245,7 +254,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/security/azure/table_storage_logging/table_storage_logging_meta_parent_rg.pt
+++ b/security/azure/table_storage_logging/table_storage_logging_meta_parent_rg.pt
@@ -406,6 +406,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -683,7 +702,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -696,7 +715,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -785,7 +804,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/webapp_tls_version_support/azure_webapp_min_tls_version_meta_parent.pt
+++ b/security/azure/webapp_tls_version_support/azure_webapp_min_tls_version_meta_parent.pt
@@ -780,7 +780,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/security/azure/webapp_tls_version_support/azure_webapp_min_tls_version_meta_parent_rg.pt
+++ b/security/azure/webapp_tls_version_support/azure_webapp_min_tls_version_meta_parent_rg.pt
@@ -400,6 +400,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -677,7 +696,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -690,7 +709,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -779,7 +798,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination

--- a/security/azure/webapp_tls_version_support/azure_webapp_min_tls_version_meta_parent_rg.pt
+++ b/security/azure/webapp_tls_version_support/azure_webapp_min_tls_version_meta_parent_rg.pt
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 parameter "param_azure_endpoint" do
   type "string"
@@ -239,7 +248,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
+++ b/tools/meta_parent_policy_compiler/azure_meta_parent.pt.template
@@ -718,7 +718,13 @@ script "js_take_in_parameters", type: "javascript" do
     var cur_account_id = subscription.subscriptionID
 
     // Name and description are the same for both create and update operations
-    var name = child_policy_information.name + ": " + subscription.subscriptionName + " (" + cur_account_id + ") (child policy)"
+    // Flexera limits policy names to 128 characters; truncate the middle part if needed
+    var name_prefix = child_policy_information.name + ": "
+    var name_suffix = " (" + cur_account_id + ") (child policy)"
+    var name_middle = subscription.subscriptionName
+    var max_middle = 128 - name_prefix.length - name_suffix.length
+    if (name_middle.length > max_middle) { name_middle = name_middle.substring(0, max_middle - 3) + "..." }
+    var name = name_prefix + name_middle + name_suffix
     var description = child_policy_information.name + " policy applied by [" + ds_format_self.name + "](" + applied_policy_url_prefix + meta_parent_policy_id + ") to Azure Subscription **" + subscription.subscriptionName + "** (`" + cur_account_id + "`).  " + child_policy_information.short_description
 
     // Build the child policy options list: parent options plus the subscription-specific subscription ID

--- a/tools/meta_parent_policy_compiler/azure_meta_parent_rg.pt.template
+++ b/tools/meta_parent_policy_compiler/azure_meta_parent_rg.pt.template
@@ -88,6 +88,15 @@ parameter "param_combined_incident_table_size" do
   default 100000
 end
 
+parameter "param_skip_consolidated_incident" do
+  type "string"
+  category "Incident Settings"
+  label "Skip Consolidated Incident"
+  description "Whether or not to skip generating the consolidated incident that combines violations from all child policy incidents. When set to 'Yes', only the status incident showing child policy management activity will be generated. Default value of 'No' preserves the standard behavior of generating a consolidated incident."
+  allowed_values "Yes", "No"
+  default "No"
+end
+
 ## Child Policy Parameters
 __PLACEHOLDER_FOR_CHILD_POLICY_PARAMETERS_BLOCKS__
 
@@ -177,7 +186,7 @@ script "js_child_policy_options", type: "javascript" do
   // Filter Options that are not appropriate for Child Policy
   var options = _.map(ds_self_policy_information.options, function(option){
     // param_combined_incident_email, param_dimension_filter_includes, param_dimension_filter_excludes", param_policy_schedule are exclusion to Meta Parent Policy Parameters
-    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
+    if (!_.contains(["param_combined_incident_email", "param_combined_incident_csv", "param_combined_incident_table_size", "param_skip_consolidated_incident", "param_dimension_filter_includes", "param_dimension_filter_excludes", "param_policy_schedule", "param_template_source"], option.name)) {
       return { "name": option.name, "value": option.value };
     }
   });

--- a/tools/meta_parent_policy_compiler/azure_meta_parent_rg.pt.template
+++ b/tools/meta_parent_policy_compiler/azure_meta_parent_rg.pt.template
@@ -338,6 +338,25 @@ datasource "ds_get_azure_resource_groups" do
   end
 end
 
+# The Bill Analysis API can return rows with a blank resource_group dimension for costs that
+# are not attributable to any resource group (e.g. subscription/EA-level charges such as
+# Marketplace purchases, support charges, or reservation purchases). These do not correspond to
+# a real resource group and would otherwise cause a child policy to be created with an empty
+# resource group, which can never match any actual resource. Filter them out here.
+datasource "ds_azure_resource_groups_filtered" do
+  run_script $js_azure_resource_groups_filtered, $ds_get_azure_resource_groups
+end
+
+script "js_azure_resource_groups_filtered", type: "javascript" do
+  parameters "ds_get_azure_resource_groups"
+  result "result"
+  code <<-'EOS'
+    result = _.filter(ds_get_azure_resource_groups, function(item) {
+      return item.resourceGroup != null && item.resourceGroup.trim() != ""
+    })
+EOS
+end
+
 script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
@@ -615,7 +634,7 @@ script "js_format_existing_policies", type: "javascript" do
 end
 
 datasource "ds_take_in_parameters" do
-  run_script $js_take_in_parameters, $ds_get_azure_resource_groups, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
+  run_script $js_take_in_parameters, $ds_azure_resource_groups_filtered, $ds_format_self, first($ds_published_child_policy_information), first($ds_project_child_policy_information), $ds_format_existing_policies, $ds_child_policy_options, $ds_child_policy_options_map, $ds_flexera_api_hosts, $param_template_source, $param_policy_schedule, policy_id, f1_app_host, rs_org_id, rs_project_id
 end
 
 # hardcode template href with id from catalog
@@ -628,7 +647,7 @@ end
 # param_exclude_tags and param_allowed_regions are arrays. I'm doing an update on the order changing but the values remaining the same.
 # If we only want to do an update on the values changing we could sort before doing the equality check.
 script "js_take_in_parameters", type: "javascript" do
-  parameters "ds_get_azure_resource_groups", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
+  parameters "ds_azure_resource_groups_filtered", "ds_format_self", "ds_published_child_policy_information", "ds_project_child_policy_information", "ds_format_existing_policies", "ds_child_policy_options", "ds_child_policy_options_map", "ds_flexera_api_hosts", "param_template_source", "param_policy_schedule", "meta_parent_policy_id", "f1_app_host", "rs_org_id", "rs_project_id"
   result "grid_and_cwf"
   code <<-'EOS'
   // Convert schedule label to iCal RRULE frequency string
@@ -717,7 +736,7 @@ script "js_take_in_parameters", type: "javascript" do
 
   // For each Azure subscription/resource group combo, decide whether to create a new child policy,
   // update the existing one, or leave it running unchanged.
-  _.each(ds_get_azure_resource_groups, function(item) {
+  _.each(ds_azure_resource_groups_filtered, function(item) {
     var subscriptionID = item.subscriptionID
     var resourceGroup = item.resourceGroup
     // Composite key uniquely identifies this subscription + resource group combination


### PR DESCRIPTION
### Description

Fixes a couple of issues with the unpublished Azure resource group-based meta parent policies that prevented them from working.
- The parameter for disabling consolidated incidents now exists and works properly.
- Blank resource group values returned by the Cost API are now ignored.

### Link to Example Applied Policy

https://app.flexera.com/orgs/28010/automation/applied-policies/projects/123559?policyId=6a72305c28854bf57eddc5e2

### Contribution Check List

- [x] New functionality includes testing.
