### PR TITLE
POL-1824 Minimum Savings Set to 1

### DIFF
--- a/cost/aws/ec2_compute_optimizer/CHANGELOG.md
+++ b/cost/aws/ec2_compute_optimizer/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.7.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.6.5
 

--- a/cost/aws/ec2_compute_optimizer/CHANGELOG.md
+++ b/cost/aws/ec2_compute_optimizer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.7.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.6.5
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/aws/ec2_compute_optimizer/aws_ec2_compute_optimizer.pt
+++ b/cost/aws/ec2_compute_optimizer/aws_ec2_compute_optimizer.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.6.5",
+  version: "0.7.0",
   provider: "AWS",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -42,7 +42,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation. This is based on the value of the 'Estimated Monthly Savings' field."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/aws/ec2_compute_optimizer/aws_ec2_compute_optimizer_meta_parent.pt
+++ b/cost/aws/ec2_compute_optimizer/aws_ec2_compute_optimizer_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.6.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.7.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation. This is based on the value of the 'Estimated Monthly Savings' field."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/aws/extended_support/CHANGELOG.md
+++ b/cost/aws/extended_support/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.3.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v1.2.3
 
 - Updated policy logic for internal consistency; no functional or user-facing changes.

--- a/cost/aws/extended_support/CHANGELOG.md
+++ b/cost/aws/extended_support/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.3.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v1.2.3
 

--- a/cost/aws/extended_support/aws_extended_support.pt
+++ b/cost/aws/extended_support/aws_extended_support.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "1.2.3",
+  version: "1.3.0",
   provider: "AWS",
   service: "All",
   policy_set: "Deprecated Resources",
@@ -42,7 +42,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation. Only applies to resources currently under extended support."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_upcoming_days" do

--- a/cost/aws/extended_support/aws_extended_support_meta_parent.pt
+++ b/cost/aws/extended_support/aws_extended_support_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "1.2.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "1.3.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation. Only applies to resources currently under extended support."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_upcoming_days" do

--- a/cost/aws/idle_fsx/CHANGELOG.md
+++ b/cost/aws/idle_fsx/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.2.4
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/aws/idle_fsx/CHANGELOG.md
+++ b/cost/aws/idle_fsx/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.2.4
 

--- a/cost/aws/idle_fsx/aws_idle_fsx.pt
+++ b/cost/aws/idle_fsx/aws_idle_fsx.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.4",
+  version: "0.3.0",
   provider: "AWS",
   service: "Storage",
   policy_set: "Unused Storage",
@@ -42,7 +42,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/aws/idle_fsx/aws_idle_fsx_meta_parent.pt
+++ b/cost/aws/idle_fsx/aws_idle_fsx_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.2.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.3.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/aws/idle_lambda_functions/CHANGELOG.md
+++ b/cost/aws/idle_lambda_functions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.1.5
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/aws/idle_lambda_functions/CHANGELOG.md
+++ b/cost/aws/idle_lambda_functions/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.1.5
 

--- a/cost/aws/idle_lambda_functions/README.md
+++ b/cost/aws/idle_lambda_functions/README.md
@@ -22,7 +22,7 @@ The policy includes the estimated monthly savings. The estimated monthly savings
 
 - *Email Addresses* - A list of email addresses to notify.
 - *Account Number* - Leave blank; this is for automated use with Meta Policies. See README for more details.
-- *Minimum Savings Threshold* - Minimum potential savings required to generate a recommendation. Default is 0.
+- *Minimum Savings Threshold* - Minimum potential savings required to generate a recommendation. Default is 1.
 - *Statistic Lookback Period* - How many days back to look at CloudWatch invocation data. Minimum: 1, Maximum: 90. Default: 30.
 - *Minimum Invocations Threshold* - Functions with total invocations at or below this number over the lookback period are considered idle. Set to 0 (default) to report only functions with zero invocations. Increase this value to also capture near-zero usage functions.
 - *Allow/Deny Regions* - Allow or Deny entered regions. See the README for more details.

--- a/cost/aws/idle_lambda_functions/aws_idle_lambda_functions.pt
+++ b/cost/aws/idle_lambda_functions/aws_idle_lambda_functions.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.1.5",
+  version: "0.2.0",
   provider: "AWS",
   service: "PaaS",
   policy_set: "Idle Lambda Functions",
@@ -42,7 +42,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_stats_lookback" do

--- a/cost/aws/idle_lambda_functions/aws_idle_lambda_functions_meta_parent.pt
+++ b/cost/aws/idle_lambda_functions/aws_idle_lambda_functions_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.1.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_stats_lookback" do

--- a/cost/aws/idle_nat_gateways/CHANGELOG.md
+++ b/cost/aws/idle_nat_gateways/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.3.10
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/aws/idle_nat_gateways/CHANGELOG.md
+++ b/cost/aws/idle_nat_gateways/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.4.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.3.10
 

--- a/cost/aws/idle_nat_gateways/aws_idle_nat_gateways.pt
+++ b/cost/aws/idle_nat_gateways/aws_idle_nat_gateways.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.10",
+  version: "0.4.0",
   provider: "AWS",
   service: "Network",
   policy_set: "Idle NAT Gateways",
@@ -42,7 +42,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_lookback" do

--- a/cost/aws/idle_nat_gateways/aws_idle_nat_gateways_meta_parent.pt
+++ b/cost/aws/idle_nat_gateways/aws_idle_nat_gateways_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.3.10", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_lookback" do

--- a/cost/aws/idle_sagemaker_endpoints/CHANGELOG.md
+++ b/cost/aws/idle_sagemaker_endpoints/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.1.3
 
 - Replaced non-ASCII punctuation (em dashes, curly quotes, etc.) with standard ASCII equivalents for consistent rendering in the Flexera UI. No functional changes.

--- a/cost/aws/idle_sagemaker_endpoints/CHANGELOG.md
+++ b/cost/aws/idle_sagemaker_endpoints/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.1.3
 

--- a/cost/aws/idle_sagemaker_endpoints/README.md
+++ b/cost/aws/idle_sagemaker_endpoints/README.md
@@ -26,7 +26,7 @@ The policy includes the estimated monthly savings. The estimated monthly savings
 
 - *Email Addresses* - A list of email addresses to notify.
 - *Account Number* - Leave blank; this is for automated use with Meta Policies. See README for more details.
-- *Minimum Savings Threshold* - Minimum potential savings required to generate a recommendation. Default is 0.
+- *Minimum Savings Threshold* - Minimum potential savings required to generate a recommendation. Default is 1.
 - *Statistic Lookback Period* - How many days back to look at CloudWatch invocation data. Minimum: 1, Maximum: 90. Default: 30.
 - *Minimum Invocations Threshold* - Endpoints with total invocations at or below this number over the lookback period are considered idle. Set to 0 (default) to report only endpoints with zero invocations. Increase this value to also capture near-zero usage endpoints.
 - *Allow/Deny Regions* - Allow or Deny entered regions. See the README for more details.

--- a/cost/aws/idle_sagemaker_endpoints/aws_idle_sagemaker_endpoints.pt
+++ b/cost/aws/idle_sagemaker_endpoints/aws_idle_sagemaker_endpoints.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.1.3",
+  version: "0.2.0",
   provider: "AWS",
   service: "SageMaker",
   policy_set: "Idle SageMaker Endpoints",
@@ -42,7 +42,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_stats_lookback" do

--- a/cost/aws/idle_sagemaker_endpoints/aws_idle_sagemaker_endpoints_meta_parent.pt
+++ b/cost/aws/idle_sagemaker_endpoints/aws_idle_sagemaker_endpoints_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_stats_lookback" do

--- a/cost/aws/old_snapshots/CHANGELOG.md
+++ b/cost/aws/old_snapshots/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v8.7.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v8.6.10
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/aws/old_snapshots/CHANGELOG.md
+++ b/cost/aws/old_snapshots/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v8.7.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v8.6.10
 

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "8.6.10",
+  version: "8.7.0",
   provider: "AWS",
   service: "Storage",
   policy_set: "Old Snapshots",
