### PR TITLE
POL-1826 Parameter Sanitization: Policy Templates #1

### DIFF
--- a/automation/aws/aws_account_credentials/CHANGELOG.md
+++ b/automation/aws/aws_account_credentials/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.2.2
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/automation/aws/aws_account_credentials/aws_account_credentials.pt
+++ b/automation/aws/aws_account_credentials/aws_account_credentials.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "0.2.2",
+  version: "0.2.3",
   provider: "AWS",
   service: "Identity & Access Management",
   policy_set: "Authentication",
@@ -182,6 +182,8 @@ script "js_aws_account_status", type:"javascript" do
   parameters "ds_cloud_vendor_accounts", "ds_get_caller_identity", "ds_applied_policy", "param_aws_account_number", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_aws_account_number = param_aws_account_number.trim()
   var csv_message = param_incident_csv == "false" ? "" : " Incident table CSV file has been attached to emails for this incident."
 
   account = _.find(ds_cloud_vendor_accounts, function(account) {

--- a/automation/aws/aws_account_credentials/aws_account_credentials_meta_parent.pt
+++ b/automation/aws/aws_account_credentials/aws_account_credentials_meta_parent.pt
@@ -7,7 +7,7 @@ category "Meta"
 default_frequency "15 minutes"
 info(
   provider: "AWS",
-  version: "0.2.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false"
 )
@@ -281,6 +281,9 @@ script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
   code <<-EOS
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_dimension_filter_includes = _.compact(_.map(param_dimension_filter_includes, function(item) { return item.trim() }))
+  param_dimension_filter_excludes = _.compact(_.map(param_dimension_filter_excludes, function(item) { return item.trim() }))
 
   billing_centers_formatted = []
 

--- a/automation/aws/aws_missing_regions/CHANGELOG.md
+++ b/automation/aws/aws_missing_regions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.3.2
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/automation/aws/aws_missing_regions/aws_missing_regions.pt
+++ b/automation/aws/aws_missing_regions/aws_missing_regions.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "0.3.2",
+  version: "0.3.3",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Automation",
@@ -249,6 +249,8 @@ script "js_missing_regions", type: "javascript" do
   parameters "ds_regions", "ds_instance_sets", "ds_aws_account", "ds_applied_policy", "param_region_list", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_region_list = _.compact(_.map(param_region_list, function(item) { return item.trim() }))
   var csv_message = param_incident_csv == "false" ? "" : " Incident table CSV file has been attached to emails for this incident."
 
   result = []

--- a/automation/aws/aws_rbd_from_org_tag/CHANGELOG.md
+++ b/automation/aws/aws_rbd_from_org_tag/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.2.2
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Updated the summary message to include the policy name.
 
 ## v0.2.1
 

--- a/automation/aws/aws_rbd_from_org_tag/CHANGELOG.md
+++ b/automation/aws/aws_rbd_from_org_tag/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.2.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/automation/aws/aws_rbd_from_org_tag/aws_rbd_from_org_tag.pt
+++ b/automation/aws/aws_rbd_from_org_tag/aws_rbd_from_org_tag.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.2.1",
+  version: "0.2.2",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Automation",
@@ -98,6 +98,18 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_effective_date_input" do
+  run_script $js_effective_date_input, $param_effective_date
+end
+
+script "js_effective_date_input", type: "javascript" do
+  parameters "param_effective_date"
+  result "result"
+  code <<-'EOS'
+  result = param_effective_date.trim()
+EOS
+end
+
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
@@ -149,11 +161,11 @@ end
 # Determine the effective date to use for the generated rules: either the static value from the
 # 'Effective Date' parameter, or the current month (YYYY-MM) when 'Effective Date Mode' is 'Current Month'
 datasource "ds_effective_date" do
-  run_script $js_effective_date, $param_effective_date, $param_effective_date_mode
+  run_script $js_effective_date, $ds_effective_date_input, $param_effective_date_mode
 end
 
 script "js_effective_date", type: "javascript" do
-  parameters "param_effective_date", "param_effective_date_mode"
+  parameters "ds_effective_date_input", "param_effective_date_mode"
   result "result"
   code <<-'EOS'
   if (param_effective_date_mode == "Current Month") {
@@ -162,7 +174,7 @@ script "js_effective_date", type: "javascript" do
     month = ("0" + (now.getUTCMonth() + 1)).slice(-2)
     result = year + "-" + month
   } else {
-    result = param_effective_date
+    result = ds_effective_date_input
   }
 EOS
 end
@@ -284,6 +296,9 @@ script "js_new_rules", type: "javascript" do
   parameters "accounts", "effective_date", "param_name_list", "param_tag_list", "param_normalize_case"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_name_list = _.compact(_.map(param_name_list, function(item) { return item.trim() }))
+  param_tag_list = _.compact(_.map(param_tag_list, function(item) { return item.trim() }))
   rule_lists = []
 
   _.each(param_tag_list, function(tag, index) {

--- a/automation/aws/aws_rbd_from_org_tag/aws_rbd_from_org_tag.pt
+++ b/automation/aws/aws_rbd_from_org_tag/aws_rbd_from_org_tag.pt
@@ -533,13 +533,25 @@ script "js_apply_rbds", type: "javascript" do
 EOS
 end
 
+datasource "ds_rbds_summary" do
+  run_script $js_rbds_summary, $ds_apply_rbds, $ds_applied_policy
+end
+
+script "js_rbds_summary", type: "javascript" do
+  parameters "ds_apply_rbds", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = [{ policy_name: ds_applied_policy["name"] }]
+EOS
+end
+
 ###############################################################################
 # Policy
 ###############################################################################
 
 policy "pol_rbds" do
-  validate $ds_apply_rbds do
-    summary_template "RBDs Generated & Applied"
+  validate $ds_rbds_summary do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: RBDs Generated & Applied"
     detail_template ""
     check eq(0, 0)
   end

--- a/automation/aws/aws_rbd_from_tag/CHANGELOG.md
+++ b/automation/aws/aws_rbd_from_tag/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.2.2
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/automation/aws/aws_rbd_from_tag/aws_rbd_from_tag.pt
+++ b/automation/aws/aws_rbd_from_tag/aws_rbd_from_tag.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "3.2.2",
+  version: "3.2.3",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Automation",
@@ -77,6 +77,18 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_effective_date_input" do
+  run_script $js_effective_date_input, $param_effective_date
+end
+
+script "js_effective_date_input", type: "javascript" do
+  parameters "param_effective_date"
+  result "result"
+  code <<-'EOS'
+  result = param_effective_date.trim()
+EOS
+end
+
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
@@ -128,11 +140,11 @@ end
 # Determine the effective date to use for the generated rules: either the static value from the
 # 'Effective Date' parameter, or the current month (YYYY-MM) when 'Effective Date Mode' is 'Current Month'
 datasource "ds_effective_date" do
-  run_script $js_effective_date, $param_effective_date, $param_effective_date_mode
+  run_script $js_effective_date, $ds_effective_date_input, $param_effective_date_mode
 end
 
 script "js_effective_date", type: "javascript" do
-  parameters "param_effective_date", "param_effective_date_mode"
+  parameters "ds_effective_date_input", "param_effective_date_mode"
   result "result"
   code <<-'EOS'
   if (param_effective_date_mode == "Current Month") {
@@ -141,7 +153,7 @@ script "js_effective_date", type: "javascript" do
     month = ("0" + (now.getUTCMonth() + 1)).slice(-2)
     result = year + "-" + month
   } else {
-    result = param_effective_date
+    result = ds_effective_date_input
   }
 EOS
 end
@@ -210,6 +222,9 @@ script "js_new_rules", type: "javascript" do
   parameters "accounts", "effective_date", "param_name_list", "param_tag_list", "param_normalize_case"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_name_list = _.compact(_.map(param_name_list, function(item) { return item.trim() }))
+  param_tag_list = _.compact(_.map(param_tag_list, function(item) { return item.trim() }))
   rule_lists = []
 
   _.each(param_tag_list, function(tag, index) {

--- a/automation/aws/aws_s3_usage_type_rbd/CHANGELOG.md
+++ b/automation/aws/aws_s3_usage_type_rbd/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.9
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.1.8
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/automation/aws/aws_s3_usage_type_rbd/aws_s3_usage_type_rbd.pt
+++ b/automation/aws/aws_s3_usage_type_rbd/aws_s3_usage_type_rbd.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.1.8",
+  version: "0.1.9",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Automation",
@@ -324,6 +324,8 @@ script "js_rbds", type: "javascript" do
   parameters "ds_s3_usage_types", "ds_existing_rbds", "param_rbd_id", "param_rbd_name", "param_effective_date"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_rbd_name = param_rbd_name.trim()
   verb = "POST"
   if (_.contains(_.pluck(ds_existing_rbds, 'id'), param_rbd_id)) { verb = "PATCH" }
 

--- a/automation/azure/azure_credential/CHANGELOG.md
+++ b/automation/azure/azure_credential/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.3.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/automation/azure/azure_credential/azure_credential.pt
+++ b/automation/azure/azure_credential/azure_credential.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "0.3.1",
+  version: "0.3.2",
   provider: "Azure",
   service: "Identity & Access Management",
   policy_set: "Authentication",

--- a/automation/azure/azure_credential/azure_credential_meta_parent.pt
+++ b/automation/azure/azure_credential/azure_credential_meta_parent.pt
@@ -7,7 +7,7 @@ category "Meta"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "0.3.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.3.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false"
 )
@@ -294,6 +294,9 @@ script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
   code <<-EOS
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_dimension_filter_includes = _.compact(_.map(param_dimension_filter_includes, function(item) { return item.trim() }))
+  param_dimension_filter_excludes = _.compact(_.map(param_dimension_filter_excludes, function(item) { return item.trim() }))
 
   billing_centers_formatted = []
 

--- a/automation/azure/azure_missing_subscriptions/CHANGELOG.md
+++ b/automation/azure/azure_missing_subscriptions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.3.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/automation/azure/azure_missing_subscriptions/azure_missing_subscriptions.pt
+++ b/automation/azure/azure_missing_subscriptions/azure_missing_subscriptions.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "0.3.1",
+  version: "0.3.2",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Automation",
@@ -307,6 +307,8 @@ script "js_missing_subscriptions_api", type: "javascript" do
   parameters "ds_flexera_cco_data", "ds_azure_subscriptions", "ds_applied_policy", "param_subscriptions_list", "param_report_selection", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   var csv_message = param_incident_csv == "false" ? "" : " Incident table CSV file has been attached to emails for this incident."
 
   result = []
@@ -350,6 +352,8 @@ script "js_missing_subscriptions_cco", type: "javascript" do
   parameters "ds_flexera_cco_data", "ds_azure_subscriptions", "ds_applied_policy", "param_subscriptions_list", "param_report_selection", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   var csv_message = param_incident_csv == "false" ? "" : " Incident table CSV file has been attached to emails for this incident."
 
   result = []

--- a/automation/azure/azure_rbd_for_tenant_id/CHANGELOG.md
+++ b/automation/azure/azure_rbd_for_tenant_id/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.1.2
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Updated the summary message to include the policy name.
 
 ## v0.1.1
 

--- a/automation/azure/azure_rbd_for_tenant_id/CHANGELOG.md
+++ b/automation/azure/azure_rbd_for_tenant_id/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/automation/azure/azure_rbd_for_tenant_id/azure_rbd_for_tenant_id.pt
+++ b/automation/azure/azure_rbd_for_tenant_id/azure_rbd_for_tenant_id.pt
@@ -584,13 +584,25 @@ script "js_apply_rbds", type: "javascript" do
 EOS
 end
 
+datasource "ds_rbds_summary" do
+  run_script $js_rbds_summary, $ds_apply_rbds, $ds_applied_policy
+end
+
+script "js_rbds_summary", type: "javascript" do
+  parameters "ds_apply_rbds", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = [{ policy_name: ds_applied_policy["name"] }]
+EOS
+end
+
 ###############################################################################
 # Policy
 ###############################################################################
 
 policy "pol_rbds" do
-  validate $ds_apply_rbds do
-    summary_template "RBD Generated & Applied"
+  validate $ds_rbds_summary do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: RBD Generated & Applied"
     detail_template ""
     check eq(0, 0)
   end

--- a/automation/azure/azure_rbd_for_tenant_id/azure_rbd_for_tenant_id.pt
+++ b/automation/azure/azure_rbd_for_tenant_id/azure_rbd_for_tenant_id.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.1.1",
+  version: "0.1.2",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Automation",
@@ -68,6 +68,18 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_effective_date_input" do
+  run_script $js_effective_date_input, $param_effective_date
+end
+
+script "js_effective_date_input", type: "javascript" do
+  parameters "param_effective_date"
+  result "result"
+  code <<-'EOS'
+  result = param_effective_date.trim()
+EOS
+end
+
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
@@ -119,11 +131,11 @@ end
 # Determine the effective date to use for the generated rules: either the static value from the
 # 'Effective Date' parameter, or the current month (YYYY-MM) when 'Effective Date Mode' is 'Current Month'
 datasource "ds_effective_date" do
-  run_script $js_effective_date, $param_effective_date, $param_effective_date_mode
+  run_script $js_effective_date, $ds_effective_date_input, $param_effective_date_mode
 end
 
 script "js_effective_date", type: "javascript" do
-  parameters "param_effective_date", "param_effective_date_mode"
+  parameters "ds_effective_date_input", "param_effective_date_mode"
   result "result"
   code <<-'EOS'
   if (param_effective_date_mode == "Current Month") {
@@ -132,7 +144,7 @@ script "js_effective_date", type: "javascript" do
     month = ("0" + (now.getUTCMonth() + 1)).slice(-2)
     result = year + "-" + month
   } else {
-    result = param_effective_date
+    result = ds_effective_date_input
   }
 EOS
 end
@@ -369,6 +381,9 @@ script "js_new_rules", type: "javascript" do
   parameters "ds_combined_data", "ds_effective_date", "param_rbd_id", "param_rbd_name"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_rbd_id = param_rbd_id.trim()
+  param_rbd_name = param_rbd_name.trim()
   rules = _.map(ds_combined_data, function(item) {
     return {
       condition: { type: "dimension_equals", dimension: "vendor_account", value: item['vendor_account'] },

--- a/automation/azure/azure_rbd_from_rg_tag/CHANGELOG.md
+++ b/automation/azure/azure_rbd_from_rg_tag/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v2.2.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/automation/azure/azure_rbd_from_rg_tag/CHANGELOG.md
+++ b/automation/azure/azure_rbd_from_rg_tag/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.2.2
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Updated the summary message to include the policy name.
 
 ## v2.2.1
 

--- a/automation/azure/azure_rbd_from_rg_tag/azure_rbd_from_rg_tag.pt
+++ b/automation/azure/azure_rbd_from_rg_tag/azure_rbd_from_rg_tag.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.2.1",
+  version: "2.2.2",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Automation",
@@ -106,6 +106,18 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_effective_date_input" do
+  run_script $js_effective_date_input, $param_effective_date
+end
+
+script "js_effective_date_input", type: "javascript" do
+  parameters "param_effective_date"
+  result "result"
+  code <<-'EOS'
+  result = param_effective_date.trim()
+EOS
+end
+
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
@@ -157,11 +169,11 @@ end
 # Determine the effective date to use for the generated rules: either the static value from the
 # 'Effective Date' parameter, or the current month (YYYY-MM) when 'Effective Date Mode' is 'Current Month'
 datasource "ds_effective_date" do
-  run_script $js_effective_date, $param_effective_date, $param_effective_date_mode
+  run_script $js_effective_date, $ds_effective_date_input, $param_effective_date_mode
 end
 
 script "js_effective_date", type: "javascript" do
-  parameters "param_effective_date", "param_effective_date_mode"
+  parameters "ds_effective_date_input", "param_effective_date_mode"
   result "result"
   code <<-'EOS'
   if (param_effective_date_mode == "Current Month") {
@@ -170,7 +182,7 @@ script "js_effective_date", type: "javascript" do
     month = ("0" + (now.getUTCMonth() + 1)).slice(-2)
     result = year + "-" + month
   } else {
-    result = param_effective_date
+    result = ds_effective_date_input
   }
 EOS
 end
@@ -314,6 +326,9 @@ script "js_new_rules", type: "javascript" do
   parameters "rgs", "accounts", "effective_date", "param_name_list", "param_tag_list", "param_subscription_fallback", "param_normalize_case"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_name_list = _.compact(_.map(param_name_list, function(item) { return item.trim() }))
+  param_tag_list = _.compact(_.map(param_tag_list, function(item) { return item.trim() }))
   rule_lists = []
 
   _.each(param_tag_list, function(tag, index) {

--- a/automation/azure/azure_rbd_from_rg_tag/azure_rbd_from_rg_tag.pt
+++ b/automation/azure/azure_rbd_from_rg_tag/azure_rbd_from_rg_tag.pt
@@ -605,13 +605,25 @@ script "js_apply_rbds", type: "javascript" do
 EOS
 end
 
+datasource "ds_rbds_summary" do
+  run_script $js_rbds_summary, $ds_apply_rbds, $ds_applied_policy
+end
+
+script "js_rbds_summary", type: "javascript" do
+  parameters "ds_apply_rbds", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = [{ policy_name: ds_applied_policy["name"] }]
+EOS
+end
+
 ###############################################################################
 # Policy
 ###############################################################################
 
 policy "pol_rbds" do
-  validate $ds_apply_rbds do
-    summary_template "RBDs Generated & Applied"
+  validate $ds_rbds_summary do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: RBDs Generated & Applied"
     detail_template ""
     check eq(0, 0)
   end

--- a/automation/azure/azure_rbd_from_tag/CHANGELOG.md
+++ b/automation/azure/azure_rbd_from_tag/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v2.2.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/automation/azure/azure_rbd_from_tag/CHANGELOG.md
+++ b/automation/azure/azure_rbd_from_tag/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.2.2
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Updated the summary message to include the policy name.
 
 ## v2.2.1
 

--- a/automation/azure/azure_rbd_from_tag/azure_rbd_from_tag.pt
+++ b/automation/azure/azure_rbd_from_tag/azure_rbd_from_tag.pt
@@ -500,13 +500,25 @@ script "js_apply_rbds", type: "javascript" do
 EOS
 end
 
+datasource "ds_rbds_summary" do
+  run_script $js_rbds_summary, $ds_apply_rbds, $ds_applied_policy
+end
+
+script "js_rbds_summary", type: "javascript" do
+  parameters "ds_apply_rbds", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = [{ policy_name: ds_applied_policy["name"] }]
+EOS
+end
+
 ###############################################################################
 # Policy
 ###############################################################################
 
 policy "pol_rbds" do
-  validate $ds_apply_rbds do
-    summary_template "RBDs Generated & Applied"
+  validate $ds_rbds_summary do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: RBDs Generated & Applied"
     detail_template ""
     check eq(0, 0)
   end

--- a/automation/azure/azure_rbd_from_tag/azure_rbd_from_tag.pt
+++ b/automation/azure/azure_rbd_from_tag/azure_rbd_from_tag.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.2.1",
+  version: "2.2.2",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Automation",
@@ -97,6 +97,18 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_effective_date_input" do
+  run_script $js_effective_date_input, $param_effective_date
+end
+
+script "js_effective_date_input", type: "javascript" do
+  parameters "param_effective_date"
+  result "result"
+  code <<-'EOS'
+  result = param_effective_date.trim()
+EOS
+end
+
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
@@ -148,11 +160,11 @@ end
 # Determine the effective date to use for the generated rules: either the static value from the
 # 'Effective Date' parameter, or the current month (YYYY-MM) when 'Effective Date Mode' is 'Current Month'
 datasource "ds_effective_date" do
-  run_script $js_effective_date, $param_effective_date, $param_effective_date_mode
+  run_script $js_effective_date, $ds_effective_date_input, $param_effective_date_mode
 end
 
 script "js_effective_date", type: "javascript" do
-  parameters "param_effective_date", "param_effective_date_mode"
+  parameters "ds_effective_date_input", "param_effective_date_mode"
   result "result"
   code <<-'EOS'
   if (param_effective_date_mode == "Current Month") {
@@ -161,7 +173,7 @@ script "js_effective_date", type: "javascript" do
     month = ("0" + (now.getUTCMonth() + 1)).slice(-2)
     result = year + "-" + month
   } else {
-    result = param_effective_date
+    result = ds_effective_date_input
   }
 EOS
 end
@@ -251,6 +263,9 @@ script "js_new_rules", type: "javascript" do
   parameters "accounts", "effective_date", "param_name_list", "param_tag_list", "param_normalize_case"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_name_list = _.compact(_.map(param_name_list, function(item) { return item.trim() }))
+  param_tag_list = _.compact(_.map(param_tag_list, function(item) { return item.trim() }))
   rule_lists = []
 
   _.each(param_tag_list, function(tag, index) {

--- a/automation/flexera/additional_dimensions/CHANGELOG.md
+++ b/automation/flexera/additional_dimensions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.2.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/automation/flexera/additional_dimensions/additional_dimensions.pt
+++ b/automation/flexera/additional_dimensions/additional_dimensions.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "monthly"
 info(
-  version: "0.2.1",
+  version: "0.2.2",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Automation",
@@ -71,6 +71,18 @@ end
 ###############################################################################
 # Datasources & Scripts
 ###############################################################################
+
+datasource "ds_effective_date_input" do
+  run_script $js_effective_date_input, $param_effective_date
+end
+
+script "js_effective_date_input", type: "javascript" do
+  parameters "param_effective_date"
+  result "result"
+  code <<-'EOS'
+  result = param_effective_date.trim()
+EOS
+end
 
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
@@ -175,11 +187,11 @@ datasource "ds_existing_rbds" do
 end
 
 datasource "ds_rbds_to_create" do
-  run_script $js_rbds_to_create, $ds_rbds_json, $ds_existing_rbds, $param_effective_date
+  run_script $js_rbds_to_create, $ds_rbds_json, $ds_existing_rbds, $ds_effective_date_input
 end
 
 script "js_rbds_to_create", type: "javascript" do
-  parameters "ds_rbds_json", "ds_existing_rbds", "param_effective_date"
+  parameters "ds_rbds_json", "ds_existing_rbds", "ds_effective_date_input"
   result "result"
   code <<-'EOS'
   existing_ids = _.pluck(ds_existing_rbds, "id")
@@ -191,7 +203,7 @@ script "js_rbds_to_create", type: "javascript" do
       id: rbd["id"],
       name: rbd["name"],
       rules: rbd["rules"],
-      effective_at: param_effective_date,
+      effective_at: ds_effective_date_input,
       verb: _.contains(existing_ids, rbd["id"]) ? "PATCH" : "POST"
     }
   }), function(item) {

--- a/automation/flexera/create_service_account/CHANGELOG.md
+++ b/automation/flexera/create_service_account/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/automation/flexera/create_service_account/create_service_account.pt
+++ b/automation/flexera/create_service_account/create_service_account.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "0.1.1",
+  version: "0.1.2",
   provider: "Flexera",
   service: "Identity & Access Management",
   policy_set: "Automation",
@@ -146,6 +146,30 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_sa_description" do
+  run_script $js_sa_description, $param_sa_description
+end
+
+script "js_sa_description", type: "javascript" do
+  parameters "param_sa_description"
+  result "result"
+  code <<-'EOS'
+  result = param_sa_description.trim()
+EOS
+end
+
+datasource "ds_sa_name" do
+  run_script $js_sa_name, $param_sa_name
+end
+
+script "js_sa_name", type: "javascript" do
+  parameters "param_sa_name"
+  result "result"
+  code <<-'EOS'
+  result = param_sa_name.trim()
+EOS
+end
+
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
 end
@@ -191,8 +215,8 @@ datasource "ds_create_service_account" do
     host val($ds_flexera_api_hosts, "flexera")
     path join(["/iam/v1/orgs/", rs_org_id, "/service-accounts"])
     header "User-Agent", "RS Policies"
-    body_field "name", $param_sa_name
-    body_field "description", $param_sa_description
+    body_field "name", $ds_sa_name
+    body_field "description", $ds_sa_description
   end
 end
 
@@ -226,15 +250,15 @@ EOS
 end
 
 datasource "ds_service_account" do
-  run_script $js_service_account, $ds_list_service_accounts, $param_sa_name
+  run_script $js_service_account, $ds_list_service_accounts, $ds_sa_name
 end
 
 script "js_service_account", type: "javascript" do
-  parameters "ds_list_service_accounts", "param_sa_name"
+  parameters "ds_list_service_accounts", "ds_sa_name"
   result "result"
   code <<-'EOS'
   result = {}
-  var match = _.find(ds_list_service_accounts, function(sa) { return sa["name"] == param_sa_name })
+  var match = _.find(ds_list_service_accounts, function(sa) { return sa["name"] == ds_sa_name })
   if (match) { result = match }
 EOS
 end
@@ -377,15 +401,15 @@ end
 
 datasource "ds_create_credential" do
   request do
-    run_script $js_create_credential, $ds_create_client, $ds_flexera_api_hosts, $param_sa_name, $param_sa_description, rs_project_id
+    run_script $js_create_credential, $ds_create_client, $ds_flexera_api_hosts, $ds_sa_name, $ds_sa_description, rs_project_id
   end
 end
 
 script "js_create_credential", type: "javascript" do
-  parameters "ds_create_client", "ds_flexera_api_hosts", "param_sa_name", "param_sa_description", "rs_project_id"
+  parameters "ds_create_client", "ds_flexera_api_hosts", "ds_sa_name", "ds_sa_description", "rs_project_id"
   result "request"
   code <<-'EOS'
-  var cred_id = param_sa_name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '')
+  var cred_id = ds_sa_name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '')
 
   var request = {
     auth: "auth_flexera",
@@ -394,8 +418,8 @@ script "js_create_credential", type: "javascript" do
     path: "/cred/v2/projects/" + rs_project_id + "/credentials/oauth2/" + cred_id,
     headers: { "Api-Version": "1.0", "User-Agent": "RS Policies" },
     body_fields: {
-      "name": param_sa_name,
-      "description": param_sa_description,
+      "name": ds_sa_name,
+      "description": ds_sa_description,
       "grantType": "client_credentials",
       "tokenUrl": "https://" + ds_flexera_api_hosts["login"] + "/oidc/token",
       "tags": [
@@ -412,7 +436,7 @@ end
 
 datasource "ds_credential" do
   request do
-    run_script $js_credential, $ds_create_credential, $ds_flexera_api_hosts, $param_sa_name, rs_project_id
+    run_script $js_credential, $ds_create_credential, $ds_flexera_api_hosts, $ds_sa_name, rs_project_id
   end
   result do
     encoding "json"
@@ -424,10 +448,10 @@ datasource "ds_credential" do
 end
 
 script "js_credential", type: "javascript" do
-  parameters "ds_create_credential", "ds_flexera_api_hosts", "param_sa_name", "rs_project_id"
+  parameters "ds_create_credential", "ds_flexera_api_hosts", "ds_sa_name", "rs_project_id"
   result "request"
   code <<-'EOS'
-  var cred_id = param_sa_name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '')
+  var cred_id = ds_sa_name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '')
 
   var request = {
     auth: "auth_flexera",
@@ -439,11 +463,11 @@ EOS
 end
 
 datasource "ds_incident" do
-  run_script $js_incident, $ds_service_account, $ds_assign_roles, $ds_credential, $ds_applied_policy, $param_sa_description
+  run_script $js_incident, $ds_service_account, $ds_assign_roles, $ds_credential, $ds_applied_policy, $ds_sa_description
 end
 
 script "js_incident", type: "javascript" do
-  parameters "ds_service_account", "ds_assign_roles", "ds_credential", "ds_applied_policy", "param_sa_description"
+  parameters "ds_service_account", "ds_assign_roles", "ds_credential", "ds_applied_policy", "ds_sa_description"
   result "result"
   code <<-'EOS'
   var sa = ds_service_account
@@ -457,7 +481,7 @@ script "js_incident", type: "javascript" do
     "### Flexera Automation Credential\n\n" +
     "- **Credential ID:** " + cred["id"] + "\n" +
     "- **Credential Name:** " + cred["name"] + "\n" +
-    "- **Credential Description:** " + (param_sa_description || "(none)") + "\n\n" +
+    "- **Credential Description:** " + (ds_sa_description || "(none)") + "\n\n" +
     "### Roles Assigned to Service Account\n\n" +
     roles_text +
     "\n### Next Steps\n\n" +

--- a/automation/flexera/disallowed_credentials/CHANGELOG.md
+++ b/automation/flexera/disallowed_credentials/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.2.2
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/automation/flexera/disallowed_credentials/disallowed_credentials.pt
+++ b/automation/flexera/disallowed_credentials/disallowed_credentials.pt
@@ -8,7 +8,7 @@ severity "high"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "0.2.2",
+  version: "0.2.3",
   provider: "Flexera",
   service: "Automation",
   policy_set: "Automation",
@@ -238,6 +238,8 @@ script "js_disallowed_credentials", type: "javascript" do
   parameters "ds_credentials_combined", "param_cred_allow_list", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_cred_allow_list = _.compact(_.map(param_cred_allow_list, function(item) { return item.trim() }))
   var csv_message = param_incident_csv == "false" ? "" : " Incident table CSV file has been attached to emails for this incident."
 
   result = _.reject(ds_credentials_combined, function(cred) {

--- a/automation/flexera/outdated_applied_policies/CHANGELOG.md
+++ b/automation/flexera/outdated_applied_policies/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.3.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/automation/flexera/outdated_applied_policies/outdated_applied_policies.pt
+++ b/automation/flexera/outdated_applied_policies/outdated_applied_policies.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "0.3.1",
+  version: "0.3.2",
   provider: "Flexera",
   service: "Automation",
   policy_set: "Automation",
@@ -266,6 +266,8 @@ script "js_outdated_policies", type: "javascript" do
   parameters "ds_applied_policies", "ds_catalog_policies", "ds_applied_aggregates", "ds_flexera_api_hosts", "ds_self_policy", "param_ignore_list", "param_report_filter", "param_incident_csv", "rs_org_id", "rs_project_id", "policy_id", "rs_optima_host"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_ignore_list = _.compact(_.map(param_ignore_list, function(item) { return item.trim() }))
   var csv_message = param_incident_csv == "false" ? "" : " Incident table CSV file has been attached to emails for this incident."
 
   tld_table = {
@@ -471,6 +473,8 @@ script "js_deprecated_policies", type: "javascript" do
   parameters "ds_applied_policies", "ds_catalog_policies", "ds_applied_aggregates", "ds_flexera_api_hosts", "ds_self_policy", "param_ignore_list", "param_report_filter", "param_incident_csv", "rs_org_id", "rs_project_id", "policy_id", "rs_optima_host"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_ignore_list = _.compact(_.map(param_ignore_list, function(item) { return item.trim() }))
   var csv_message = param_incident_csv == "false" ? "" : " Incident table CSV file has been attached to emails for this incident."
 
   tld_table = {

--- a/automation/flexera/rbd_from_custom_tag/CHANGELOG.md
+++ b/automation/flexera/rbd_from_custom_tag/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.2.2
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Updated the summary message to include the policy name.
 
 ## v0.2.1
 

--- a/automation/flexera/rbd_from_custom_tag/CHANGELOG.md
+++ b/automation/flexera/rbd_from_custom_tag/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.2.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/automation/flexera/rbd_from_custom_tag/rbd_from_custom_tag.pt
+++ b/automation/flexera/rbd_from_custom_tag/rbd_from_custom_tag.pt
@@ -549,13 +549,25 @@ script "js_apply_rbds", type: "javascript" do
 EOS
 end
 
+datasource "ds_rbds_summary" do
+  run_script $js_rbds_summary, $ds_apply_rbds, $ds_applied_policy
+end
+
+script "js_rbds_summary", type: "javascript" do
+  parameters "ds_apply_rbds", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = [{ policy_name: ds_applied_policy["name"] }]
+EOS
+end
+
 ###############################################################################
 # Policy
 ###############################################################################
 
 policy "pol_rbds" do
-  validate $ds_apply_rbds do
-    summary_template "RBDs Generated & Applied"
+  validate $ds_rbds_summary do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: RBDs Generated & Applied"
     detail_template ""
     check eq(0, 0)
   end

--- a/automation/flexera/rbd_from_custom_tag/rbd_from_custom_tag.pt
+++ b/automation/flexera/rbd_from_custom_tag/rbd_from_custom_tag.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.2.1",
+  version: "0.2.2",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Automation",
@@ -77,6 +77,18 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_effective_date_input" do
+  run_script $js_effective_date_input, $param_effective_date
+end
+
+script "js_effective_date_input", type: "javascript" do
+  parameters "param_effective_date"
+  result "result"
+  code <<-'EOS'
+  result = param_effective_date.trim()
+EOS
+end
+
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
@@ -128,11 +140,11 @@ end
 # Determine the effective date to use for the generated rules: either the static value from the
 # 'Effective Date' parameter, or the current month (YYYY-MM) when 'Effective Date Mode' is 'Current Month'
 datasource "ds_effective_date" do
-  run_script $js_effective_date, $param_effective_date, $param_effective_date_mode
+  run_script $js_effective_date, $ds_effective_date_input, $param_effective_date_mode
 end
 
 script "js_effective_date", type: "javascript" do
-  parameters "param_effective_date", "param_effective_date_mode"
+  parameters "ds_effective_date_input", "param_effective_date_mode"
   result "result"
   code <<-'EOS'
   if (param_effective_date_mode == "Current Month") {
@@ -141,7 +153,7 @@ script "js_effective_date", type: "javascript" do
     month = ("0" + (now.getUTCMonth() + 1)).slice(-2)
     result = year + "-" + month
   } else {
-    result = param_effective_date
+    result = ds_effective_date_input
   }
 EOS
 end
@@ -214,6 +226,8 @@ script "js_custom_tags", type: "javascript" do
   parameters "ds_dimensions", "param_tag_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_tag_list = _.compact(_.map(param_tag_list, function(item) { return item.trim() }))
   result = _.filter(ds_dimensions, function(dimension) {
     return dimension["type"] == "Tags" && (_.contains(param_tag_list, dimension['name']) || _.contains(param_tag_list, dimension['id']))
   })
@@ -313,6 +327,8 @@ script "js_new_rules", type: "javascript" do
   parameters "ds_tag_values", "effective_date", "param_name_list", "param_normalize_case"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_name_list = _.compact(_.map(param_name_list, function(item) { return item.trim() }))
   rule_lists = []
 
   _.each(ds_tag_values, function(item, index) {

--- a/automation/flexera/spot/commitment_source_rbd/CHANGELOG.md
+++ b/automation/flexera/spot/commitment_source_rbd/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.2.2
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Updated the summary message to include the policy name.
 
 ## v0.2.1
 

--- a/automation/flexera/spot/commitment_source_rbd/CHANGELOG.md
+++ b/automation/flexera/spot/commitment_source_rbd/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.2.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/automation/flexera/spot/commitment_source_rbd/commitment_source_rbd.pt
+++ b/automation/flexera/spot/commitment_source_rbd/commitment_source_rbd.pt
@@ -361,13 +361,25 @@ script "js_apply_rbds", type: "javascript" do
 EOS
 end
 
+datasource "ds_rbds_summary" do
+  run_script $js_rbds_summary, $ds_apply_rbds, $ds_applied_policy
+end
+
+script "js_rbds_summary", type: "javascript" do
+  parameters "ds_apply_rbds", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = [{ policy_name: ds_applied_policy["name"] }]
+EOS
+end
+
 ###############################################################################
 # Policy
 ###############################################################################
 
 policy "pol_rbds" do
-  validate $ds_apply_rbds do
-    summary_template "Commitment Source RBD Generated & Applied"
+  validate $ds_rbds_summary do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: Commitment Source RBD Generated & Applied"
     detail_template ""
     check eq(0, 0)
   end

--- a/automation/flexera/spot/commitment_source_rbd/commitment_source_rbd.pt
+++ b/automation/flexera/spot/commitment_source_rbd/commitment_source_rbd.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.2.1",
+  version: "0.2.2",
   provider: "Flexera",
   service: "Spot Eco",
   policy_set: "Spot Eco",
@@ -96,6 +96,18 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_effective_date_input" do
+  run_script $js_effective_date_input, $param_effective_date
+end
+
+script "js_effective_date_input", type: "javascript" do
+  parameters "param_effective_date"
+  result "result"
+  code <<-'EOS'
+  result = param_effective_date.trim()
+EOS
+end
+
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
@@ -147,11 +159,11 @@ end
 # Determine the effective date to use for the generated rules: either the static value from the
 # 'Effective Date' parameter, or the current month (YYYY-MM) when 'Effective Date Mode' is 'Current Month'
 datasource "ds_effective_date" do
-  run_script $js_effective_date, $param_effective_date, $param_effective_date_mode
+  run_script $js_effective_date, $ds_effective_date_input, $param_effective_date_mode
 end
 
 script "js_effective_date", type: "javascript" do
-  parameters "param_effective_date", "param_effective_date_mode"
+  parameters "ds_effective_date_input", "param_effective_date_mode"
   result "result"
   code <<-'EOS'
   if (param_effective_date_mode == "Current Month") {
@@ -160,7 +172,7 @@ script "js_effective_date", type: "javascript" do
     month = ("0" + (now.getUTCMonth() + 1)).slice(-2)
     result = year + "-" + month
   } else {
-    result = param_effective_date
+    result = ds_effective_date_input
   }
 EOS
 end
@@ -197,6 +209,8 @@ script "js_eco_commitments", type: "javascript" do
   parameters "param_spot_org_id"
   result "request"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_spot_org_id = param_spot_org_id.trim()
   start_date = new Date("2010-01-01")
   start_date = Math.round(start_date.getTime() / 1000).toString()
 
@@ -243,6 +257,9 @@ script "js_rbds", type: "javascript" do
   parameters "ds_eco_commitments", "ds_existing_rbds", "ds_applied_policy", "effective_date", "param_rbd_name", "param_rbd_id"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_rbd_name = param_rbd_name.trim()
+  param_rbd_id = param_rbd_id.trim()
   eco_rbd = _.find(ds_existing_rbds, function(rbd) { return rbd['id'] == param_rbd_id })
   eco_purchased = _.filter(ds_eco_commitments, function(entry) { return entry["source"] == "Eco" })
 

--- a/automation/flexera/spot/container_cost_visibility/CHANGELOG.md
+++ b/automation/flexera/spot/container_cost_visibility/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.5
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.1.4
 
 - Replaced non-ASCII punctuation (em dashes, curly quotes, etc.) with standard ASCII equivalents for consistent rendering in the Flexera UI. No functional changes.

--- a/automation/flexera/spot/container_cost_visibility/flexera_spot_container_cost_visibility.pt
+++ b/automation/flexera/spot/container_cost_visibility/flexera_spot_container_cost_visibility.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "monthly"
 info(
-  version: "0.1.4",
+  version: "0.1.5",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Container Cost Visibility",
@@ -175,6 +175,8 @@ script "js_bill_connect_request", type: "javascript" do
   parameters "ds_existing_bill_connects", "ds_flexera_api_hosts", "param_spot_ocean_org_id", "rs_org_id"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_spot_ocean_org_id = param_spot_ocean_org_id.trim()
   var bill_identifier = "org-" + param_spot_ocean_org_id
   var bill_connect_id = "cbi-oi-ocean-" + bill_identifier
 
@@ -577,6 +579,8 @@ script "js_updated_adjustments", type: "javascript" do
   parameters "ds_current_adjustments", "ds_bill_connect", "param_hide_ccv_costs", "param_spot_ocean_org_id"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_spot_ocean_org_id = param_spot_ocean_org_id.trim()
   result = []
 
   if (param_hide_ccv_costs == "Yes") {
@@ -860,6 +864,8 @@ script "js_results", type: "javascript" do
   parameters "ds_bill_connect", "ds_create_dashboard", "ds_existing_dashboards", "ds_create_tag_dimensions", "ds_apply_adjustments", "ds_spot_cco_integration", "ds_apply_rightsizing", "ds_existing_bill_connects", "ds_published_templates", "ds_applied_policies", "ds_flexera_api_hosts", "param_spot_ocean_org_id", "param_create_dashboard", "param_create_tag_dimensions", "param_hide_ccv_costs", "param_apply_rightsizing", "rs_org_id"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_spot_ocean_org_id = param_spot_ocean_org_id.trim()
   var bill_connect_id = "cbi-oi-ocean-org-" + param_spot_ocean_org_id
   var ui_host = ds_flexera_api_hosts["ui"]
   var flexera_host = ds_flexera_api_hosts["flexera"]


### PR DESCRIPTION
### Description

One of several PRs focused on sanitizing inputs for PT parameters. This is to prevent users from breaking policy template execution because they entered a parameter incorrectly, such as putting whitespace at the beginning or end of the value.

Also corrects some Dangerfile-reported issues with the touched PTs.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
