### PR TITLE
POL-1822 Make change history generation incremental

### DIFF
--- a/data/change_history/change_history.json
+++ b/data/change_history/change_history.json
@@ -1,6 +1,118 @@
 {
   "merged_prs": [
     {
+      "number": 4794,
+      "title": "Update Azure Compute Instance Types Data",
+      "description": "Updated Azure Compute Instance Types from GitHub Actions Workflow [Generate Azure Compute Instance Types JSON](https://github.com/flexera-public/policy_templates/actions/runs/31932109973)",
+      "labels": [
+        "automation",
+        "data",
+        "azure"
+      ],
+      "href": "https://github.com/flexera-public/policy_templates/pull/4794",
+      "created_at": "2026-08-16 06:45:33 UTC",
+      "merged_at": "2026-08-17 09:26:55 UTC",
+      "modified_files": [
+        "data/azure/azure_compute_instance_types.json"
+      ]
+    },
+    {
+      "number": 4793,
+      "title": "Update AWS EC2 Instance Types Data",
+      "description": "Updated AWS EC2 Instance Types from GitHub Actions Workflow [Generate AWS EC2 Instance Types JSON](https://github.com/flexera-public/policy_templates/actions/runs/31930500005)",
+      "labels": [
+        "automation",
+        "data",
+        "aws"
+      ],
+      "href": "https://github.com/flexera-public/policy_templates/pull/4793",
+      "created_at": "2026-08-16 06:04:38 UTC",
+      "merged_at": "2026-08-17 09:26:43 UTC",
+      "modified_files": [
+        "data/aws/aws_ec2_instance_types.json"
+      ]
+    },
+    {
+      "number": 4790,
+      "title": "Update AWS RDS Pricing Data",
+      "description": "Updated AWS RDS Pricing from GitHub Actions Workflow [Generate AWS RDS Pricing JSON](https://github.com/flexera-public/policy_templates/actions/runs/31923846595)",
+      "labels": [
+        "automation",
+        "data",
+        "aws"
+      ],
+      "href": "https://github.com/flexera-public/policy_templates/pull/4790",
+      "created_at": "2026-08-16 03:16:57 UTC",
+      "merged_at": "2026-08-17 09:26:28 UTC",
+      "modified_files": [
+        "data/aws/aws_rds_pricing.json"
+      ]
+    },
+    {
+      "number": 4792,
+      "title": "Update GCP Compute Instance Types Data",
+      "description": "Updated GCP Compute Instance Types from GitHub Actions Workflow [Generate GCP Compute Instance Types JSON](https://github.com/flexera-public/policy_templates/actions/runs/31929495290)",
+      "labels": [
+        "automation",
+        "data",
+        "google",
+        "gcp"
+      ],
+      "href": "https://github.com/flexera-public/policy_templates/pull/4792",
+      "created_at": "2026-08-16 05:40:01 UTC",
+      "merged_at": "2026-08-17 09:23:29 UTC",
+      "modified_files": [
+        "data/google/google_compute_instance_types.json"
+      ]
+    },
+    {
+      "number": 4791,
+      "title": "Update Azure VM Pricing Data",
+      "description": "Updated Azure VM Pricing from GitHub Actions Workflow [Generate Azure VM Pricing JSON](https://github.com/flexera-public/policy_templates/actions/runs/31928204547)",
+      "labels": [
+        "automation",
+        "data",
+        "azure"
+      ],
+      "href": "https://github.com/flexera-public/policy_templates/pull/4791",
+      "created_at": "2026-08-16 05:14:05 UTC",
+      "merged_at": "2026-08-17 09:21:43 UTC",
+      "modified_files": [
+        "data/azure/azure_vm_pricing.json"
+      ]
+    },
+    {
+      "number": 4789,
+      "title": "Update AWS EC2 Pricing Data",
+      "description": "Updated AWS EC2 Pricing from GitHub Actions Workflow [Generate AWS EC2 Pricing JSON](https://github.com/flexera-public/policy_templates/actions/runs/31921847795)",
+      "labels": [
+        "automation",
+        "data",
+        "aws"
+      ],
+      "href": "https://github.com/flexera-public/policy_templates/pull/4789",
+      "created_at": "2026-08-16 02:31:23 UTC",
+      "merged_at": "2026-08-17 09:19:02 UTC",
+      "modified_files": [
+        "data/aws/aws_ec2_pricing.json"
+      ]
+    },
+    {
+      "number": 4788,
+      "title": "Update Change History",
+      "description": "Update Change History from GitHub Actions Workflow [Update Change History](https://github.com/flexera-public/policy_templates/actions/runs/31919604319)",
+      "labels": [
+        "automation"
+      ],
+      "href": "https://github.com/flexera-public/policy_templates/pull/4788",
+      "created_at": "2026-08-16 01:57:57 UTC",
+      "merged_at": "2026-08-17 09:18:38 UTC",
+      "modified_files": [
+        "HISTORY.md",
+        "data/change_history/change_history.json"
+      ]
+    },
+    {
       "number": 4787,
       "title": "Update Active Policy List",
       "description": "Update Active Policy List from GitHub Actions Workflow [Update Active Policy List](https://github.com/flexera-public/policy_templates/actions/runs/31708654519)",

--- a/tools/change_history/README.md
+++ b/tools/change_history/README.md
@@ -5,6 +5,12 @@ Script to generate the `data/change_history/change_history.json` and `HISTORY.md
 - `data/change_history/change_history.json`: A list of all pull requests merged into the repository with the exception of pull requests to update that file.
 - `HISTORY.md`: A curated, human-readable list of the last 100 pull requests that updated a policy asset.
 
+## Incremental Fetching
+
+The script only asks the Github Search API for pull requests merged after the most recent one already recorded in `data/change_history/change_history.json`, then merges those into the existing data. It does not re-fetch or re-process the entire pull request history on every run.
+
+If `data/change_history/change_history.json` does not exist or cannot be parsed, the script falls back to a one-time full historical fetch using the Pull Requests API (the Search API caps results at 1,000 per query, so it cannot be used to rebuild the complete history). This full fetch is slow, since it makes a separate API call per pull request to determine which files it modified, so avoid deleting `data/change_history/change_history.json` unless a full rebuild is actually needed.
+
 ## Usage
 
 - Create a new branch and switch to that branch.

--- a/tools/change_history/generate_change_history.rb
+++ b/tools/change_history/generate_change_history.rb
@@ -2,6 +2,20 @@
 # This script generates the following files:
 # data/change_history/change_history.json: Full history of the repository in JSON format
 # HISTORY.md: Human readable history of the last 100 merges that impacted policies
+#
+# The script fetches incrementally: it loads any previously recorded pull requests from
+# data/change_history/change_history.json and only asks the Github Search API for pull
+# requests merged after the most recent one already on record. This avoids re-fetching and
+# re-processing the entire pull request history (thousands of pull requests and growing) on
+# every run, which does not scale and risks exhausting the Github API rate limit. Per-pull
+# request calls (needed only to list modified files, since the Search API does not return
+# them) are now limited to the small number of newly-merged pull requests instead of the
+# entire history.
+#
+# If data/change_history/change_history.json does not exist or cannot be parsed, the script
+# falls back to a full historical fetch to bootstrap the file. The Search API caps results at
+# 1,000 per query, so it is not suitable for this initial bootstrap; the full Pull Requests API
+# is used instead, exactly as this script originally worked.
 
 require 'rubygems'
 require 'json'
@@ -17,15 +31,12 @@ github_api_token = ENV["GITHUB_API_TOKEN"]
 github_client = Octokit::Client.new(access_token: github_api_token)
 github_client.auto_paginate = true
 
-# Gather list of PRs via API and filter for ones merged into master.
-# Also sort the list by date with the most recent PRs coming first
-merged_pull_requests = github_client.pull_requests(repo_name, state: 'closed').select do |pr|
-  # Omit PRs triggered by this script to avoid an infinite loop
-  pr.merged_at && pr.base.ref == 'master'
-end.sort_by(&:merged_at).reverse
+change_history_file = 'data/change_history/change_history.json'
 
-# Convert the API results into a simple object
-pr_list = merged_pull_requests.map do |pr|
+# Converts a Github API pull request (or search result) into the simple object stored in
+# data/change_history/change_history.json. Always makes a dedicated call to fetch the list of
+# modified files since neither the Search API nor the base pull request payload includes it.
+def build_pr_entry(github_client, repo_name, pr, merged_at)
   {
     number: pr.number,
     title: pr.title,
@@ -33,16 +44,79 @@ pr_list = merged_pull_requests.map do |pr|
     labels: pr.labels.map(&:name),
     href: pr.html_url,
     created_at: pr.created_at,
-    merged_at: pr.merged_at,
+    merged_at: merged_at,
     modified_files: github_client.pull_request_files(repo_name, pr.number).map(&:filename)
   }
 end
+
+# `merged_at` is a Time object for newly-fetched pull requests but a String once it has been
+# through a JSON round trip (i.e. for previously recorded pull requests). Normalize to Time so
+# both can be compared/sorted consistently.
+def to_time(value)
+  value.is_a?(String) ? Time.parse(value) : value
+end
+
+# Load any previously recorded pull requests so we can fetch incrementally instead of
+# re-fetching the entire repository history on every run. Symbolize names so previously
+# recorded and newly-fetched entries share the same (symbol) keys.
+existing_prs = []
+if File.exist?(change_history_file)
+  begin
+    existing_data = JSON.parse(File.read(change_history_file), symbolize_names: true)
+    existing_prs = existing_data[:merged_prs] || []
+  rescue JSON::ParserError
+    existing_prs = []
+  end
+end
+
+existing_pr_numbers = existing_prs.map { |pr| pr[:number] }
+last_merged_at = existing_prs.map { |pr| to_time(pr[:merged_at]) }.max
+
+new_pr_list = []
+
+if last_merged_at.nil?
+  # Bootstrap: no existing (or parseable) history found, so fetch the full set of pull
+  # requests merged into master. Only happens once, when the file is first created.
+  puts Time.now.strftime("%H:%M:%S.%L") + " * No existing change history found. Performing a full historical fetch..."
+
+  merged_pull_requests = github_client.pull_requests(repo_name, state: 'closed').select do |pr|
+    # Omit PRs triggered by this script to avoid an infinite loop
+    pr.merged_at && pr.base.ref == branch
+  end.sort_by(&:merged_at).reverse
+
+  new_pr_list = merged_pull_requests.map { |pr| build_pr_entry(github_client, repo_name, pr, pr.merged_at) }
+else
+  # Incremental fetch: only ask the Github Search API for pull requests merged after the most
+  # recently recorded merge. A one day buffer is subtracted from the cutoff to guard against
+  # any clock skew or API eventual-consistency; pull requests we already have on record are
+  # skipped below by number, so re-checking a small window of already-known pull requests is
+  # harmless.
+  cutoff = (last_merged_at - 86400).strftime('%Y-%m-%d')
+  puts Time.now.strftime("%H:%M:%S.%L") + " * Existing change history found. Fetching pull requests merged on or after #{cutoff}..."
+
+  query = "repo:#{repo_name} is:pr is:merged base:#{branch} merged:>=#{cutoff}"
+  search_results = github_client.search_issues(query, per_page: 100)
+
+  search_results.items.each do |pr|
+    next if existing_pr_numbers.include?(pr.number)
+    next unless pr.pull_request && pr.pull_request.merged_at
+
+    new_pr_list << build_pr_entry(github_client, repo_name, pr, pr.pull_request.merged_at)
+  end
+end
+
+puts Time.now.strftime("%H:%M:%S.%L") + " * Found #{new_pr_list.length} newly merged pull request(s)."
+
+# Combine newly-found pull requests with the previously recorded ones (in case the incremental
+# window above overlapped with pull requests we already have), then sort by merge date with the
+# most recent pull requests coming first.
+pr_list = (new_pr_list + existing_prs).uniq { |pr| pr[:number] }.sort_by { |pr| to_time(pr[:merged_at]) }.reverse
 
 # Construct final object
 merged_prs = { "merged_prs": pr_list }
 
 # Write the data/change_history/change_history.json file
-File.open('data/change_history/change_history.json', 'w') {
+File.open(change_history_file, 'w') {
   |file| file.write(JSON.pretty_generate(merged_prs) + "\n")
 }
 


### PR DESCRIPTION
generate_change_history.rb previously recomputed the entire pull request history from scratch on every run: it fetched every closed PR ever merged via the core Pull Requests API and made a separate pull_request_files API call for each one (N+1), even though only a handful of PRs typically merge between runs. This already took 24-35 minutes per weekly run in production and would eventually hit Github's API rate limit as the repository's PR history keeps growing.

The script now loads the existing data/change_history/change_history.json, determines the most recently recorded merge, and uses the Github Search API (merged:>=<date>) to fetch only pull requests merged since then (with a one day buffer and de-duplication by PR number for safety). Per-PR pull_request_files calls are now limited to the small number of newly-merged PRs instead of the entire history.

Also updated tools/change_history/README.md to document the incremental fetch behavior and bootstrap fallback.
