### PR TITLE
POL-1819 Code Normalization

### DIFF
--- a/.dangerfile/general_tests.rb
+++ b/.dangerfile/general_tests.rb
@@ -107,6 +107,26 @@ def general_bad_markdown?(file)
 end
 
 ### Bad URL test
+# Perform an HTTP GET, retrying a small number of times if a transient-looking error
+# code is returned (e.g. 403/429/5xx from bot or rate-limit protection at the
+# destination). This avoids failing a PR due to a flaky response from a third-party
+# host rather than an actually broken URL.
+def general_bad_urls_fetch(url)
+  retryable_codes = ['403', '429', '500', '502', '503', '504']
+  max_attempts = 3
+  retry_delay = 2
+
+  response = Net::HTTP.get_response(url)
+  attempts = 1
+  while retryable_codes.include?(response.code) && attempts < max_attempts
+    sleep retry_delay
+    response = Net::HTTP.get_response(url)
+    attempts += 1
+  end
+
+  response
+end
+
 # Return false if no invalid URLs are found.
 def general_bad_urls?(file, file_diff)
   return false if file.start_with?(".github/agents/")
@@ -163,7 +183,7 @@ def general_bad_urls?(file, file_diff)
           next if url.host !~ /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}$)/
 
           # Make HTTP request to URL
-          response = Net::HTTP.get_response(url)
+          response = general_bad_urls_fetch(url)
 
           # Test again when the file isn't found and the URL points to this repo.
           # URLs referencing /master/ may legitimately 404 before the PR is merged
@@ -176,7 +196,7 @@ def general_bad_urls?(file, file_diff)
             url = URI(url_string)
 
             # Make HTTP request to URL again
-            response = Net::HTTP.get_response(url)
+            response = general_bad_urls_fetch(url)
           end
 
           # Return error details if a proper response code was not received

--- a/.dangerfile/general_tests.rb
+++ b/.dangerfile/general_tests.rb
@@ -151,6 +151,7 @@ def general_bad_urls?(file, file_diff)
     'ec2.amazonaws.com',
     'storage.azure.com', # Not a legitimate URL but used in request headers for generating Azure tokens
     'contoso.sharepoint.com', # Not legitimate URL but used in Microsoft Graph API docs/examples
+    'docs.flexera.com', # Consistently blocks automated requests (403) despite being a valid, reachable URL
   ]
 
   regex = /(^\+)/

--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -1642,12 +1642,19 @@ def policy_bad_comma_spacing?(file, file_lines)
     # Skip image charts stuff
     next if line.include?("chxt=") || line.include?("chxs=") || line.include?("chco=") || line.include?("chdls=") || line.include?("chls=") || line.include?("chma=") || line.include?("chxr=") || line.include?("chg=") || line.include?("chf=")
 