@@ -60,7 +60,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "8.6.10", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "8.7.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -122,7 +122,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/aws/reserved_instances/recommendations/CHANGELOG.md
+++ b/cost/aws/reserved_instances/recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.9.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v3.8.2
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/aws/reserved_instances/recommendations/CHANGELOG.md
+++ b/cost/aws/reserved_instances/recommendations/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v3.9.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v3.8.2
 

--- a/cost/aws/reserved_instances/recommendations/aws_reserved_instance_recommendations.pt
+++ b/cost/aws/reserved_instances/recommendations/aws_reserved_instance_recommendations.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.8.2",
+  version: "3.9.0",
   provider: "AWS",
   service: "Compute",
   policy_set: "Reserved Instances",
@@ -42,7 +42,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Specify the minimum estimated monthly savings that should result in a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_days" do

--- a/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.5.10
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.6.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.5.10
 

--- a/cost/aws/rightsize_ebs_volumes/aws_rightsize_ebs_volumes.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_rightsize_ebs_volumes.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.10",
+  version: "0.6.0",
   provider: "AWS",
   service: "EBS",
   policy_set: "Unused Volumes",
@@ -70,7 +70,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/aws/rightsize_ebs_volumes/aws_rightsize_ebs_volumes_meta_parent.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_rightsize_ebs_volumes_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.5.10", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.6.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -132,7 +132,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/aws/rightsize_ec2_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_ec2_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v5.8.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v5.7.6
 

--- a/cost/aws/rightsize_ec2_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_ec2_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.8.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v5.7.6
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "5.7.6",
+  version: "5.8.0",
   provider: "AWS",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -42,7 +42,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_downsize_multiple" do

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "5.7.6", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.8.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_downsize_multiple" do

--- a/cost/aws/rightsize_ec2_instances_cross_family/CHANGELOG.md
+++ b/cost/aws/rightsize_ec2_instances_cross_family/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.1.3
 

--- a/cost/aws/rightsize_ec2_instances_cross_family/CHANGELOG.md
+++ b/cost/aws/rightsize_ec2_instances_cross_family/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.1.3
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/aws/rightsize_ec2_instances_cross_family/README.md
+++ b/cost/aws/rightsize_ec2_instances_cross_family/README.md
@@ -79,7 +79,7 @@ The policy includes the estimated monthly savings. The estimated monthly savings
   - `Key!~/Regex/` - Filter all resources where the value for the specified key does not match the specified regex string. This will also filter all resources missing the specified tag key.
 - *Exclusion Tags: Any / All* - Whether to filter instances containing any of the specified tags or only those that contain all of them. Only applicable if more than one value is entered in the `Exclusion Tags` field.
 - *Filter GPU Instances* - Whether or not to exclude GPU-focused EC2 instances from the results. Note: GPU metrics are not considered when producing recommendations.
-- *Minimum Savings Threshold* - Minimum potential savings required to generate a recommendation. Set to 0 to report all findings.
+- *Minimum Savings Threshold* - Minimum potential savings required to generate a recommendation. Default is 1. Set to 0 to report all findings regardless of savings.
 - *Allow Intel/AMD Recommendations* - Whether to allow recommendations that switch between Intel and AMD processors (both x86_64). Set to `Yes` to allow cross-manufacturer recommendations; `No` (default) to keep the same CPU manufacturer.
 - *Statistic Lookback Period* - How many days back to look at CPU and memory data for instances. Maximum is 90 days (AWS CloudWatch data retention limit).
 - *Rightsizing Safety Factor* - A multiplier applied to peak utilization when computing required resources for a rightsized instance. Default is 1.5 (50% headroom). Set higher for more conservative recommendations.

--- a/cost/aws/rightsize_ec2_instances_cross_family/aws_rightsize_ec2_instances_cross_family.pt
+++ b/cost/aws/rightsize_ec2_instances_cross_family/aws_rightsize_ec2_instances_cross_family.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "0.1.3",
+  version: "0.2.0",
   provider: "AWS",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -42,7 +42,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/aws/rightsize_ec2_instances_cross_family/aws_rightsize_ec2_instances_cross_family_meta_parent.pt
+++ b/cost/aws/rightsize_ec2_instances_cross_family/aws_rightsize_ec2_instances_cross_family_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/aws/rightsize_elasticache/CHANGELOG.md
+++ b/cost/aws/rightsize_elasticache/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.6.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.5.11
 

--- a/cost/aws/rightsize_elasticache/CHANGELOG.md
+++ b/cost/aws/rightsize_elasticache/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.5.11
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/aws/rightsize_elasticache/aws_rightsize_elasticache.pt
+++ b/cost/aws/rightsize_elasticache/aws_rightsize_elasticache.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.11",
+  version: "0.6.0",
   provider: "AWS",
   service: "Database",
   policy_set: "Rightsize Database Instances",
@@ -42,7 +42,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_downsize_multiple" do

--- a/cost/aws/rightsize_elasticache/aws_rightsize_elasticache_meta_parent.pt
+++ b/cost/aws/rightsize_elasticache/aws_rightsize_elasticache_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.5.11", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.6.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_downsize_multiple" do

--- a/cost/aws/rightsize_rds_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_rds_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v5.12.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v5.11.4
 

--- a/cost/aws/rightsize_rds_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_rds_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.12.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v5.11.4
 
 - Fixed the region-accessibility probe to use the correct `MaxRecords` query parameter (instead of `MaxResults`) for the RDS `DescribeDBInstances` API call, ensuring the probe works reliably across all regions.

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "5.11.4",
+  version: "5.12.0",
   provider: "AWS",
   service: "RDS",
   policy_set: "Rightsize Database Instances",
@@ -42,7 +42,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_downsize_multiple" do

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "5.11.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.12.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_downsize_multiple" do

--- a/cost/aws/rightsize_redshift/CHANGELOG.md
+++ b/cost/aws/rightsize_redshift/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.3.5
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/aws/rightsize_redshift/CHANGELOG.md
+++ b/cost/aws/rightsize_redshift/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.4.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.3.5
 

--- a/cost/aws/rightsize_redshift/aws_rightsize_redshift.pt
+++ b/cost/aws/rightsize_redshift/aws_rightsize_redshift.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.5",
+  version: "0.4.0",
   provider: "AWS",
   service: "Database",
   policy_set: "Rightsize Database Instances",
@@ -42,7 +42,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/aws/rightsize_redshift/aws_rightsize_redshift_meta_parent.pt
+++ b/cost/aws/rightsize_redshift/aws_rightsize_redshift_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.3.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/aws/savings_plan/recommendations/CHANGELOG.md
+++ b/cost/aws/savings_plan/recommendations/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.1.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v4.0.2
 

--- a/cost/aws/savings_plan/recommendations/CHANGELOG.md
+++ b/cost/aws/savings_plan/recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.1.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v4.0.2
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/aws/savings_plan/recommendations/aws_savings_plan_recommendations.pt
+++ b/cost/aws/savings_plan/recommendations/aws_savings_plan_recommendations.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.0.2",
+  version: "4.1.0",
   provider: "AWS",
   service: "Compute",
   policy_set: "Savings Plans",
@@ -42,7 +42,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Specify the minimum estimated monthly savings that should result in a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_days" do

--- a/cost/aws/superseded_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/superseded_ebs_volumes/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v6.7.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v6.6.4
 

--- a/cost/aws/superseded_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/superseded_ebs_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.7.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v6.6.4
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
+++ b/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "6.6.4",
+  version: "6.7.0",
   provider: "AWS",
   service: "Compute",
   policy_set: "Inefficient Disk Usage",
@@ -42,7 +42,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_pricing_api_endpoint" do

--- a/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes_meta_parent.pt
+++ b/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "6.6.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.7.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_pricing_api_endpoint" do