+    # Skip JS regex literals (e.g. /([A-Za-z,]*)/.test(str)) since commas inside character
+    # classes and quantifiers are pattern syntax, not natural-language list items.
+    next if line.match?(/\/[^\/]*,[^\/]*\/\.(test|match|exec|replace)\(/)
+
     # Strip content inside quotation marks to avoid false positives from comma-separated
     # API parameter strings (e.g. metricnames, aggregation) and other string literal values.
     # Lines starting with a quote are included so that JSON-style key-value pairs like
     # `"metricnames": "Percentage CPU,Memory"` have their string values stripped correctly.
-    parts = line.split("\"") if line.include?("\"") && !line.include?("'")
-    parts = line.split("'") if !line.include?("\"") && line.include?("'") && !line.start_with?("'")
+    # A limit of -1 is passed to split so that a trailing empty string is preserved when the
+    # line ends exactly on a closing quote (Ruby's split otherwise silently drops it, which
+    # previously caused the stripping logic below to be skipped for these lines).
+    parts = line.split("\"", -1) if line.include?("\"") && !line.include?("'")
+    parts = line.split("'", -1) if !line.include?("\"") && line.include?("'") && !line.start_with?("'")
 
     if parts.length > 2
       test_parts = []

--- a/.github/agents/policy-dev.agent.md
+++ b/.github/agents/policy-dev.agent.md
@@ -367,25 +367,7 @@ Directory structure for Flexera-product templates:
 
 Every policy template must begin with the following header block. All fields are required unless noted:
 
-```
-name "Provider Example Policy"
-rs_pt_ver 20180301
-type "policy"
-short_description "Does X and Y. See the [README](https://github.com/flexera-public/policy_templates/tree/master/CATEGORY/PROVIDER/POLICY_NAME) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera-one/automation/) to learn more."
-long_description ""
-doc_link "https://github.com/flexera-public/policy_templates/tree/master/CATEGORY/PROVIDER/POLICY_NAME"
-category "Cost"          # Must match the top-level directory: Cost, Compliance, Operational, Security, SaaS, Automation
-severity "low"           # low, medium, high, critical
-default_frequency "weekly"  # valid values: "15 minutes", "hourly", "daily", "weekly", "monthly"
-info(
-  version: "0.1.0",
-  provider: "AWS",           # e.g. AWS, Azure, Google, Flexera, etc.
-  service: "Storage",        # The provider service this policy targets
-  policy_set: "",            # Grouping label for recommendations; must be non-blank for recommendation templates
-  recommendation_type: "Usage Reduction",  # Required for recommendation templates: "Usage Reduction" or "Rate Reduction"; omit for non-cost templates
-  hide_skip_approvals: "true"  # Required for recommendation templates; hides "Skip Approval" UI button
-)
-```
+**Example:** See "Policy Template Anatomy - Header Block" in `data/agent/code_examples.txt`.
 
 The `short_description` must always end with links to the README and Flexera Automation docs using the exact pattern shown above.
 
@@ -395,238 +377,68 @@ The `short_description` must always end with links to the README and Flexera Aut
 
 All catalog templates follow a fixed section order, with each section preceded by a standardized divider comment. Always structure `.pt` files in this order:
 
-```
-###############################################################################
-# Parameters
-###############################################################################
-
-###############################################################################
-# Authentication
-###############################################################################
-
-###############################################################################
-# Pagination
-###############################################################################
-
-###############################################################################
-# Datasources & Scripts
-###############################################################################
-
-###############################################################################
-# Policy
-###############################################################################
-
-###############################################################################
-# Escalations
-###############################################################################
-
-###############################################################################
-# Cloud Workflow
-###############################################################################
-```
+**Example:** See "Policy Template Structure - Section Divider Skeleton" in `data/agent/code_examples.txt`.
 
 "Authentication" = `credentials` blocks. "Datasources & Scripts" = both `datasource` and `script` blocks. "Cloud Workflow" = `define` blocks. Omit sections that aren't needed.
 
 ## DSL Quick Reference
 
+All canonical code examples for the patterns described in this section (and in
+"Standard Parameter Conventions" below) live in `data/agent/code_examples.txt`,
+organized under headers that match the subsections here. This section explains
+when and why to use each pattern; consult that file for the exact code to copy.
+
 ### Credentials
 
-```
-credentials "auth_aws" do
-  schemes "aws", "aws_sts"
-  label "AWS"
-  description "Select the AWS Credential from the list"
-  tags "provider=aws"
-  aws_account_number $param_aws_account_number  # for Meta Policy cross-account support
-end
-
-credentials "auth_azure" do
-  schemes "oauth2"
-  label "Azure"
-  description "Select the Azure Resource Manager Credential from the list."
-  tags "provider=azure_rm"
-end
-
-credentials "auth_google" do
-  schemes "oauth2"
-  label "Google"
-  description "Select the Google Cloud Credential from the list."
-  tags "provider=gce"
-end
-
-credentials "auth_flexera" do
-  schemes "oauth2"
-  label "Flexera"
-  description "Select Flexera One OAuth2 credentials"
-  tags "provider=flexera"
-end
-
-credentials "auth_oracle" do
-  schemes "oracle"
-  label "Oracle"
-  description "Select the Oracle Cloud (OCI) Credential from the list."
-  tags "provider=oracle"
-end
-```
+**Example:** See "Credentials" in `data/agent/code_examples.txt`.
 
 Correct `tags` values by provider: `provider=aws`, `provider=azure_rm` (Azure), `provider=gce` (Google), `provider=flexera`, `provider=oracle` (Oracle OCI).
 
 ### Pagination
 
-```
-pagination "pagination_aws" do
-  get_page_marker do
-    body_path jmes_path(response, "NextToken")      # where to read the cursor from the response
-  end
-  set_page_marker do
-    body_field "NextToken"                           # where to write the cursor in the next request
-  end
-end
-```
+**Example:** See "Pagination" in `data/agent/code_examples.txt`.
 
 Use `query "NextToken"` instead of `body_field` when the cursor must be sent as a query parameter. Use `body_path "//XPath/Expression"` for XML APIs.
 
 Azure APIs return `nextLink` as a **complete URL** for the next page. Use `uri true` so the engine uses it directly instead of inserting it as a parameter:
 
-```
-pagination "pagination_azure" do
-  get_page_marker do
-    body_path "nextLink"
-  end
-  set_page_marker do
-    uri true    # nextLink IS the full URL for the next page — do not append as a parameter
-  end
-end
-```
+**Example:** See "Pagination" in `data/agent/code_examples.txt`.
 
 Google APIs return a `nextPageToken` in the response body and expect it back as a `pageToken` query parameter:
 
-```
-pagination "pagination_google" do
-  get_page_marker do
-    body_path "nextPageToken"
-  end
-  set_page_marker do
-    query "pageToken"
-  end
-end
-```
+**Example:** See "Pagination" in `data/agent/code_examples.txt`.
 
 ### Datasource — REST Request
 
-```
-datasource "ds_example" do
-  request do
-    auth $auth_aws
-    pagination $pagination_aws   # omit if the endpoint is not paginated
-    host "ec2.amazonaws.com"
-    path "/some/endpoint"
-    query "param", "value"
-    header "Accept", "application/json"
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "items[*]") do
-      field "id", jmes_path(col_item, "Id")
-      field "name", jmes_path(col_item, "Name")
-    end
-  end
-end
-```
+**Example:** See "Datasource - REST Request" in `data/agent/code_examples.txt`.
 
 For AWS APIs that return XML (many older EC2/RDS endpoints), use `encoding "xml"` and XPath expressions instead of JMESPath:
 
-```
-  result do
-    encoding "xml"
-    collect xpath(response, "//item") do
-      field "id", xpath(col_item, "snapshotId/text()")
-      field "size", xpath(col_item, "volumeSize/text()")
-    end
-  end
-```
+**Example:** See "Datasource - REST Request" in `data/agent/code_examples.txt`.
 
 Use `encoding "text"` for raw text responses (e.g. CSV). The entire response body becomes the datasource value — no `field` declarations needed:
 
-```
-  result do
-    encoding "text"    # entire response body is the datasource value (a string)
-  end
-```
+**Example:** See "Datasource - REST Request" in `data/agent/code_examples.txt`.
 
 To iterate a datasource over a list (e.g. one request per region):
 
-```
-datasource "ds_per_region" do
-  iterate $ds_regions
-  request do
-    auth $auth_aws
-    host join(["ec2.", val(iter_item, "region"), ".amazonaws.com"])
-    path "/some/endpoint"
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "Items[*]") do
-      field "id", jmes_path(col_item, "Id")
-      field "region", val(iter_item, "region")
-    end
-  end
-end
-```
+**Example:** See "Datasource - REST Request" in `data/agent/code_examples.txt`.
 
 Add `ignore_status [403, 404]` inside any `request do` block to suppress specific HTTP error codes instead of failing. Use this when an API returns 404 for missing resources, 403 for inaccessible regions, etc.
 
 **`collect` vs no `collect`:** Use `collect` when the response (or a sub-expression) is an **array** — each element becomes a datasource row. Omit `collect` when the response is a **single object** (as in `ds_applied_policy` above):
 
-```
-# Single-object response — no collect
-result do
-  encoding "json"
-  field "id", jmes_path(response, "id")
-  field "name", jmes_path(response, "name")
-end
-```
+**Example:** See "Datasource - REST Request" in `data/agent/code_examples.txt`.
 
 ### Datasource — Static POST / PUT / DELETE Request
 
 For POST (or any non-GET) requests where the body is static or can be built from DSL expressions, use `verb`, `body_field`, and/or `body` directly in the `request do` block — no JavaScript script required. Use the dynamic `run_script` pattern only when the body needs conditional logic or complex data transformation.
 
-```
-datasource "ds_create_items" do
-  iterate $ds_items_to_create
-  request do
-    auth $auth_flexera
-    verb "POST"                                           # override the default GET verb
-    host val($ds_flexera_api_hosts, "flexera")
-    path join(["/some/api/v1/orgs/", rs_org_id, "/items"])
-    header "User-Agent", "RS Policies"
-    body_field "name", val(iter_item, "name")    # individual JSON body fields
-    body_field "params", val(iter_item, "params")  # repeat for each field
-  end
-  result do
-    encoding "json"
-    field "id", jmes_path(response, "id")
-  end
-end
-```
+**Example:** See "Datasource - Static POST / PUT / DELETE Request" in `data/agent/code_examples.txt`.
 
 For APIs that expect a raw string body (CSV, XML, empty JSON object, etc.) use `body` instead of `body_field`:
 
-```
-datasource "ds_post_raw" do
-  request do
-    auth $auth_aws
-    verb "POST"
-    host "some-aws-api.amazonaws.com"
-    path "/some/endpoint"
-    body "{}"    # send an empty JSON object body; can also be val(...) or join([...]) expressions
-  end
-  result do
-    encoding "json"
-    field "id", jmes_path(response, "id")
-  end
-end
-```
+**Example:** See "Datasource - Static POST / PUT / DELETE Request" in `data/agent/code_examples.txt`.
 
 `body_field` and `body` are mutually exclusive — use one or the other per request block, not both.
 
@@ -634,68 +446,13 @@ end
 
 Use `request do { run_script }` when the request URL, verb, or body must be constructed dynamically (e.g. POST requests to Flexera billing APIs). The script must return a `request` object — note that `result` must be named `"request"`, and credentials are passed as a **string** name, not a `$variable`:
 
-```
-datasource "ds_billing_data" do
-  request do
-    run_script $js_billing_request, $ds_billing_centers, rs_org_id, rs_optima_host
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "rows[*]") do
-      field "account_id", jmes_path(col_item, "dimensions.vendor_account")
-      field "account_name", jmes_path(col_item, "dimensions.vendor_account_name")
-      field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
-    end
-  end
-end
-
-script "js_billing_request", type: "javascript" do
-  parameters "billing_centers", "rs_org_id", "rs_optima_host"
-  result "request"   # MUST be named "request" when used inside request do
-  code <<-'EOS'
-    var end_date = new Date(); end_date.setDate(end_date.getDate() - 1)
-    var start_date = new Date(); start_date.setDate(start_date.getDate() - 30)
-
-    request = {
-      auth: "auth_flexera",    // credential name as a string, NOT a $variable
-      host: rs_optima_host,
-      verb: "POST",
-      path: "/bill-analysis/orgs/" + rs_org_id + "/costs/select",
-      body_fields: {
-        dimensions: ["vendor_account", "vendor_account_name"],
-        granularity: "day",
-        start_at: start_date.toISOString().split("T")[0],
-        end_at: end_date.toISOString().split("T")[0],
-        metrics: ["cost_amortized_unblended_adj"],
-        billing_center_ids: _.pluck(billing_centers, "id")
-      },
-      headers: { "Api-Version": "1.0", "User-Agent": "RS Policies" },
-      ignore_status: [400]
-    }
-EOS
-end
-```
+**Example:** See "Datasource - Dynamic / POST Request" in `data/agent/code_examples.txt`.
 
 ### Datasource — JavaScript Transform
 
 Use `run_script` at the datasource top level to transform or combine data with JavaScript:
 
-```
-datasource "ds_filtered" do
-  run_script $js_filter_items, $ds_raw_items, $param_threshold
-end
-
-script "js_filter_items", type: "javascript" do
-  parameters "items", "threshold"
-  result "result"
-  code <<-'EOS'
-    // Underscore.js (_) is available for use in all script blocks
-    result = _.filter(items, function(item) {
-      return item.value > threshold
-    })
-EOS
-end
-```
+**Example:** See "Datasource - JavaScript Transform" in `data/agent/code_examples.txt`.
 
 **Datasource structure rules:**
 - A datasource can have EITHER `iterate` OR top-level `run_script`, not both
@@ -722,85 +479,17 @@ The `param_exclusion_tags` + `param_exclusion_tags_boolean` parameter pair is fi
 - **AWS:** `resource['tags']` is an array of `{ key: "k", value: "v" }` — iterate to build a flat map
 - **Azure/GCP:** `resource['tags']` is already a flat `{ Key: Value }` object
 
-```
-script "js_filter_resources", type: "javascript" do
-  parameters "resources", "param_exclusion_tags", "param_exclusion_tags_boolean"
-  result "result"
-  code <<-'EOS'
-    comparators = _.map(param_exclusion_tags, function(item) {
-      if (item.indexOf('==') != -1) {
-        return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
-      }
-      if (item.indexOf('!=') != -1) {
-        return { comparison: '!=', key: item.split('!=')[0], value: item.split('!=')[1], string: item }
-      }
-      if (item.indexOf('=~') != -1) {
-        value = item.split('=~')[1]
-        regex = new RegExp(value.slice(1, value.length - 1))
-        return { comparison: '=~', key: item.split('=~')[0], value: regex, string: item }
-      }
-      if (item.indexOf('!~') != -1) {
-        value = item.split('!~')[1]
-        regex = new RegExp(value.slice(1, value.length - 1))
-        return { comparison: '!~', key: item.split('!~')[0], value: regex, string: item }
-      }
-      return { comparison: 'key', key: item, value: null, string: item }
-    })
-
-    result = _.reject(resources, function(resource) {
-      resource_tags = {}
-      // AWS: tags are [{key: "k", value: "v"}, ...] — adjust for Azure/GCP as needed
-      if (typeof(resource['tags']) == 'object') {
-        _.each(resource['tags'], function(tag) { resource_tags[tag['key']] = tag['value'] })
-      }
-
-      found_tags = []
-      _.each(comparators, function(comparator) {
-        resource_tag = resource_tags[comparator['key']]
-        if (comparator['comparison'] == 'key' && resource_tag != undefined)                                          { found_tags.push(comparator['string']) }
-        if (comparator['comparison'] == '==' && resource_tag == comparator['value'])                                 { found_tags.push(comparator['string']) }
-        if (comparator['comparison'] == '!=' && resource_tag != comparator['value'])                                 { found_tags.push(comparator['string']) }
-        if (comparator['comparison'] == '=~' && resource_tag != undefined && comparator['value'].test(resource_tag)) { found_tags.push(comparator['string']) }
-        if (comparator['comparison'] == '!~' && (resource_tag == undefined || !comparator['value'].test(resource_tag))) { found_tags.push(comparator['string']) }
-      })
-
-      if (param_exclusion_tags.length == 0) { return false }
-      if (param_exclusion_tags_boolean == 'Any') { return found_tags.length > 0 }
-      return found_tags.length == comparators.length  // 'All'
-    })
-EOS
-end
-```
+**Example:** See "Common JavaScript Patterns - Tag Filtering" in `data/agent/code_examples.txt`.
 
 ### Common JavaScript Patterns — Region Filtering
 
 The `param_regions_allow_or_deny` + `param_regions_list` parameter pair is applied in JavaScript using this standard pattern. An empty list means "no filter — include all regions":
 
-```
-script "js_filter_regions", type: "javascript" do
-  parameters "regions", "param_regions_list", "param_regions_allow_or_deny"
-  result "result"
-  code <<-'EOS'
-    allow_deny_test = { "Allow": true, "Deny": false }
-
-    if (param_regions_list.length > 0) {
-      result = _.filter(regions, function(item) {
-        return _.contains(param_regions_list, item['region']) == allow_deny_test[param_regions_allow_or_deny]
-      })
-    } else {
-      result = regions  // empty list = no filter; include all regions
-    }
-EOS
-end
-```
+**Example:** See "Common JavaScript Patterns - Region Filtering" in `data/agent/code_examples.txt`.
 
 Wrap in a companion datasource:
 
-```
-datasource "ds_regions" do
-  run_script $js_regions, $ds_describe_regions, $param_regions_allow_or_deny, $param_regions_list
-end
-```
+**Example:** See "Common JavaScript Patterns - Region Filtering" in `data/agent/code_examples.txt`.
 
 Downstream datasources use `iterate $ds_regions`. Adapt field name as needed (`item['location']` for Azure, `item['name']` for Google).
 
@@ -808,72 +497,21 @@ Downstream datasources use `iterate $ds_regions`. Adapt field name as needed (`i
 
 The `param_subscriptions_allow_or_deny` + `param_subscriptions_list` parameter pair is applied in JavaScript using this standard pattern. It matches by either subscription **ID or name** to be user-friendly. An empty list means no filter:
 
-```
-script "js_filter_subscriptions", type: "javascript" do
-  parameters "subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
-  result "result"
-  code <<-'EOS'
-    if (param_subscriptions_list.length > 0) {
-      result = _.filter(subscriptions, function(subscription) {
-        include_subscription = _.contains(param_subscriptions_list, subscription['id']) ||
-                               _.contains(param_subscriptions_list, subscription['name'])
-
-        if (param_subscriptions_allow_or_deny == "Deny") {
-          include_subscription = !include_subscription
-        }
-
-        return include_subscription
-      })
-    } else {
-      result = subscriptions  // empty list = no filter; include all subscriptions
-    }
-EOS
-end
-```
+**Example:** See "Common JavaScript Patterns - Azure Subscription Filtering" in `data/agent/code_examples.txt`.
 
 Wrap in a companion datasource; downstream datasources use `iterate $ds_azure_subscriptions_filtered`:
 
-```
-datasource "ds_azure_subscriptions_filtered" do
-  run_script $js_azure_subscriptions_filtered, $ds_azure_subscriptions, $param_subscriptions_allow_or_deny, $param_subscriptions_list
-end
-```
+**Example:** See "Common JavaScript Patterns - Azure Subscription Filtering" in `data/agent/code_examples.txt`.
 
 ### Common JavaScript Patterns — Google Project Filtering
 
 The `param_projects_allow_or_deny` + `param_projects_list` parameter pair is applied in JavaScript using this standard pattern. It matches by project **ID, name, or number** (Google projects have all three identifiers). An empty list means no filter:
 
-```
-script "js_filter_projects", type: "javascript" do
-  parameters "projects", "param_projects_allow_or_deny", "param_projects_list"
-  result "result"
-  code <<-'EOS'
-    if (param_projects_list.length > 0) {
-      result = _.filter(projects, function(project) {
-        include_project = _.contains(param_projects_list, project['id']) ||
-                          _.contains(param_projects_list, project['name']) ||
-                          _.contains(param_projects_list, project['number'])
-
-        if (param_projects_allow_or_deny == "Deny") {
-          include_project = !include_project
-        }
-
-        return include_project
-      })
-    } else {
-      result = projects  // empty list = no filter; include all projects
-    }
-EOS
-end
-```
+**Example:** See "Common JavaScript Patterns - Google Project Filtering" in `data/agent/code_examples.txt`.
 
 Wrap in a companion datasource; downstream datasources use `iterate $ds_google_projects_filtered`:
 
-```
-datasource "ds_google_projects_filtered" do
-  run_script $js_google_projects_filtered, $ds_google_projects, $param_projects_allow_or_deny, $param_projects_list
-end
-```
+**Example:** See "Common JavaScript Patterns - Google Project Filtering" in `data/agent/code_examples.txt`.
 
 ### Policy Block
 
@@ -887,51 +525,7 @@ end
 
 `{{ .policy_name }}` and `{{ .message }}` are populated by the final JavaScript transform. Always use `with index data 0` to safely handle empty datasources.
 
-```
-policy "pol_example" do
-  validate_each $ds_items do
-    # IMPORTANT: 'check' fires the incident when it evaluates to FALSE (not true).
-    # Use logic_or with $ds_parent_policy_terminated ONLY in Meta Policy-compatible templates
-    # (i.e. templates that iterate through AWS accounts, Azure subscriptions, or Google projects).
-    check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
-    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Items Found"
-    detail_template <<-'EOS'
-    **Details:** {{ with index data 0 }}{{ .message }}{{ end }}
-    EOS
-    escalate $esc_email
-    escalate $esc_delete
-    hash_exclude "tags", "savings"  # exclude volatile fields that would cause spurious incident re-triggers
-    export do
-      resource_level true  # set true when each row represents a distinct cloud resource
-      field "id" do label "Resource ID" end
-      field "name" do label "Resource Name" end
-      field "region" do label "Region" end
-      field "display_id" do  # use 'path' to alias a field to a different source field
-        label "ID"
-        path "id"
-      end
-      field "console_link" do       # 'format "link-external"' renders the value as a clickable URL
-        label "Console Link"
-        format "link-external"
-      end
-    end
-  end
-
-  # Error-check pattern: validate (NOT validate_each) checks the whole datasource at once.
-  # check eq(size(data), 0) passes when there are zero errors and fires an incident when any exist.
-  validate $ds_identify_errors do
-    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
-    detail_template <<-'EOS'
-    **Error Details:**
-    {{ range data -}}
-      - {{ .error }}
-    {{ end -}}
-    EOS
-    check eq(size(data), 0)
-    escalate $esc_email_errors_identified
-  end
-end
-```
+**Example:** See "Policy Block" in `data/agent/code_examples.txt`.
 
 **`validate` vs `validate_each`:** The main incident block uses `validate_each` (checks each row individually). The region-error block uses `validate` (without `_each`) — it evaluates `check` once against the entire datasource. Use `validate` when you want a single incident that fires if the datasource is non-empty, not a per-row check.
 
@@ -947,114 +541,7 @@ end
 
 **Probe endpoint selection:** The `ds_region_check` probe must use an API endpoint whose result-limit parameter accepts small values (e.g. `MaxResults=5`). **Do not probe RDS `DescribeDBInstances`** — that action uses `MaxRecords` (not `MaxResults`), which requires a minimum value of 20 and returns an API error for smaller values. When the template's primary service uses a restrictive API (e.g. RDS), probe a different service such as ElastiCache (`DescribeCacheClusters`) or EC2 (`DescribeNatGateways`) instead, since both accept `MaxResults` with values as small as 5. The convention across existing catalog templates is `query "MaxResults", "5"`.
 
-```
-# 1. Probe each region for accessibility
-datasource "ds_region_check" do
-  iterate $ds_regions
-  request do
-    auth $auth_aws
-    host join(["lambda.", val(iter_item, "region"), ".amazonaws.com"])
-    path "/2015-03-31/functions/"
-    query "MaxItems", "1"
-    header "User-Agent", "RS Policies"
-    ignore_status [403, 401]
-  end
-  result do
-    encoding "xml"
-    field "region", val(iter_item, "region")
-    field "status", "OK"
-  end
-end
-
-# 2. Identify inaccessible regions
-datasource "ds_identify_errors" do
-  run_script $js_identify_errors, $ds_regions, $ds_region_check, $ds_applied_policy, $param_regions_allow_or_deny, $param_regions_list
-end
-
-script "js_identify_errors", type: "javascript" do
-  parameters "ds_regions", "ds_region_check", "ds_applied_policy", "param_regions_allow_or_deny", "param_regions_list"
-  result "errors"
-  code <<-'EOS'
-  var errors = []
-
-  var region_responses = {}
-  _.each(ds_region_check, function(item) {
-    if (item.region) { region_responses[item.region] = "OK" }
-  })
-
-  var allowed_regions = _.keys(region_responses)
-  var forbidden_regions = []
-
-  _.each(ds_regions, function(region_obj) {
-    if (!_.contains(allowed_regions, region_obj.region)) {
-      forbidden_regions.push(region_obj.region)
-    }
-  })
-
-  if (forbidden_regions.length > 0) {
-    var regions_string = forbidden_regions.sort().join(", ")
-    var successful_regions = allowed_regions.sort().join(", ")
-    var filter_guidance = ""
-
-    if (param_regions_list.length > 0) {
-      filter_guidance = " You are currently using the 'Allow/Deny Regions List' parameter. "
-      filter_guidance += "You can update this list to exclude the inaccessible regions if appropriate."
-    } else {
-      filter_guidance = " You can use the 'Allow/Deny Regions List' parameter to exclude these regions."
-    }
-
-    errors.push(
-      "HTTP error received when attempting to list [resources] in some AWS region(s).\n" +
-      "\n - Failed Regions: " + regions_string +
-      "\n - Successful Regions: " + successful_regions +
-      "\n\nThis typically indicates that the AWS credential does not have the required " +
-      "'[service]:[Action]' permission for these regions, or these regions may not be enabled." +
-      " To resolve: (1) Verify the credential has the required permission, " +
-      "(2) Ensure these regions are opted-in in your account, or " +
-      "(3) Exclude these regions using the region filter parameters." +
-      filter_guidance
-    )
-  }
-
-  errors = _.uniq(errors)
-  errors = _.map(errors, function(err) { return { "error": err } })
-
-  if (errors.length > 0) {
-    var policy_name = "AWS Policy"
-    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
-    errors[0].policy_name = policy_name
-  }
-EOS
-end
-
-# 3. In the policy block — use 'validate' (not validate_each) for the error datasource
-  validate $ds_identify_errors do
-    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
-    detail_template <<-'EOS'
-    The policy was unable to access one or more AWS regions due to permission or configuration errors.
-
-    **Error Details:**
-    {{ range data -}}
-      - {{ .error }}
-    {{ end -}}
-
-    **Recommended Actions:**
-    1. Verify the AWS credential has the required permissions for all policy regions.
-    2. Ensure any opt-in regions are enabled in your AWS account.
-    3. Use the Allow/Deny Regions List parameter to exclude inaccessible regions.
-    EOS
-    check eq(size(data), 0)
-    escalate $esc_email_errors_identified
-  end
-
-# 4. In escalations — simple email with no table attachment
-escalation "esc_email_errors_identified" do
-  automatic true
-  label "Send Email"
-  description "Send incident email"
-  email $param_email
-end
-```
+**Example:** See "AWS Region Error-Reporting Pattern" in `data/agent/code_examples.txt`.
 
 **`check` semantics:** Incident fires when `check` evaluates to `false`, `0`, empty string, empty array, or empty object. Multiple `check` statements evaluate in order, stopping at first failure. `eq(val(item, "id"), "")` is the standard sentinel for "no incident when datasource is empty".
 
@@ -1073,11 +560,7 @@ The last datasource in every template is typically a JavaScript transform (`run_
 
 **Standard fields set on `result[0]`** (the first item in the result array):
 
-```javascript
-result[0]['policy_name'] = ds_applied_policy['name']  // always — feeds {{ .policy_name }} in summary_template
-result[0]['message']     = "Multi-line markdown string..."  // feeds {{ .message }} in detail_template
-result[0]['total_savings'] = "Total Estimated Monthly Savings: " + currency_symbol + total  // cost templates only
-```
+**Example:** See "Common JavaScript Patterns - Final Transform / Cost Template Conventions" in `data/agent/code_examples.txt`.
 
 **Standard per-row fields for cost recommendation templates:**
 
@@ -1128,95 +611,17 @@ The Flexera platform scrapes incident export data to populate the Total Potentia
 
 **Standard field order in the export block** (follow this order — resource-specific fields fill in between region and savings):
 
-```
-accountID → accountName → resourceID → resourceName → tags → recommendationDetails →
-region → [resource-specific fields] → savings → savingsCurrency →
-[lookbackPeriod, threshold, metric fields] → service → resourceARN → id
-```
+**Example:** See "Common JavaScript Patterns - Final Transform / Cost Template Conventions" in `data/agent/code_examples.txt`.
 
 **Canonical export block example:**
 
-```
-export do
-  resource_level true
-  field "accountID" do
-    label "Account ID"
-  end
-  field "accountName" do
-    label "Account Name"
-  end
-  field "resourceID" do
-    label "Resource ID"
-  end
-  field "resourceName" do
-    label "Resource Name"
-  end
-  field "tags" do
-    label "Resource Tags"
-  end
-  field "recommendationDetails" do
-    label "Recommendation"
-  end
-  field "region" do
-    label "Region"
-  end
-  field "state" do
-    label "State"
-  end
-  field "resourceType" do
-    label "Resource Type"
-    path "runtime"    # use 'path' to alias a data field to a standard name
-  end
-  field "savings" do
-    label "Estimated Monthly Savings"
-  end
-  field "savingsCurrency" do
-    label "Savings Currency"
-  end
-  field "lookbackPeriod" do
-    label "Look Back Period (Days)"
-  end
-  field "service" do
-    label "Service"
-  end
-  field "resourceARN" do
-    label "Resource ARN"
-  end
-  field "id" do
-    label "ID"
-    path "resourceID"
-  end
-end
-```
+**Example:** See "Common JavaScript Patterns - Final Transform / Cost Template Conventions" in `data/agent/code_examples.txt`.
 
 **`hash_exclude` minimum** — always exclude volatile fields that change without indicating a meaningful state change. Extend as needed for utilization metrics or age fields. **Only include field names that are actually declared in the `export` block** — `hash_exclude` has no effect on fields that are not exported. The fields `message`, `policy_name`, and `total_savings` are metadata set on `result[0]` for use in `summary_template` / `detail_template`; only add them to `hash_exclude` if they are explicitly declared in the `export` block:
 
-```
-hash_exclude "tags", "savings", "savingsCurrency"
-```
+**Example:** See "Common JavaScript Patterns - Final Transform / Cost Template Conventions" in `data/agent/code_examples.txt`.
 
-```javascript
-result.push({
-  // Account info
-  accountID: ds_aws_account['id'],              // required — note capital ID
-  accountName: ds_aws_account['name'],
-  // Resource identity
-  resourceID: resource['id'],                   // required
-  resourceName: resource['name'],
-  // Metadata
-  tags: tags.join(', '),                        // required — joined display string, NOT a raw array
-  recommendationDetails: recommendationDetails,
-  region: region,
-  // Resource-specific fields here ...
-  // Financial
-  savings: parseFloat(item_savings.toFixed(3)), // required — number
-  savingsCurrency: ds_currency['symbol'],
-  // Contextual
-  lookbackPeriod: param_lookback_days,          // bare number (days), NOT a string with units
-  service: "EC2",
-  resourceARN: resource['arn'],                 // full ARN for audit trail
-})
-```
+**Example:** See "Common JavaScript Patterns - Final Transform / Cost Template Conventions" in `data/agent/code_examples.txt`.
 
 Always add `"savings"`, `"savingsCurrency"`, and `"tags"` to `hash_exclude` in the `validate_each` block so that savings recalculations don't trigger spurious incident re-opens. If `"message"` or `"total_savings"` are declared as fields in the `export` block, add them too — but do **not** add them if they are not exported, as `hash_exclude` only operates on exported fields.
 
@@ -1226,190 +631,53 @@ For cost templates, the `ds_currency` datasource (fetched from the Flexera billi
 
 A single `esc_email` escalation block is shared across **all** `validate_each` (and `validate`) blocks in the policy that report on cloud resources. Only specialty incidents — such as the AWS region-error `validate $ds_identify_errors` block — use their own dedicated escalation (e.g. `esc_email_errors_identified`) because those incidents have different email behaviour (no table attachment, no CSV, etc.). Do **not** create duplicate `esc_email_*` blocks that are structurally identical; reference the same `$esc_email` escalation from every standard incident block.
 
-```
-escalation "esc_email" do
-  automatic true
-  label "Send Email"
-  description "Send incident email"
-  email $param_email do
-    attach_export_table $param_incident_csv      # attach CSV export of incident data; use "false" to disable
-    body_table_max_rows $param_incident_table_size  # cap inline table rows to avoid oversized emails
-  end
-end
-
-# Automated action — runs without approval when param contains the action name
-escalation "esc_delete" do
-  automatic contains($param_automatic_action, "Delete Items")
-  label "Delete Items"
-  description "Approval to delete all selected items"
-  run "delete_items", data, $param_some_option
-  # 'data' is a DSL reserved word — it refers to the incident's violation rows (the items
-  # that failed 'check'). The same list is passed as the first argument to the Cloud Workflow
-  # 'define' that handles the action (e.g. $data in 'define delete_items($data, ...)').
-end
-
-# Optional: auto-close the incident after the escalation finishes.
-# Place 'resolve_incident' inside any escalation block to automatically resolve the
-# incident once the escalation (action) has completed successfully.
-escalation "esc_create_and_resolve" do
-  automatic true
-  label "Create Items"
-  description "Creates the listed items and closes the incident"
-  run "create_items", data
-  resolve_incident
-end
-```
+**Example:** See "Escalations" in `data/agent/code_examples.txt`.
 
 ### Cloud Workflow (Actions)
 
 **Variable scoping:** `$variable` is local to the current `define` block. `$$variable` is global and shared across all `define` calls in the same execution. Use `$$` for any state that must survive across `call` boundaries (accumulated results, error lists).
 
-```
-define delete_items($data, $param_some_option) return $all_responses do
-  $$all_responses = []
-  $$errors = []
-
-  foreach $item in $data do
-    sub on_error: handle_error() do
-      call delete_one_item($item) retrieve $response
-    end
-    $$all_responses << $response
-  end
-
-  # Raise all collected errors at the end
-  if size($$errors) > 0
-    raise join($$errors, "\n")
-  end
-end
-
-# Pattern A — AWS/Oracle: http_request with split host/href and explicit https: flag
-# Choose ONE pattern that matches your provider; do NOT use both in the same template.
-define delete_one_item_aws($item) return $response do
-  $response = http_request(
-    auth: $$auth_aws,
-    https: true,
-    verb: "delete",
-    host: "example.com",
-    href: join(["/items/", $item["id"]]),
-    headers: { "Accept": "application/json" }
-  )
-end
-
-# Pattern B — Google/Azure: shorthand method with a single full URL; no https: flag needed
-define delete_one_item_azure($item) return $response do
-  $response = http_delete(
-    auth: $$auth_google,
-    url: join(["https://example.com/items/", $item["id"]]),
-    headers: { "Accept": "application/json" }
-  )
-end
-
-define handle_error() do
-  if !$$errors
-    $$errors = []
-  end
-  $$errors << $_error["type"] + ": " + $_error["message"]
-  $_error_behavior = "skip"  # prevents the sub block from re-raising
-end
-```
+**Example:** See "Cloud Workflow (Actions)" in `data/agent/code_examples.txt`.
 
 **`$_error` object:** In `sub on_error:` handlers: `$_error["type"]` (e.g. `"http"`, `"general"`) and `$_error["message"]`. Set `$_error_behavior = "skip"` to suppress re-raising.
 
 **`call` and `retrieve`:** Use `retrieve` to capture return values; omit when not needed:
 
-```
-  call delete_one_item($item) retrieve $response   # captures return value
-  call log_event($item)                            # fire-and-forget; no return value needed
-```
+**Example:** See "Cloud Workflow (Actions)" in `data/agent/code_examples.txt`.
 
 **`task_label(msg)`:** Log HTTP operations to the execution audit trail. Pass HTTP verb + URL for easy failure diagnosis:
 
-```
-define delete_one_item($item) return $response do
-  $url = "https://example.com/items/" + $item["id"]
-  task_label("DELETE " + $url)
-  $response = http_request(
-    auth: $$auth_aws,
-    https: true,
-    verb: "delete",
-    host: "example.com",
-    href: join(["/items/", $item["id"]])
-  )
-  task_label("DELETE " + $url + " response: " + to_json($response))
-end
-```
+**Example:** See "Cloud Workflow (Actions)" in `data/agent/code_examples.txt`.
 
 **`to_json($obj)`:** Serialize to JSON string. Use in `task_label` calls and error messages.
 
 **`inspect($$var)`:** Returns `"null"` when unset. Idiomatic null-check: `inspect($$errors) != "null"`:
 
-```
-  if inspect($$errors) != "null"
-    raise "\n" + join($$errors, "\n") + "\n"
-  end
-```
+**Example:** See "Cloud Workflow (Actions)" in `data/agent/code_examples.txt`.
 
 **`concurrent foreach`:** Use for independent iterations that can run in parallel. Individual `sub on_error:` handlers still work per-iteration:
 
-```
-  concurrent foreach $instance in $data do
-    sub on_error: handle_error() do
-      call stop_one_instance($instance)
-    end
-  end
-```
+**Example:** See "Cloud Workflow (Actions)" in `data/agent/code_examples.txt`.
 
 **Response code validation:** Check `$response["code"]` and `raise` on unexpected values. Success codes: `200`, `201`, `202`, `204`:
 
-```
-  if $response["code"] != 200 && $response["code"] != 202 && $response["code"] != 204
-    raise "Unexpected response deleting item " + $item["id"] + ": " + to_json($response)
-  else
-    task_label("Successfully deleted item: " + $item["id"])
-  end
-```
+**Example:** See "Cloud Workflow (Actions)" in `data/agent/code_examples.txt`.
 
 **`sleep($seconds)`:** Pause execution. Use in polling loops:
 
-```
-  while $instance_state != "running" do
-    call get_instance_state($instance) retrieve $instance_state
-    sleep(10)
-  end
-```
+**Example:** See "Cloud Workflow (Actions)" in `data/agent/code_examples.txt`.
 
 **`while` loops:** Combine with `sleep()` and `sub timeout:` for polling:
 
-```
-  sub timeout: 5m, on_timeout: skip do
-    while $state != "RUNNING" do
-      call get_state($item) retrieve $state
-      sleep(5)
-    end
-  end
-```
+**Example:** See "Cloud Workflow (Actions)" in `data/agent/code_examples.txt`.
 
 **`sub timeout:` with `on_timeout:`:** Use `skip` to silently continue, or call a handler `define`:
 
-```
-  sub timeout: 5m, on_timeout: handle_timeout() do
-    while $state == null do
-      call get_state($item) retrieve $state
-      sleep(10)
-    end
-  end
-```
+**Example:** See "Cloud Workflow (Actions)" in `data/agent/code_examples.txt`.
 
 **HTTP shorthand functions:** `http_get`, `http_post`, `http_patch`, `http_delete` take a single `url` parameter. Use for Google/Azure:
 
-```
-  $response = http_post(
-    auth: $$auth_google,
-    url: $url,
-    headers: { "content-type": "application/json" },
-    body: { "labels": $new_labels }
-  )
-```
+**Example:** See "Cloud Workflow (Actions)" in `data/agent/code_examples.txt`.
 
 ### Built-in Runtime Variables
 
@@ -1472,89 +740,21 @@ Commonly used built-in DSL functions for use in `check`, `request`, and `result`
 
 Any template that calls a Flexera API must include `ds_flexera_api_hosts` to route requests to the correct regional endpoint. Include it at the top of the Datasources section:
 
-```
-datasource "ds_flexera_api_hosts" do
-  run_script $js_flexera_api_hosts, rs_optima_host
-end
-
-script "js_flexera_api_hosts", type: "javascript" do
-  parameters "rs_optima_host"
-  result "result"
-  code <<-'EOS'
-    host_table = {
-      "api.optima.flexeraeng.com": { flexera: "api.flexera.com", optima: "api.optima.flexeraeng.com" },
-      "api.optima-eu.flexeraeng.com": { flexera: "api.flexera.eu", optima: "api.optima-eu.flexeraeng.com" },
-      "api.optima-apac.flexeraeng.com": { flexera: "api.flexera.au", optima: "api.optima-apac.flexeraeng.com" }
-    }
-    result = host_table[rs_optima_host]
-EOS
-end
-```
+**Example:** See "Flexera API Boilerplate Datasources" in `data/agent/code_examples.txt`.
 
 Use `val($ds_flexera_api_hosts, "flexera")` as `host` in Flexera API requests. For FSM/GRS APIs, copy the full boilerplate (including `fsm`, `grs`, `api`, `ui`, `tld` keys) from an existing template.
 
 Include `ds_applied_policy` in templates that reference `{{ .policy_name }}` in `summary_template`:
 
-```
-datasource "ds_applied_policy" do
-  request do
-    auth $auth_flexera
-    host val($ds_flexera_api_hosts, "flexera")
-    path join(["/policy/v1/orgs/", rs_org_id, "/projects/", rs_project_id, "/applied-policies/", policy_id])
-  end
-  result do
-    encoding "json"
-    field "id", jmes_path(response, "id")
-    field "name", jmes_path(response, "name")
-  end
-end
-```
+**Example:** See "Flexera API Boilerplate Datasources" in `data/agent/code_examples.txt`.
 
 Include `ds_billing_centers` in cost templates that query billing data:
 
-```
-datasource "ds_billing_centers" do
-  request do
-    auth $auth_flexera
-    host rs_optima_host     # use rs_optima_host directly, NOT val($ds_flexera_api_hosts, ...)
-    path join(["/analytics/orgs/", rs_org_id, "/billing_centers"])
-    query "view", "allocation_table"
-    header "Api-Version", "1.0"
-    header "User-Agent", "RS Policies"
-    ignore_status [403]
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "[*]") do
-      field "href", jmes_path(col_item, "href")
-      field "id", jmes_path(col_item, "id")
-      field "name", jmes_path(col_item, "name")
-      field "parent_id", jmes_path(col_item, "parent_id")
-    end
-  end
-end
-```
+**Example:** See "Flexera API Boilerplate Datasources" in `data/agent/code_examples.txt`.
 
 Include `ds_cloud_vendor_accounts` to display account/subscription names. The `id` field path differs by provider:
 
-```
-datasource "ds_cloud_vendor_accounts" do
-  request do
-    auth $auth_flexera
-    host val($ds_flexera_api_hosts, "flexera")
-    path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
-    header "Api-Version", "1.0"
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "values[*]") do
-      field "id", jmes_path(col_item, "aws.accountId")  # use azure.subscriptionId, gcp.projectId etc. for other providers
-      field "name", jmes_path(col_item, "name")
-      field "tags", jmes_path(col_item, "tags")
-    end
-  end
-end
-```
+**Example:** See "Flexera API Boilerplate Datasources" in `data/agent/code_examples.txt`.
 
 **When to add Meta Policy support:** Meta Policies work by deploying one child policy per cloud account. This only makes sense for templates that iterate through and make API calls to individual AWS accounts, Azure subscriptions, or Google projects. **Do not add Meta Policy support to:**
 - Pure CCO/billing templates (templates that only query Flexera APIs — no cloud provider credential needed)
@@ -1567,43 +767,7 @@ For Meta Policy support, the complete Meta Policy block **must be placed at the 
 
 The canonical Meta Policy section (copy verbatim):
 
-```
-###############################################################################
-# Meta Policy [alpha]
-# Not intended to be modified or used by policy developers
-###############################################################################
-
-# If the meta_parent_policy_id is not set it will evaluate to an empty string and we will look for the policy itself,
-# if it is set we will look for the parent policy.
-datasource "ds_get_parent_policy" do
-  request do
-    auth $auth_flexera
-    host val($ds_flexera_api_hosts, "flexera")
-    path join(["/policy/v1/orgs/", rs_org_id, "/projects/", rs_project_id, "/applied-policies/", switch(ne(meta_parent_policy_id, ""), meta_parent_policy_id, policy_id) ])
-	  ignore_status [404]
-  end
-  result do
-    encoding "json"
-    field "id", jmes_path(response, "id")
-  end
-end
-
-# If the policy was applied by a meta_parent_policy we confirm it exists if it doesn't we confirm we are deleting
-# This information is used in two places:
-# - determining whether or not we make a delete call
-# - determining if we should create an incident (we don't want to create an incident on the run where we terminate)
-datasource "ds_parent_policy_terminated" do
-  run_script $js_parent_policy_terminated, $ds_get_parent_policy, meta_parent_policy_id
-end
-
-script "js_parent_policy_terminated", type: "javascript" do
-  parameters "ds_get_parent_policy", "meta_parent_policy_id"
-  result "result"
-  code <<-'EOS'
-  result = meta_parent_policy_id != "" && ds_get_parent_policy["id"] == undefined
-EOS
-end
-```
+**Example:** See "Meta Policy Canonical Block" in `data/agent/code_examples.txt`.
 
 Use `$ds_parent_policy_terminated` in every `check` line in the `# Policy` section.
 
@@ -1613,263 +777,25 @@ Multi-region/subscription/project templates start with a datasource listing all 
 
 **AWS — `ds_describe_regions`:** Pass through region allow/deny filter before iterating:
 
-```
-datasource "ds_describe_regions" do
-  request do
-    auth $auth_aws
-    host "ec2.amazonaws.com"
-    path "/"
-    query "Action", "DescribeRegions"
-    query "Version", "2016-11-15"
-    query "Filter.1.Name", "opt-in-status"
-    query "Filter.1.Value.1", "opt-in-not-required"
-    query "Filter.1.Value.2", "opted-in"
-    header "Meta-Flexera", val($ds_is_deleted, "path")
-  end
-  result do
-    encoding "xml"
-    collect xpath(response, "//DescribeRegionsResponse/regionInfo/item", "array") do
-      field "region", xpath(col_item, "regionName")
-    end
-  end
-end
-```
+**Example:** See "Provider Boilerplate Datasources" in `data/agent/code_examples.txt`.
 
 **Azure — `ds_azure_subscriptions`:** Use `$param_azure_endpoint` as host to support Azure China:
 
-```
-datasource "ds_azure_subscriptions" do
-  request do
-    auth $auth_azure
-    pagination $pagination_azure
-    host $param_azure_endpoint
-    path "/subscriptions/"
-    query "api-version", "2020-01-01"
-    header "User-Agent", "RS Policies"
-    header "Meta-Flexera", val($ds_is_deleted, "path")
-    ignore_status [400, 403, 404]
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "value[*]") do
-      field "id", jmes_path(col_item, "subscriptionId")
-      field "name", jmes_path(col_item, "displayName")
-      field "state", jmes_path(col_item, "state")
-    end
-  end
-end
-```
+**Example:** See "Provider Boilerplate Datasources" in `data/agent/code_examples.txt`.
 
 **Google — `ds_google_projects`:**
 
-```
-datasource "ds_google_projects" do
-  request do
-    auth $auth_google
-    pagination $pagination_google
-    host "cloudresourcemanager.googleapis.com"
-    path "/v1/projects/"
-    query "filter", "(lifecycleState:ACTIVE)"
-    header "Meta-Flexera", val($ds_is_deleted, "path")
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "projects[*]") do
-      field "number", jmes_path(col_item, "projectNumber")
-      field "id", jmes_path(col_item, "projectId")
-      field "name", jmes_path(col_item, "name")
-    end
-  end
-end
-```
+**Example:** See "Provider Boilerplate Datasources" in `data/agent/code_examples.txt`.
 
 **`ds_terminate_self` + `ds_is_deleted`** — Meta Policy self-termination: `ds_terminate_self` issues `DELETE` when `$ds_parent_policy_terminated` is true, otherwise `GET`. `ds_is_deleted` produces sentinel `{ path: "/" }` to enforce evaluation order. These belong in the `# Meta Policy [alpha]` section at the bottom of the file:
 
-```
-# Two potentials ways to set this up:
-# - this way and make a unneeded 'get' request when not deleting
-# - make the delete request an interate and have it iterate over an empty array when not deleting and an array with one item when deleting
-datasource "ds_terminate_self" do
-  request do
-    run_script $js_make_terminate_request, $ds_parent_policy_terminated, $ds_flexera_api_hosts, policy_id, rs_org_id, rs_project_id
-  end
-end
-
-script "js_make_terminate_request", type: "javascript" do
-  parameters "ds_parent_policy_terminated", "ds_flexera_api_hosts", "policy_id", "rs_org_id", "rs_project_id"
-  result "request"
-  code <<-'EOS'
-  var request = {
-    auth: "auth_flexera",
-    host: ds_flexera_api_hosts["flexera"],
-    path: [ "/policy/v1/orgs/", rs_org_id, "/projects/", rs_project_id, "/applied-policies", policy_id ? "/"+policy_id : "" ].join(''),
-    verb: ds_parent_policy_terminated ? "DELETE" : "GET"
-  }
-EOS
-end
-
-# This is just a way to have the check delete request connect to the farthest leaf from policy.
-# We want the delete check to the first thing the policy does to avoid the policy erroring before it can decide whether or not it needs to self terminate
-# Example a customer deletes a credential and then terminates the parent policy. We still want the children to self terminate
-# The only way I could see this not happening is if the user who applied the parent_meta_policy was offboarded or lost policy access, the policies who are impersonating the user
-# would not have access to self-terminate
-# It may be useful for the backend to enable a mass terminate at some point for all meta_child_policies associated with an id.
-datasource "ds_is_deleted" do
-  run_script $js_is_deleted, $ds_terminate_self
-end
-
-script "js_is_deleted", type: "javascript" do
-  parameters "ds_terminate_self"
-  result "result"
-  code 'result = { path: "/"}'
-end
-```
+**Example:** See "Provider Boilerplate Datasources" in `data/agent/code_examples.txt`.
 
 ## Standard Parameter Conventions
 
 Use exact labels/descriptions for UI consistency:
 
-```
-# Always first — recipient list for incident emails
-parameter "param_email" do
-  type "list"
-  category "Policy Settings"
-  label "Email Addresses"
-  description "A list of email addresses to notify."
-  default []
-end
-
-# Required for Meta Policy support — leave blank for normal use
-parameter "param_aws_account_number" do
-  type "string"
-  category "Policy Settings"
-  label "Account Number"
-  description "Leave blank; this is for automated use with Meta Policies. See README for more details."
-  default ""
-end
-
-# Optional automated action — default [] means manual approval required
-parameter "param_automatic_action" do
-  type "list"
-  category "Actions"
-  label "Automatic Actions"
-  description "When set, the policy will automatically take the selected action(s)."
-  allowed_values ["Delete Items"]
-  default []
-end
-
-# Cost recommendation policies — skip low-value findings
-parameter "param_min_savings" do
-  type "number"
-  category "Policy Settings"
-  label "Minimum Savings Threshold"
-  description "Minimum potential savings required to generate a recommendation."
-  min_value 0
-  default 0
-end
-
-# Region/subscription/resource-group filter pair (use together)
-parameter "param_regions_allow_or_deny" do
-  type "string"
-  category "Filters"
-  label "Allow/Deny Regions"
-  description "Allow or Deny entered regions. See the README for more details."
-  allowed_values "Allow", "Deny"
-  default "Allow"
-end
-
-parameter "param_regions_list" do
-  type "list"
-  category "Filters"
-  label "Allow/Deny Regions List"
-  description "A list of allowed or denied regions. See the README for more details."
-  default []
-end
-
-# Azure subscription filter pair — use in all Azure templates (analogous to region filter for Azure)
-parameter "param_subscriptions_allow_or_deny" do
-  type "string"
-  category "Filters"
-  label "Allow/Deny Subscriptions"
-  description "Allow or Deny entered subscriptions. See the README for more details."
-  allowed_values "Allow", "Deny"
-  default "Allow"
-end
-
-parameter "param_subscriptions_list" do
-  type "list"
-  category "Filters"
-  label "Allow/Deny Subscriptions List"
-  description "A list of allowed or denied subscription IDs/names. See the README for more details."
-  default []
-end
-
-# Google project filter pair — use in all Google templates (analogous to region filter for Google)
-parameter "param_projects_allow_or_deny" do
-  type "string"
-  category "Filters"
-  label "Allow/Deny Projects"
-  description "Allow or Deny entered Projects. See the README for more details."
-  allowed_values "Allow", "Deny"
-  default "Allow"
-end
-
-parameter "param_projects_list" do
-  type "list"
-  category "Filters"
-  label "Allow/Deny Projects List"
-  description "A list of allowed or denied project IDs/names. See the README for more details."
-  default []
-end
-
-# Azure endpoint — include in all Azure templates; allows targeting Azure China cloud
-parameter "param_azure_endpoint" do
-  type "string"
-  category "Policy Settings"
-  label "Azure Endpoint"
-  description "Select the API endpoint to use for Azure. Use default value of management.azure.com unless using Azure China."
-  allowed_values "management.azure.com", "management.chinacloudapi.cn"
-  default "management.azure.com"
-end
-
-# Tag-based exclusion — common across all providers
-parameter "param_exclusion_tags" do
-  type "list"
-  category "Filters"
-  label "Exclusion Tags"
-  description "Cloud native tags to ignore resources that you don't want to produce recommendations for. Enter the Key name to filter resources with a specific Key, regardless of Value, and enter Key==Value to filter resources with a specific Key:Value pair. Other operators and regex are supported; please see the README for more details."
-  default []
-end
-
-parameter "param_exclusion_tags_boolean" do
-  type "string"
-  category "Filters"
-  label "Exclusion Tags: Any / All"
-  description "Whether to filter resources containing any of the specified tags or only those that contain all of them."
-  allowed_values "Any", "All"
-  default "Any"
-end
-
-# Incident output controls — include in templates that send large incident tables
-parameter "param_incident_table_size" do
-  type "number"
-  category "Policy Settings"
-  label "Incident Table Size"
-  description "Maximum number of rows to include in the incident table in the email. Larger values may cause email delivery issues."
-  min_value 1
-  max_value 500
-  default 20
-end
-
-parameter "param_incident_csv" do
-  type "string"
-  category "Policy Settings"
-  label "Attach Incident CSV"
-  description "Whether or not to attach a CSV of the incident data to the incident email."
-  allowed_values "true", "false"
-  default "true"
-end
-```
+**Example:** See "Standard Parameter Conventions" in `data/agent/code_examples.txt`.
 
 Other useful parameter fields (beyond `type`, `label`, `description`, `default`, `allowed_values`, `min_value`/`max_value`, `min_length`/`max_length`):
 
@@ -1898,17 +824,7 @@ Key rules:
 - **Description** must mention the CloudWatch 90-day retention ceiling: *"This value cannot be set higher than 90 because AWS does not retain metrics for longer than 90 days."*
 - The export field label for the lookback in the incident output should remain `"Look Back Period (Days)"` (the Flexera scraping standard) — the `category`/`label` change is only for the parameter UI.
 
-```
-parameter "param_stats_lookback" do
-  type "number"
-  category "Statistics"
-  label "Statistic Lookback Period"
-  description "How many days back to look at CloudWatch data when assessing resources. This value cannot be set higher than 90 because AWS does not retain metrics for longer than 90 days."
-  min_value 1
-  max_value 90
-  default 30
-end
-```
+**Example:** See "Statistics Category Parameters" in `data/agent/code_examples.txt`.
 
 ## Style Rules
 

--- a/automation/aws/aws_account_credentials/CHANGELOG.md
+++ b/automation/aws/aws_account_credentials/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.2.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/automation/aws/aws_account_credentials/aws_account_credentials.pt
+++ b/automation/aws/aws_account_credentials/aws_account_credentials.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "0.2.1",
+  version: "0.2.2",
   provider: "AWS",
   service: "Identity & Access Management",
   policy_set: "Authentication",
@@ -139,7 +139,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
     # Header X-Meta-Flexera has no affect on datasource query, but is required for Meta Policies

--- a/automation/aws/aws_missing_regions/CHANGELOG.md
+++ b/automation/aws/aws_missing_regions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.3.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/automation/aws/aws_missing_regions/aws_missing_regions.pt
+++ b/automation/aws/aws_missing_regions/aws_missing_regions.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "0.3.1",
+  version: "0.3.2",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Automation",
@@ -146,7 +146,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/automation/aws/aws_missing_regions/aws_missing_regions_meta_parent.pt
+++ b/automation/aws/aws_missing_regions/aws_missing_regions_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.3.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.3.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/automation/aws/aws_rbd_from_tag/CHANGELOG.md
+++ b/automation/aws/aws_rbd_from_tag/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.2.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/automation/aws/aws_rbd_from_tag/aws_rbd_from_tag.pt
+++ b/automation/aws/aws_rbd_from_tag/aws_rbd_from_tag.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "3.2.1",
+  version: "3.2.2",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Automation",
@@ -159,7 +159,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/automation/aws/aws_rbd_from_tag/aws_rbd_from_tag.pt
+++ b/automation/aws/aws_rbd_from_tag/aws_rbd_from_tag.pt
@@ -444,13 +444,25 @@ script "js_apply_rbds", type: "javascript" do
 EOS
 end
 
+datasource "ds_rbds_summary" do
+  run_script $js_rbds_summary, $ds_apply_rbds, $ds_applied_policy
+end
+
+script "js_rbds_summary", type: "javascript" do
+  parameters "ds_apply_rbds", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = [{ policy_name: ds_applied_policy["name"] }]
+EOS
+end
+
 ###############################################################################
 # Policy
 ###############################################################################
 
 policy "pol_rbds" do
-  validate $ds_apply_rbds do
-    summary_template "RBDs Generated & Applied"
+  validate $ds_rbds_summary do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: RBDs Generated & Applied"
     detail_template ""
     check eq(0, 0)
   end

--- a/automation/flexera/disallowed_credentials/CHANGELOG.md
+++ b/automation/flexera/disallowed_credentials/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.2.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/automation/flexera/disallowed_credentials/disallowed_credentials.pt
+++ b/automation/flexera/disallowed_credentials/disallowed_credentials.pt
@@ -8,7 +8,7 @@ severity "high"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "0.2.1",
+  version: "0.2.2",
   provider: "Flexera",
   service: "Automation",
   policy_set: "Automation",
@@ -146,7 +146,7 @@ end
 datasource "ds_org_credentials" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/cred/v2/orgs/", rs_org_id, "/credentials"])
     header "Api-Version", "1.0"
   end
@@ -169,7 +169,7 @@ end
 datasource "ds_project_credentials" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/cred/v2/projects/", rs_project_id, "/credentials"])
     header "Api-Version", "1.0"
   end

--- a/automation/flexera/expiring_credentials/CHANGELOG.md
+++ b/automation/flexera/expiring_credentials/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.2.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/automation/flexera/expiring_credentials/expiring_credentials.pt
+++ b/automation/flexera/expiring_credentials/expiring_credentials.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "0.2.1",
+  version: "0.2.2",
   provider: "Flexera",
   service: "Automation",
   policy_set: "Automation",
@@ -156,7 +156,7 @@ end
 datasource "ds_org_credentials" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/cred/v2/orgs/", rs_org_id, "/credentials"])
     header "Api-Version", "1.0"
   end
@@ -179,7 +179,7 @@ end
 datasource "ds_project_credentials" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/cred/v2/projects/", rs_project_id, "/credentials"])
     header "Api-Version", "1.0"
   end

--- a/automation/google/google_rbd_from_tag/CHANGELOG.md
+++ b/automation/google/google_rbd_from_tag/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.2.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/automation/google/google_rbd_from_tag/google_rbd_from_tag.pt
+++ b/automation/google/google_rbd_from_tag/google_rbd_from_tag.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.2.1",
+  version: "0.2.2",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Automation",
@@ -149,6 +149,7 @@ script "js_flexera_api_hosts", type: "javascript" do
       tld: "flexeratest.com"
     }
   }
+
   result = host_table[rs_optima_host]
 EOS
 end

--- a/automation/google/google_rbd_from_tag/google_rbd_from_tag.pt
+++ b/automation/google/google_rbd_from_tag/google_rbd_from_tag.pt
@@ -525,13 +525,25 @@ script "js_apply_rbds", type: "javascript" do
 EOS
 end
 
+datasource "ds_rbds_summary" do
+  run_script $js_rbds_summary, $ds_apply_rbds, $ds_applied_policy
+end
+
+script "js_rbds_summary", type: "javascript" do
+  parameters "ds_apply_rbds", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = [{ policy_name: ds_applied_policy["name"] }]
+EOS
+end
+
 ###############################################################################
 # Policy
 ###############################################################################
 
 policy "pol_rbds" do
-  validate $ds_apply_rbds do
-    summary_template "RBDs Generated & Applied"
+  validate $ds_rbds_summary do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: RBDs Generated & Applied"
     detail_template ""
     check eq(0, 0)
   end

--- a/compliance/aws/disallowed_regions/CHANGELOG.md
+++ b/compliance/aws/disallowed_regions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.1.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v5.1.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/aws/disallowed_regions/aws_disallowed_regions.pt
+++ b/compliance/aws/disallowed_regions/aws_disallowed_regions.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.1.2",
+  version: "5.1.3",
   provider: "AWS",
   service: "Compute",
   policy_set: "Disallowed Regions",
@@ -177,7 +177,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/compliance/aws/disallowed_regions/aws_disallowed_regions_meta_parent.pt
+++ b/compliance/aws/disallowed_regions/aws_disallowed_regions_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "5.1.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/compliance/aws/ecs_unused/CHANGELOG.md
+++ b/compliance/aws/ecs_unused/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.2.7
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v4.2.6
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/aws/ecs_unused/aws_unused_ecs_clusters.pt
+++ b/compliance/aws/ecs_unused/aws_unused_ecs_clusters.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Compliance"
 default_frequency "weekly"
 info(
-  version: "4.2.6",
+  version: "4.2.7",
   provider: "AWS",
   service: "Compute",
   policy_set: "Unused Containers",
@@ -181,7 +181,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/compliance/aws/ecs_unused/aws_unused_ecs_clusters_meta_parent.pt
+++ b/compliance/aws/ecs_unused/aws_unused_ecs_clusters_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "4.2.6", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.2.7", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/compliance/aws/iam_role_audit/CHANGELOG.md
+++ b/compliance/aws/iam_role_audit/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.0.14
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.0.13
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/aws/iam_role_audit/aws_iam_role_audit.pt
+++ b/compliance/aws/iam_role_audit/aws_iam_role_audit.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Compliance"
 default_frequency "daily"
 info(
-  version: "3.0.13",
+  version: "3.0.14",
   provider:"AWS",
   service: "Identity & Access Management",
   policy_set: "Identity & Access Management",
@@ -149,7 +149,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/compliance/aws/iam_role_audit/aws_iam_role_audit_meta_parent.pt
+++ b/compliance/aws/iam_role_audit/aws_iam_role_audit_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "3.0.13", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.0.14", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/compliance/aws/long_stopped_instances/CHANGELOG.md
+++ b/compliance/aws/long_stopped_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.1.7
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v6.1.6
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt
+++ b/compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Compliance"
 default_frequency "weekly"
 info(
-  version: "6.1.6",
+  version: "6.1.7",
   provider: "AWS",
   service: "Compute",
   policy_set: "Long Stopped Instances",
@@ -191,7 +191,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/compliance/aws/long_stopped_instances/aws_long_stopped_instances_meta_parent.pt
+++ b/compliance/aws/long_stopped_instances/aws_long_stopped_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "6.1.6", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.1.7", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/compliance/aws/rds_backup/CHANGELOG.md
+++ b/compliance/aws/rds_backup/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.7
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.6
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/aws/rds_backup/aws_rds_backup.pt
+++ b/compliance/aws/rds_backup/aws_rds_backup.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "medium"
 default_frequency "weekly"
 info(
-  version: "3.1.6",
+  version: "3.1.7",
   provider: "AWS",
   service: "RDS",
   policy_set: "",
@@ -245,7 +245,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/compliance/aws/rds_backup/aws_rds_backup_meta_parent.pt
+++ b/compliance/aws/rds_backup/aws_rds_backup_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "3.1.6", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.1.7", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/compliance/aws/untagged_resources/CHANGELOG.md
+++ b/compliance/aws/untagged_resources/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.0.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v6.0.2
 
 - Improved the policy's reliability when checking which AWS regions it can access, making it less likely to fail to run due to expected access restrictions in certain regions

--- a/compliance/aws/untagged_resources/aws_untagged_resources.pt
+++ b/compliance/aws/untagged_resources/aws_untagged_resources.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.0.2",
+  version: "6.0.3",
   provider: "AWS",
   service: "Compute",
   policy_set: "Untagged Resources",
@@ -220,7 +220,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end
@@ -379,7 +379,7 @@ end
 datasource "ds_tag_dimensions" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-customizations/v1/orgs/", rs_org_id, "/tag-dimensions"])
     header "Api-Version", "1.0"
   end

--- a/compliance/aws/untagged_resources/aws_untagged_resources_meta_parent.pt
+++ b/compliance/aws/untagged_resources/aws_untagged_resources_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "6.0.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.0.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/compliance/azure/azure_untagged_resources/CHANGELOG.md
+++ b/compliance/azure/azure_untagged_resources/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.0.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v5.0.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/azure/azure_untagged_resources/untagged_resources.pt
+++ b/compliance/azure/azure_untagged_resources/untagged_resources.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.0.1",
+  version: "5.0.2",
   provider: "Azure",
   service: "Compute",
   policy_set: "Untagged Resources",
@@ -254,7 +254,7 @@ end
 datasource "ds_tag_dimensions" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-customizations/v1/orgs/", rs_org_id, "/tag-dimensions"])
     header "Api-Version", "1.0"
   end

--- a/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent.pt
+++ b/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "5.0.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.0.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent_rg.pt
+++ b/compliance/azure/azure_untagged_resources/untagged_resources_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "5.0.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.0.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/compliance/azure/azure_untagged_vms/CHANGELOG.md
+++ b/compliance/azure/azure_untagged_vms/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.0.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v2.0.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/azure/azure_untagged_vms/untagged_vms.pt
+++ b/compliance/azure/azure_untagged_vms/untagged_vms.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "2.0.2",
+  version: "2.0.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "Untagged Resources",
@@ -246,7 +246,7 @@ end
 datasource "ds_tag_dimensions" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-customizations/v1/orgs/", rs_org_id, "/tag-dimensions"])
     header "Api-Version", "1.0"
   end

--- a/compliance/azure/azure_untagged_vms/untagged_vms_meta_parent.pt
+++ b/compliance/azure/azure_untagged_vms/untagged_vms_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "2.0.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "2.0.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/compliance/azure/azure_untagged_vms/untagged_vms_meta_parent_rg.pt
+++ b/compliance/azure/azure_untagged_vms/untagged_vms_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "2.0.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "2.0.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/compliance/google/unlabeled_resources/CHANGELOG.md
+++ b/compliance/google/unlabeled_resources/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.0.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v5.0.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/google/unlabeled_resources/unlabeled_resources.pt
+++ b/compliance/google/unlabeled_resources/unlabeled_resources.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.0.1",
+  version: "5.0.2",
   provider: "Google",
   service: "Compute",
   policy_set: "Untagged Resources",
@@ -331,7 +331,7 @@ end
 datasource "ds_tag_dimensions" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-customizations/v1/orgs/", rs_org_id, "/tag-dimensions"])
     header "Api-Version", "1.0"
   end

--- a/compliance/google/unlabeled_resources/unlabeled_resources_meta_parent.pt
+++ b/compliance/google/unlabeled_resources/unlabeled_resources_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "5.0.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.0.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/asg_recommendations/CHANGELOG.md
+++ b/cost/aws/asg_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.1.2
 
 - Improved the policy's reliability when checking which AWS regions it can access, making it less likely to fail to run due to expected access restrictions in certain regions

--- a/cost/aws/asg_recommendations/aws_asg_recommendations.pt
+++ b/cost/aws/asg_recommendations/aws_asg_recommendations.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.1.2",
+  version: "0.1.3",
   provider: "AWS",
   service: "Compute",
   policy_set: "Auto Scaling Recommendations",
@@ -247,8 +247,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, "flexera")
-    path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
+    host val($ds_flexera_api_hosts, 'flexera')
     header "Api-Version", "1.0"
   end
   result do
@@ -293,6 +292,7 @@ script "js_top_level_bcs", type: "javascript" do
   filtered_bcs = _.filter(ds_billing_centers, function(bc) {
     return bc['parent_id'] == null || bc['parent_id'] == undefined
   })
+
   result = _.compact(_.pluck(filtered_bcs, 'id'))
 EOS
 end

--- a/cost/aws/asg_recommendations/aws_asg_recommendations.pt
+++ b/cost/aws/asg_recommendations/aws_asg_recommendations.pt
@@ -247,7 +247,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/asg_recommendations/aws_asg_recommendations.pt
+++ b/cost/aws/asg_recommendations/aws_asg_recommendations.pt
@@ -248,6 +248,7 @@ datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
     host val($ds_flexera_api_hosts, 'flexera')
+    path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end
   result do

--- a/cost/aws/asg_recommendations/aws_asg_recommendations_meta_parent.pt
+++ b/cost/aws/asg_recommendations/aws_asg_recommendations_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.1.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/burstable_ec2_instances/CHANGELOG.md
+++ b/cost/aws/burstable_ec2_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.5.6
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v4.5.5
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/aws/burstable_ec2_instances/aws_burstable_ec2_instances.pt
+++ b/cost/aws/burstable_ec2_instances/aws_burstable_ec2_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "monthly"
 info(
-  version: "4.5.5",
+  version: "4.5.6",
   provider: "AWS",
   service: "Compute",
   policy_set: "Burstable Compute Instances",
@@ -222,7 +222,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/burstable_ec2_instances/aws_burstable_ec2_instances_meta_parent.pt
+++ b/cost/aws/burstable_ec2_instances/aws_burstable_ec2_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "4.5.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.5.6", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/cloudtrail_read_logging/CHANGELOG.md
+++ b/cost/aws/cloudtrail_read_logging/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.6
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.2.5
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/aws/cloudtrail_read_logging/aws_cloudtrail_read_logging.pt
+++ b/cost/aws/cloudtrail_read_logging/aws_cloudtrail_read_logging.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.5",
+  version: "0.2.6",
   provider: "AWS",
   service: "CloudTrail",
   policy_set: "Logging",
@@ -164,7 +164,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/cloudtrail_read_logging/aws_cloudtrail_read_logging_meta_parent.pt
+++ b/cost/aws/cloudtrail_read_logging/aws_cloudtrail_read_logging_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.2.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.6", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/ec2_compute_optimizer/CHANGELOG.md
+++ b/cost/aws/ec2_compute_optimizer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.5
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.6.4
 
 - Improved the policy's reliability when checking which AWS regions it can access, making it less likely to fail to run due to expected access restrictions in certain regions

--- a/cost/aws/ec2_compute_optimizer/aws_ec2_compute_optimizer.pt
+++ b/cost/aws/ec2_compute_optimizer/aws_ec2_compute_optimizer.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.6.4",
+  version: "0.6.5",
   provider: "AWS",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -240,7 +240,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/ec2_compute_optimizer/aws_ec2_compute_optimizer_meta_parent.pt
+++ b/cost/aws/ec2_compute_optimizer/aws_ec2_compute_optimizer_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.6.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.6.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/eks_without_spot/CHANGELOG.md
+++ b/cost/aws/eks_without_spot/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.8
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.2.7
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/aws/eks_without_spot/aws_eks_without_spot.pt
+++ b/cost/aws/eks_without_spot/aws_eks_without_spot.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.7",
+  version: "0.2.8",
   provider: "AWS",
   service: "Compute",
   policy_set: "Autoscaling",
@@ -185,7 +185,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/eks_without_spot/aws_eks_without_spot_meta_parent.pt
+++ b/cost/aws/eks_without_spot/aws_eks_without_spot_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.2.7", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.8", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/extended_support/CHANGELOG.md
+++ b/cost/aws/extended_support/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.2.3
+
+- Updated policy logic for internal consistency; no functional or user-facing changes.
+
 ## v1.2.2
 
 - Improved the policy's reliability when checking which AWS regions it can access, making it less likely to fail to run due to expected access restrictions in certain regions

--- a/cost/aws/extended_support/aws_extended_support.pt
+++ b/cost/aws/extended_support/aws_extended_support.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "1.2.2",
+  version: "1.2.3",
   provider: "AWS",
   service: "All",
   policy_set: "Deprecated Resources",
@@ -500,11 +500,11 @@ datasource "ds_describe_regions" do
 end
 
 datasource "ds_regions" do
-  run_script $js_regions, $ds_describe_regions, $param_regions_allow_or_deny, $param_regions_list
+  run_script $js_regions, $ds_describe_regions, $param_regions_list, $param_regions_allow_or_deny
 end
 
 script "js_regions", type: "javascript" do
-  parameters "ds_describe_regions", "param_regions_allow_or_deny", "param_regions_list"
+  parameters "ds_describe_regions", "param_regions_list", "param_regions_allow_or_deny"
   result "result"
   code <<-'EOS'
   allow_deny_test = { "Allow": true, "Deny": false }

--- a/cost/aws/extended_support/aws_extended_support_meta_parent.pt
+++ b/cost/aws/extended_support/aws_extended_support_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "1.2.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "1.2.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/idle_fsx/CHANGELOG.md
+++ b/cost/aws/idle_fsx/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.4
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.2.3
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/aws/idle_fsx/aws_idle_fsx.pt
+++ b/cost/aws/idle_fsx/aws_idle_fsx.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.3",
+  version: "0.2.4",
   provider: "AWS",
   service: "Storage",
   policy_set: "Unused Storage",
@@ -214,7 +214,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'api')
+    host val($ds_flexera_api_hosts, "api")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/idle_fsx/aws_idle_fsx_meta_parent.pt
+++ b/cost/aws/idle_fsx/aws_idle_fsx_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.2.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/idle_lambda_functions/CHANGELOG.md
+++ b/cost/aws/idle_lambda_functions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.5
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.1.4
 
 - Improved the policy's reliability when checking which AWS regions it can access, making it less likely to fail to run due to expected access restrictions in certain regions

--- a/cost/aws/idle_lambda_functions/aws_idle_lambda_functions.pt
+++ b/cost/aws/idle_lambda_functions/aws_idle_lambda_functions.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.1.4",
+  version: "0.1.5",
   provider: "AWS",
   service: "PaaS",
   policy_set: "Idle Lambda Functions",
@@ -228,8 +228,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, "flexera")
-    path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
+    host val($ds_flexera_api_hosts, 'flexera')
     header "Api-Version", "1.0"
   end
   result do

--- a/cost/aws/idle_lambda_functions/aws_idle_lambda_functions.pt
+++ b/cost/aws/idle_lambda_functions/aws_idle_lambda_functions.pt
@@ -228,7 +228,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/idle_lambda_functions/aws_idle_lambda_functions.pt
+++ b/cost/aws/idle_lambda_functions/aws_idle_lambda_functions.pt
@@ -229,6 +229,7 @@ datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
     host val($ds_flexera_api_hosts, 'flexera')
+    path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end
   result do

--- a/cost/aws/idle_lambda_functions/aws_idle_lambda_functions_meta_parent.pt
+++ b/cost/aws/idle_lambda_functions/aws_idle_lambda_functions_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.1.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.1.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/idle_nat_gateways/CHANGELOG.md
+++ b/cost/aws/idle_nat_gateways/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.10
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.3.9
 
 - Improved the policy's reliability when checking which AWS regions it can access, making it less likely to fail to run due to expected access restrictions in certain regions

--- a/cost/aws/idle_nat_gateways/aws_idle_nat_gateways.pt
+++ b/cost/aws/idle_nat_gateways/aws_idle_nat_gateways.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.9",
+  version: "0.3.10",
   provider: "AWS",
   service: "Network",
   policy_set: "Idle NAT Gateways",
@@ -214,7 +214,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/idle_nat_gateways/aws_idle_nat_gateways_meta_parent.pt
+++ b/cost/aws/idle_nat_gateways/aws_idle_nat_gateways_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.3.9", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.3.10", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/idle_sagemaker_endpoints/CHANGELOG.md
+++ b/cost/aws/idle_sagemaker_endpoints/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/aws/idle_sagemaker_endpoints/aws_idle_sagemaker_endpoints.pt
+++ b/cost/aws/idle_sagemaker_endpoints/aws_idle_sagemaker_endpoints.pt
@@ -228,7 +228,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/idle_sagemaker_endpoints/aws_idle_sagemaker_endpoints.pt
+++ b/cost/aws/idle_sagemaker_endpoints/aws_idle_sagemaker_endpoints.pt
@@ -229,6 +229,7 @@ datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
     host val($ds_flexera_api_hosts, 'flexera')
+    path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end
   result do

--- a/cost/aws/idle_sagemaker_endpoints/aws_idle_sagemaker_endpoints.pt
+++ b/cost/aws/idle_sagemaker_endpoints/aws_idle_sagemaker_endpoints.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.1.1",
+  version: "0.1.2",
   provider: "AWS",
   service: "SageMaker",
   policy_set: "Idle SageMaker Endpoints",
@@ -228,8 +228,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, "flexera")
-    path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
+    host val($ds_flexera_api_hosts, 'flexera')
     header "Api-Version", "1.0"
   end
   result do

--- a/cost/aws/idle_sagemaker_endpoints/aws_idle_sagemaker_endpoints_meta_parent.pt
+++ b/cost/aws/idle_sagemaker_endpoints/aws_idle_sagemaker_endpoints_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.1.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.1.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/object_storage_optimization/CHANGELOG.md
+++ b/cost/aws/object_storage_optimization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.0.14
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v4.0.13
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.0.13",
+  version: "4.0.14",
   provider: "AWS",
   service: "Storage",
   policy_set: "Object Store Optimization",
@@ -205,7 +205,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "4.0.13", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.0.14", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "true",
   hide_skip_approvals: "true"

--- a/cost/aws/old_snapshots/CHANGELOG.md
+++ b/cost/aws/old_snapshots/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v8.6.10
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v8.6.9
 
 - Improved the policy's reliability when checking which AWS regions it can access, making it less likely to fail to run due to expected access restrictions in certain regions

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "8.6.9",
+  version: "8.6.10",
   provider: "AWS",
   service: "Storage",
   policy_set: "Old Snapshots",
@@ -275,7 +275,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "8.6.9", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "8.6.10", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/reserved_instances/recommendations/CHANGELOG.md
+++ b/cost/aws/reserved_instances/recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.8.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.8.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/aws/reserved_instances/recommendations/aws_reserved_instance_recommendations.pt
+++ b/cost/aws/reserved_instances/recommendations/aws_reserved_instance_recommendations.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.8.1",
+  version: "3.8.2",
   provider: "AWS",
   service: "Compute",
   policy_set: "Reserved Instances",
@@ -256,7 +256,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.10
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.5.9
 
 - Improved the policy's reliability when checking which AWS regions it can access, making it less likely to fail to run due to expected access restrictions in certain regions

--- a/cost/aws/rightsize_ebs_volumes/aws_rightsize_ebs_volumes.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_rightsize_ebs_volumes.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.9",
+  version: "0.5.10",
   provider: "AWS",
   service: "EBS",
   policy_set: "Unused Volumes",
@@ -267,7 +267,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/rightsize_ebs_volumes/aws_rightsize_ebs_volumes_meta_parent.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_rightsize_ebs_volumes_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.5.9", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.5.10", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/rightsize_ec2_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_ec2_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.7.6
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v5.7.5
 
 - Improved the policy's reliability when checking which AWS regions it can access, making it less likely to fail to run due to expected access restrictions in certain regions

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "5.7.5",
+  version: "5.7.6",
   provider: "AWS",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -290,7 +290,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'api')
+    host val($ds_flexera_api_hosts, "api")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "5.7.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.7.6", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/rightsize_ec2_instances_cross_family/CHANGELOG.md
+++ b/cost/aws/rightsize_ec2_instances_cross_family/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.1.2
 
 - Improved the policy's reliability when checking which AWS regions it can access, making it less likely to fail to run due to expected access restrictions in certain regions

--- a/cost/aws/rightsize_ec2_instances_cross_family/aws_rightsize_ec2_instances_cross_family.pt
+++ b/cost/aws/rightsize_ec2_instances_cross_family/aws_rightsize_ec2_instances_cross_family.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "0.1.2",
+  version: "0.1.3",
   provider: "AWS",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -241,7 +241,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'api')
+    host val($ds_flexera_api_hosts, "api")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/rightsize_ec2_instances_cross_family/aws_rightsize_ec2_instances_cross_family_meta_parent.pt
+++ b/cost/aws/rightsize_ec2_instances_cross_family/aws_rightsize_ec2_instances_cross_family_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.1.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/rightsize_elasticache/CHANGELOG.md
+++ b/cost/aws/rightsize_elasticache/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.11
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.5.10
 
 - Improved the policy's reliability when checking which AWS regions it can access, making it less likely to fail to run due to expected access restrictions in certain regions

--- a/cost/aws/rightsize_elasticache/aws_rightsize_elasticache.pt
+++ b/cost/aws/rightsize_elasticache/aws_rightsize_elasticache.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.10",
+  version: "0.5.11",
   provider: "AWS",
   service: "Database",
   policy_set: "Rightsize Database Instances",
@@ -252,7 +252,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/rightsize_elasticache/aws_rightsize_elasticache_meta_parent.pt
+++ b/cost/aws/rightsize_elasticache/aws_rightsize_elasticache_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.5.10", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.5.11", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/rightsize_rds_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_rds_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.11.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v5.11.2
 
 - Improved the policy's reliability when checking which AWS regions it can access, making it less likely to fail to run due to expected access restrictions in certain regions

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "5.11.2",
+  version: "5.11.3",
   provider: "AWS",
   service: "RDS",
   policy_set: "Rightsize Database Instances",