--- a/cost/aws/superseded_instances/CHANGELOG.md
+++ b/cost/aws/superseded_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v3.3.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v3.2.10
 

--- a/cost/aws/superseded_instances/CHANGELOG.md
+++ b/cost/aws/superseded_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.3.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v3.2.10
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/aws/superseded_instances/aws_superseded_instances.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.2.10",
+  version: "3.3.0",
   provider: "AWS",
   service: "Compute",
   policy_set: "Superseded Compute Instances",
@@ -60,7 +60,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "3.2.10", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.3.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -122,7 +122,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/aws/superseded_rds_instances/CHANGELOG.md
+++ b/cost/aws/superseded_rds_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.1.3
 

--- a/cost/aws/superseded_rds_instances/CHANGELOG.md
+++ b/cost/aws/superseded_rds_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.1.3
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/aws/superseded_rds_instances/aws_superseded_rds_instances.pt
+++ b/cost/aws/superseded_rds_instances/aws_superseded_rds_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "0.1.3",
+  version: "0.2.0",
   provider: "AWS",
   service: "RDS",
   policy_set: "Superseded Compute Instances",
@@ -60,7 +60,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/aws/superseded_rds_instances/aws_superseded_rds_instances_meta_parent.pt
+++ b/cost/aws/superseded_rds_instances/aws_superseded_rds_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -122,7 +122,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/aws/unused_albs/CHANGELOG.md
+++ b/cost/aws/unused_albs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.5.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.4.10
 

--- a/cost/aws/unused_albs/CHANGELOG.md
+++ b/cost/aws/unused_albs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.4.10
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/aws/unused_albs/aws_unused_albs.pt
+++ b/cost/aws/unused_albs/aws_unused_albs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.10",
+  version: "0.5.0",
   provider: "AWS",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -42,7 +42,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_loadbalancer_age" do

--- a/cost/aws/unused_albs/aws_unused_albs_meta_parent.pt
+++ b/cost/aws/unused_albs/aws_unused_albs_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.4.10", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_loadbalancer_age" do

--- a/cost/aws/unused_clbs/CHANGELOG.md
+++ b/cost/aws/unused_clbs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.7.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v6.6.5
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/aws/unused_clbs/CHANGELOG.md
+++ b/cost/aws/unused_clbs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v6.7.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v6.6.5
 

--- a/cost/aws/unused_clbs/aws_unused_clbs.pt
+++ b/cost/aws/unused_clbs/aws_unused_clbs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.6.5",
+  version: "6.7.0",
   provider: "AWS",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -42,7 +42,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_loadbalancer_age" do

--- a/cost/aws/unused_clbs/aws_unused_clbs_meta_parent.pt
+++ b/cost/aws/unused_clbs/aws_unused_clbs_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "6.6.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.7.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_loadbalancer_age" do

--- a/cost/aws/unused_nlbs/CHANGELOG.md
+++ b/cost/aws/unused_nlbs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.5.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.4.10
 

--- a/cost/aws/unused_nlbs/CHANGELOG.md
+++ b/cost/aws/unused_nlbs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.4.10
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/aws/unused_nlbs/aws_unused_nlbs.pt
+++ b/cost/aws/unused_nlbs/aws_unused_nlbs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.10",
+  version: "0.5.0",
   provider: "AWS",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -42,7 +42,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_loadbalancer_age" do

--- a/cost/aws/unused_nlbs/aws_unused_nlbs_meta_parent.pt
+++ b/cost/aws/unused_nlbs/aws_unused_nlbs_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.4.10", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_loadbalancer_age" do

--- a/cost/azure/advisor_compute/CHANGELOG.md
+++ b/cost/azure/advisor_compute/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.4.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/advisor_compute/CHANGELOG.md
+++ b/cost/azure/advisor_compute/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.5.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.4.2
 

--- a/cost/azure/advisor_compute/azure_advisor_compute.pt
+++ b/cost/azure/advisor_compute/azure_advisor_compute.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.2",
+  version: "0.5.0",
   provider: "Azure",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -44,7 +44,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/azure/advisor_compute/azure_advisor_compute_meta_parent.pt
+++ b/cost/azure/advisor_compute/azure_advisor_compute_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/azure/advisor_compute/azure_advisor_compute_meta_parent_rg.pt
+++ b/cost/azure/advisor_compute/azure_advisor_compute_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/azure/hybrid_use_benefit/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v5.7.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v5.6.2
 

--- a/cost/azure/hybrid_use_benefit/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.7.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v5.6.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "5.6.2",
+  version: "5.7.0",
   provider: "Azure",
   service: "Compute",
   policy_set: "Hybrid Use Benefit",
@@ -43,7 +43,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_subscriptions_allow_or_deny" do

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "5.6.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.7.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent_rg.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "5.6.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.7.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/azure/hybrid_use_benefit_linux/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit_linux/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.6.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v5.5.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/hybrid_use_benefit_linux/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit_linux/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v5.6.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v5.5.2
 

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "5.5.2",
+  version: "5.6.0",
   provider: "Azure",
   service: "Compute",
   policy_set: "Hybrid Use Benefit",
@@ -43,7 +43,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_subscriptions_allow_or_deny" do

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "5.5.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.6.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent_rg.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "5.5.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.6.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/azure/hybrid_use_benefit_sql/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit_sql/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.9.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v4.8.2
 

--- a/cost/azure/hybrid_use_benefit_sql/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit_sql/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.9.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v4.8.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "4.8.2",
+  version: "4.9.0",
   provider: "Azure",
   service: "SQL",
   policy_set: "Hybrid Use Benefit",
@@ -129,7 +129,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_automatic_action" do

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "4.8.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.9.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -165,7 +165,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_automatic_action" do

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent_rg.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "4.8.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.9.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -165,7 +165,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_automatic_action" do

--- a/cost/azure/idle_ml_online_endpoints/CHANGELOG.md
+++ b/cost/azure/idle_ml_online_endpoints/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.1.2
 

--- a/cost/azure/idle_ml_online_endpoints/CHANGELOG.md
+++ b/cost/azure/idle_ml_online_endpoints/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.1.2
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/azure/idle_ml_online_endpoints/README.md
+++ b/cost/azure/idle_ml_online_endpoints/README.md
@@ -28,7 +28,7 @@ The policy includes the estimated monthly savings. The estimated monthly savings
 
 - *Email Addresses* - A list of email addresses to notify.
 - *Azure Endpoint* - The Azure API endpoint to use. Use the default value of `management.azure.com` unless targeting Azure China (`management.chinacloudapi.cn`).
-- *Minimum Savings Threshold* - Minimum potential savings required to generate a recommendation. Default is 0 (all idle endpoints are reported).
+- *Minimum Savings Threshold* - Minimum potential savings required to generate a recommendation. Default is 1. Set to 0 to report all idle endpoints regardless of savings.
 - *Statistic Lookback Period* - How many days back to query Azure Monitor metrics for inference traffic. This value cannot be set higher than 90 because Azure does not retain metrics for longer than 90 days. Default is 30 days.
 - *Requests Threshold* - Endpoints with total `RequestsPerMinute` metric values at or below this threshold over the lookback period are flagged as idle. Set to 0 to flag only endpoints with absolutely zero traffic. Higher values can be used to catch near-idle endpoints.
 - *Allow/Deny Subscriptions* - Allow or Deny entered subscriptions to filter results.

--- a/cost/azure/idle_ml_online_endpoints/azure_idle_ml_online_endpoints.pt
+++ b/cost/azure/idle_ml_online_endpoints/azure_idle_ml_online_endpoints.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.1.2",
+  version: "0.2.0",
   provider: "Azure",
   service: "Compute",
   policy_set: "Idle ML Online Endpoints",
@@ -43,7 +43,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_stats_lookback" do