@@ -362,7 +362,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "5.11.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.11.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/rightsize_redshift/CHANGELOG.md
+++ b/cost/aws/rightsize_redshift/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.5
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.3.4
 
 - Improved the policy's reliability when checking which AWS regions it can access, making it less likely to fail to run due to expected access restrictions in certain regions

--- a/cost/aws/rightsize_redshift/aws_rightsize_redshift.pt
+++ b/cost/aws/rightsize_redshift/aws_rightsize_redshift.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.4",
+  version: "0.3.5",
   provider: "AWS",
   service: "Database",
   policy_set: "Rightsize Database Instances",
@@ -233,7 +233,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/rightsize_redshift/aws_rightsize_redshift_meta_parent.pt
+++ b/cost/aws/rightsize_redshift/aws_rightsize_redshift_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.3.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.3.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/s3_bucket_size/CHANGELOG.md
+++ b/cost/aws/s3_bucket_size/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.0.5
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v4.0.4
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/aws/s3_bucket_size/aws_bucket_size.pt
+++ b/cost/aws/s3_bucket_size/aws_bucket_size.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "medium"
 default_frequency "weekly"
 info(
-  version: "4.0.4",
+  version: "4.0.5",
   provider: "AWS",
   service: "Storage",
   policy_set: "",
@@ -181,7 +181,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/s3_bucket_size/aws_bucket_size_meta_parent.pt
+++ b/cost/aws/s3_bucket_size/aws_bucket_size_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "4.0.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.0.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/s3_lifecycle/CHANGELOG.md
+++ b/cost/aws/s3_lifecycle/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.6
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.2.5
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/aws/s3_lifecycle/aws_s3_lifecycle.pt
+++ b/cost/aws/s3_lifecycle/aws_s3_lifecycle.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "medium"
 default_frequency "weekly"
 info(
-  version: "0.2.5",
+  version: "0.2.6",
   provider: "AWS",
   service: "Storage",
   policy_set: "",
@@ -172,7 +172,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/s3_lifecycle/aws_s3_lifecycle_meta_parent.pt
+++ b/cost/aws/s3_lifecycle/aws_s3_lifecycle_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.2.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.6", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/s3_multipart_uploads/CHANGELOG.md
+++ b/cost/aws/s3_multipart_uploads/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.6
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.2.5
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/aws/s3_multipart_uploads/aws_s3_multipart_uploads.pt
+++ b/cost/aws/s3_multipart_uploads/aws_s3_multipart_uploads.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.5",
+  version: "0.2.6",
   provider: "AWS",
   service: "Storage",
   policy_set: "",
@@ -190,7 +190,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/s3_multipart_uploads/aws_s3_multipart_uploads_meta_parent.pt
+++ b/cost/aws/s3_multipart_uploads/aws_s3_multipart_uploads_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.2.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.6", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/s3_storage_policy/CHANGELOG.md
+++ b/cost/aws/s3_storage_policy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.2.8
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v4.2.7
 
 - Improved the policy's reliability when checking which AWS regions it can access, making it less likely to fail to run due to expected access restrictions in certain regions

--- a/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check.pt
+++ b/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "medium"
 default_frequency "weekly"
 info(
-  version: "4.2.7",
+  version: "4.2.8",
   provider: "AWS",
   service: "Storage",
   policy_set: "Object Store Optimization",
@@ -227,7 +227,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check_meta_parent.pt
+++ b/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "4.2.7", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.2.8", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/savings_plan/purchase_analysis/CHANGELOG.md
+++ b/cost/aws/savings_plan/purchase_analysis/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.2.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/aws/savings_plan/purchase_analysis/aws_sp_purchase_analysis.pt
+++ b/cost/aws/savings_plan/purchase_analysis/aws_sp_purchase_analysis.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "0.2.1",
+  version: "0.2.2",
   provider: "AWS",
   service: "Compute",
   policy_set: "Savings Plans",
@@ -282,7 +282,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/savings_plan/recommendations/CHANGELOG.md
+++ b/cost/aws/savings_plan/recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.0.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v4.0.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/aws/savings_plan/recommendations/aws_savings_plan_recommendations.pt
+++ b/cost/aws/savings_plan/recommendations/aws_savings_plan_recommendations.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.0.1",
+  version: "4.0.2",
   provider: "AWS",
   service: "Compute",
   policy_set: "Savings Plans",
@@ -247,7 +247,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/schedule_instance/CHANGELOG.md
+++ b/cost/aws/schedule_instance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v8.0.12
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v8.0.11
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/aws/schedule_instance/aws_schedule_instance.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "15 minutes"
 info(
-  version: "8.0.11",
+  version: "8.0.12",
   provider: "AWS",
   service: "Compute",
   policy_set: "Schedule Instance",
@@ -474,7 +474,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'api')
+    host val($ds_flexera_api_hosts, "api")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/schedule_instance/aws_schedule_instance_meta_parent.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "8.0.11", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "8.0.12", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/superseded_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/superseded_ebs_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.6.4
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v6.6.3
 
 - Improved the policy's reliability when checking which AWS regions it can access, making it less likely to fail to run due to expected access restrictions in certain regions

--- a/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
+++ b/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "6.6.3",
+  version: "6.6.4",
   provider: "AWS",
   service: "Compute",
   policy_set: "Inefficient Disk Usage",
@@ -232,7 +232,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes_meta_parent.pt
+++ b/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "6.6.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.6.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/superseded_instances/CHANGELOG.md
+++ b/cost/aws/superseded_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2.10
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.2.9
 
 - Improved the policy's reliability when checking which AWS regions it can access, making it less likely to fail to run due to expected access restrictions in certain regions

--- a/cost/aws/superseded_instances/aws_superseded_instances.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.2.9",
+  version: "3.2.10",
   provider: "AWS",
   service: "Compute",
   policy_set: "Superseded Compute Instances",
@@ -239,7 +239,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "3.2.9", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.2.10", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/superseded_rds_instances/CHANGELOG.md
+++ b/cost/aws/superseded_rds_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.1.2
 
 - Improved the policy's reliability when checking which AWS regions it can access, making it less likely to fail to run due to expected access restrictions in certain regions

--- a/cost/aws/superseded_rds_instances/aws_superseded_rds_instances.pt
+++ b/cost/aws/superseded_rds_instances/aws_superseded_rds_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "0.1.2",
+  version: "0.1.3",
   provider: "AWS",
   service: "RDS",
   policy_set: "Superseded Compute Instances",
@@ -273,8 +273,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, "flexera")
-    path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
+    host val($ds_flexera_api_hosts, 'flexera')
     header "Api-Version", "1.0"
   end
   result do

--- a/cost/aws/superseded_rds_instances/aws_superseded_rds_instances.pt
+++ b/cost/aws/superseded_rds_instances/aws_superseded_rds_instances.pt
@@ -274,6 +274,7 @@ datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
     host val($ds_flexera_api_hosts, 'flexera')
+    path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end
   result do

--- a/cost/aws/superseded_rds_instances/aws_superseded_rds_instances.pt
+++ b/cost/aws/superseded_rds_instances/aws_superseded_rds_instances.pt
@@ -273,7 +273,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/superseded_rds_instances/aws_superseded_rds_instances_meta_parent.pt
+++ b/cost/aws/superseded_rds_instances/aws_superseded_rds_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.1.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/unused_albs/CHANGELOG.md
+++ b/cost/aws/unused_albs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.10
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.4.9
 
 - Improved the policy's reliability when checking which AWS regions it can access, making it less likely to fail to run due to expected access restrictions in certain regions

--- a/cost/aws/unused_albs/aws_unused_albs.pt
+++ b/cost/aws/unused_albs/aws_unused_albs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.9",
+  version: "0.4.10",
   provider: "AWS",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -200,7 +200,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/unused_albs/aws_unused_albs_meta_parent.pt
+++ b/cost/aws/unused_albs/aws_unused_albs_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.4.9", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.4.10", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/unused_clbs/CHANGELOG.md
+++ b/cost/aws/unused_clbs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.6.5
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v6.6.4
 
 - Improved the policy's reliability when checking which AWS regions it can access, making it less likely to fail to run due to expected access restrictions in certain regions

--- a/cost/aws/unused_clbs/aws_unused_clbs.pt
+++ b/cost/aws/unused_clbs/aws_unused_clbs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.6.4",
+  version: "6.6.5",
   provider: "AWS",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -200,7 +200,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/unused_clbs/aws_unused_clbs_meta_parent.pt
+++ b/cost/aws/unused_clbs/aws_unused_clbs_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "6.6.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.6.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/unused_ip_addresses/CHANGELOG.md
+++ b/cost/aws/unused_ip_addresses/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v9.5.5
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v9.5.4
 
 - Improved the policy's reliability when checking which AWS regions it can access, making it less likely to fail to run due to expected access restrictions in certain regions

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "9.5.4",
+  version: "9.5.5",
   provider: "AWS",
   service: "Compute",
   policy_set: "Unused IP Addresses",
@@ -205,7 +205,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "9.5.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "9.5.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/unused_nlbs/CHANGELOG.md
+++ b/cost/aws/unused_nlbs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.10
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.4.9
 
 - Improved the policy's reliability when checking which AWS regions it can access, making it less likely to fail to run due to expected access restrictions in certain regions

--- a/cost/aws/unused_nlbs/aws_unused_nlbs.pt
+++ b/cost/aws/unused_nlbs/aws_unused_nlbs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.9",
+  version: "0.4.10",
   provider: "AWS",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -200,7 +200,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/cost/aws/unused_nlbs/aws_unused_nlbs_meta_parent.pt
+++ b/cost/aws/unused_nlbs/aws_unused_nlbs_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.4.9", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.4.10", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/idle_ml_online_endpoints/CHANGELOG.md
+++ b/cost/azure/idle_ml_online_endpoints/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/idle_ml_online_endpoints/azure_idle_ml_online_endpoints.pt
+++ b/cost/azure/idle_ml_online_endpoints/azure_idle_ml_online_endpoints.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.1.1",
+  version: "0.1.2",
   provider: "Azure",
   service: "Compute",
   policy_set: "Idle ML Online Endpoints",
@@ -246,6 +246,7 @@ script "js_flexera_api_hosts", type: "javascript" do
       tld: "flexeratest.com"
     }
   }
+
   result = host_table[rs_optima_host]
 EOS
 end

--- a/cost/azure/idle_ml_online_endpoints/azure_idle_ml_online_endpoints_meta_parent.pt
+++ b/cost/azure/idle_ml_online_endpoints/azure_idle_ml_online_endpoints_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.1.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.1.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/idle_ml_online_endpoints/azure_idle_ml_online_endpoints_meta_parent_rg.pt
+++ b/cost/azure/idle_ml_online_endpoints/azure_idle_ml_online_endpoints_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.1.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.1.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/rightsize_netapp/CHANGELOG.md
+++ b/cost/azure/rightsize_netapp/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.3.3
+
+- Updated policy logic for internal consistency; no functional or user-facing changes.
+
 ## v2.3.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/rightsize_netapp/azure_rightsize_netapp.pt
+++ b/cost/azure/rightsize_netapp/azure_rightsize_netapp.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "2.3.2",
+  version: "2.3.3",
   provider: "Azure",
   service: "NetApp Files",
   policy_set: "Rightsize Storage",
@@ -360,7 +360,11 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
-      if (param_subscriptions_allow_or_deny == "Deny") { include_subscription = !include_subscription }
+
+      if (param_subscriptions_allow_or_deny == "Deny") {
+        include_subscription = !include_subscription
+      }
+
       return include_subscription
     })
   } else {

--- a/cost/azure/rightsize_netapp/azure_rightsize_netapp_meta_parent.pt
+++ b/cost/azure/rightsize_netapp/azure_rightsize_netapp_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "2.3.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "2.3.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/rightsize_netapp/azure_rightsize_netapp_meta_parent_rg.pt
+++ b/cost/azure/rightsize_netapp/azure_rightsize_netapp_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "2.3.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "2.3.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/unused_storage_accounts/CHANGELOG.md
+++ b/cost/azure/unused_storage_accounts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.3
+
+- Updated policy logic for internal consistency; no functional or user-facing changes.
+
 ## v0.4.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/unused_storage_accounts/azure_unused_storage_accounts.pt
+++ b/cost/azure/unused_storage_accounts/azure_unused_storage_accounts.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "0.4.2",
+  version: "0.4.3",
   provider: "Azure",
   service: "Storage",
   policy_set: "Unused Storage Accounts",
@@ -378,7 +378,11 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
-      if (param_subscriptions_allow_or_deny == "Deny") { include_subscription = !include_subscription }
+
+      if (param_subscriptions_allow_or_deny == "Deny") {
+        include_subscription = !include_subscription
+      }
+
       return include_subscription
     })
   } else {

--- a/cost/azure/unused_storage_accounts/azure_unused_storage_accounts_meta_parent.pt
+++ b/cost/azure/unused_storage_accounts/azure_unused_storage_accounts_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.4.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/unused_storage_accounts/azure_unused_storage_accounts_meta_parent_rg.pt
+++ b/cost/azure/unused_storage_accounts/azure_unused_storage_accounts_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.4.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/flexera/cco/budget_v_actual_spend_report/CHANGELOG.md
+++ b/cost/flexera/cco/budget_v_actual_spend_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.7.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v2.7.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/flexera/cco/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
+++ b/cost/flexera/cco/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.7.1",
+  version: "2.7.2",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -233,7 +233,7 @@ end
 datasource "ds_budgets" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/budgets"])
     header "Api-Version", "1.0"
     header "User-Agent", "RS Policies"

--- a/cost/google/rightsize_persistent_disks/CHANGELOG.md
+++ b/cost/google/rightsize_persistent_disks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.2
+
+- Updated policy logic for internal consistency; no functional or user-facing changes.
+
 ## v0.2.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/google/rightsize_persistent_disks/google_rightsize_persistent_disks.pt
+++ b/cost/google/rightsize_persistent_disks/google_rightsize_persistent_disks.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.1",
+  version: "0.2.2",
   provider: "Google",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -1840,7 +1840,7 @@ script "js_make_terminate_request", type: "javascript" do
   var request = {
     auth: "auth_flexera",
     host: ds_flexera_api_hosts["flexera"],
-    path: ["/policy/v1/orgs/", rs_org_id, "/projects/", rs_project_id, "/applied-policies", policy_id ? "/" + policy_id : ""].join(''),
+    path: [ "/policy/v1/orgs/", rs_org_id, "/projects/", rs_project_id, "/applied-policies", policy_id ? "/"+policy_id : "" ].join(''),
     verb: ds_parent_policy_terminated ? "DELETE" : "GET"
   }
 EOS
@@ -1853,5 +1853,5 @@ end
 script "js_is_deleted", type: "javascript" do
   parameters "ds_terminate_self"
   result "result"
-  code 'result = { path: "/" }'
+  code 'result = { path: "/"}'
 end

--- a/cost/google/rightsize_persistent_disks/google_rightsize_persistent_disks_meta_parent.pt
+++ b/cost/google/rightsize_persistent_disks/google_rightsize_persistent_disks_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "0.2.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/turbonomics/allocate_virtual_machines_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/allocate_virtual_machines_recommendations/aws/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.3.7
+
+- Fixed an issue that could cause the policy to fail when retrieving business unit information
+
 ## v2.3.6
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/turbonomics/allocate_virtual_machines_recommendations/aws/turbonomics_allocate_virtual_machines.pt
+++ b/cost/turbonomics/allocate_virtual_machines_recommendations/aws/turbonomics_allocate_virtual_machines.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.3.6",
+  version: "2.3.7",
   provider: "AWS",
   source: "Turbonomic",
   service: "Compute",
@@ -201,7 +201,7 @@ script "js_get_business_units", type: "javascript" do
         "type":"DISCOVERED"
       },
       headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
         "Authorization": "Bearer " + access_token
       }
     }

--- a/cost/turbonomics/allocate_virtual_machines_recommendations/azure/CHANGELOG.md
+++ b/cost/turbonomics/allocate_virtual_machines_recommendations/azure/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.3.7
+
+- Fixed an issue that could cause the policy to fail when retrieving business unit information
+
 ## v2.3.6
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/turbonomics/allocate_virtual_machines_recommendations/azure/turbonomics_allocate_virtual_machines.pt
+++ b/cost/turbonomics/allocate_virtual_machines_recommendations/azure/turbonomics_allocate_virtual_machines.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.3.6",
+  version: "2.3.7",
   provider: "Azure",
   source: "Turbonomic",
   service: "Compute",
@@ -203,7 +203,7 @@ script "js_get_business_units", type: "javascript" do
         "type":"DISCOVERED"
       },
       headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
         "Authorization": "Bearer " + access_token
       }
     }

--- a/cost/turbonomics/allocate_virtual_machines_recommendations/google/CHANGELOG.md
+++ b/cost/turbonomics/allocate_virtual_machines_recommendations/google/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.3.8
+
+- Fixed an issue that could cause the policy to fail when retrieving business unit information
+
 ## v2.3.7
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/turbonomics/allocate_virtual_machines_recommendations/google/turbonomics_allocate_virtual_machines.pt
+++ b/cost/turbonomics/allocate_virtual_machines_recommendations/google/turbonomics_allocate_virtual_machines.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.3.7",
+  version: "2.3.8",
   provider: "Google",
   source: "Turbonomic",
   service: "Compute",
@@ -203,7 +203,7 @@ script "js_get_business_units", type: "javascript" do
         "type":"DISCOVERED"
       },
       headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
         "Authorization": "Bearer " + access_token
       }
     }

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.8
+
+- Fixed an issue that could cause the policy to fail when retrieving business unit information
+
 ## v0.3.7
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.3.7",
+  version: "0.3.8",
   provider: "AWS",
   source: "Turbonomic",
   service: "Usage Discount",
@@ -206,7 +206,7 @@ script "js_get_business_units", type: "javascript" do
           "type": "DISCOVERED"
       },
       headers: {
-          "Content-Type": "application/json"
+          "Content-Type": "application/json",
           "Authorization": "Bearer " + access_token
         }
   }

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/CHANGELOG.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.8
+
+- Fixed an issue that could cause the policy to fail when retrieving business unit information
+
 ## v0.3.7
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.3.7",
+  version: "0.3.8",
   provider: "Azure",
   source: "Turbonomic",
   service: "Usage Discount",
@@ -190,7 +190,7 @@ script "js_get_business_units", type: "javascript" do
           "type": "DISCOVERED"
       },
       headers: {
-          "Content-Type": "application/json"
+          "Content-Type": "application/json",
           "Authorization": "Bearer " + access_token
       }
   }

--- a/cost/turbonomics/delete_unattached_volumes/aws/CHANGELOG.md
+++ b/cost/turbonomics/delete_unattached_volumes/aws/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.8
+
+- Fixed an issue that could cause the policy to fail when retrieving business unit information
+
 ## v0.6.7
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/turbonomics/delete_unattached_volumes/aws/turbonomics_delete_virtual_volumes.pt
+++ b/cost/turbonomics/delete_unattached_volumes/aws/turbonomics_delete_virtual_volumes.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.6.7",
+  version: "0.6.8",
   provider: "AWS",
   source: "Turbonomic",
   service: "Storage",
@@ -226,7 +226,7 @@ script "js_get_business_units", type: "javascript" do
         "type":"DISCOVERED"
       },
       headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
         "Authorization": "Bearer " + access_token
       }
     }

--- a/cost/turbonomics/delete_unattached_volumes/azure/CHANGELOG.md
+++ b/cost/turbonomics/delete_unattached_volumes/azure/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.8
+
+- Fixed an issue that could cause the policy to fail when retrieving business unit information
+
 ## v0.5.7
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/turbonomics/delete_unattached_volumes/azure/turbonomics_delete_virtual_volumes.pt
+++ b/cost/turbonomics/delete_unattached_volumes/azure/turbonomics_delete_virtual_volumes.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.5.7",
+  version: "0.5.8",
   provider: "Azure",
   source: "Turbonomic",
   service: "Storage",
@@ -222,7 +222,7 @@ script "js_get_business_units", type: "javascript" do
         "type":"DISCOVERED"
       },
       headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
         "Authorization": "Bearer " + access_token
       }
     }

--- a/cost/turbonomics/delete_unattached_volumes/google/CHANGELOG.md
+++ b/cost/turbonomics/delete_unattached_volumes/google/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.8
+
+- Fixed an issue that could cause the policy to fail when retrieving business unit information
+
 ## v0.6.7
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/turbonomics/delete_unattached_volumes/google/turbonomics_delete_virtual_volumes.pt
+++ b/cost/turbonomics/delete_unattached_volumes/google/turbonomics_delete_virtual_volumes.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.6.7",
+  version: "0.6.8",
   provider: "Google",
   source: "Turbonomic",
   service: "Storage",
@@ -223,7 +223,7 @@ script "js_get_business_units", type: "javascript" do
         "type":"DISCOVERED"
       },
       headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
         "Authorization": "Bearer " + access_token
       }
     }

--- a/cost/turbonomics/rightsize_databases_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_databases_recommendations/aws/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.8
+
+- Fixed an issue that could cause the policy to fail when retrieving business unit information
+
 ## v0.4.7
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
+++ b/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.4.7",
+  version: "0.4.8",
   source: "Turbonomic",
   service: "Usage Discount",
   provider: "AWS",
@@ -206,7 +206,7 @@ script "js_get_business_units", type: "javascript" do
       path: "/api/v3/businessunits",
       query_params: query_params,
       headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
         "Authorization": "Bearer " + access_token
       }
     }

--- a/cost/turbonomics/rightsize_databases_recommendations/azure/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_databases_recommendations/azure/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.8
+
+- Fixed an issue that could cause the policy to fail when retrieving business unit information
+
 ## v0.5.7
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/turbonomics/rightsize_databases_recommendations/azure/turbonomics_rightsize_databases_recommendations.pt
+++ b/cost/turbonomics/rightsize_databases_recommendations/azure/turbonomics_rightsize_databases_recommendations.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.5.7",
+  version: "0.5.8",
   source: "Turbonomic",
   service: "Usage Discount",
   provider: "Azure",
@@ -206,7 +206,7 @@ script "js_get_business_units", type: "javascript" do
       path: "/api/v3/businessunits",
       query_params: query_params,
       headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
         "Authorization": "Bearer " + access_token
       }
     }

--- a/cost/turbonomics/rightsize_databases_recommendations/google/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_databases_recommendations/google/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.5.8
+
+- Fixed an issue that could cause the policy to fail when retrieving business unit information
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.5.7
 
 - Minor code formatting fixes. Functionality unchanged.

--- a/cost/turbonomics/rightsize_databases_recommendations/google/turbonomics_rightsize_databases_recommendations.pt
+++ b/cost/turbonomics/rightsize_databases_recommendations/google/turbonomics_rightsize_databases_recommendations.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.5.7",
+  version: "0.5.8",
   source: "Turbonomic",
   service: "Usage Discount",
   provider: "Google",
@@ -207,8 +207,8 @@ script "js_get_business_units", type: "javascript" do
       path: "/api/v3/businessunits",
       query_params: query_params,
       headers: {
-        "Content-Type": "application/json"
-         "Authorization": "Bearer " + access_token
+        "Content-Type": "application/json",
+        "Authorization": "Bearer " + access_token
       }
     }
   EOS

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/aws/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.8
+
+- Fixed an issue that could cause the policy to fail when retrieving business unit information
+
 ## v0.4.7
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/aws/turbonomics_rightsize_virtual_volumes_recommendations.pt
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/aws/turbonomics_rightsize_virtual_volumes_recommendations.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.4.7",
+  version: "0.4.8",
   source: "Turbonomic",
   service: "Usage Discount",
   provider: "AWS",
@@ -231,7 +231,7 @@ script "js_get_business_units", type: "javascript" do
       path: "/api/v3/businessunits",
       query_params: query_params,
       headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
         "Authorization": "Bearer " + access_token
       }
     }

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/azure/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/azure/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.8
+
+- Fixed an issue that could cause the policy to fail when retrieving business unit information
+
 ## v0.4.7
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/azure/turbonomics_rightsize_virtual_volumes_recommendations.pt
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/azure/turbonomics_rightsize_virtual_volumes_recommendations.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.4.7",
+  version: "0.4.8",
   source: "Turbonomic",
   service: "Usage Discount",
   provider: "Azure",
@@ -231,7 +231,7 @@ script "js_get_business_units", type: "javascript" do
       path: "/api/v3/businessunits",
       query_params: query_params,
       headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
         "Authorization": "Bearer " + access_token
       }
     }

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/google/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/google/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.7
+
+- Fixed an issue that could cause the policy to fail when retrieving business unit information
+
 ## v0.4.6
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/google/turbonomics_rightsize_virtual_volumes_recommendations.pt
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/google/turbonomics_rightsize_virtual_volumes_recommendations.pt
@@ -14,7 +14,8 @@ info(
   provider: "Google",
   policy_set: "Rightsize Volumes",
   recommendation_type: "Usage Reduction",
-  publish: "false"
+  publish: "false",
+  hide_skip_approvals: "true"
 )
 
 ###############################################################################

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/google/turbonomics_rightsize_virtual_volumes_recommendations.pt
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/google/turbonomics_rightsize_virtual_volumes_recommendations.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.4.6",
+  version: "0.4.7",
   source: "Turbonomic",
   service: "Usage Discount",
   provider: "Google",
@@ -207,7 +207,7 @@ script "js_get_business_units", type: "javascript" do
       path: "/api/v3/businessunits",
       query_params: query_params,
       headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
         "Authorization": "Bearer " + access_token
       }
     }

--- a/cost/turbonomics/scale_virtual_machines_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/aws/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.8
+
+- Fixed an issue that could cause the policy to fail when retrieving business unit information
+
 ## v0.6.7
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/turbonomics/scale_virtual_machines_recommendations/aws/turbonomics_scale_virtual_machines.pt
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/aws/turbonomics_scale_virtual_machines.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.6.7",
+  version: "0.6.8",
   provider: "AWS",
   source: "Turbonomic",
   service: "Compute",
@@ -238,7 +238,7 @@ script "js_get_business_units", type: "javascript" do
         "type":"DISCOVERED"
       },
       headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
         "Authorization": "Bearer " + access_token
       }
     }

--- a/cost/turbonomics/scale_virtual_machines_recommendations/azure/CHANGELOG.md
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/azure/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.8
+
+- Fixed an issue that could cause the policy to fail when retrieving business unit information
+
 ## v0.6.7
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/turbonomics/scale_virtual_machines_recommendations/azure/turbonomics_scale_virtual_machines.pt
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/azure/turbonomics_scale_virtual_machines.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.6.7",
+  version: "0.6.8",
   provider: "Azure",
   source: "Turbonomic",
   service: "Compute",
@@ -238,7 +238,7 @@ script "js_get_business_units", type: "javascript" do
         "type":"DISCOVERED"
       },
       headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
         "Authorization": "Bearer " + access_token
       }
     }

--- a/cost/turbonomics/scale_virtual_machines_recommendations/google/CHANGELOG.md
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/google/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.7.8
+
+- Fixed an issue that could cause the policy to fail when retrieving business unit information
+
 ## v0.7.7
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/turbonomics/scale_virtual_machines_recommendations/google/turbonomics_scale_virtual_machines.pt
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/google/turbonomics_scale_virtual_machines.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.7.7",
+  version: "0.7.8",
   provider: "Google",
   source: "Turbonomic",
   service: "Compute",
@@ -238,7 +238,7 @@ script "js_get_business_units", type: "javascript" do
         "type":"DISCOVERED"
       },
       headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
         "Authorization": "Bearer " + access_token
       }
     }

--- a/data/agent/README.md
+++ b/data/agent/README.md
@@ -1,0 +1,25 @@
+# Agent Reference Data
+
+This directory contains manually-maintained reference material used by the `policy-dev` agent (`.github/agents/policy-dev.agent.md`) when creating and reviewing policy templates.
+
+## Manually Maintained Files
+
+### code_examples.txt
+
+**Description:** The canonical DSL and JavaScript code examples for the Flexera Policy Template Language, covering credentials, pagination, datasource patterns, common JavaScript patterns (tag/region/subscription/project filtering), the policy block, the AWS region error-reporting pattern, the final transform/cost template conventions, escalations, cloud workflow actions, Flexera API boilerplate datasources, the Meta Policy canonical block, provider boilerplate datasources, standard parameter conventions, and statistics category parameters.
+
+`.github/agents/policy-dev.agent.md` references this file by section title instead of embedding the code inline, so the examples only need to be updated in one place. Each section is introduced by a `##` or `###` header whose title exactly matches the corresponding header in `policy-dev.agent.md`, so the two files can be cross-referenced by title. This file intentionally contains code only (with brief inline comments where needed to distinguish variants); the prose explanations of when/why/how to use each pattern live in `policy-dev.agent.md`.
+
+**Example:**
+
+```text
+### Credentials
+
+credentials "auth_aws" do
+  schemes "aws", "aws_sts"
+  label "AWS"
+  description "Select the AWS Credential from the list"
+  tags "provider=aws"
+  aws_account_number $param_aws_account_number  # for Meta Policy cross-account support
+end
+```