--- a/cost/azure/idle_ml_online_endpoints/azure_idle_ml_online_endpoints_meta_parent.pt
+++ b/cost/azure/idle_ml_online_endpoints/azure_idle_ml_online_endpoints_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.1.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_stats_lookback" do

--- a/cost/azure/idle_ml_online_endpoints/azure_idle_ml_online_endpoints_meta_parent_rg.pt
+++ b/cost/azure/idle_ml_online_endpoints/azure_idle_ml_online_endpoints_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.1.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_stats_lookback" do

--- a/cost/azure/long_stopped_instances/CHANGELOG.md
+++ b/cost/azure/long_stopped_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v6.4.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v6.3.2
 

--- a/cost/azure/long_stopped_instances/CHANGELOG.md
+++ b/cost/azure/long_stopped_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.4.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v6.3.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/long_stopped_instances/long_stopped_instances_azure.pt
+++ b/cost/azure/long_stopped_instances/long_stopped_instances_azure.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.3.2",
+  version: "6.4.0",
   provider: "Azure",
   service: "Compute",
   policy_set: "Long Stopped Instances",
@@ -121,7 +121,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_include_disk_savings" do

--- a/cost/azure/long_stopped_instances/long_stopped_instances_azure_meta_parent.pt
+++ b/cost/azure/long_stopped_instances/long_stopped_instances_azure_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "6.3.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -157,7 +157,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_include_disk_savings" do

--- a/cost/azure/long_stopped_instances/long_stopped_instances_azure_meta_parent_rg.pt
+++ b/cost/azure/long_stopped_instances/long_stopped_instances_azure_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "6.3.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -157,7 +157,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_include_disk_savings" do

--- a/cost/azure/old_snapshots/CHANGELOG.md
+++ b/cost/azure/old_snapshots/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v7.6.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v7.5.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/old_snapshots/CHANGELOG.md
+++ b/cost/azure/old_snapshots/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v7.6.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v7.5.2
 

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "7.5.2",
+  version: "7.6.0",
   provider: "Azure",
   service: "Storage",
   policy_set: "Old Snapshots",
@@ -43,7 +43,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_snapshot_age" do

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "7.5.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "7.6.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_snapshot_age" do

--- a/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent_rg.pt
+++ b/cost/azure/old_snapshots/azure_delete_old_snapshots_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "7.5.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "7.6.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_snapshot_age" do

--- a/cost/azure/reserved_instances/recommendations/CHANGELOG.md
+++ b/cost/azure/reserved_instances/recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.9.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v4.8.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/reserved_instances/recommendations/CHANGELOG.md
+++ b/cost/azure/reserved_instances/recommendations/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.9.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v4.8.1
 

--- a/cost/azure/reserved_instances/recommendations/azure_reserved_instance_recommendations.pt
+++ b/cost/azure/reserved_instances/recommendations/azure_reserved_instance_recommendations.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.8.1",
+  version: "4.9.0",
   provider: "Azure",
   service: "Compute",
   policy_set: "Reserved Instances",
@@ -43,7 +43,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_delay_time_between_requests" do

--- a/cost/azure/reserved_instances/recommendations/azure_reserved_instance_recommendations_meta_parent.pt
+++ b/cost/azure/reserved_instances/recommendations/azure_reserved_instance_recommendations_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "4.8.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.9.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_delay_time_between_requests" do

--- a/cost/azure/reserved_instances/recommendations/azure_reserved_instance_recommendations_meta_parent_rg.pt
+++ b/cost/azure/reserved_instances/recommendations/azure_reserved_instance_recommendations_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "4.8.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.9.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_delay_time_between_requests" do

--- a/cost/azure/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.7.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v6.6.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/rightsize_compute_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v6.7.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v6.6.2
 

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.6.2",
+  version: "6.7.0",
   provider: "Azure",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -43,7 +43,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "6.6.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.7.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent_rg.pt
+++ b/cost/azure/rightsize_compute_instances/azure_compute_rightsizing_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "6.6.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.7.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/azure/rightsize_compute_instances_cross_family/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances_cross_family/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.2.2
 
 - Replaced non-ASCII punctuation (em dashes, curly quotes, etc.) with standard ASCII equivalents for consistent rendering in the Flexera UI. No functional changes.

--- a/cost/azure/rightsize_compute_instances_cross_family/CHANGELOG.md
+++ b/cost/azure/rightsize_compute_instances_cross_family/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.2.2
 

--- a/cost/azure/rightsize_compute_instances_cross_family/azure_rightsize_compute_instances_cross_family.pt
+++ b/cost/azure/rightsize_compute_instances_cross_family/azure_rightsize_compute_instances_cross_family.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.2",
+  version: "0.3.0",
   provider: "Azure",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -43,7 +43,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/azure/rightsize_compute_instances_cross_family/azure_rightsize_compute_instances_cross_family_meta_parent.pt
+++ b/cost/azure/rightsize_compute_instances_cross_family/azure_rightsize_compute_instances_cross_family_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.2.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.3.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/azure/rightsize_compute_instances_cross_family/azure_rightsize_compute_instances_cross_family_meta_parent_rg.pt
+++ b/cost/azure/rightsize_compute_instances_cross_family/azure_rightsize_compute_instances_cross_family_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.2.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.3.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/azure/rightsize_managed_disks/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_disks/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## v2.10.0
-
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
-
 ## v2.9.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/rightsize_managed_disks/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_disks/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v2.10.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v2.9.2
 