--- a/data/agent/code_examples.txt
+++ b/data/agent/code_examples.txt
@@ -1,0 +1,1764 @@
+Canonical DSL and JavaScript code examples for the Flexera Policy Template
+Language. Referenced by section title from .github/agents/policy-dev.agent.md.
+This file intentionally contains code only, not prose explanation - consult
+policy-dev.agent.md for the rules, rationale, and full field/label tables.
+
+================================================================================
+## Policy Template Anatomy - Header Block
+================================================================================
+
+name "Provider Example Policy"
+rs_pt_ver 20180301
+type "policy"
+short_description "Does X and Y. See the [README](https://github.com/flexera-public/policy_templates/tree/master/CATEGORY/PROVIDER/POLICY_NAME) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera-one/automation/) to learn more."
+long_description ""
+doc_link "https://github.com/flexera-public/policy_templates/tree/master/CATEGORY/PROVIDER/POLICY_NAME"
+category "Cost"          # Cost, Compliance, Operational, Security, SaaS, Automation
+severity "low"           # low, medium, high, critical
+default_frequency "weekly"  # "15 minutes", "hourly", "daily", "weekly", "monthly"
+info(
+  version: "0.1.0",
+  provider: "AWS",
+  service: "Storage",
+  policy_set: "",
+  recommendation_type: "Usage Reduction",  # "Usage Reduction" or "Rate Reduction"
+  hide_skip_approvals: "true"
+)
+
+================================================================================
+## Policy Template Structure - Section Divider Skeleton
+================================================================================
+
+###############################################################################
+# Parameters
+###############################################################################
+
+###############################################################################
+# Authentication
+###############################################################################
+
+###############################################################################
+# Pagination
+###############################################################################
+
+###############################################################################
+# Datasources & Scripts
+###############################################################################
+
+###############################################################################
+# Policy
+###############################################################################
+
+###############################################################################
+# Escalations
+###############################################################################
+
+###############################################################################
+# Cloud Workflow
+###############################################################################
+
+================================================================================
+## DSL Quick Reference
+================================================================================
+
+### Credentials
+
+credentials "auth_aws" do
+  schemes "aws", "aws_sts"
+  label "AWS"
+  description "Select the AWS Credential from the list"
+  tags "provider=aws"
+  aws_account_number $param_aws_account_number  # for Meta Policy cross-account support
+end
+
+credentials "auth_azure" do
+  schemes "oauth2"
+  label "Azure"
+  description "Select the Azure Resource Manager Credential from the list."
+  tags "provider=azure_rm"
+end
+
+credentials "auth_google" do
+  schemes "oauth2"
+  label "Google"
+  description "Select the Google Cloud Credential from the list."
+  tags "provider=gce"
+end
+
+credentials "auth_flexera" do
+  schemes "oauth2"
+  label "Flexera"
+  description "Select Flexera One OAuth2 credentials"
+  tags "provider=flexera"
+end
+
+credentials "auth_oracle" do
+  schemes "oracle"
+  label "Oracle"
+  description "Select the Oracle Cloud (OCI) Credential from the list."
+  tags "provider=oracle"
+end
+
+### Pagination
+
+pagination "pagination_aws" do
+  get_page_marker do
+    body_path jmes_path(response, "NextToken")
+  end
+  set_page_marker do
+    body_field "NextToken"
+  end
+end
+
+pagination "pagination_azure" do
+  get_page_marker do
+    body_path "nextLink"
+  end
+  set_page_marker do
+    uri true    # nextLink IS the full URL for the next page - do not append as a parameter
+  end
+end
+
+pagination "pagination_google" do
+  get_page_marker do
+    body_path "nextPageToken"
+  end
+  set_page_marker do
+    query "pageToken"
+  end
+end
+
+### Datasource - REST Request
+
+datasource "ds_example" do
+  request do
+    auth $auth_aws
+    pagination $pagination_aws   # omit if the endpoint is not paginated
+    host "ec2.amazonaws.com"
+    path "/some/endpoint"
+    query "param", "value"
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "items[*]") do
+      field "id", jmes_path(col_item, "Id")
+      field "name", jmes_path(col_item, "Name")
+    end
+  end
+end
+
+# Variant: XML response (many older AWS EC2/RDS endpoints)
+
+  result do
+    encoding "xml"
+    collect xpath(response, "//item") do
+      field "id", xpath(col_item, "snapshotId/text()")
+      field "size", xpath(col_item, "volumeSize/text()")
+    end
+  end
+
+# Variant: raw text response (e.g. CSV)
+
+  result do
+    encoding "text"    # entire response body is the datasource value (a string)
+  end
+
+# Variant: iterate a datasource over a list (e.g. one request per region)
+
+datasource "ds_per_region" do
+  iterate $ds_regions
+  request do
+    auth $auth_aws
+    host join(["ec2.", val(iter_item, "region"), ".amazonaws.com"])
+    path "/some/endpoint"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "Items[*]") do
+      field "id", jmes_path(col_item, "Id")
+      field "region", val(iter_item, "region")
+    end
+  end
+end
+
+# Variant: single-object response - no collect
+
+result do
+  encoding "json"
+  field "id", jmes_path(response, "id")
+  field "name", jmes_path(response, "name")
+end
+
+### Datasource - Static POST / PUT / DELETE Request
+
+datasource "ds_create_items" do
+  iterate $ds_items_to_create
+  request do
+    auth $auth_flexera
+    verb "POST"
+    host val($ds_flexera_api_hosts, "flexera")
+    path join(["/some/api/v1/orgs/", rs_org_id, "/items"])
+    header "User-Agent", "RS Policies"
+    body_field "name", val(iter_item, "name")
+    body_field "params", val(iter_item, "params")
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+  end
+end
+
+# Variant: raw string body instead of body_field
+
+datasource "ds_post_raw" do
+  request do
+    auth $auth_aws
+    verb "POST"
+    host "some-aws-api.amazonaws.com"
+    path "/some/endpoint"
+    body "{}"
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+  end
+end
+
+### Datasource - Dynamic / POST Request
+
+datasource "ds_billing_data" do
+  request do
+    run_script $js_billing_request, $ds_billing_centers, rs_org_id, rs_optima_host
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "rows[*]") do
+      field "account_id", jmes_path(col_item, "dimensions.vendor_account")
+      field "account_name", jmes_path(col_item, "dimensions.vendor_account_name")
+      field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
+    end
+  end
+end
+
+script "js_billing_request", type: "javascript" do
+  parameters "billing_centers", "rs_org_id", "rs_optima_host"
+  result "request"   # MUST be named "request" when used inside request do
+  code <<-'EOS'
+    var end_date = new Date(); end_date.setDate(end_date.getDate() - 1)
+    var start_date = new Date(); start_date.setDate(start_date.getDate() - 30)
+
+    request = {
+      auth: "auth_flexera",    // credential name as a string, NOT a $variable
+      host: rs_optima_host,
+      verb: "POST",
+      path: "/bill-analysis/orgs/" + rs_org_id + "/costs/select",
+      body_fields: {
+        dimensions: ["vendor_account", "vendor_account_name"],
+        granularity: "day",
+        start_at: start_date.toISOString().split("T")[0],
+        end_at: end_date.toISOString().split("T")[0],
+        metrics: ["cost_amortized_unblended_adj"],
+        billing_center_ids: _.pluck(billing_centers, "id")
+      },
+      headers: { "Api-Version": "1.0", "User-Agent": "RS Policies" },
+      ignore_status: [400]
+    }
+EOS
+end
+
+### Datasource - JavaScript Transform
+
+datasource "ds_filtered" do
+  run_script $js_filter_items, $ds_raw_items, $param_threshold
+end
+
+script "js_filter_items", type: "javascript" do
+  parameters "items", "threshold"
+  result "result"
+  code <<-'EOS'
+    // Underscore.js (_) is available for use in all script blocks
+    result = _.filter(items, function(item) {
+      return item.value > threshold
+    })
+EOS
+end
+
+### Common JavaScript Patterns - Tag Filtering
+
+script "js_filter_resources", type: "javascript" do
+  parameters "resources", "param_exclusion_tags", "param_exclusion_tags_boolean"
+  result "result"
+  code <<-'EOS'
+    comparators = _.map(param_exclusion_tags, function(item) {
+      if (item.indexOf('==') != -1) {
+        return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
+      }
+      if (item.indexOf('!=') != -1) {
+        return { comparison: '!=', key: item.split('!=')[0], value: item.split('!=')[1], string: item }
+      }
+      if (item.indexOf('=~') != -1) {
+        value = item.split('=~')[1]
+        regex = new RegExp(value.slice(1, value.length - 1))
+        return { comparison: '=~', key: item.split('=~')[0], value: regex, string: item }
+      }
+      if (item.indexOf('!~') != -1) {
+        value = item.split('!~')[1]
+        regex = new RegExp(value.slice(1, value.length - 1))
+        return { comparison: '!~', key: item.split('!~')[0], value: regex, string: item }
+      }
+      return { comparison: 'key', key: item, value: null, string: item }
+    })
+
+    result = _.reject(resources, function(resource) {
+      resource_tags = {}
+      // AWS: tags are [{key: "k", value: "v"}, ...] - adjust for Azure/GCP as needed
+      if (typeof(resource['tags']) == 'object') {
+        _.each(resource['tags'], function(tag) { resource_tags[tag['key']] = tag['value'] })
+      }
+
+      found_tags = []
+      _.each(comparators, function(comparator) {
+        resource_tag = resource_tags[comparator['key']]
+        if (comparator['comparison'] == 'key' && resource_tag != undefined)                                          { found_tags.push(comparator['string']) }
+        if (comparator['comparison'] == '==' && resource_tag == comparator['value'])                                 { found_tags.push(comparator['string']) }
+        if (comparator['comparison'] == '!=' && resource_tag != comparator['value'])                                 { found_tags.push(comparator['string']) }
+        if (comparator['comparison'] == '=~' && resource_tag != undefined && comparator['value'].test(resource_tag)) { found_tags.push(comparator['string']) }
+        if (comparator['comparison'] == '!~' && (resource_tag == undefined || !comparator['value'].test(resource_tag))) { found_tags.push(comparator['string']) }
+      })
+
+      if (param_exclusion_tags.length == 0) { return false }
+      if (param_exclusion_tags_boolean == 'Any') { return found_tags.length > 0 }
+      return found_tags.length == comparators.length  // 'All'
+    })
+EOS
+end
+
+### Common JavaScript Patterns - Region Filtering
+
+datasource "ds_regions" do
+  run_script $js_regions, $ds_describe_regions, $param_regions_list, $param_regions_allow_or_deny
+end
+
+script "js_regions", type:"javascript" do
+  parameters "ds_describe_regions", "param_regions_list", "param_regions_allow_or_deny"
+  result "result"
+  code <<-'EOS'
+  allow_deny_test = { "Allow": true, "Deny": false }
+
+  if (param_regions_list.length > 0) {
+    result = _.filter(ds_describe_regions, function(item) {
+      return _.contains(param_regions_list, item['region']) == allow_deny_test[param_regions_allow_or_deny]
+    })
+  } else {
+    result = ds_describe_regions
+  }
+EOS
+end
+
+### Common JavaScript Patterns - Azure Subscription Filtering
+
+datasource "ds_azure_subscriptions_filtered" do
+  run_script $js_azure_subscriptions_filtered, $ds_azure_subscriptions, $param_subscriptions_allow_or_deny, $param_subscriptions_list
+end
+
+script "js_azure_subscriptions_filtered", type: "javascript" do
+  parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
+  result "result"
+  code <<-'EOS'
+  if (param_subscriptions_list.length > 0) {
+    result = _.filter(ds_azure_subscriptions, function(subscription) {
+      include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
+
+      if (param_subscriptions_allow_or_deny == "Deny") {
+        include_subscription = !include_subscription
+      }
+
+      return include_subscription
+    })
+  } else {
+    result = ds_azure_subscriptions
+  }
+EOS
+end
+
+datasource "ds_no_subscriptions_error" do
+  run_script $js_no_subscriptions_error, $ds_azure_subscriptions, $ds_applied_policy
+end
+
+script "js_no_subscriptions_error", type: "javascript" do
+  parameters "ds_azure_subscriptions", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_azure_subscriptions.length == 0) {
+    result = [{
+      policy_name: ds_applied_policy['name'],
+      error: "No Azure Subscriptions found. This is usually caused by a lack of permissions or an expired/invalid credential."
+    }]
+  }
+EOS
+end
+
+### Common JavaScript Patterns - Google Project Filtering
+
+datasource "ds_google_projects_filtered" do
+  run_script $js_google_projects_filtered, $ds_google_projects, $param_projects_allow_or_deny, $param_projects_list
+end
+
+script "js_google_projects_filtered", type: "javascript" do
+  parameters "ds_google_projects", "param_projects_allow_or_deny", "param_projects_list"
+  result "result"
+  code <<-'EOS'
+  if (param_projects_list.length > 0) {
+    result = _.filter(ds_google_projects, function(project) {
+      include_project = _.contains(param_projects_list, project['id']) || _.contains(param_projects_list, project['name'])
+
+      if (param_projects_allow_or_deny == "Deny") {
+        include_project = !include_project
+      }
+
+      return include_project
+    })
+  } else {
+    result = ds_google_projects
+  }
+EOS
+end
+
+datasource "ds_no_projects_error" do
+  run_script $js_no_projects_error, $ds_google_projects, $ds_applied_policy
+end
+
+script "js_no_projects_error", type: "javascript" do
+  parameters "ds_google_projects", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = []
+
+  if (ds_google_projects.length == 0) {
+    var policy_name = "Google Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+
+    result = [{
+      error: "No Google projects were returned. This typically indicates that the Google credential does not have the required 'resourcemanager.projects.get' permission, or that there are no accessible Google projects associated with this credential.",
+      policy_name: policy_name
+    }]
+  }
+EOS
+end
+
+### Policy Block
+
+policy "pol_example" do
+  validate_each $ds_items do
+    check logic_or($ds_parent_policy_terminated, eq(val(item, "id"), ""))
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Items Found"
+    detail_template <<-'EOS'
+    **Details:** {{ with index data 0 }}{{ .message }}{{ end }}
+    EOS
+    escalate $esc_email
+    escalate $esc_delete
+    hash_exclude "tags", "savings"
+    export do
+      resource_level true
+      field "id" do label "Resource ID" end
+      field "name" do label "Resource Name" end
+      field "region" do label "Region" end
+      field "display_id" do
+        label "ID"
+        path "id"
+      end
+      field "console_link" do
+        label "Console Link"
+        format "link-external"
+      end
+    end
+  end
+
+  validate $ds_identify_errors do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
+end
+
+### AWS Region Error-Reporting Pattern
+
+# 1. Probe each region for accessibility
+datasource "ds_region_check" do
+  iterate $ds_regions
+  request do
+    auth $auth_aws
+    host join(["lambda.", val(iter_item, "region"), ".amazonaws.com"])
+    path "/2015-03-31/functions/"
+    query "MaxItems", "1"
+    header "User-Agent", "RS Policies"
+    ignore_status [403, 401]
+  end
+  result do
+    encoding "xml"
+    field "region", val(iter_item, "region")
+    field "status", "OK"
+  end
+end
+
+# 2. Identify inaccessible regions
+datasource "ds_identify_errors" do
+  run_script $js_identify_errors, $ds_regions, $ds_region_check, $ds_applied_policy, $param_regions_allow_or_deny, $param_regions_list
+end
+
+script "js_identify_errors", type: "javascript" do
+  parameters "ds_regions", "ds_region_check", "ds_applied_policy", "param_regions_allow_or_deny", "param_regions_list"
+  result "errors"
+  code <<-'EOS'
+  var errors = []
+
+  var region_responses = {}
+  _.each(ds_region_check, function(item) {
+    if (item.region) { region_responses[item.region] = "OK" }
+  })
+
+  var allowed_regions = _.keys(region_responses)
+  var forbidden_regions = []
+
+  _.each(ds_regions, function(region_obj) {
+    if (!_.contains(allowed_regions, region_obj.region)) {
+      forbidden_regions.push(region_obj.region)
+    }
+  })
+
+  if (forbidden_regions.length > 0) {
+    var regions_string = forbidden_regions.sort().join(", ")
+    var successful_regions = allowed_regions.sort().join(", ")
+    var filter_guidance = ""
+
+    if (param_regions_list.length > 0) {
+      filter_guidance = " You are currently using the 'Allow/Deny Regions List' parameter. "
+      filter_guidance += "You can update this list to exclude the inaccessible regions if appropriate."
+    } else {
+      filter_guidance = " You can use the 'Allow/Deny Regions List' parameter to exclude these regions."
+    }
+
+    errors.push(
+      "HTTP error received when attempting to list [resources] in some AWS region(s).\n" +
+      "\n - Failed Regions: " + regions_string +
+      "\n - Successful Regions: " + successful_regions +
+      "\n\nThis typically indicates that the AWS credential does not have the required " +
+      "'[service]:[Action]' permission for these regions, or these regions may not be enabled." +
+      " To resolve: (1) Verify the credential has the required permission, " +
+      "(2) Ensure these regions are opted-in in your account, or " +
+      "(3) Exclude these regions using the region filter parameters." +
+      filter_guidance
+    )
+  }
+
+  errors = _.uniq(errors)
+  errors = _.map(errors, function(err) { return { "error": err } })
+
+  if (errors.length > 0) {
+    var policy_name = "AWS Policy"
+    if (ds_applied_policy && ds_applied_policy.name) { policy_name = ds_applied_policy.name }
+    errors[0].policy_name = policy_name
+  }
+EOS
+end
+
+# 3. Policy block uses 'validate' (not validate_each) for the error datasource
+  validate $ds_identify_errors do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: {{ len data }} Errors Identified"
+    detail_template <<-'EOS'
+    The policy was unable to access one or more AWS regions due to permission or configuration errors.
+
+    **Error Details:**
+    {{ range data -}}
+      - {{ .error }}
+    {{ end -}}
+
+    **Recommended Actions:**
+    1. Verify the AWS credential has the required permissions for all policy regions.
+    2. Ensure any opt-in regions are enabled in your AWS account.
+    3. Use the Allow/Deny Regions List parameter to exclude inaccessible regions.
+    EOS
+    check eq(size(data), 0)
+    escalate $esc_email_errors_identified
+  end
+
+# 4. Dedicated escalation - simple email with no table attachment
+escalation "esc_email_errors_identified" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email
+end
+
+### Common JavaScript Patterns - Final Transform / Cost Template Conventions
+
+# Standard fields set on result[0] (the first item in the result array):
+result[0]['policy_name'] = ds_applied_policy['name']
+result[0]['message']     = "Multi-line markdown string..."
+result[0]['total_savings'] = "Total Estimated Monthly Savings: " + currency_symbol + total
+
+# Canonical export block example:
+export do
+  resource_level true
+  field "accountID" do
+    label "Account ID"
+  end
+  field "accountName" do
+    label "Account Name"
+  end
+  field "resourceID" do
+    label "Resource ID"
+  end
+  field "resourceName" do
+    label "Resource Name"
+  end
+  field "tags" do
+    label "Resource Tags"
+  end
+  field "recommendationDetails" do
+    label "Recommendation"
+  end
+  field "region" do
+    label "Region"
+  end
+  field "state" do
+    label "State"
+  end
+  field "resourceType" do
+    label "Resource Type"
+    path "runtime"    # use 'path' to alias a data field to a standard name
+  end
+  field "savings" do
+    label "Estimated Monthly Savings"
+  end
+  field "savingsCurrency" do
+    label "Savings Currency"
+  end
+  field "lookbackPeriod" do
+    label "Look Back Period (Days)"
+  end
+  field "service" do
+    label "Service"
+  end
+  field "resourceARN" do
+    label "Resource ARN"
+  end
+  field "id" do
+    label "ID"
+    path "resourceID"
+  end
+end
+
+hash_exclude "tags", "savings", "savingsCurrency"
+
+# Final transform result.push example:
+result.push({
+  accountID: ds_aws_account['id'],
+  accountName: ds_aws_account['name'],
+  resourceID: resource['id'],
+  resourceName: resource['name'],
+  tags: tags.join(', '),
+  recommendationDetails: recommendationDetails,
+  region: region,
+  // Resource-specific fields here ...
+  savings: parseFloat(item_savings.toFixed(3)),
+  savingsCurrency: ds_currency['symbol'],
+  lookbackPeriod: param_lookback_days,
+  service: "EC2",
+  resourceARN: resource['arn'],
+})
+
+### Escalations
+
+escalation "esc_email" do
+  automatic true
+  label "Send Email"
+  description "Send incident email"
+  email $param_email do
+    attach_export_table $param_incident_csv
+    body_table_max_rows $param_incident_table_size
+  end
+end
+
+escalation "esc_delete" do
+  automatic contains($param_automatic_action, "Delete Items")
+  label "Delete Items"
+  description "Approval to delete all selected items"
+  run "delete_items", data, $param_some_option
+end
+
+escalation "esc_create_and_resolve" do
+  automatic true
+  label "Create Items"
+  description "Creates the listed items and closes the incident"
+  run "create_items", data
+  resolve_incident
+end
+
+### Cloud Workflow (Actions)
+
+define delete_items($data, $param_some_option) return $all_responses do
+  $$all_responses = []
+  $$errors = []
+
+  foreach $item in $data do
+    sub on_error: handle_error() do
+      call delete_one_item($item) retrieve $response
+    end
+    $$all_responses << $response
+  end
+
+  if size($$errors) > 0
+    raise join($$errors, "\n")
+  end
+end
+
+# Pattern A - AWS/Oracle: http_request with split host/href and explicit https: flag
+define delete_one_item_aws($item) return $response do
+  $response = http_request(
+    auth: $$auth_aws,
+    https: true,
+    verb: "delete",
+    host: "example.com",
+    href: join(["/items/", $item["id"]]),
+    headers: { "Accept": "application/json" }
+  )
+end
+
+# Pattern B - Google/Azure: shorthand method with a single full URL
+define delete_one_item_azure($item) return $response do
+  $response = http_delete(
+    auth: $$auth_google,
+    url: join(["https://example.com/items/", $item["id"]]),
+    headers: { "Accept": "application/json" }
+  )
+end
+
+define handle_error() do
+  if !$$errors
+    $$errors = []
+  end
+  $$errors << $_error["type"] + ": " + $_error["message"]
+  $_error_behavior = "skip"
+end
+
+  call delete_one_item($item) retrieve $response   # captures return value
+  call log_event($item)                            # fire-and-forget; no return value needed
+
+define delete_one_item($item) return $response do
+  $url = "https://example.com/items/" + $item["id"]
+  task_label("DELETE " + $url)
+  $response = http_request(
+    auth: $$auth_aws,
+    https: true,
+    verb: "delete",
+    host: "example.com",
+    href: join(["/items/", $item["id"]])
+  )
+  task_label("DELETE " + $url + " response: " + to_json($response))
+end
+
+  if inspect($$errors) != "null"
+    raise "\n" + join($$errors, "\n") + "\n"
+  end
+
+  concurrent foreach $instance in $data do
+    sub on_error: handle_error() do
+      call stop_one_instance($instance)
+    end
+  end
+
+  if $response["code"] != 200 && $response["code"] != 202 && $response["code"] != 204
+    raise "Unexpected response deleting item " + $item["id"] + ": " + to_json($response)
+  else
+    task_label("Successfully deleted item: " + $item["id"])
+  end
+
+  while $instance_state != "running" do
+    call get_instance_state($instance) retrieve $instance_state
+    sleep(10)
+  end
+
+  sub timeout: 5m, on_timeout: skip do
+    while $state != "RUNNING" do
+      call get_state($item) retrieve $state
+      sleep(5)
+    end
+  end
+
+  sub timeout: 5m, on_timeout: handle_timeout() do
+    while $state == null do
+      call get_state($item) retrieve $state
+      sleep(10)
+    end
+  end
+
+  $response = http_post(
+    auth: $$auth_google,
+    url: $url,
+    headers: { "content-type": "application/json" },
+    body: { "labels": $new_labels }
+  )
+
+### Flexera API Boilerplate Datasources
+
+datasource "ds_flexera_api_hosts" do
+  run_script $js_flexera_api_hosts, rs_optima_host
+end
+
+script "js_flexera_api_hosts", type: "javascript" do
+  parameters "rs_optima_host"
+  result "result"
+  code <<-'EOS'
+  host_table = {
+    "api.optima.flexeraeng.com": {
+      api: "api.flexera.com",
+      flexera: "api.flexera.com",
+      fsm: "api.fsm.flexeraeng.com",
+      grs: "grs-front.iam-us-east-1.flexeraeng.com",
+      ui: "app.flexera.com",
+      tld: "flexera.com"
+    },
+    "api.optima-eu.flexeraeng.com": {
+      api: "api.flexera.eu",
+      flexera: "api.flexera.eu",
+      fsm: "api.fsm-eu.flexeraeng.com",
+      grs: "grs-front.eu-central-1.iam-eu.flexeraeng.com",
+      ui: "app.flexera.eu",
+      tld: "flexera.eu"
+    },
+    "api.optima-apac.flexeraeng.com": {
+      api: "api.flexera.au",
+      flexera: "api.flexera.au",
+      fsm: "api.fsm-apac.flexeraeng.com",
+      grs: "grs-front.ap-southeast-2.iam-apac.flexeraeng.com",
+      ui: "app.flexera.au",
+      tld: "flexera.au"
+    },
+    "api.optima.flexeraengdev.com": {
+      api: "api.flexeratest.com",
+      flexera: "api.flexeratest.com",
+      fsm: "api.fsm.flexeraengdev.com",
+      grs: "grs-front.iam-us-east-1.flexeraengdev.com",
+      ui: "app.flexeratest.com",
+      tld: "flexeratest.com"
+    }
+  }
+
+  result = host_table[rs_optima_host]
+EOS
+end
+
+datasource "ds_applied_policy" do
+  request do
+    auth $auth_flexera
+    host val($ds_flexera_api_hosts, "flexera")
+    path join(["/policy/v1/orgs/", rs_org_id, "/projects/", rs_project_id, "/applied-policies", switch(policy_id, join(["/", policy_id]), "")])
+  end
+end
+
+datasource "ds_billing_centers" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host     # use rs_optima_host directly, NOT val($ds_flexera_api_hosts, ...)
+    path join(["/analytics/orgs/", rs_org_id, "/billing_centers"])
+    query "view", "allocation_table"
+    header "Api-Version", "1.0"
+    header "User-Agent", "RS Policies"
+    ignore_status [403]
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "href", jmes_path(col_item, "href")
+      field "id", jmes_path(col_item, "id")
+      field "name", jmes_path(col_item, "name")
+      field "parent_id", jmes_path(col_item, "parent_id")
+    end
+  end
+end
+
+datasource "ds_top_level_bcs" do
+  run_script $js_top_level_bcs, $ds_billing_centers
+end
+
+script "js_top_level_bcs", type: "javascript" do
+  parameters "ds_billing_centers"
+  result "result"
+  code <<-'EOS'
+  filtered_bcs = _.filter(ds_billing_centers, function(bc) {
+    return bc['parent_id'] == null || bc['parent_id'] == undefined
+  })
+
+  result = _.compact(_.pluck(filtered_bcs, 'id'))
+EOS
+end
+
+datasource "ds_billing_centers_filtered" do
+  run_script $js_billing_centers_filtered, $ds_billing_centers, $param_bc_allow_or_deny, $param_bc_list
+end
+
+script "js_billing_centers_filtered", type: "javascript" do
+  parameters "ds_billing_centers", "param_bc_allow_or_deny", "param_bc_list"
+  result "result"
+  code <<-'EOS'
+  allow_deny_test = { "Allow": true, "Deny": false }
+
+  if (param_bc_list.length > 0) {
+    billing_centers = _.filter(ds_billing_centers, function(item) {
+      id_found = _.contains(param_bc_list, item['id']) == allow_deny_test[param_bc_allow_or_deny]
+      name_found = _.contains(param_bc_list, item['name']) == allow_deny_test[param_bc_allow_or_deny]
+      return id_found || name_found
+    })
+
+    // Check for conflicting parents/children and remove children if present
+    bc_ids = _.compact(_.pluck(billing_centers, 'id'))
+    bad_children = _.filter(ds_billing_centers, function(bc) { return _.contains(bc_ids, bc['parent_id']) })
+    bad_children_ids = _.pluck(bad_children, 'id')
+
+    // Create final result with the bad children removed
+    result = _.reject(billing_centers, function(bc) { return _.contains(bad_children_ids, bc['id']) })
+  } else {
+    // If we're not filtering at all, just grab all of the top level billing centers
+    result = _.filter(ds_billing_centers, function(bc) {
+      return bc['parent_id'] == null || bc['parent_id'] == undefined
+    })
+  }
+EOS
+end
+
+datasource "ds_cloud_vendor_accounts" do
+  request do
+    auth $auth_flexera
+    host val($ds_flexera_api_hosts, 'flexera')
+    path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
+    header "Api-Version", "1.0"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "values[*]") do
+      field "id", jmes_path(col_item, "aws.accountId")  # use azure.subscriptionId, gcp.projectId etc. for other providers
+      field "name", jmes_path(col_item, "name")
+      field "tags", jmes_path(col_item, "tags")
+    end
+  end
+end
+
+# Variant: Fallback for AWS account name lookup when ds_cloud_vendor_accounts lacks the account
+# (queries the Bill Analysis API directly for a vendor_account/vendor_account_name pair)
+
+datasource "ds_cloud_vendor_accounts_fallback" do
+  request do
+    run_script $js_cloud_vendor_accounts_fallback, $ds_top_level_bcs, rs_org_id, rs_optima_host
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "rows[*]") do
+      field "id", jmes_path(col_item, "dimensions.vendor_account")
+      field "name", jmes_path(col_item, "dimensions.vendor_account_name")
+    end
+  end
+end
+
+script "js_cloud_vendor_accounts_fallback", type: "javascript" do
+  parameters "ds_top_level_bcs", "rs_org_id", "rs_optima_host"
+  result "request"
+  code <<-'EOS'
+  end_date = new Date()
+  end_date.setDate(end_date.getDate() - 2)
+  end_date = end_date.toISOString().split('T')[0]
+
+  start_date = new Date()
+  start_date.setDate(start_date.getDate() - 3)
+  start_date = start_date.toISOString().split('T')[0]
+
+  var request = {
+    auth: "auth_flexera",
+    host: rs_optima_host,
+    verb: "POST",
+    path: "/bill-analysis/orgs/" + rs_org_id + "/costs/aggregated",
+    body_fields: {
+      dimensions: ["vendor_account", "vendor_account_name"],
+      granularity: "day",
+      start_at: start_date,
+      end_at: end_date,
+      metrics: ["cost_amortized_unblended_adj"],
+      billing_center_ids: ds_top_level_bcs
+    },
+    headers: {
+      'User-Agent': "RS Policies",
+      'Api-Version': "1.0"
+    },
+    ignore_status: [400]
+  }
+EOS
+end
+
+### Meta Policy Canonical Block
+
+###############################################################################
+# Meta Policy [alpha]
+# Not intended to be modified or used by policy developers
+###############################################################################
+
+datasource "ds_get_parent_policy" do
+  request do
+    auth $auth_flexera
+    host val($ds_flexera_api_hosts, "flexera")
+    path join(["/policy/v1/orgs/", rs_org_id, "/projects/", rs_project_id, "/applied-policies/", switch(ne(meta_parent_policy_id, ""), meta_parent_policy_id, policy_id) ])
+    ignore_status [404]
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+  end
+end
+
+datasource "ds_parent_policy_terminated" do
+  run_script $js_parent_policy_terminated, $ds_get_parent_policy, meta_parent_policy_id
+end
+
+script "js_parent_policy_terminated", type: "javascript" do
+  parameters "ds_get_parent_policy", "meta_parent_policy_id"
+  result "result"
+  code <<-'EOS'
+  result = meta_parent_policy_id != "" && ds_get_parent_policy["id"] == undefined
+EOS
+end
+
+### Provider Boilerplate Datasources
+
+datasource "ds_describe_regions" do
+  request do
+    auth $auth_aws
+    host "ec2.amazonaws.com"
+    path "/"
+    query "Action", "DescribeRegions"
+    query "Version", "2016-11-15"
+    query "Filter.1.Name", "opt-in-status"
+    query "Filter.1.Value.1", "opt-in-not-required"
+    query "Filter.1.Value.2", "opted-in"
+    header "Meta-Flexera", val($ds_is_deleted, "path")
+  end
+  result do
+    encoding "xml"
+    collect xpath(response, "//DescribeRegionsResponse/regionInfo/item", "array") do
+      field "region", xpath(col_item, "regionName")
+    end
+  end
+end
+
+datasource "ds_azure_subscriptions" do
+  request do
+    auth $auth_azure
+    pagination $pagination_azure
+    host $param_azure_endpoint
+    path "/subscriptions/"
+    query "api-version", "2020-01-01"
+    header "User-Agent", "RS Policies"
+    header "Meta-Flexera", val($ds_is_deleted, "path")
+    ignore_status [400, 403, 404]
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "value[*]") do
+      field "id", jmes_path(col_item, "subscriptionId")
+      field "name", jmes_path(col_item, "displayName")
+      field "state", jmes_path(col_item, "state")
+    end
+  end
+end
+
+datasource "ds_google_projects" do
+  request do
+    run_script $js_google_projects, $ds_is_deleted, $param_projects_ignore_sys, $param_projects_ignore_app
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "projects[*]") do
+      field "id", jmes_path(col_item, "projectId")
+      field "name", jmes_path(col_item, "name")
+      field "labels", jmes_path(col_item, "labels")
+    end
+  end
+end
+
+script "js_google_projects", type: "javascript" do
+  parameters "ds_is_deleted", "param_projects_ignore_sys", "param_projects_ignore_app"
+  result "request"
+  code <<-'EOS'
+  query = []
+  if (param_projects_ignore_sys == "Yes") { query.push("-projectId:sys-") }
+  if (param_projects_ignore_app == "Yes") { query.push("-projectId:app-") }
+
+  var request = {
+    auth: "auth_google",
+    pagination: "pagination_google",
+    host: "cloudresourcemanager.googleapis.com",
+    path: "/v3/projects:search",
+    query_params: { "query": query.join(" ") },
+    // Header Meta-Flexera has no affect on datasource query, but is required for Meta Policies
+    // Forces `ds_is_deleted` datasource to run first during policy execution
+    headers: {
+      "Meta-Flexera": ds_is_deleted["path"]
+    }
+  }
+EOS
+end
+
+datasource "ds_terminate_self" do
+  request do
+    run_script $js_make_terminate_request, $ds_parent_policy_terminated, $ds_flexera_api_hosts, policy_id, rs_org_id, rs_project_id
+  end
+end
+
+script "js_make_terminate_request", type: "javascript" do
+  parameters "ds_parent_policy_terminated", "ds_flexera_api_hosts", "policy_id", "rs_org_id", "rs_project_id"
+  result "request"
+  code <<-'EOS'
+  var request = {
+    auth: "auth_flexera",
+    host: ds_flexera_api_hosts["flexera"],
+    path: [ "/policy/v1/orgs/", rs_org_id, "/projects/", rs_project_id, "/applied-policies", policy_id ? "/"+policy_id : "" ].join(''),
+    verb: ds_parent_policy_terminated ? "DELETE" : "GET"
+  }
+EOS
+end
+
+datasource "ds_is_deleted" do
+  run_script $js_is_deleted, $ds_terminate_self
+end
+
+script "js_is_deleted", type: "javascript" do
+  parameters "ds_terminate_self"
+  result "result"
+  code 'result = { path: "/"}'
+end
+
+================================================================================
+## Standard Parameter Conventions
+================================================================================
+
+parameter "param_email" do
+  type "list"
+  category "Policy Settings"
+  label "Email Addresses"
+  description "A list of email addresses to notify."
+  default []
+end
+
+parameter "param_aws_account_number" do
+  type "string"
+  category "Policy Settings"
+  label "Account Number"
+  description "Leave blank; this is for automated use with Meta Policies. See README for more details."
+  default ""
+end
+
+parameter "param_automatic_action" do
+  type "list"
+  category "Actions"
+  label "Automatic Actions"
+  description "When set, the policy will automatically take the selected action(s)."
+  allowed_values ["Delete Items"]
+  default []
+end
+
+parameter "param_min_savings" do
+  type "number"
+  category "Policy Settings"
+  label "Minimum Savings Threshold"
+  description "Minimum potential savings required to generate a recommendation."
+  min_value 0
+  default 0
+end
+
+parameter "param_regions_allow_or_deny" do
+  type "string"
+  category "Filters"
+  label "Allow/Deny Regions"
+  description "Allow or Deny entered regions. See the README for more details."
+  allowed_values "Allow", "Deny"
+  default "Allow"
+end
+
+parameter "param_regions_list" do
+  type "list"
+  category "Filters"
+  label "Allow/Deny Regions List"
+  description "A list of allowed or denied regions. See the README for more details."
+  default []
+end
+
+parameter "param_subscriptions_allow_or_deny" do
+  type "string"
+  category "Filters"
+  label "Allow/Deny Subscriptions"
+  description "Allow or Deny entered subscriptions. See the README for more details."
+  allowed_values "Allow", "Deny"
+  default "Allow"
+end
+
+parameter "param_subscriptions_list" do
+  type "list"
+  category "Filters"
+  label "Allow/Deny Subscriptions List"
+  description "A list of allowed or denied subscription IDs/names. See the README for more details."
+  default []
+end
+
+parameter "param_projects_allow_or_deny" do
+  type "string"
+  category "Filters"
+  label "Allow/Deny Projects"
+  description "Allow or Deny entered Projects. See the README for more details."
+  allowed_values "Allow", "Deny"
+  default "Allow"
+end
+
+parameter "param_projects_list" do
+  type "list"
+  category "Filters"
+  label "Allow/Deny Projects List"
+  description "A list of allowed or denied project IDs/names. See the README for more details."
+  default []
+end
+
+parameter "param_azure_endpoint" do
+  type "string"
+  category "Policy Settings"
+  label "Azure Endpoint"
+  description "Select the API endpoint to use for Azure. Use default value of management.azure.com unless using Azure China."
+  allowed_values "management.azure.com", "management.chinacloudapi.cn"
+  default "management.azure.com"
+end
+
+parameter "param_exclusion_tags" do
+  type "list"
+  category "Filters"
+  label "Exclusion Tags"
+  description "Cloud native tags to ignore resources that you don't want to produce recommendations for. Enter the Key name to filter resources with a specific Key, regardless of Value, and enter Key==Value to filter resources with a specific Key:Value pair. Other operators and regex are supported; please see the README for more details."
+  default []
+end
+
+parameter "param_exclusion_tags_boolean" do
+  type "string"
+  category "Filters"
+  label "Exclusion Tags: Any / All"
+  description "Whether to filter resources containing any of the specified tags or only those that contain all of them."
+  allowed_values "Any", "All"
+  default "Any"
+end
+
+parameter "param_incident_table_size" do
+  type "number"
+  category "Policy Settings"
+  label "Incident Table Size"
+  description "Maximum number of rows to include in the incident table in the email. Larger values may cause email delivery issues."
+  min_value 1
+  max_value 500
+  default 20
+end
+
+parameter "param_incident_csv" do
+  type "string"
+  category "Policy Settings"
+  label "Attach Incident CSV"
+  description "Whether or not to attach a CSV of the incident data to the incident email."
+  allowed_values "true", "false"
+  default "true"
+end
+
+### Statistics Category Parameters
+
+parameter "param_stats_lookback" do
+  type "number"
+  category "Statistics"
+  label "Statistic Lookback Period"
+  description "How many days back to look at CloudWatch data when assessing resources. This value cannot be set higher than 90 because AWS does not retain metrics for longer than 90 days."
+  min_value 1
+  max_value 90
+  default 30
+end
+
+### Currency Conversion Boilerplate
+
+datasource "ds_currency_reference" do
+  request do
+    host "raw.githubusercontent.com"
+    path "/flexera-public/policy_templates/master/data/currency/currency_reference.json"
+    header "User-Agent", "RS Policies"
+  end
+end
+
+datasource "ds_currency_code" do
+  request do
+    auth $auth_flexera
+    host rs_optima_host
+    path join(["/bill-analysis/orgs/", rs_org_id, "/settings/currency_code"])
+    header "Api-Version", "0.1"
+    header "User-Agent", "RS Policies"
+    ignore_status [403]
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+    field "value", jmes_path(response, "value")
+  end
+end
+
+datasource "ds_currency" do
+  run_script $js_currency, $ds_currency_reference, $ds_currency_code
+end
+
+script "js_currency", type:"javascript" do
+  parameters "ds_currency_reference", "ds_currency_code"
+  result "result"
+  code <<-'EOS'
+  symbol = "$"
+  separator = ","
+
+  if (ds_currency_code['value'] != undefined) {
+    if (ds_currency_reference[ds_currency_code['value']] != undefined) {
+      symbol = ds_currency_reference[ds_currency_code['value']]['symbol']
+
+      if (ds_currency_reference[ds_currency_code['value']]['t_separator'] != undefined) {
+        separator = ds_currency_reference[ds_currency_code['value']]['t_separator']
+      } else {
+        separator = ""
+      }
+    }
+  }
+
+  result = {
+    symbol: symbol,
+    separator: separator
+  }
+EOS
+end
+
+# Variant: templates that convert costs into the org's currency (rather than just formatting $)
+# chain ds_currency_target -> ds_conditional_currency_conversion -> ds_currency_conversion -> ds_currency
+
+datasource "ds_currency_target" do
+  run_script $js_currency_target, $ds_currency_reference, $ds_currency_code
+end
+
+script "js_currency_target", type:"javascript" do
+  parameters "ds_currency_reference", "ds_currency_code"
+  result "result"
+  code <<-'EOS'
+  // Default to USD if currency is not found
+  result = ds_currency_reference['USD']
+
+  if (ds_currency_code['value'] != undefined && ds_currency_reference[ds_currency_code['value']] != undefined) {
+    result = ds_currency_reference[ds_currency_code['value']]
+  }
+EOS
+end
+
+datasource "ds_conditional_currency_conversion" do
+  run_script $js_conditional_currency_conversion, $ds_currency_target
+end
+
+script "js_conditional_currency_conversion", type: "javascript" do
+  parameters "ds_currency_target"
+  result "result"
+  code <<-'EOS'
+  result = []
+  // Make the request only if the target currency is not USD
+  if (ds_currency_target['code'] != 'USD') {
+    result = [1]
+  }
+EOS
+end
+
+datasource "ds_currency_conversion" do
+  # Only make a request if the target currency is not USD
+  iterate $ds_conditional_currency_conversion
+  request do
+    host "api.xe-auth.flexeraeng.com"
+    path "/prod/{proxy+}"
+    query "from", "USD"
+    query "to", val($ds_currency_target, 'code')
+    query "amount", "1"
+    # Ignore currency conversion if API has issues
+    ignore_status [400, 404, 502]
+  end
+  result do
+    encoding "json"
+    field "from", jmes_path(response, "from")
+    field "to", jmes_path(response, "to")
+    field "amount", jmes_path(response, "amount")
+    field "year", jmes_path(response, "year")
+  end
+end
+
+datasource "ds_currency" do
+  run_script $js_currency, $ds_currency_target, $ds_currency_conversion
+end
+
+script "js_currency", type:"javascript" do
+  parameters "ds_currency_target", "ds_currency_conversion"
+  result "result"
+  code <<-'EOS'
+  result = ds_currency_target
+  result['exchange_rate'] = 1
+
+  if (ds_currency_conversion.length > 0) {
+    currency_code = ds_currency_target['code']
+    current_month = parseInt(new Date().toISOString().split('-')[1])
+
+    conversion_block = _.find(ds_currency_conversion[0]['to'][currency_code], function(item) {
+      return item['month'] == current_month
+    })
+
+    if (conversion_block != undefined) {
+      result['exchange_rate'] = conversion_block['monthlyAverage']
+    }
+  }
+EOS
+end
+
+### Common JavaScript Patterns - Multi-Stage Resource Filter Pipeline
+
+# Resource-heavy templates (e.g. Azure Storage Accounts, Azure SQL Servers) chain tag -> region -> resource-group
+# filters in sequence, each stage consuming the prior stage's output datasource.
+
+datasource "ds_azure_storage_accounts_tag_filtered" do
+  run_script $js_azure_storage_accounts_tag_filtered, $ds_azure_storage_accounts, $param_exclusion_tags, $param_exclusion_tags_boolean
+end
+
+script "js_azure_storage_accounts_tag_filtered", type: "javascript" do
+  parameters "ds_azure_storage_accounts", "param_exclusion_tags", "param_exclusion_tags_boolean"
+  result "result"
+  code <<-'EOS'
+  comparators = _.map(param_exclusion_tags, function(item) {
+    if (item.indexOf('==') != -1) {
+      return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
+    }
+
+    if (item.indexOf('!=') != -1) {
+      return { comparison: '!=', key: item.split('!=')[0], value: item.split('!=')[1], string: item }
+    }
+
+    if (item.indexOf('=~') != -1) {
+      value = item.split('=~')[1]
+      regex = new RegExp(value.slice(1, value.length - 1))
+      return { comparison: '=~', key: item.split('=~')[0], value: regex, string: item }
+    }
+
+    if (item.indexOf('!~') != -1) {
+      value = item.split('!~')[1]
+      regex = new RegExp(value.slice(1, value.length - 1))
+      return { comparison: '!~', key: item.split('!~')[0], value: regex, string: item }
+    }
+
+    // If = is present but none of the above are, assume user error and that the user intended ==
+    if (item.indexOf('=') != -1) {
+      return { comparison: '==', key: item.split('=')[0], value: item.split('=')[1], string: item }
+    }
+
+    // Assume we're just testing for a key if none of the comparators are found
+    return { comparison: 'key', key: item, value: null, string: item }
+  })
+
+  if (param_exclusion_tags.length > 0) {
+    result = _.reject(ds_azure_storage_accounts, function(resource) {
+      resource_tags = {}
+      if (typeof(resource['tags']) == 'object') { resource_tags = resource['tags'] }
+
+      // Store a list of found tags
+      found_tags = []
+
+      _.each(comparators, function(comparator) {
+        comparison = comparator['comparison']
+        value = comparator['value']
+        string = comparator['string']
+        resource_tag = resource_tags[comparator['key']]
+
+        if (comparison == 'key' && resource_tag != undefined) { found_tags.push(string) }
+        if (comparison == '==' && resource_tag == value) { found_tags.push(string) }
+        if (comparison == '!=' && resource_tag != value) { found_tags.push(string) }
+
+        if (comparison == '=~') {
+          if (resource_tag != undefined && value.test(resource_tag)) { found_tags.push(string) }
+        }
+
+        if (comparison == '!~') {
+          if (resource_tag == undefined || !value.test(resource_tag)) { found_tags.push(string) }
+        }
+      })
+
+      all_tags_found = found_tags.length == comparators.length
+      any_tags_found = found_tags.length > 0 && param_exclusion_tags_boolean == 'Any'
+
+      return all_tags_found || any_tags_found
+    })
+  } else {
+    result = ds_azure_storage_accounts
+  }
+EOS
+end
+
+datasource "ds_azure_storage_accounts_region_filtered" do
+  run_script $js_azure_storage_accounts_region_filtered, $ds_azure_storage_accounts_tag_filtered, $param_regions_allow_or_deny, $param_regions_list
+end
+
+script "js_azure_storage_accounts_region_filtered", type: "javascript" do
+  parameters "ds_azure_storage_accounts_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
+  result "result"
+  code <<-'EOS'
+  if (param_regions_list.length > 0) {
+    result = _.filter(ds_azure_storage_accounts_tag_filtered, function(account) {
+      include_account = _.contains(param_regions_list, account['region'])
+
+      if (param_regions_allow_or_deny == "Deny") {
+        include_account = !include_account
+      }
+
+      return include_account
+    })
+  } else {
+    result = ds_azure_storage_accounts_tag_filtered
+  }
+EOS
+end
+
+datasource "ds_azure_storage_accounts_rg_filtered" do
+  run_script $js_azure_storage_accounts_rg_filtered, $ds_azure_storage_accounts_name_filtered, $param_resource_groups_allow_or_deny, $param_resource_groups_list
+end
+
+script "js_azure_storage_accounts_rg_filtered", type: "javascript" do
+  parameters "ds_azure_storage_accounts_name_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
+  result "result"
+  code <<-'EOS'
+    if (param_resource_groups_list.length > 0) {
+      result = _.filter(ds_azure_storage_accounts_name_filtered, function(resource) {
+        rg = resource['resourceGroup']
+        sub = resource['subscriptionId'] || resource['subscriptionID']
+        include_resource = _.any(param_resource_groups_list, function(rg_entry) {
+          if (rg_entry.indexOf('/') != -1) {
+            entry_parts = rg_entry.split('/')
+            return sub == entry_parts[0] && rg == entry_parts[1]
+          }
+          return rg == rg_entry
+        })
+        if (param_resource_groups_allow_or_deny == "Deny") {
+          include_resource = !include_resource
+        }
+        return include_resource
+      })
+    } else {
+      result = ds_azure_storage_accounts_name_filtered
+    }
+EOS
+end
+
+### AWS Instance Type Reference Datasources
+
+datasource "ds_aws_instance_types" do
+  request do
+    host "raw.githubusercontent.com"
+    path "/flexera-public/policy_templates/master/data/aws/aws_ec2_instance_types.json"
+    header "User-Agent", "RS Policies"
+  end
+end
+
+datasource "ds_aws_instance_type_map" do
+  run_script $js_aws_instance_type_map, $ds_aws_instance_types
+end
+
+script "js_aws_instance_type_map", type: "javascript" do
+  parameters "ds_aws_instance_types"
+  result "result"
+  code <<-'EOS'
+  result = {}
+  _.each(ds_aws_instance_types, function(entry) { result[entry["name"]] = entry })
+EOS
+end
+
+### Common Bill Ingestion (CBI) / Rule-Based Dimensions (RBD) Datasources
+
+datasource "ds_existing_bill_connects" do
+  request do
+    auth $auth_flexera
+    host val($ds_flexera_api_hosts, "flexera")
+    path join(["/finops-onboarding/v1/orgs/", rs_org_id, "/bill-connects"])
+    header "User-Agent", "RS Policies"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "values[*]") do
+      field "id", jmes_path(col_item, "id")
+      field "kind", jmes_path(col_item, "kind")
+      field "created_at", jmes_path(col_item, "created_at")
+      field "updated_at", jmes_path(col_item, "updated_at")
+      field "billIdentifier", jmes_path(col_item, "cbi.billIdentifier")
+      field "integrationId", jmes_path(col_item, "cbi.integrationId")
+      field "name", jmes_path(col_item, "cbi.name")
+      field "displayName", jmes_path(col_item, "cbi.params.displayName")
+      field "vendorName", jmes_path(col_item, "cbi.params.vendorName")
+    end
+  end
+end
+
+datasource "ds_pending_bill_uploads" do
+  run_script $js_pending_bill_uploads, $ds_existing_bill_uploads
+end
+
+script "js_pending_bill_uploads", type: "javascript" do
+  parameters "ds_existing_bill_uploads"
+  result "result"
+  code <<-'EOS'
+  result = _.filter(ds_existing_bill_uploads, function(item) {
+    return item["status"] != "complete" && item["status"] != "aborted"
+  })
+EOS
+end
+
+datasource "ds_abort_pending_bill_uploads" do
+  iterate $ds_pending_bill_uploads
+  request do
+    auth $auth_flexera
+    verb "POST"
+    host rs_optima_host
+    path join(["/optima/orgs/", rs_org_id, "/billUploads/", val(iter_item, "id"), "/operations"])
+    header "User-Agent", "RS Policies"
+    body_field "operation", "abort"
+    ignore_status [400, 401, 402, 403, 404, 405, 429, 500, 502]
+  end
+  result do
+    encoding "json"
+    field "id", jmes_path(response, "id")
+    field "status", jmes_path(response, "status")
+    field "billConnectId", jmes_path(response, "billConnectId")
+    field "billingPeriod", jmes_path(response, "billingPeriod")
+    field "createdAt", jmes_path(response, "createdAt")
+    field "updatedAt", jmes_path(response, "updatedAt")
+  end
+end
+
+datasource "ds_effective_date" do
+  run_script $js_effective_date, $param_effective_date, $param_effective_date_mode
+end
+
+script "js_effective_date", type: "javascript" do
+  parameters "param_effective_date", "param_effective_date_mode"
+  result "result"
+  code <<-'EOS'
+  if (param_effective_date_mode == "Current Month") {
+    now = new Date()
+    year = now.getUTCFullYear()
+    month = ("0" + (now.getUTCMonth() + 1)).slice(-2)
+    result = year + "-" + month
+  } else {
+    result = param_effective_date
+  }
+EOS
+end
+
+# Rule-Based Dimensions (RBD): create the RBD, then apply its ruleset in a second dependent call
+# `ds_create_rbds` is passed as a parameter into `js_apply_rbds` purely to force execution order
+
+datasource "ds_create_rbds" do
+  iterate $ds_rbds
+  request do
+    run_script $js_create_rbds, val(iter_item, "id"), val(iter_item, "verb"), val(iter_item, "name"), val($ds_flexera_api_hosts, "flexera"), rs_org_id
+  end
+  result do
+    encoding "text"
+  end
+end
+
+script "js_create_rbds", type: "javascript" do
+  parameters "rbd_id", "verb", "name", "api_host", "rs_org_id"
+  result "request"
+  code <<-'EOS'
+  var request = {
+    auth: "auth_flexera",
+    verb: verb,
+    host: api_host,
+    path: ["/finops-customizations/v1/orgs/", rs_org_id, "/rule-based-dimensions/", rbd_id].join(''),
+    body_fields: { name: name }
+  }
+EOS
+end
+
+datasource "ds_apply_rbds" do
+  iterate $ds_rbds
+  request do
+    # ds_create_rbds is a parameter to ensure that it executes before ds_apply_rbds does
+    run_script $js_apply_rbds, val(iter_item, "id"), val(iter_item, "effective_at"), val(iter_item, "rules"), val($ds_flexera_api_hosts, "flexera"), $ds_create_rbds, rs_org_id
+  end
+  result do
+    encoding "text"
+  end
+end
+
+script "js_apply_rbds", type: "javascript" do
+  parameters "rbd_id", "effective_at", "rules", "api_host", "ds_create_rbds", "rs_org_id"
+  result "request"
+  code <<-'EOS'
+  var request = {
+    auth: "auth_flexera",
+    verb: "PUT",
+    host: api_host,
+    path: ["/finops-customizations/v1/orgs/", rs_org_id, "/rule-based-dimensions/", rbd_id, "/rules/", effective_at].join(''),
+    body_fields: { rules: rules }
+  }
+EOS
+end
+
+### Turbonomic Token / API Datasources
+
+datasource "ds_get_turbonomic_token" do
+  request do
+    run_script $js_get_turbonomic_token, $param_turbonomic_endpoint, $param_turbonomic_audience
+  end
+  result do
+    encoding "json"
+    field "access_token", jmes_path(response, "access_token")
+  end
+end
+
+script "js_get_turbonomic_token", type: "javascript" do
+  parameters "turbonomic_endpoint", "audience"
+  result "request"
+  code <<-'EOS'
+    var request = {
+      verb: "POST",
+      auth: "auth_turbonomic"
+      host: turbonomic_endpoint,
+      path: "/oauth2/token",
+      headers: {
+      "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: "grant_type=client_credentials" + "&audience=" + audience + "&scope=role:OBSERVER"
+
+    }
+EOS
+end
+
+datasource "ds_get_business_units" do
+  request do
+    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_endpoint, $param_provider
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "[*]") do
+      field "uuid", jmes_path(col_item, "uuid")
+      field "accountID", jmes_path(col_item, "accountId")
+      field "displayName", jmes_path(col_item, "displayName")
+    end
+  end
+end

--- a/data/agent/code_examples.txt
+++ b/data/agent/code_examples.txt
@@ -939,7 +939,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/operational/aws/cost_reallocation/support/CHANGELOG.md
+++ b/operational/aws/cost_reallocation/support/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.4
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.1.3
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/aws/cost_reallocation/support/aws_cost_reallocation_support.pt
+++ b/operational/aws/cost_reallocation/support/aws_cost_reallocation_support.pt
@@ -8,7 +8,7 @@ severity "critical"
 default_frequency "daily"
 category "Operational"
 info(
-  version: "0.1.3",
+  version: "0.1.4",
   provider: "AWS",
   service: "Support",
   category: "Operational",
@@ -254,7 +254,7 @@ end
 datasource "ds_rule_based_dimensions" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-customizations/v1/orgs/", rs_org_id, "/rule-based-dimensions"])
   end
   result do
@@ -293,7 +293,7 @@ datasource "ds_rule_based_dimensions_rules" do
   iterate $ds_rule_based_dimensions_effectiveAt_list
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-customizations/v1/orgs/", rs_org_id, "/rule-based-dimensions/", val(iter_item, "id"), "/rules/", val(iter_item, "effectiveAt")])
   end
 end
@@ -332,7 +332,7 @@ datasource "ds_tag_dimensions_used_in_rbd_rules_tag_key" do
   iterate $ds_tag_dimensions_used_in_rbd_rules
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-customizations/v1/orgs/", rs_org_id, "/tag-dimensions/", iter_item])
   end
   result do

--- a/operational/aws/ec2_stopped_report/CHANGELOG.md
+++ b/operational/aws/ec2_stopped_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.8
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.3.7
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/aws/ec2_stopped_report/aws_ec2_stopped_report.pt
+++ b/operational/aws/ec2_stopped_report/aws_ec2_stopped_report.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "0.3.7",
+  version: "0.3.8",
   provider: "AWS",
   service: "Compute",
   policy_set: "",
@@ -211,7 +211,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/operational/aws/ec2_stopped_report/aws_ec2_stopped_report_meta_parent.pt
+++ b/operational/aws/ec2_stopped_report/aws_ec2_stopped_report_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.3.7", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.3.8", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/operational/aws/lambda_functions_with_high_error_rate/CHANGELOG.md
+++ b/operational/aws/lambda_functions_with_high_error_rate/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.1.9
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v5.1.8
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate.pt
+++ b/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate.pt
@@ -8,7 +8,7 @@ severity "high"
 category "Operational"
 default_frequency "hourly"
 info(
-  version: "5.1.8",
+  version: "5.1.9",
   provider: "AWS",
   service: "PaaS",
   policy_set: "Lambda",
@@ -204,7 +204,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate_meta_parent.pt
+++ b/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "5.1.8", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.1.9", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/operational/aws/lambda_provisioned_concurrency/CHANGELOG.md
+++ b/operational/aws/lambda_provisioned_concurrency/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.7
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.2.6
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/aws/lambda_provisioned_concurrency/aws_lambda_provisioned_concurrency.pt
+++ b/operational/aws/lambda_provisioned_concurrency/aws_lambda_provisioned_concurrency.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.6",
+  version: "0.2.7",
   provider: "AWS",
   service: "PaaS",
   policy_set: "Lambda",
@@ -172,7 +172,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/operational/aws/lambda_provisioned_concurrency/aws_lambda_provisioned_concurrency_meta_parent.pt
+++ b/operational/aws/lambda_provisioned_concurrency/aws_lambda_provisioned_concurrency_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.2.6", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.7", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/operational/aws/long_running_instances/CHANGELOG.md
+++ b/operational/aws/long_running_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.2.8
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v5.2.7
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/aws/long_running_instances/long_running_instances.pt
+++ b/operational/aws/long_running_instances/long_running_instances.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.2.7",
+  version: "5.2.8",
   provider: "AWS",
   service: "Compute",
   policy_set: "Long Running Instances",
@@ -212,7 +212,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
+++ b/operational/aws/long_running_instances/long_running_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "5.2.7", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.2.8", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/operational/aws/overutilized_ec2_instances/CHANGELOG.md
+++ b/operational/aws/overutilized_ec2_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.8
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.2.7
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/aws/overutilized_ec2_instances/aws_overutilized_ec2.pt
+++ b/operational/aws/overutilized_ec2_instances/aws_overutilized_ec2.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "0.2.7",
+  version: "0.2.8",
   provider: "AWS",
   service: "Compute",
   policy_set: "Overutilized Compute Instances",
@@ -242,7 +242,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/operational/aws/overutilized_ec2_instances/aws_overutilized_ec2_meta_parent.pt
+++ b/operational/aws/overutilized_ec2_instances/aws_overutilized_ec2_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.2.7", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.8", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/operational/aws/scheduled_ec2_events/CHANGELOG.md
+++ b/operational/aws/scheduled_ec2_events/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.1.7
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v4.1.6
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/aws/scheduled_ec2_events/aws_scheduled_ec2_events.pt
+++ b/operational/aws/scheduled_ec2_events/aws_scheduled_ec2_events.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "medium"
 default_frequency "weekly"
 info(
-  version: "4.1.6",
+  version: "4.1.7",
   provider: "AWS",
   service: "Compute",
   policy_set: "",
@@ -190,7 +190,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/operational/aws/scheduled_ec2_events/aws_scheduled_ec2_events_meta_parent.pt
+++ b/operational/aws/scheduled_ec2_events/aws_scheduled_ec2_events_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "4.1.6", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.1.7", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/operational/azure/azure_long_running_instances/CHANGELOG.md
+++ b/operational/azure/azure_long_running_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.4.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v6.4.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.4.2",
+  version: "6.4.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "Long Running Instances",
@@ -588,25 +588,25 @@ script "js_azure_instances_rg_filtered", type: "javascript" do
   parameters "ds_azure_instances_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
-  if (param_resource_groups_list.length > 0) {
-    result = _.filter(ds_azure_instances_region_filtered, function(resource) {
-      rg = resource['resourceGroup']
-      sub = resource['subscriptionId'] || resource['subscriptionID']
-      include_resource = _.any(param_resource_groups_list, function(rg_entry) {
-        if (rg_entry.indexOf('/') != -1) {
-          entry_parts = rg_entry.split('/')
-          return sub == entry_parts[0] && rg == entry_parts[1]
+    if (param_resource_groups_list.length > 0) {
+      result = _.filter(ds_azure_instances_region_filtered, function(resource) {
+        rg = resource['resourceGroup']
+        sub = resource['subscriptionId'] || resource['subscriptionID']
+        include_resource = _.any(param_resource_groups_list, function(rg_entry) {
+          if (rg_entry.indexOf('/') != -1) {
+            entry_parts = rg_entry.split('/')
+            return sub == entry_parts[0] && rg == entry_parts[1]
+          }
+          return rg == rg_entry
+        })
+        if (param_resource_groups_allow_or_deny == "Deny") {
+          include_resource = !include_resource
         }
-        return rg == rg_entry
+        return include_resource
       })
-      if (param_resource_groups_allow_or_deny == "Deny") {
-        include_resource = !include_resource
-      }
-      return include_resource
-    })
-  } else {
-    result = ds_azure_instances_region_filtered
-  }
+    } else {
+      result = ds_azure_instances_region_filtered
+    }
 EOS
 end
 

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "6.4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.4.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent_rg.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "6.4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.4.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/operational/azure/overutilized_compute_instances/CHANGELOG.md
+++ b/operational/azure/overutilized_compute_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.4.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/azure/overutilized_compute_instances/azure_compute_overutilized.pt
+++ b/operational/azure/overutilized_compute_instances/azure_compute_overutilized.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.2",
+  version: "0.4.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "Overutilized Compute Instances",
@@ -681,25 +681,25 @@ script "js_azure_instances_rg_filtered", type: "javascript" do
   parameters "ds_azure_instances_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
-  if (param_resource_groups_list.length > 0) {
-    result = _.filter(ds_azure_instances_region_filtered, function(resource) {
-      rg = resource['resourceGroup']
-      sub = resource['subscriptionId'] || resource['subscriptionID']
-      include_resource = _.any(param_resource_groups_list, function(rg_entry) {
-        if (rg_entry.indexOf('/') != -1) {
-          entry_parts = rg_entry.split('/')
-          return sub == entry_parts[0] && rg == entry_parts[1]
+    if (param_resource_groups_list.length > 0) {
+      result = _.filter(ds_azure_instances_region_filtered, function(resource) {
+        rg = resource['resourceGroup']
+        sub = resource['subscriptionId'] || resource['subscriptionID']
+        include_resource = _.any(param_resource_groups_list, function(rg_entry) {
+          if (rg_entry.indexOf('/') != -1) {
+            entry_parts = rg_entry.split('/')
+            return sub == entry_parts[0] && rg == entry_parts[1]
+          }
+          return rg == rg_entry
+        })
+        if (param_resource_groups_allow_or_deny == "Deny") {
+          include_resource = !include_resource
         }
-        return rg == rg_entry
+        return include_resource
       })
-      if (param_resource_groups_allow_or_deny == "Deny") {
-        include_resource = !include_resource
-      }
-      return include_resource
-    })
-  } else {
-    result = ds_azure_instances_region_filtered
-  }
+    } else {
+      result = ds_azure_instances_region_filtered
+    }
 EOS
 end
 

--- a/operational/azure/overutilized_compute_instances/azure_compute_overutilized_meta_parent.pt
+++ b/operational/azure/overutilized_compute_instances/azure_compute_overutilized_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.4.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/operational/azure/overutilized_compute_instances/azure_compute_overutilized_meta_parent_rg.pt
+++ b/operational/azure/overutilized_compute_instances/azure_compute_overutilized_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.4.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/operational/flexera/cco/cost_reallocation/CHANGELOG.md
+++ b/operational/flexera/cco/cost_reallocation/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.6
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.1.5
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/flexera/cco/cost_reallocation/flexera_cost_reallocation.pt
+++ b/operational/flexera/cco/cost_reallocation/flexera_cost_reallocation.pt
@@ -8,7 +8,7 @@ severity "critical"
 default_frequency "daily"
 category "Operational"
 info(
-  version: "0.1.5",
+  version: "0.1.6",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   category: "Operational",
@@ -288,7 +288,7 @@ end
 datasource "ds_rule_based_dimensions" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-customizations/v1/orgs/", rs_org_id, "/rule-based-dimensions"])
   end
   result do
@@ -326,7 +326,7 @@ datasource "ds_rule_based_dimensions_rules" do
   iterate $ds_rule_based_dimensions_effectiveAt_list
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-customizations/v1/orgs/", rs_org_id, "/rule-based-dimensions/", val(iter_item, "id"), "/rules/", val(iter_item, "effectiveAt")])
   end
 end
@@ -375,7 +375,7 @@ datasource "ds_tag_dimensions_used_in_rbd_rules_tag_key" do
   iterate $ds_tag_dimensions_used_in_rbd_rules
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-customizations/v1/orgs/", rs_org_id, "/tag-dimensions/", iter_item])
   end
   result do

--- a/operational/flexera/cco/onboarding/CHANGELOG.md
+++ b/operational/flexera/cco/onboarding/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.10
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.1.9
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/flexera/cco/onboarding/flexera_onboarding.pt
+++ b/operational/flexera/cco/onboarding/flexera_onboarding.pt
@@ -9,7 +9,7 @@ default_frequency "15 minutes"
 category "Operational"
 info(
   publish: "true",
-  version: "0.1.9",
+  version: "0.1.10",
   provider: "Flexera",
   service: "All",
   policy_set: "N/A",
@@ -106,7 +106,7 @@ end
 datasource "ds_service_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/iam/v1/orgs/", rs_org_id, "/service-accounts"])
   end
 end
@@ -116,7 +116,7 @@ datasource "ds_service_account_clients" do
   iterate $ds_service_accounts
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/iam/v1/orgs/", rs_org_id, "/service-accounts/", val(iter_item, "id"), "/clients"])
   end
   result do
@@ -175,7 +175,7 @@ end
 datasource "ds_bill_connects" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-onboarding/v1/orgs/", rs_org_id, "/bill-connects"])
   end
   result do
@@ -202,7 +202,7 @@ end
 #   iterate jq($ds_bill_connects, '[ .[] | select(.kind != "finops:bill-connect-azure-ea") ]', "array")
 #   request do
 #     auth $auth_flexera
-#     host val($ds_flexera_api_hosts, 'flexera')
+#     host val($ds_flexera_api_hosts, "flexera")
 #     path join(["/finops-onboarding/v1/orgs/", rs_org_id, "/bill-connects/", val(iter_item, "type"), "/", val(iter_item, "id"), "/validation"])
 #   end
 #   result do
@@ -217,7 +217,7 @@ end
 datasource "ds_bill_connect_validations" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-onboarding/v1/orgs/", rs_org_id, "/bill-connects/validations"])
   end
 end
@@ -374,7 +374,7 @@ datasource "ds_applied_policies" do
   request do
     auth $auth_flexera
     pagination $pagination_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/policy/v1/orgs/", rs_org_id, "/projects/", rs_project_id, "/applied-policies"])
     query "limit", "5000"
     query "view", "extended"
@@ -423,7 +423,7 @@ end
 #   request do
 #     auth $auth_flexera
 #     pagination $pagination_flexera
-#     host val($ds_flexera_api_hosts, 'flexera')
+#     host val($ds_flexera_api_hosts, "flexera")
 #     path join(["/policy/v1/orgs/", rs_org_id, "/policy-aggregates"])
 #     query "limit", "5000"
 #   end
@@ -434,7 +434,7 @@ datasource "ds_published_templates" do
   request do
     auth $auth_flexera
     pagination $pagination_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/policy/v1/orgs/", rs_org_id, "/published-templates"])
     query "limit", "5000"
     query "view", "extended"
@@ -459,7 +459,7 @@ datasource "ds_credentials" do
   request do
     auth $auth_flexera
     pagination $pagination_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/cred/v2/projects/", rs_project_id, "/credentials"])
     query "limit", "5000"
     query "view", "extended"
@@ -840,7 +840,7 @@ end
 datasource "ds_rule_based_dimensions" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-customizations/v1/orgs/", rs_org_id, "/rule-based-dimensions"])
     # query "view", "extended"
   end
@@ -861,7 +861,7 @@ end
 datasource "ds_tag_dimensions" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-customizations/v1/orgs/", rs_org_id, "/tag-dimensions"])
     query "view", "extended"
   end
@@ -1186,7 +1186,7 @@ end
 datasource "ds_idps" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/iam/v1/orgs/", rs_org_id, "/idps"])
   end
 end
@@ -1208,7 +1208,7 @@ datasource "ds_idp_domains" do
   iterate $ds_idp_ids
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/iam/v1/orgs/", rs_org_id, "/idps/", iter_item, "/domains"])
   end
 end
@@ -1217,7 +1217,7 @@ end
 datasource "ds_login_policy" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/iam/v1/orgs/", rs_org_id, "/login-policy"])
   end
 end

--- a/operational/flexera/cco/rbds_from_csv_in_policy_template/CHANGELOG.md
+++ b/operational/flexera/cco/rbds_from_csv_in_policy_template/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.5
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.1.4
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/flexera/cco/rbds_from_csv_in_policy_template/rbds_from_csv.pt
+++ b/operational/flexera/cco/rbds_from_csv_in_policy_template/rbds_from_csv.pt
@@ -1,7 +1,7 @@
 name "Rule-Based Dimensions from CSV in Policy Template"
 rs_pt_ver 20180301
 type "policy"
-short_description "Creates and updates custom Rule-Based Dimensions based on data provided in CSV format. Please see the [README](https://github.com/flexera-public/policy_templates/tree/master/operational/flexera/cco/rbds_from_csv_in_policy_template/) for more information."
+short_description "Creates and updates custom Rule-Based Dimensions based on data provided in CSV format. See the [README](https://github.com/flexera-public/policy_templates/tree/master/operational/flexera/cco/rbds_from_csv_in_policy_template/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera-one/automation/) to learn more."
 long_description ""
 doc_link "https://github.com/flexera-public/policy_templates/tree/master/operational/flexera/cco/rbds_from_csv_in_policy_template/"
 category "Operational"

--- a/operational/flexera/cco/rbds_from_csv_in_policy_template/rbds_from_csv.pt
+++ b/operational/flexera/cco/rbds_from_csv_in_policy_template/rbds_from_csv.pt
@@ -9,7 +9,7 @@ severity "low"
 default_frequency "daily"
 info(
   publish: "false",
-  version: "0.1.4",
+  version: "0.1.5",
   provider: "Flexera",
   service: "FinOps Customizations",
   policy_set: "Automation",
@@ -120,7 +120,7 @@ datasource "ds_policy_templates" do
   request do
     auth $auth_flexera
     pagination $pagination_flexera
-    host val($ds_flexera_api_hosts, 'api')
+    host val($ds_flexera_api_hosts, "api")
     path join(["/policy/v1/orgs/", rs_org_id, "/projects/", rs_project_id, "/policy-templates"])
     query "filter", "name co 'CSV for Rule-Based Dimensions from CSV'"
     query "orderBy", "updatedAt desc"
@@ -142,7 +142,7 @@ datasource "ds_policy_template_details" do
   request do
     auth $auth_flexera
     pagination $pagination_flexera
-    host val($ds_flexera_api_hosts, 'api')
+    host val($ds_flexera_api_hosts, "api")
     path join(["/policy/v1/orgs/", rs_org_id, "/projects/", rs_project_id, "/policy-templates/", val(iter_item, "id")])
     query "view", "source"
   end
@@ -245,7 +245,7 @@ end
 datasource "ds_existing_rbds" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'api')
+    host val($ds_flexera_api_hosts, "api")
     path join(["/finops-customizations/v1/orgs/", rs_org_id, "/rule-based-dimensions"])
   end
   result do

--- a/operational/flexera/itam/schedule_itam_report/CHANGELOG.md
+++ b/operational/flexera/itam/schedule_itam_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.7
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.2.6
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/flexera/itam/schedule_itam_report/schedule_itam_report.pt
+++ b/operational/flexera/itam/schedule_itam_report/schedule_itam_report.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "0.2.6",
+  version: "0.2.7",
   provider: "Flexera",
   service: "IT Asset Management",
   policy_set: "Schedule Report",
@@ -134,7 +134,7 @@ datasource "ds_fnms_reports" do
   request do
     auth $auth_flexera
     pagination $pagination_itam
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/fnms/v1/orgs/", rs_org_id, "/reports/", $param_report_id, "/execute"])
     header "Content-Type","application/json"
     header "User-Agent", "RS Policies"

--- a/operational/flexera/msp/customer_usage_insights_report/CHANGELOG.md
+++ b/operational/flexera/msp/customer_usage_insights_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.7
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.1.6
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/operational/flexera/msp/customer_usage_insights_report/CHANGELOG.md
+++ b/operational/flexera/msp/customer_usage_insights_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.6
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.1.5
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/flexera/msp/customer_usage_insights_report/flexera_msp_customer_usage_insights_report.pt
+++ b/operational/flexera/msp/customer_usage_insights_report/flexera_msp_customer_usage_insights_report.pt
@@ -1362,7 +1362,7 @@ script "js_report", type: "javascript" do
     });
 
     result = {
-      subject: rs_org_name + " - " + rs_org_id + " - " + ds_applied_policy.name,
+      subject: rs_org_name + " - " + rs_org_id,
       policy_name: ds_applied_policy.name,
       report: markdown,
       netTotalCost: netTotalCost,
@@ -1378,7 +1378,7 @@ end
 
 policy "pol_group_sync" do
   validate $ds_report do
-    summary_template "{{ data.subject }}"
+    summary_template "{{ data.subject }} - {{ data.policy_name }}"
     detail_template <<-'EOS'
 {{ data.report }}
 

--- a/operational/flexera/msp/customer_usage_insights_report/flexera_msp_customer_usage_insights_report.pt
+++ b/operational/flexera/msp/customer_usage_insights_report/flexera_msp_customer_usage_insights_report.pt
@@ -9,7 +9,7 @@ severity "low"
 default_frequency "daily"
 info(
   provider: "Flexera",
-  version: "0.1.6",
+  version: "0.1.7",
   publish: "false",
   service: "Cloud Cost Optimization",
   policy_set: "Usage Report",
@@ -244,7 +244,7 @@ end
 datasource "ds_applied_policy_template" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/policy/v1/orgs/", rs_org_id, "/projects/", rs_project_id, "/policy-templates/", jq($ds_applied_policy, ".policyTemplate.id")])
     query "view", "source"
   end
@@ -267,7 +267,7 @@ end
 datasource "ds_organizations" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/msp/v1/orgs/", rs_org_id, "/customers"])
     ignore_status 403 #Ignore Status 403 so we can gracefully handle that kind of error
   end
@@ -296,7 +296,7 @@ end
 datasource "ds_parent_org_rbds" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-customizations/v1/orgs/", rs_org_id, "/rule-based-dimensions"])
   end
 end
@@ -507,7 +507,7 @@ datasource "ds_children_org_get_roles_step1" do
   iterate $ds_organizations_filtered
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/iam/v1/orgs/", val(iter_item, "id"), "/roles"])
     ignore_status 403 # Ignore status 403 so we can gracefully handle that kind of error
   end
@@ -660,7 +660,7 @@ datasource "ds_children_org_get_users_step6" do
   request do
     auth $auth_flexera
     pagination $pagination_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/iam/v1/orgs/", val(val(iter_item, "org"), "id"), "/users"])
     ignore_status 403 # Ignore status 403 so we can gracefully handle that kind of error
   end
@@ -681,7 +681,7 @@ datasource "ds_children_org_get_bill_connects_step7" do
   request do
     auth $auth_flexera
     pagination $pagination_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-onboarding/v1/orgs/", val(val(iter_item, "org"), "id"), "/bill-connects"])
     ignore_status 403 # Ignore status 403 so we can gracefully handle that kind of error
   end

--- a/operational/flexera/msp/customer_usage_insights_report/flexera_msp_customer_usage_insights_report.pt
+++ b/operational/flexera/msp/customer_usage_insights_report/flexera_msp_customer_usage_insights_report.pt
@@ -9,7 +9,7 @@ severity "low"
 default_frequency "daily"
 info(
   provider: "Flexera",
-  version: "0.1.5",
+  version: "0.1.6",
   publish: "false",
   service: "Cloud Cost Optimization",
   policy_set: "Usage Report",
@@ -235,7 +235,7 @@ end
 datasource "ds_applied_policy" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/policy/v1/orgs/", rs_org_id, "/projects/", rs_project_id, "/applied-policies", switch(policy_id, join(["/", policy_id]), "")])
   end
 end

--- a/operational/flexera/msp/customer_usage_insights_report/flexera_msp_customer_usage_insights_report.pt
+++ b/operational/flexera/msp/customer_usage_insights_report/flexera_msp_customer_usage_insights_report.pt
@@ -1363,6 +1363,7 @@ script "js_report", type: "javascript" do
 
     result = {
       subject: rs_org_name + " - " + rs_org_id + " - " + ds_applied_policy.name,
+      policy_name: ds_applied_policy.name,
       report: markdown,
       netTotalCost: netTotalCost,
       excludedTotalCost: excludedTotalCost,

--- a/operational/flexera/msp/msp_invoiceable_spend_report/CHANGELOG.md
+++ b/operational/flexera/msp/msp_invoiceable_spend_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/flexera/msp/msp_invoiceable_spend_report/flexera_msp_invoiceable_spend_report.pt
+++ b/operational/flexera/msp/msp_invoiceable_spend_report/flexera_msp_invoiceable_spend_report.pt
@@ -9,7 +9,7 @@ severity "low"
 default_frequency "monthly"
 info(
   provider: "Flexera",
-  version: "0.1.1",
+  version: "0.1.2",
   service: "Cloud Cost Optimization",
   policy_set: "Invoiceable Spend Report",
   skip_permissions: "true",
@@ -244,7 +244,7 @@ end
 datasource "ds_organizations" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/msp/v1/orgs/", rs_org_id, "/customers"])
     ignore_status 403
   end
@@ -309,7 +309,7 @@ end
 datasource "ds_parent_org_rbds" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-customizations/v1/orgs/", rs_org_id, "/rule-based-dimensions"])
   end
 end

--- a/operational/google/cost_reallocation/cloud_logging/CHANGELOG.md
+++ b/operational/google/cost_reallocation/cloud_logging/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.6
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v0.1.5
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/google/cost_reallocation/cloud_logging/google_cost_reallocation_cloud_logging.pt
+++ b/operational/google/cost_reallocation/cloud_logging/google_cost_reallocation_cloud_logging.pt
@@ -8,7 +8,7 @@ severity "critical"
 default_frequency "hourly"
 category "Operational"
 info(
-  version: "0.1.5",
+  version: "0.1.6",
   provider: "Google",
   service: "Cloud Logging",
   category: "Operational",
@@ -450,7 +450,7 @@ end
 datasource "ds_rule_based_dimensions" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-customizations/v1/orgs/", rs_org_id, "/rule-based-dimensions"])
   end
   result do
@@ -489,7 +489,7 @@ datasource "ds_rule_based_dimensions_rules" do
   iterate $ds_rule_based_dimensions_effectiveAt_list
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-customizations/v1/orgs/", rs_org_id, "/rule-based-dimensions/", val(iter_item, "id"), "/rules/", val(iter_item, "effectiveAt")])
   end
 end
@@ -528,7 +528,7 @@ datasource "ds_tag_dimensions_used_in_rbd_rules_tag_key" do
   iterate $ds_tag_dimensions_used_in_rbd_rules
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-customizations/v1/orgs/", rs_org_id, "/tag-dimensions/", iter_item])
   end
   result do

--- a/security/aws/aws_config_enabled/CHANGELOG.md
+++ b/security/aws/aws_config_enabled/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/aws_config_enabled/aws_config_enabled.pt
+++ b/security/aws/aws_config_enabled/aws_config_enabled.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.2",
+  version: "3.1.3",
   provider: "AWS",
   service: "Config",
   policy_set: "CIS",
@@ -161,7 +161,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/aws_config_enabled/aws_config_enabled_meta_parent.pt
+++ b/security/aws/aws_config_enabled/aws_config_enabled_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "3.1.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/security/aws/ebs_ensure_encryption_default/CHANGELOG.md
+++ b/security/aws/ebs_ensure_encryption_default/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.1.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v4.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/ebs_ensure_encryption_default/ebs_ensure_encryption_default.pt
+++ b/security/aws/ebs_ensure_encryption_default/ebs_ensure_encryption_default.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "4.1.1",
+  version: "4.1.2",
   provider: "AWS",
   service: "DBS",
   policy_set: "CIS",
@@ -169,7 +169,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/ebs_ensure_encryption_default/ebs_ensure_encryption_default_meta_parent.pt
+++ b/security/aws/ebs_ensure_encryption_default/ebs_ensure_encryption_default_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "4.1.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.1.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/security/aws/ebs_unencrypted_volumes/CHANGELOG.md
+++ b/security/aws/ebs_unencrypted_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.1.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v5.1.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes.pt
+++ b/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.1.2",
+  version: "5.1.3",
   provider: "AWS",
   service: "EBS",
   policy_set: "",
@@ -185,7 +185,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes_meta_parent.pt
+++ b/security/aws/ebs_unencrypted_volumes/aws_unencrypted_volumes_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "5.1.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/security/aws/elb_unencrypted/CHANGELOG.md
+++ b/security/aws/elb_unencrypted/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.1.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v4.1.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/elb_unencrypted/aws_elb_encryption.pt
+++ b/security/aws/elb_unencrypted/aws_elb_encryption.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "medium"
 default_frequency "daily"
 info(
-  version: "4.1.2",
+  version: "4.1.3",
   provider: "AWS",
   service: "Network",
   policy_set: "",
@@ -181,7 +181,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/elb_unencrypted/aws_elb_encryption_meta_parent.pt
+++ b/security/aws/elb_unencrypted/aws_elb_encryption_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "4.1.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/security/aws/iam_access_analyzer_enabled/CHANGELOG.md
+++ b/security/aws/iam_access_analyzer_enabled/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.1.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v4.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/iam_access_analyzer_enabled/iam_access_analyzer_enabled.pt
+++ b/security/aws/iam_access_analyzer_enabled/iam_access_analyzer_enabled.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "4.1.1",
+  version: "4.1.2",
   provider: "AWS",
   service: "Identity & Access Management",
   policy_set: "CIS",
@@ -161,7 +161,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/iam_expired_ssl_certs/CHANGELOG.md
+++ b/security/aws/iam_expired_ssl_certs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/iam_expired_ssl_certs/iam_expired_ssl_certs.pt
+++ b/security/aws/iam_expired_ssl_certs/iam_expired_ssl_certs.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.1",
+  version: "3.1.2",
   provider: "AWS",
   service: "Identity & Access Management",
   policy_set: "CIS",
@@ -143,7 +143,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/iam_hwmfa_enabled_for_root/CHANGELOG.md
+++ b/security/aws/iam_hwmfa_enabled_for_root/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/iam_hwmfa_enabled_for_root/aws_iam_hwmfa_enabled.pt
+++ b/security/aws/iam_hwmfa_enabled_for_root/aws_iam_hwmfa_enabled.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "15 minutes"
 info(
-  version: "3.1.1",
+  version: "3.1.2",
   provider: "AWS",
   service: "Identity & Access Management",
   policy_set: "CIS",
@@ -143,7 +143,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/iam_mfa_enabled_for_iam_users/CHANGELOG.md
+++ b/security/aws/iam_mfa_enabled_for_iam_users/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/iam_mfa_enabled_for_iam_users/iam_mfa_enabled_for_iam_users.pt
+++ b/security/aws/iam_mfa_enabled_for_iam_users/iam_mfa_enabled_for_iam_users.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "15 minutes"
 info(
-  version: "3.1.1",
+  version: "3.1.2",
   provider: "AWS",
   service: "Identity & Access Management",
   policy_set: "CIS",
@@ -152,7 +152,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/iam_mfa_enabled_for_root/CHANGELOG.md
+++ b/security/aws/iam_mfa_enabled_for_root/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/iam_mfa_enabled_for_root/iam_mfa_enabled.pt
+++ b/security/aws/iam_mfa_enabled_for_root/iam_mfa_enabled.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "15 minutes"
 info(
-  version: "3.1.1",
+  version: "3.1.2",
   provider: "AWS",
   service: "Identity & Access Management",
   policy_set: "CIS",
@@ -143,7 +143,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/iam_min_password_length/CHANGELOG.md
+++ b/security/aws/iam_min_password_length/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/iam_min_password_length/iam_min_password_length.pt
+++ b/security/aws/iam_min_password_length/iam_min_password_length.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.1",
+  version: "3.1.2",
   provider: "AWS",
   service: "Identity & Access Management",
   policy_set: "CIS",
@@ -152,7 +152,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/iam_no_admin_iam_policies_attached/CHANGELOG.md
+++ b/security/aws/iam_no_admin_iam_policies_attached/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/iam_no_admin_iam_policies_attached/iam_no_admin_iam_policies_attached.pt
+++ b/security/aws/iam_no_admin_iam_policies_attached/iam_no_admin_iam_policies_attached.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.1",
+  version: "3.1.2",
   provider: "AWS",
   service: "Identity & Access Management",
   policy_set: "CIS",
@@ -143,7 +143,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/iam_no_root_access_keys/CHANGELOG.md
+++ b/security/aws/iam_no_root_access_keys/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/iam_no_root_access_keys/aws_iam_no_root_access_keys.pt
+++ b/security/aws/iam_no_root_access_keys/aws_iam_no_root_access_keys.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "15 minutes"
 info(
-  version: "3.1.1",
+  version: "3.1.2",
   provider: "AWS",
   service: "Identity & Access Management",
   policy_set: "CIS",
@@ -143,7 +143,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/iam_no_root_for_tasks/CHANGELOG.md
+++ b/security/aws/iam_no_root_for_tasks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/iam_no_root_for_tasks/iam_no_root_for_tasks.pt
+++ b/security/aws/iam_no_root_for_tasks/iam_no_root_for_tasks.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.1",
+  version: "3.1.2",
   provider: "AWS",
   service: "Identity & Access Management",
   policy_set: "CIS",
@@ -152,7 +152,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/iam_one_active_key_per_user/CHANGELOG.md
+++ b/security/aws/iam_one_active_key_per_user/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/iam_one_active_key_per_user/iam_one_active_key_per_user.pt
+++ b/security/aws/iam_one_active_key_per_user/iam_one_active_key_per_user.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.1",
+  version: "3.1.2",
   provider: "AWS",
   service: "Identity & Access Management",
   policy_set: "CIS",
@@ -152,7 +152,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/iam_prevent_password_reuse/CHANGELOG.md
+++ b/security/aws/iam_prevent_password_reuse/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/iam_prevent_password_reuse/iam_prevent_password_reuse.pt
+++ b/security/aws/iam_prevent_password_reuse/iam_prevent_password_reuse.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.1",
+  version: "3.1.2",
   provider: "AWS",
   service: "Identity & Access Management",
   policy_set: "CIS",
@@ -152,7 +152,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/iam_rotate_access_keys/CHANGELOG.md
+++ b/security/aws/iam_rotate_access_keys/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/iam_rotate_access_keys/iam_rotate_access_keys.pt
+++ b/security/aws/iam_rotate_access_keys/iam_rotate_access_keys.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.1",
+  version: "3.1.2",
   provider: "AWS",
   service: "Identity & Access Management",
   policy_set: "CIS",
@@ -152,7 +152,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/iam_support_role_created/CHANGELOG.md
+++ b/security/aws/iam_support_role_created/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/iam_support_role_created/iam_support_role_created.pt
+++ b/security/aws/iam_support_role_created/iam_support_role_created.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "low"
 default_frequency "daily"
 info(
-  version: "3.1.1",
+  version: "3.1.2",
   provider: "AWS",
   service: "Identity & Access Management",
   policy_set: "CIS",
@@ -143,7 +143,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/iam_unused_creds/CHANGELOG.md
+++ b/security/aws/iam_unused_creds/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/iam_unused_creds/iam_unused_creds.pt
+++ b/security/aws/iam_unused_creds/iam_unused_creds.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.1",
+  version: "3.1.2",
   provider: "AWS",
   service: "Identity & Access Management",
   policy_set: "CIS",
@@ -152,7 +152,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/iam_users_perms_via_groups_only/CHANGELOG.md
+++ b/security/aws/iam_users_perms_via_groups_only/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/iam_users_perms_via_groups_only/iam_users_perms_via_groups_only.pt
+++ b/security/aws/iam_users_perms_via_groups_only/iam_users_perms_via_groups_only.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.1",
+  version: "3.1.2",
   provider: "AWS",
   service: "Identity & Access Management",
   policy_set: "CIS",
@@ -143,7 +143,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/kms_rotation/CHANGELOG.md
+++ b/security/aws/kms_rotation/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/kms_rotation/kms_rotation.pt
+++ b/security/aws/kms_rotation/kms_rotation.pt
@@ -8,7 +8,7 @@ severity "high"
 category "Security"
 default_frequency "daily"
 info(
-  version: "3.1.2",
+  version: "3.1.3",
   provider: "AWS",
   service: "KMS",
   policy_set: "CIS",
@@ -161,7 +161,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/loadbalancer_internet_facing/CHANGELOG.md
+++ b/security/aws/loadbalancer_internet_facing/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.1.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v4.1.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/loadbalancer_internet_facing/aws_internet_facing_elbs.pt
+++ b/security/aws/loadbalancer_internet_facing/aws_internet_facing_elbs.pt
@@ -8,7 +8,7 @@ severity "high"
 category "Security"
 default_frequency "daily"
 info(
-  version: "4.1.2",
+  version: "4.1.3",
   provider: "AWS",
   service: "Network",
   policy_set: "",
@@ -190,7 +190,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/loadbalancer_internet_facing/aws_internet_facing_elbs_meta_parent.pt
+++ b/security/aws/loadbalancer_internet_facing/aws_internet_facing_elbs_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "4.1.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/security/aws/log_cloudtrail_cloudwatch_integrated/CHANGELOG.md
+++ b/security/aws/log_cloudtrail_cloudwatch_integrated/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/log_cloudtrail_cloudwatch_integrated/log_cloudtrail_cloudwatch_integrated.pt
+++ b/security/aws/log_cloudtrail_cloudwatch_integrated/log_cloudtrail_cloudwatch_integrated.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.2",
+  version: "3.1.3",
   provider: "AWS",
   service: "CloudTrail",
   policy_set: "CIS",
@@ -152,7 +152,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/log_ensure_cloudtrail_bucket_access_logging/CHANGELOG.md
+++ b/security/aws/log_ensure_cloudtrail_bucket_access_logging/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/log_ensure_cloudtrail_bucket_access_logging/log_ensure_cloudtrail_bucket_access_logging.pt
+++ b/security/aws/log_ensure_cloudtrail_bucket_access_logging/log_ensure_cloudtrail_bucket_access_logging.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.2",
+  version: "3.1.3",
   provider: "AWS",
   service: "CloudTrail",
   policy_set: "CIS",
@@ -143,7 +143,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/log_ensure_cloudtrail_bucket_not_public/CHANGELOG.md
+++ b/security/aws/log_ensure_cloudtrail_bucket_not_public/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/log_ensure_cloudtrail_bucket_not_public/log_ensure_cloudtrail_bucket_not_public.pt
+++ b/security/aws/log_ensure_cloudtrail_bucket_not_public/log_ensure_cloudtrail_bucket_not_public.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.2",
+  version: "3.1.3",
   provider: "AWS",
   service: "CloudTrail",
   policy_set: "CIS",
@@ -143,7 +143,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/log_ensure_cloudtrail_bucket_object_logging/CHANGELOG.md
+++ b/security/aws/log_ensure_cloudtrail_bucket_object_logging/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/log_ensure_cloudtrail_bucket_object_logging/log_ensure_cloudtrail_bucket_object_logging.pt
+++ b/security/aws/log_ensure_cloudtrail_bucket_object_logging/log_ensure_cloudtrail_bucket_object_logging.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.2",
+  version: "3.1.3",
   provider: "AWS",
   service: "CloudTrail",
   policy_set: "CIS",
@@ -143,7 +143,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/log_ensure_cloudtrail_encrypted/CHANGELOG.md
+++ b/security/aws/log_ensure_cloudtrail_encrypted/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/log_ensure_cloudtrail_encrypted/log_ensure_cloudtrail_encrypted.pt
+++ b/security/aws/log_ensure_cloudtrail_encrypted/log_ensure_cloudtrail_encrypted.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.2",
+  version: "3.1.3",
   provider: "AWS",
   service: "CloudTrail",
   policy_set: "CIS",
@@ -143,7 +143,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/log_ensure_cloudtrail_multiregion/CHANGELOG.md
+++ b/security/aws/log_ensure_cloudtrail_multiregion/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/log_ensure_cloudtrail_multiregion/log_ensure_cloudtrail_multiregion.pt
+++ b/security/aws/log_ensure_cloudtrail_multiregion/log_ensure_cloudtrail_multiregion.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.2",
+  version: "3.1.3",
   provider: "AWS",
   service: "CloudTrail",
   policy_set: "CIS",
@@ -143,7 +143,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/log_file_validation_enabled/CHANGELOG.md
+++ b/security/aws/log_file_validation_enabled/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/log_file_validation_enabled/log_file_validation_enabled.pt
+++ b/security/aws/log_file_validation_enabled/log_file_validation_enabled.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.2",
+  version: "3.1.3",
   provider: "AWS",
   service: "CloudTrail",
   policy_set: "CIS",
@@ -143,7 +143,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/public_buckets/CHANGELOG.md
+++ b/security/aws/public_buckets/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.2.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/public_buckets/aws_public_buckets.pt
+++ b/security/aws/public_buckets/aws_public_buckets.pt
@@ -8,7 +8,7 @@ severity "high"
 category "Security"
 default_frequency "daily"
 info(
-  version: "3.2.2",
+  version: "3.2.3",
   provider: "AWS",
   service: "S3",
   policy_set: "Open S3 Buckets",
@@ -155,7 +155,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/public_buckets/aws_public_buckets_meta_parent.pt
+++ b/security/aws/public_buckets/aws_public_buckets_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "3.2.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.2.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/security/aws/rds_publicly_accessible/CHANGELOG.md
+++ b/security/aws/rds_publicly_accessible/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.2.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v5.2.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances.pt
+++ b/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "hourly"
 info(
-  version: "5.2.2",
+  version: "5.2.3",
   provider: "AWS",
   service: "RDS",
   policy_set: "",
@@ -203,7 +203,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances_meta_parent.pt
+++ b/security/aws/rds_publicly_accessible/aws_publicly_accessible_rds_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "5.2.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.2.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/security/aws/rds_unencrypted/CHANGELOG.md
+++ b/security/aws/rds_unencrypted/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.2.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v4.2.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/rds_unencrypted/aws_unencrypted_rds_instances.pt
+++ b/security/aws/rds_unencrypted/aws_unencrypted_rds_instances.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "medium"
 default_frequency "daily"
 info(
-  version: "4.2.2",
+  version: "4.2.3",
   provider: "AWS",
   service: "RDS",
   policy_set: "CIS",
@@ -209,7 +209,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/rds_unencrypted/aws_unencrypted_rds_instances_meta_parent.pt
+++ b/security/aws/rds_unencrypted/aws_unencrypted_rds_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "4.2.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.2.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/security/aws/s3_buckets_deny_http/CHANGELOG.md
+++ b/security/aws/s3_buckets_deny_http/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/s3_buckets_deny_http/s3_buckets_deny_http.pt
+++ b/security/aws/s3_buckets_deny_http/s3_buckets_deny_http.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.2",
+  version: "3.1.3",
   provider: "AWS",
   service: "Storage",
   policy_set: "CIS",
@@ -186,7 +186,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/s3_buckets_deny_http/s3_buckets_deny_http_meta_parent.pt
+++ b/security/aws/s3_buckets_deny_http/s3_buckets_deny_http_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "3.1.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/security/aws/s3_buckets_without_server_access_logging/CHANGELOG.md
+++ b/security/aws/s3_buckets_without_server_access_logging/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/s3_buckets_without_server_access_logging/aws_s3_buckets_without_server_access_logging.pt
+++ b/security/aws/s3_buckets_without_server_access_logging/aws_s3_buckets_without_server_access_logging.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.2",
+  version: "3.1.3",
   provider: "AWS",
   service: "Storage",
   policy_set: "",
@@ -180,7 +180,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/s3_buckets_without_server_access_logging/aws_s3_buckets_without_server_access_logging_meta_parent.pt
+++ b/security/aws/s3_buckets_without_server_access_logging/aws_s3_buckets_without_server_access_logging_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "3.1.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/security/aws/s3_ensure_buckets_block_public_access/CHANGELOG.md
+++ b/security/aws/s3_ensure_buckets_block_public_access/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/s3_ensure_buckets_block_public_access/s3_ensure_buckets_block_public_access.pt
+++ b/security/aws/s3_ensure_buckets_block_public_access/s3_ensure_buckets_block_public_access.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.2",
+  version: "3.1.3",
   provider: "AWS",
   service: "Storage",
   policy_set: "CIS",
@@ -186,7 +186,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/s3_ensure_buckets_block_public_access/s3_ensure_buckets_block_public_access_meta_parent.pt
+++ b/security/aws/s3_ensure_buckets_block_public_access/s3_ensure_buckets_block_public_access_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "3.1.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/security/aws/s3_ensure_mfa_delete_enabled/CHANGELOG.md
+++ b/security/aws/s3_ensure_mfa_delete_enabled/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/s3_ensure_mfa_delete_enabled/s3_ensure_mfa_delete_enabled.pt
+++ b/security/aws/s3_ensure_mfa_delete_enabled/s3_ensure_mfa_delete_enabled.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.1.2",
+  version: "3.1.3",
   provider: "AWS",
   service: "Storage",
   policy_set: "CIS",
@@ -186,7 +186,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/s3_ensure_mfa_delete_enabled/s3_ensure_mfa_delete_enabled_meta_parent.pt
+++ b/security/aws/s3_ensure_mfa_delete_enabled/s3_ensure_mfa_delete_enabled_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "3.1.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/security/aws/unencrypted_s3_buckets/CHANGELOG.md
+++ b/security/aws/unencrypted_s3_buckets/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v3.1.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/unencrypted_s3_buckets/aws_unencrypted_s3_buckets.pt
+++ b/security/aws/unencrypted_s3_buckets/aws_unencrypted_s3_buckets.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "low"
 default_frequency "daily"
 info(
-  version: "3.1.2",
+  version: "3.1.3",
   provider: "AWS",
   service: "Storage",
   policy_set: "CIS",
@@ -195,7 +195,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/unencrypted_s3_buckets/aws_unencrypted_s3_buckets_meta_parent.pt
+++ b/security/aws/unencrypted_s3_buckets/aws_unencrypted_s3_buckets_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "3.1.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/security/aws/vpcs_without_flow_logs_enabled/CHANGELOG.md
+++ b/security/aws/vpcs_without_flow_logs_enabled/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.1.3
+
+- Minor code formatting cleanup. No functional or user-facing changes.
+
 ## v4.1.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/aws/vpcs_without_flow_logs_enabled/aws_vpcs_without_flow_logs_enabled.pt
+++ b/security/aws/vpcs_without_flow_logs_enabled/aws_vpcs_without_flow_logs_enabled.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "medium"
 default_frequency "daily"
 info(
-  version: "4.1.2",
+  version: "4.1.3",
   provider: "AWS",
   service: "Network",
   policy_set: "",
@@ -185,7 +185,7 @@ end
 datasource "ds_cloud_vendor_accounts" do
   request do
     auth $auth_flexera
-    host val($ds_flexera_api_hosts, 'flexera')
+    host val($ds_flexera_api_hosts, "flexera")
     path join(["/finops-analytics/v1/orgs/", rs_org_id, "/cloud-vendor-accounts"])
     header "Api-Version", "1.0"
   end

--- a/security/aws/vpcs_without_flow_logs_enabled/aws_vpcs_without_flow_logs_enabled_meta_parent.pt
+++ b/security/aws/vpcs_without_flow_logs_enabled/aws_vpcs_without_flow_logs_enabled_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "4.1.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/security/azure/eol_resources/CHANGELOG.md
+++ b/security/azure/eol_resources/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.2
+
+- Updated policy logic for internal consistency; no functional or user-facing changes.
+
 ## v0.2.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/security/azure/eol_resources/azure_eol_resources.pt
+++ b/security/azure/eol_resources/azure_eol_resources.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "weekly"
 info(
-  version: "0.2.1",
+  version: "0.2.2",
   provider: "Azure",
   service: "Compute",
   policy_set: "Deprecated Resources",
@@ -242,8 +242,7 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   code <<-'EOS'
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
-      include_subscription = _.contains(param_subscriptions_list, subscription['id']) ||
-                             _.contains(param_subscriptions_list, subscription['name'])
+      include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
 
       if (param_subscriptions_allow_or_deny == "Deny") {
         include_subscription = !include_subscription

--- a/security/azure/eol_resources/azure_eol_resources_meta_parent.pt
+++ b/security/azure/eol_resources/azure_eol_resources_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.2.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"


### PR DESCRIPTION
### Description

- Moves canonical code examples from `.github/agents/policy-dev.agent.md` to a new file `data/agent/code_examples.txt` that the agent is instead instructed to reference.
- Expanded the canonical code examples.
- Updated several policy templates to use the canonical version of the relevant code.
  - Fixed a few minor bugs and Dangerfile issues with some of the touched policy templates along the way.
- Updated Dangerfile tests to trigger fewer false positives