--- a/cost/azure/rightsize_managed_disks/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_disks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.10.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v2.9.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "monthly"
 info(
-  version: "2.10.0",
+  version: "2.9.2",
   provider: "Azure",
   service: "Managed Disks",
   policy_set: "Rightsize Storage",
@@ -43,7 +43,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 1
+  default 0
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "monthly"
 info(
-  version: "2.9.2",
+  version: "2.10.0",
   provider: "Azure",
   service: "Managed Disks",
   policy_set: "Rightsize Storage",
@@ -43,7 +43,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks_meta_parent.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "2.9.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "2.10.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks_meta_parent.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "2.10.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "2.9.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 1
+  default 0
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks_meta_parent_rg.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "2.10.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "2.9.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 1
+  default 0
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks_meta_parent_rg.pt
+++ b/cost/azure/rightsize_managed_disks/azure_rightsize_managed_disks_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "2.9.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "2.10.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/azure/rightsize_managed_sql/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_sql/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.7.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.6.2
 

--- a/cost/azure/rightsize_managed_sql/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_sql/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.7.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.6.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql.pt
+++ b/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.6.2",
+  version: "0.7.0",
   provider: "Azure",
   service: "SQL",
   policy_set: "Rightsize Database Instances",
@@ -43,7 +43,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_subscriptions_allow_or_deny" do

--- a/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql_meta_parent.pt
+++ b/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.6.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.7.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql_meta_parent_rg.pt
+++ b/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.6.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.7.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/azure/rightsize_managed_sql_storage/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_sql_storage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.5.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/rightsize_managed_sql_storage/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_sql_storage/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.6.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.5.2
 

--- a/cost/azure/rightsize_managed_sql_storage/azure_rightsize_managed_sql_storage.pt
+++ b/cost/azure/rightsize_managed_sql_storage/azure_rightsize_managed_sql_storage.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.2",
+  version: "0.6.0",
   provider: "Azure",
   service: "SQL",
   policy_set: "Rightsize Database Instances",
@@ -43,7 +43,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_subscriptions_allow_or_deny" do

--- a/cost/azure/rightsize_managed_sql_storage/azure_rightsize_managed_sql_storage_meta_parent.pt
+++ b/cost/azure/rightsize_managed_sql_storage/azure_rightsize_managed_sql_storage_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.5.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.6.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/azure/rightsize_managed_sql_storage/azure_rightsize_managed_sql_storage_meta_parent_rg.pt
+++ b/cost/azure/rightsize_managed_sql_storage/azure_rightsize_managed_sql_storage_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.5.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.6.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/azure/rightsize_mysql_flexible/CHANGELOG.md
+++ b/cost/azure/rightsize_mysql_flexible/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.5.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/rightsize_mysql_flexible/CHANGELOG.md
+++ b/cost/azure/rightsize_mysql_flexible/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.6.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.5.2
 

--- a/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible.pt
+++ b/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.2",
+  version: "0.6.0",
   provider: "Azure",
   service: "MySQL",
   policy_set: "Rightsize Database Instances",
@@ -43,7 +43,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_subscriptions_allow_or_deny" do

--- a/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible_meta_parent.pt
+++ b/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.5.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.6.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible_meta_parent_rg.pt
+++ b/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.5.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.6.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/azure/rightsize_mysql_single/CHANGELOG.md
+++ b/cost/azure/rightsize_mysql_single/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.5.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/rightsize_mysql_single/CHANGELOG.md
+++ b/cost/azure/rightsize_mysql_single/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.6.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.5.2
 

--- a/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single.pt
+++ b/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.2",
+  version: "0.6.0",
   provider: "Azure",
   service: "MySQL",
   policy_set: "Rightsize Database Instances",
@@ -43,7 +43,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_subscriptions_allow_or_deny" do

--- a/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single_meta_parent.pt
+++ b/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.5.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.6.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single_meta_parent_rg.pt
+++ b/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.5.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.6.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/azure/rightsize_netapp/CHANGELOG.md
+++ b/cost/azure/rightsize_netapp/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v2.4.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v2.3.3
 

--- a/cost/azure/rightsize_netapp/CHANGELOG.md
+++ b/cost/azure/rightsize_netapp/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.4.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v2.3.3
 
 - Updated policy logic for internal consistency; no functional or user-facing changes.

--- a/cost/azure/rightsize_netapp/azure_rightsize_netapp.pt
+++ b/cost/azure/rightsize_netapp/azure_rightsize_netapp.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "2.3.3",
+  version: "2.4.0",
   provider: "Azure",
   service: "NetApp Files",
   policy_set: "Rightsize Storage",
@@ -149,7 +149,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_automatic_action" do

--- a/cost/azure/rightsize_netapp/azure_rightsize_netapp_meta_parent.pt
+++ b/cost/azure/rightsize_netapp/azure_rightsize_netapp_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "2.3.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "2.4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -185,7 +185,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_automatic_action" do

--- a/cost/azure/rightsize_netapp/azure_rightsize_netapp_meta_parent_rg.pt
+++ b/cost/azure/rightsize_netapp/azure_rightsize_netapp_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "2.3.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "2.4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -185,7 +185,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_automatic_action" do

--- a/cost/azure/rightsize_postgresql_flexible/CHANGELOG.md
+++ b/cost/azure/rightsize_postgresql_flexible/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/rightsize_postgresql_flexible/CHANGELOG.md
+++ b/cost/azure/rightsize_postgresql_flexible/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.1.1
 

--- a/cost/azure/rightsize_postgresql_flexible/azure_rightsize_postgresql_flexible.pt
+++ b/cost/azure/rightsize_postgresql_flexible/azure_rightsize_postgresql_flexible.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.1.1",
+  version: "0.2.0",
   provider: "Azure",
   service: "PostgreSQL",
   policy_set: "Rightsize Database Instances",
@@ -43,7 +43,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_subscriptions_allow_or_deny" do

--- a/cost/azure/rightsize_postgresql_flexible/azure_rightsize_postgresql_flexible_meta_parent.pt
+++ b/cost/azure/rightsize_postgresql_flexible/azure_rightsize_postgresql_flexible_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.1.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/azure/rightsize_postgresql_flexible/azure_rightsize_postgresql_flexible_meta_parent_rg.pt
+++ b/cost/azure/rightsize_postgresql_flexible/azure_rightsize_postgresql_flexible_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.1.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/azure/rightsize_postgresql_single/CHANGELOG.md
+++ b/cost/azure/rightsize_postgresql_single/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/rightsize_postgresql_single/CHANGELOG.md
+++ b/cost/azure/rightsize_postgresql_single/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.1.1
 

--- a/cost/azure/rightsize_postgresql_single/azure_rightsize_postgresql_single.pt
+++ b/cost/azure/rightsize_postgresql_single/azure_rightsize_postgresql_single.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.1.1",
+  version: "0.2.0",
   provider: "Azure",
   service: "PostgreSQL",
   policy_set: "Rightsize Database Instances",
@@ -43,7 +43,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_subscriptions_allow_or_deny" do

--- a/cost/azure/rightsize_postgresql_single/azure_rightsize_postgresql_single_meta_parent.pt
+++ b/cost/azure/rightsize_postgresql_single/azure_rightsize_postgresql_single_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.1.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/azure/rightsize_postgresql_single/azure_rightsize_postgresql_single_meta_parent_rg.pt
+++ b/cost/azure/rightsize_postgresql_single/azure_rightsize_postgresql_single_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.1.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/azure/rightsize_sql_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_sql_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v6.4.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v6.3.3
 

--- a/cost/azure/rightsize_sql_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_sql_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.4.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v6.3.3
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.3.3",
+  version: "6.4.0",
   provider: "Azure",
   service: "SQL",
   policy_set: "Rightsize Database Instances",
@@ -43,7 +43,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_minimum_age" do

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "6.3.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_minimum_age" do

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent_rg.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "6.3.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_minimum_age" do

--- a/cost/azure/rightsize_sql_storage/CHANGELOG.md
+++ b/cost/azure/rightsize_sql_storage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.4.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/rightsize_sql_storage/CHANGELOG.md
+++ b/cost/azure/rightsize_sql_storage/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.5.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.4.2
 

--- a/cost/azure/rightsize_sql_storage/azure_rightsize_sql_storage.pt
+++ b/cost/azure/rightsize_sql_storage/azure_rightsize_sql_storage.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.2",
+  version: "0.5.0",
   provider: "Azure",
   service: "SQL",
   policy_set: "Rightsize Database Instances",
@@ -43,7 +43,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_minimum_age" do

--- a/cost/azure/rightsize_sql_storage/azure_rightsize_sql_storage_meta_parent.pt
+++ b/cost/azure/rightsize_sql_storage/azure_rightsize_sql_storage_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_minimum_age" do

--- a/cost/azure/rightsize_sql_storage/azure_rightsize_sql_storage_meta_parent_rg.pt
+++ b/cost/azure/rightsize_sql_storage/azure_rightsize_sql_storage_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_minimum_age" do

--- a/cost/azure/rightsize_synapse_sql_pools/CHANGELOG.md
+++ b/cost/azure/rightsize_synapse_sql_pools/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.4.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/rightsize_synapse_sql_pools/CHANGELOG.md
+++ b/cost/azure/rightsize_synapse_sql_pools/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.5.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.4.2
 

--- a/cost/azure/rightsize_synapse_sql_pools/azure_rightsize_synapse_sql_pools.pt
+++ b/cost/azure/rightsize_synapse_sql_pools/azure_rightsize_synapse_sql_pools.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.2",
+  version: "0.5.0",
   provider: "Azure",
   service: "SQL",
   policy_set: "Rightsize Synapse SQL Pools",
@@ -170,7 +170,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_automatic_pause" do

--- a/cost/azure/savings_plan/recommendations/CHANGELOG.md
+++ b/cost/azure/savings_plan/recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.8.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v3.7.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/savings_plan/recommendations/CHANGELOG.md
+++ b/cost/azure/savings_plan/recommendations/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v3.8.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v3.7.1
 

--- a/cost/azure/savings_plan/recommendations/azure_savings_plan_recommendations.pt
+++ b/cost/azure/savings_plan/recommendations/azure_savings_plan_recommendations.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.7.1",
+  version: "3.8.0",
   provider: "Azure",
   service: "Compute",
   policy_set: "Savings Plans",
@@ -43,7 +43,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_subscriptions_allow_or_deny" do

--- a/cost/azure/savings_plan/recommendations/azure_savings_plan_recommendations_meta_parent.pt
+++ b/cost/azure/savings_plan/recommendations/azure_savings_plan_recommendations_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "3.7.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.8.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_days" do

--- a/cost/azure/savings_plan/recommendations/azure_savings_plan_recommendations_meta_parent_rg.pt
+++ b/cost/azure/savings_plan/recommendations/azure_savings_plan_recommendations_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "3.7.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.8.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_days" do

--- a/cost/azure/sentinel_commitment_tiers/CHANGELOG.md
+++ b/cost/azure/sentinel_commitment_tiers/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.4.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/sentinel_commitment_tiers/CHANGELOG.md
+++ b/cost/azure/sentinel_commitment_tiers/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.5.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.4.1
 

--- a/cost/azure/sentinel_commitment_tiers/azure_sentinel_commitment_tiers.pt
+++ b/cost/azure/sentinel_commitment_tiers/azure_sentinel_commitment_tiers.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "0.4.1",
+  version: "0.5.0",
   provider: "Azure",
   service: "Sentinel",
   policy_set: "Commitment Tiers",
@@ -43,7 +43,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential monthly savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_lookback_days" do

--- a/cost/azure/sentinel_commitment_tiers/azure_sentinel_commitment_tiers_meta_parent.pt
+++ b/cost/azure/sentinel_commitment_tiers/azure_sentinel_commitment_tiers_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.4.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential monthly savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_lookback_days" do

--- a/cost/azure/sentinel_commitment_tiers/azure_sentinel_commitment_tiers_meta_parent_rg.pt
+++ b/cost/azure/sentinel_commitment_tiers/azure_sentinel_commitment_tiers_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.4.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential monthly savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_lookback_days" do

--- a/cost/azure/superseded_instances/CHANGELOG.md
+++ b/cost/azure/superseded_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.4.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v4.3.2
 

--- a/cost/azure/superseded_instances/CHANGELOG.md
+++ b/cost/azure/superseded_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.4.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v4.3.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/superseded_instances/azure_superseded_instances.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.3.2",
+  version: "4.4.0",
   provider: "Azure",
   service: "Compute",
   policy_set: "Superseded Compute Instances",
@@ -43,7 +43,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "4.3.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/azure/superseded_instances/azure_superseded_instances_meta_parent_rg.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "4.3.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_exclusion_tags" do

--- a/cost/azure/unused_app_service_plans/CHANGELOG.md
+++ b/cost/azure/unused_app_service_plans/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.4.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/unused_app_service_plans/CHANGELOG.md
+++ b/cost/azure/unused_app_service_plans/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.5.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.4.2
 

--- a/cost/azure/unused_app_service_plans/azure_unused_app_service_plans.pt
+++ b/cost/azure/unused_app_service_plans/azure_unused_app_service_plans.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.2",
+  version: "0.5.0",
   provider: "Azure",
   service: "PaaS",
   policy_set: "PaaS Optimization",
@@ -43,7 +43,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_subscriptions_allow_or_deny" do

--- a/cost/azure/unused_app_service_plans/azure_unused_app_service_plans_meta_parent.pt
+++ b/cost/azure/unused_app_service_plans/azure_unused_app_service_plans_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/azure/unused_app_service_plans/azure_unused_app_service_plans_meta_parent_rg.pt
+++ b/cost/azure/unused_app_service_plans/azure_unused_app_service_plans_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/azure/unused_firewalls/CHANGELOG.md
+++ b/cost/azure/unused_firewalls/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.5.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/unused_firewalls/CHANGELOG.md
+++ b/cost/azure/unused_firewalls/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.6.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.5.2
 

--- a/cost/azure/unused_firewalls/azure_unused_firewalls.pt
+++ b/cost/azure/unused_firewalls/azure_unused_firewalls.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.2",
+  version: "0.6.0",
   provider: "Azure",
   service: "Network",
   policy_set: "Unused Firewalls",
@@ -53,7 +53,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_subscriptions_allow_or_deny" do

--- a/cost/azure/unused_firewalls/azure_unused_firewalls_meta_parent.pt
+++ b/cost/azure/unused_firewalls/azure_unused_firewalls_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.5.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.6.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -123,7 +123,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/azure/unused_firewalls/azure_unused_firewalls_meta_parent_rg.pt
+++ b/cost/azure/unused_firewalls/azure_unused_firewalls_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.5.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.6.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -123,7 +123,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/azure/unused_ip_addresses/CHANGELOG.md
+++ b/cost/azure/unused_ip_addresses/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v7.7.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v7.6.2
 

--- a/cost/azure/unused_ip_addresses/CHANGELOG.md
+++ b/cost/azure/unused_ip_addresses/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v7.7.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v7.6.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "7.6.2",
+  version: "7.7.0",
   provider: "Azure",
   service: "Compute",
   policy_set: "Unused IP Addresses",
@@ -43,7 +43,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_days_unattached" do

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "7.6.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "7.7.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_days_unattached" do

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent_rg.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "7.6.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "7.7.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_days_unattached" do

--- a/cost/azure/unused_load_balancers/CHANGELOG.md
+++ b/cost/azure/unused_load_balancers/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.4.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/unused_load_balancers/CHANGELOG.md
+++ b/cost/azure/unused_load_balancers/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.5.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.4.2
 

--- a/cost/azure/unused_load_balancers/azure_unused_load_balancers.pt
+++ b/cost/azure/unused_load_balancers/azure_unused_load_balancers.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.2",
+  version: "0.5.0",
   provider: "Azure",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -53,7 +53,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_subscriptions_allow_or_deny" do

--- a/cost/azure/unused_load_balancers/azure_unused_load_balancers_meta_parent.pt
+++ b/cost/azure/unused_load_balancers/azure_unused_load_balancers_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -123,7 +123,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/azure/unused_load_balancers/azure_unused_load_balancers_meta_parent_rg.pt
+++ b/cost/azure/unused_load_balancers/azure_unused_load_balancers_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -123,7 +123,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/azure/unused_storage_accounts/CHANGELOG.md
+++ b/cost/azure/unused_storage_accounts/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.5.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.4.3
 

--- a/cost/azure/unused_storage_accounts/CHANGELOG.md
+++ b/cost/azure/unused_storage_accounts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.4.3
 
 - Updated policy logic for internal consistency; no functional or user-facing changes.

--- a/cost/azure/unused_storage_accounts/azure_unused_storage_accounts.pt
+++ b/cost/azure/unused_storage_accounts/azure_unused_storage_accounts.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "0.4.3",
+  version: "0.5.0",
   provider: "Azure",
   service: "Storage",
   policy_set: "Unused Storage Accounts",
@@ -42,7 +42,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_subscriptions_allow_or_deny" do

--- a/cost/azure/unused_storage_accounts/azure_unused_storage_accounts_meta_parent.pt
+++ b/cost/azure/unused_storage_accounts/azure_unused_storage_accounts_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.4.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/azure/unused_storage_accounts/azure_unused_storage_accounts_meta_parent_rg.pt
+++ b/cost/azure/unused_storage_accounts/azure_unused_storage_accounts_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.4.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do

--- a/cost/azure/unused_volumes/CHANGELOG.md
+++ b/cost/azure/unused_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v8.6.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v8.5.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/unused_volumes/CHANGELOG.md
+++ b/cost/azure/unused_volumes/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v8.6.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v8.5.2
 

--- a/cost/azure/unused_volumes/azure_unused_volumes.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "8.5.2",
+  version: "8.6.0",
   provider: "Azure",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -43,7 +43,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_minimum_age" do

--- a/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "8.5.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "8.6.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_minimum_age" do

--- a/cost/azure/unused_volumes/azure_unused_volumes_meta_parent_rg.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "8.5.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "8.6.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -113,7 +113,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_minimum_age" do

--- a/cost/flexera/spot/ocean_recommendations/CHANGELOG.md
+++ b/cost/flexera/spot/ocean_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.4.3
 
 - Added `hash_exclude` for volatile savings and utilization fields so that recalculated estimates alone no longer cause incidents to be treated as changed/reopened.

--- a/cost/flexera/spot/ocean_recommendations/CHANGELOG.md
+++ b/cost/flexera/spot/ocean_recommendations/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.5.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.4.3
 

--- a/cost/flexera/spot/ocean_recommendations/spot_ocean_recommendations.pt
+++ b/cost/flexera/spot/ocean_recommendations/spot_ocean_recommendations.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "0.4.3",
+  version: "0.5.0",
   provider: "Flexera",
   service: "Kubernetes",
   policy_set: "Rightsize Containers",
@@ -44,7 +44,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation. This is based on the value of the 'Estimated Monthly Savings' field."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_spotinst_accounts_allow_or_deny" do

--- a/cost/google/cud_recommendations/CHANGELOG.md
+++ b/cost/google/cud_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.9.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v4.8.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/google/cud_recommendations/CHANGELOG.md
+++ b/cost/google/cud_recommendations/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.9.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v4.8.1
 

--- a/cost/google/cud_recommendations/google_committed_use_discount_recommendations.pt
+++ b/cost/google/cud_recommendations/google_committed_use_discount_recommendations.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.8.1",
+  version: "4.9.0",
   provider: "Google",
   service: "Compute",
   recommendation_type: "Rate Reduction",
@@ -34,7 +34,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_recommendation_scope" do

--- a/cost/google/cud_recommendations/google_committed_use_discount_recommendations_meta_parent.pt
+++ b/cost/google/cud_recommendations/google_committed_use_discount_recommendations_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "4.8.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.9.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_recommendation_scope" do

--- a/cost/google/extended_support/CHANGELOG.md
+++ b/cost/google/extended_support/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.2.2
 
 - Replaced non-ASCII punctuation (em dashes, curly quotes, etc.) with standard ASCII equivalents for consistent rendering in the Flexera UI. No functional changes.

--- a/cost/google/extended_support/CHANGELOG.md
+++ b/cost/google/extended_support/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.2.2
 

--- a/cost/google/extended_support/google_extended_support.pt
+++ b/cost/google/extended_support/google_extended_support.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.2",
+  version: "0.3.0",
   provider: "Google",
   service: "All",
   policy_set: "Deprecated Resources",
@@ -34,7 +34,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation. Only applies to resources currently under extended support."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_upcoming_days" do

--- a/cost/google/extended_support/google_extended_support_meta_parent.pt
+++ b/cost/google/extended_support/google_extended_support_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "0.2.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.3.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation. Only applies to resources currently under extended support."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_upcoming_days" do

--- a/cost/google/idle_ip_address_recommendations/CHANGELOG.md
+++ b/cost/google/idle_ip_address_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.6.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v4.5.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/google/idle_ip_address_recommendations/CHANGELOG.md
+++ b/cost/google/idle_ip_address_recommendations/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.6.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v4.5.1
 

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.5.1",
+  version: "4.6.0",
   provider: "Google",
   service: "Compute",
   policy_set: "Unused IP Addresses",
@@ -34,7 +34,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_projects_allow_or_deny" do

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "4.5.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.6.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_projects_ignore_sys" do

--- a/cost/google/idle_persistent_disk_recommendations/CHANGELOG.md
+++ b/cost/google/idle_persistent_disk_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.6.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v4.5.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/google/idle_persistent_disk_recommendations/CHANGELOG.md
+++ b/cost/google/idle_persistent_disk_recommendations/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.6.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v4.5.1
 

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.5.1",
+  version: "4.6.0",
   provider: "Google",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -44,7 +44,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_projects_allow_or_deny" do

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "4.5.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.6.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -114,7 +114,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_projects_ignore_sys" do

--- a/cost/google/idle_vertex_ai_endpoints/CHANGELOG.md
+++ b/cost/google/idle_vertex_ai_endpoints/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/google/idle_vertex_ai_endpoints/CHANGELOG.md
+++ b/cost/google/idle_vertex_ai_endpoints/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.2.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.1.1
 

--- a/cost/google/idle_vertex_ai_endpoints/google_idle_vertex_ai_endpoints.pt
+++ b/cost/google/idle_vertex_ai_endpoints/google_idle_vertex_ai_endpoints.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.1.1",
+  version: "0.2.0",
   provider: "Google",
   service: "AI and Machine Learning",
   policy_set: "Idle Vertex AI Endpoints",
@@ -34,7 +34,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_stats_lookback" do

--- a/cost/google/old_snapshots/CHANGELOG.md
+++ b/cost/google/old_snapshots/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v5.6.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v5.5.1
 

--- a/cost/google/old_snapshots/CHANGELOG.md
+++ b/cost/google/old_snapshots/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.6.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v5.5.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/google/old_snapshots/google_delete_old_snapshots.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.5.1",
+  version: "5.6.0",
   provider:"Google",
   service: "Storage",
   policy_set: "Old Snapshots",
@@ -34,7 +34,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_snapshot_age" do

--- a/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "5.5.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.6.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_snapshot_age" do

--- a/cost/google/recommender/CHANGELOG.md
+++ b/cost/google/recommender/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.4.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v3.3.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/google/recommender/CHANGELOG.md
+++ b/cost/google/recommender/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v3.4.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v3.3.1
 

--- a/cost/google/recommender/recommender.pt
+++ b/cost/google/recommender/recommender.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.3.1",
+  version: "3.4.0",
   provider: "Google",
   service: "All",
   policy_set: "Native Recommendations",
@@ -33,7 +33,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_recommenders" do

--- a/cost/google/recommender/recommender_meta_parent.pt
+++ b/cost/google/recommender/recommender_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "3.3.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_recommenders" do

--- a/cost/google/rightsize_cloudsql_instances/CHANGELOG.md
+++ b/cost/google/rightsize_cloudsql_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.3.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/google/rightsize_cloudsql_instances/CHANGELOG.md
+++ b/cost/google/rightsize_cloudsql_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.4.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.3.1
 

--- a/cost/google/rightsize_cloudsql_instances/google_rightsize_cloudsql_instances.pt
+++ b/cost/google/rightsize_cloudsql_instances/google_rightsize_cloudsql_instances.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.1",
+  version: "0.4.0",
   provider: "Google",
   service: "Compute",
   policy_set: "Rightsize Database Instances",
@@ -34,7 +34,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_cross_family" do

--- a/cost/google/rightsize_cloudsql_instances/google_rightsize_cloudsql_instances_meta_parent.pt
+++ b/cost/google/rightsize_cloudsql_instances/google_rightsize_cloudsql_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "0.3.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_cross_family" do

--- a/cost/google/rightsize_cloudsql_recommendations/CHANGELOG.md
+++ b/cost/google/rightsize_cloudsql_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.5.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/google/rightsize_cloudsql_recommendations/CHANGELOG.md
+++ b/cost/google/rightsize_cloudsql_recommendations/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.6.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.5.1
 

--- a/cost/google/rightsize_cloudsql_recommendations/google_rightsize_cloudsql_recommendations.pt
+++ b/cost/google/rightsize_cloudsql_recommendations/google_rightsize_cloudsql_recommendations.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.1",
+  version: "0.6.0",
   provider: "Google",
   service: "Compute",
   policy_set: "Rightsize Database Instances",
@@ -34,7 +34,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_projects_allow_or_deny" do

--- a/cost/google/rightsize_cloudsql_recommendations/google_rightsize_cloudsql_recommendations_meta_parent.pt
+++ b/cost/google/rightsize_cloudsql_recommendations/google_rightsize_cloudsql_recommendations_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "0.5.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.6.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_projects_ignore_sys" do

--- a/cost/google/rightsize_persistent_disks/CHANGELOG.md
+++ b/cost/google/rightsize_persistent_disks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.2.3
 
 - Replaced non-ASCII punctuation (em dashes, curly quotes, etc.) with standard ASCII equivalents for consistent rendering in the Flexera UI. No functional changes.

--- a/cost/google/rightsize_persistent_disks/CHANGELOG.md
+++ b/cost/google/rightsize_persistent_disks/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.2.3
 

--- a/cost/google/rightsize_persistent_disks/google_rightsize_persistent_disks.pt
+++ b/cost/google/rightsize_persistent_disks/google_rightsize_persistent_disks.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.3",
+  version: "0.3.0",
   provider: "Google",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -34,7 +34,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_days_unattached" do

--- a/cost/google/rightsize_persistent_disks/google_rightsize_persistent_disks_meta_parent.pt
+++ b/cost/google/rightsize_persistent_disks/google_rightsize_persistent_disks_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "0.2.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.3.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_days_unattached" do

--- a/cost/google/rightsize_vm_instances/CHANGELOG.md
+++ b/cost/google/rightsize_vm_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.3.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/google/rightsize_vm_instances/CHANGELOG.md
+++ b/cost/google/rightsize_vm_instances/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.4.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.3.1
 

--- a/cost/google/rightsize_vm_instances/google_rightsize_vm_instances.pt
+++ b/cost/google/rightsize_vm_instances/google_rightsize_vm_instances.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.1",
+  version: "0.4.0",
   provider: "Google",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -34,7 +34,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_cross_family" do

--- a/cost/google/rightsize_vm_instances/google_rightsize_vm_instances_meta_parent.pt
+++ b/cost/google/rightsize_vm_instances/google_rightsize_vm_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "0.3.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_cross_family" do

--- a/cost/google/rightsize_vm_recommendations/CHANGELOG.md
+++ b/cost/google/rightsize_vm_recommendations/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v3.5.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v3.4.1
 

--- a/cost/google/rightsize_vm_recommendations/CHANGELOG.md
+++ b/cost/google/rightsize_vm_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.5.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v3.4.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations.pt
+++ b/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "3.4.1",
+  version: "3.5.0",
   provider: "Google",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -34,7 +34,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_projects_allow_or_deny" do

--- a/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
+++ b/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "3.4.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.5.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_projects_ignore_sys" do

--- a/cost/google/unused_disks/CHANGELOG.md
+++ b/cost/google/unused_disks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.3.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/google/unused_disks/CHANGELOG.md
+++ b/cost/google/unused_disks/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.4.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.3.1
 

--- a/cost/google/unused_disks/google_unused_disks.pt
+++ b/cost/google/unused_disks/google_unused_disks.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.1",
+  version: "0.4.0",
   provider: "Google",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -35,7 +35,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_days_unattached" do

--- a/cost/google/unused_disks/google_unused_disks_meta_parent.pt
+++ b/cost/google/unused_disks/google_unused_disks_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "0.3.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.4.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "true",
   hide_skip_approvals: "true"
@@ -104,7 +104,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_days_unattached" do

--- a/cost/kubecost/sizing/CHANGELOG.md
+++ b/cost/kubecost/sizing/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.5.4
 
 - Added `hash_exclude` for volatile savings and utilization fields so that recalculated estimates alone no longer cause incidents to be treated as changed/reopened.

--- a/cost/kubecost/sizing/CHANGELOG.md
+++ b/cost/kubecost/sizing/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.6.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.5.4
 

--- a/cost/kubecost/sizing/kubecost_resizing_recommendation.pt
+++ b/cost/kubecost/sizing/kubecost_resizing_recommendation.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.4",
+  version: "0.6.0",
   provider: "Kubecost",
   service: "Kubernetes",
   policy_set: "Rightsize Containers",
@@ -43,7 +43,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_scope" do

--- a/cost/oracle/advisor_lifecycle_mgmt/CHANGELOG.md
+++ b/cost/oracle/advisor_lifecycle_mgmt/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.2.4
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/oracle/advisor_lifecycle_mgmt/CHANGELOG.md
+++ b/cost/oracle/advisor_lifecycle_mgmt/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.2.4
 

--- a/cost/oracle/advisor_lifecycle_mgmt/oracle_advisor_lifecycle_mgmt.pt
+++ b/cost/oracle/advisor_lifecycle_mgmt/oracle_advisor_lifecycle_mgmt.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.4",
+  version: "0.3.0",
   provider: "Oracle",
   service: "Storage",
   policy_set: "",
@@ -33,7 +33,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_root_compartment" do

--- a/cost/oracle/advisor_rightsize_autodbs/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_autodbs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.2.4
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/oracle/advisor_rightsize_autodbs/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_autodbs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.2.4
 

--- a/cost/oracle/advisor_rightsize_autodbs/oracle_advisor_rightsize_autodbs.pt
+++ b/cost/oracle/advisor_rightsize_autodbs/oracle_advisor_rightsize_autodbs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.4",
+  version: "0.3.0",
   provider: "Oracle",
   service: "Database",
   policy_set: "Rightsize Database Instances",
@@ -34,7 +34,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_root_compartment" do

--- a/cost/oracle/advisor_rightsize_basedbs/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_basedbs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.2.4
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/oracle/advisor_rightsize_basedbs/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_basedbs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.2.4
 

--- a/cost/oracle/advisor_rightsize_basedbs/oracle_advisor_rightsize_basedbs.pt
+++ b/cost/oracle/advisor_rightsize_basedbs/oracle_advisor_rightsize_basedbs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.4",
+  version: "0.3.0",
   provider: "Oracle",
   service: "Database",
   policy_set: "Rightsize Database Instances",
@@ -34,7 +34,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_root_compartment" do

--- a/cost/oracle/advisor_rightsize_lbs/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_lbs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.2.4
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/oracle/advisor_rightsize_lbs/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_lbs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.2.4
 

--- a/cost/oracle/advisor_rightsize_lbs/oracle_advisor_rightsize_lbs.pt
+++ b/cost/oracle/advisor_rightsize_lbs/oracle_advisor_rightsize_lbs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.4",
+  version: "0.3.0",
   provider: "Oracle",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -34,7 +34,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_root_compartment" do

--- a/cost/oracle/advisor_rightsize_vms/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_vms/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.4.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.3.4
 

--- a/cost/oracle/advisor_rightsize_vms/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_vms/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.3.4
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/oracle/advisor_rightsize_vms/oracle_advisor_rightsize_vms.pt
+++ b/cost/oracle/advisor_rightsize_vms/oracle_advisor_rightsize_vms.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.4",
+  version: "0.4.0",
   provider: "Oracle",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -34,7 +34,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_root_compartment" do

--- a/cost/oracle/advisor_unattached_volumes/CHANGELOG.md
+++ b/cost/oracle/advisor_unattached_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.0
+
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+
 ## v0.2.4
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/oracle/advisor_unattached_volumes/CHANGELOG.md
+++ b/cost/oracle/advisor_unattached_volumes/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3.0
 
-- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default. This only affects new applications of the policy; existing applied policies keep their current setting unless updated.
+- Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.
 
 ## v0.2.4
 

--- a/cost/oracle/advisor_unattached_volumes/oracle_advisor_unattached_volumes.pt
+++ b/cost/oracle/advisor_unattached_volumes/oracle_advisor_unattached_volumes.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.4",
+  version: "0.3.0",
   provider: "Oracle",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -34,7 +34,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation"
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_root_compartment" do

--- a/data/agent/code_examples.txt
+++ b/data/agent/code_examples.txt
@@ -1179,7 +1179,7 @@ parameter "param_min_savings" do
   label "Minimum Savings Threshold"
   description "Minimum potential savings required to generate a recommendation."
   min_value 0
-  default 0
+  default 1
 end
 
 parameter "param_regions_allow_or_deny" do


### PR DESCRIPTION
### Description

Updates the default value of the Minimum Savings Threshold parameter from 0 to 1 in all relevant policy templates. 

(Dangerfile issues unrelated to this change)
