### PR TITLE
POL-1826 Parameter Sanitization: Policy Templates #2

### DIFF
--- a/automation/google/google_credential/CHANGELOG.md
+++ b/automation/google/google_credential/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.2.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/automation/google/google_credential/google_credential_meta_parent.pt
+++ b/automation/google/google_credential/google_credential_meta_parent.pt
@@ -7,7 +7,7 @@ category "Meta"
 default_frequency "15 minutes"
 info(
   provider: "Google",
-  version: "0.2.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false"
 )
@@ -286,6 +286,9 @@ script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
   code <<-EOS
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_dimension_filter_includes = _.compact(_.map(param_dimension_filter_includes, function(item) { return item.trim() }))
+  param_dimension_filter_excludes = _.compact(_.map(param_dimension_filter_excludes, function(item) { return item.trim() }))
 
   billing_centers_formatted = []
 

--- a/automation/google/google_missing_projects/CHANGELOG.md
+++ b/automation/google/google_missing_projects/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.3.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/automation/google/google_missing_projects/google_missing_projects.pt
+++ b/automation/google/google_missing_projects/google_missing_projects.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.1",
+  version: "0.3.2",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Automation",
@@ -308,6 +308,8 @@ script "js_missing_projects_api", type: "javascript" do
   parameters "ds_flexera_cco_data", "ds_google_projects", "ds_applied_policy", "param_projects_list", "param_report_selection", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_projects_list = _.compact(_.map(param_projects_list, function(item) { return item.trim() }))
   var csv_message = param_incident_csv == "false" ? "" : " Incident table CSV file has been attached to emails for this incident."
 
   result = []
@@ -351,6 +353,8 @@ script "js_missing_projects_cco", type: "javascript" do
   parameters "ds_flexera_cco_data", "ds_google_projects", "ds_applied_policy", "param_projects_list", "param_report_selection", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_projects_list = _.compact(_.map(param_projects_list, function(item) { return item.trim() }))
   var csv_message = param_incident_csv == "false" ? "" : " Incident table CSV file has been attached to emails for this incident."
 
   result = []

--- a/automation/google/google_rbd_from_label/CHANGELOG.md
+++ b/automation/google/google_rbd_from_label/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v2.2.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/automation/google/google_rbd_from_label/CHANGELOG.md
+++ b/automation/google/google_rbd_from_label/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.2.2
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Updated the summary message to include the policy name.
 
 ## v2.2.1
 

--- a/automation/google/google_rbd_from_label/google_rbd_from_label.pt
+++ b/automation/google/google_rbd_from_label/google_rbd_from_label.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.2.1",
+  version: "2.2.2",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Automation",
@@ -97,6 +97,18 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_effective_date_input" do
+  run_script $js_effective_date_input, $param_effective_date
+end
+
+script "js_effective_date_input", type: "javascript" do
+  parameters "param_effective_date"
+  result "result"
+  code <<-'EOS'
+  result = param_effective_date.trim()
+EOS
+end
+
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
@@ -148,11 +160,11 @@ end
 # Determine the effective date to use for the generated rules: either the static value from the
 # 'Effective Date' parameter, or the current month (YYYY-MM) when 'Effective Date Mode' is 'Current Month'
 datasource "ds_effective_date" do
-  run_script $js_effective_date, $param_effective_date, $param_effective_date_mode
+  run_script $js_effective_date, $ds_effective_date_input, $param_effective_date_mode
 end
 
 script "js_effective_date", type: "javascript" do
-  parameters "param_effective_date", "param_effective_date_mode"
+  parameters "ds_effective_date_input", "param_effective_date_mode"
   result "result"
   code <<-'EOS'
   if (param_effective_date_mode == "Current Month") {
@@ -161,7 +173,7 @@ script "js_effective_date", type: "javascript" do
     month = ("0" + (now.getUTCMonth() + 1)).slice(-2)
     result = year + "-" + month
   } else {
-    result = param_effective_date
+    result = ds_effective_date_input
   }
 EOS
 end
@@ -238,6 +250,9 @@ script "js_new_rules", type: "javascript" do
   parameters "accounts", "effective_date", "param_name_list", "param_tag_list", "param_normalize_case"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_name_list = _.compact(_.map(param_name_list, function(item) { return item.trim() }))
+  param_tag_list = _.compact(_.map(param_tag_list, function(item) { return item.trim() }))
   rule_lists = []
 
   _.each(param_tag_list, function(tag, index) {

--- a/automation/google/google_rbd_from_label/google_rbd_from_label.pt
+++ b/automation/google/google_rbd_from_label/google_rbd_from_label.pt
@@ -487,13 +487,25 @@ script "js_apply_rbds", type: "javascript" do
 EOS
 end
 
+datasource "ds_rbds_summary" do
+  run_script $js_rbds_summary, $ds_apply_rbds, $ds_applied_policy
+end
+
+script "js_rbds_summary", type: "javascript" do
+  parameters "ds_apply_rbds", "ds_applied_policy"
+  result "result"
+  code <<-'EOS'
+  result = [{ policy_name: ds_applied_policy["name"] }]
+EOS
+end
+
 ###############################################################################
 # Policy
 ###############################################################################
 
 policy "pol_rbds" do
-  validate $ds_apply_rbds do
-    summary_template "RBDs Generated & Applied"
+  validate $ds_rbds_summary do
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }}: RBDs Generated & Applied"
     detail_template ""
     check eq(0, 0)
   end

--- a/automation/google/google_rbd_from_tag/CHANGELOG.md
+++ b/automation/google/google_rbd_from_tag/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.2.2
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/automation/google/google_rbd_from_tag/google_rbd_from_tag.pt
+++ b/automation/google/google_rbd_from_tag/google_rbd_from_tag.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.2.2",
+  version: "0.2.3",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Automation",
@@ -106,6 +106,18 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_effective_date_input" do
+  run_script $js_effective_date_input, $param_effective_date
+end
+
+script "js_effective_date_input", type: "javascript" do
+  parameters "param_effective_date"
+  result "result"
+  code <<-'EOS'
+  result = param_effective_date.trim()
+EOS
+end
+
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
@@ -157,11 +169,11 @@ end
 # Determine the effective date to use for the generated rules: either the static value from the
 # 'Effective Date' parameter, or the current month (YYYY-MM) when 'Effective Date Mode' is 'Current Month'
 datasource "ds_effective_date" do
-  run_script $js_effective_date, $param_effective_date, $param_effective_date_mode
+  run_script $js_effective_date, $ds_effective_date_input, $param_effective_date_mode
 end
 
 script "js_effective_date", type: "javascript" do
-  parameters "param_effective_date", "param_effective_date_mode"
+  parameters "ds_effective_date_input", "param_effective_date_mode"
   result "result"
   code <<-'EOS'
   if (param_effective_date_mode == "Current Month") {
@@ -170,7 +182,7 @@ script "js_effective_date", type: "javascript" do
     month = ("0" + (now.getUTCMonth() + 1)).slice(-2)
     result = year + "-" + month
   } else {
-    result = param_effective_date
+    result = ds_effective_date_input
   }
 EOS
 end
@@ -291,6 +303,9 @@ script "js_new_rules", type: "javascript" do
   parameters "accounts", "effective_date", "param_name_list", "param_tag_list", "param_normalize_case"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_name_list = _.compact(_.map(param_name_list, function(item) { return item.trim() }))
+  param_tag_list = _.compact(_.map(param_tag_list, function(item) { return item.trim() }))
   rule_lists = []
 
   _.each(param_tag_list, function(tag, index) {

--- a/compliance/aws/ecs_unused/CHANGELOG.md
+++ b/compliance/aws/ecs_unused/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.2.8
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.2.7
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/compliance/aws/ecs_unused/aws_unused_ecs_clusters.pt
+++ b/compliance/aws/ecs_unused/aws_unused_ecs_clusters.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Compliance"
 default_frequency "weekly"
 info(
-  version: "4.2.7",
+  version: "4.2.8",
   provider: "AWS",
   service: "Compute",
   policy_set: "Unused Containers",
@@ -471,6 +471,8 @@ script "js_aws_ecs_clusters_tag_filtered", type: "javascript" do
   parameters "ds_aws_ecs_clusters_detailed", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/compliance/aws/iam_role_audit/CHANGELOG.md
+++ b/compliance/aws/iam_role_audit/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.0.15
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.0.14
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/compliance/aws/iam_role_audit/aws_iam_role_audit.pt
+++ b/compliance/aws/iam_role_audit/aws_iam_role_audit.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Compliance"
 default_frequency "daily"
 info(
-  version: "3.0.14",
+  version: "3.0.15",
   provider:"AWS",
   service: "Identity & Access Management",
   policy_set: "Identity & Access Management",
@@ -336,6 +336,8 @@ script "js_iam_roles_filtered", type:"javascript" do
   parameters "ds_iam_roles_without_tags", "param_role_names"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_role_names = _.compact(_.map(param_role_names, function(item) { return item.trim() }))
   result = _.filter(ds_iam_roles_without_tags, function(role) {
     return _.contains(param_role_names, role['roleId']) || _.contains(param_role_names, role['roleName']) || _.contains(param_role_names, role['arn'])
   })
@@ -383,6 +385,8 @@ script "js_missing_roles", type: "javascript" do
   parameters "ds_iam_roles", "ds_aws_account", "ds_applied_policy", "param_role_names"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_role_names = _.compact(_.map(param_role_names, function(item) { return item.trim() }))
   existing_roles_by_name = {}
   existing_roles_by_id = {}
   existing_roles_by_arn = {}

--- a/compliance/aws/instances_without_fnm_agent/CHANGELOG.md
+++ b/compliance/aws/instances_without_fnm_agent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.4.4
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.4.3
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent.pt
+++ b/compliance/aws/instances_without_fnm_agent/aws_instances_not_running_flexnet_inventory_agent.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Compliance"
 default_frequency "weekly"
 info(
-  version: "4.4.3",
+  version: "4.4.4",
   provider: "AWS",
   service: "Compute",
   policy_set: "Instances not running FlexNet Inventory Agent",
@@ -120,6 +120,18 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_report_id" do
+  run_script $js_report_id, $param_report_id
+end
+
+script "js_report_id", type: "javascript" do
+  parameters "param_report_id"
+  result "result"
+  code <<-'EOS'
+  result = param_report_id.trim()
+EOS
+end
+
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
@@ -201,6 +213,8 @@ script "js_regions", type:"javascript" do
   parameters "all_regions", "user_entered_regions", "regions_allow_or_deny"
   result "regions"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    user_entered_regions = _.compact(_.map(user_entered_regions, function(item) { return item.trim() }))
     if(_.isEmpty(user_entered_regions)){
       regions = all_regions;
     }else{
@@ -281,7 +295,7 @@ datasource "ds_fnms_report" do
     '<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:tem="http://tempuri.org/">',
     '  <soap:Body>',
     '    <tem:GetCustomView>',
-    '      <tem:customViewID>', $param_report_id, '</tem:customViewID>',
+    '      <tem:customViewID>', $ds_report_id, '</tem:customViewID>',
     '      <tem:rowLimit>100000</tem:rowLimit>',
     '   </tem:GetCustomView>',
     '  </soap:Body>',
@@ -305,6 +319,8 @@ script "js_formatted_instances", type: "javascript" do
   parameters "ds_aws_ec2_instances_list", "ds_fnms_report", "param_exclude_tags", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclude_tags = _.compact(_.map(param_exclude_tags, function(item) { return item.trim() }))
   csv_message = param_incident_csv == "false" ? "" : "Incident table CSV file has been attached to emails for this incident."
 
   var result = [];

--- a/compliance/aws/long_stopped_instances/CHANGELOG.md
+++ b/compliance/aws/long_stopped_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.2.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v6.2.0
 
 - Added a region-error-reporting incident that alerts if the policy is unable to retrieve EC2 instance data from one or more AWS regions due to permission or configuration errors.

--- a/compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt
+++ b/compliance/aws/long_stopped_instances/aws_long_stopped_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Compliance"
 default_frequency "weekly"
 info(
-  version: "6.2.0",
+  version: "6.2.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Long Stopped Instances",
@@ -448,6 +448,8 @@ script "js_instances_tag_filtered", type: "javascript" do
   parameters "ds_instance_sets", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/compliance/aws/missing_scps/CHANGELOG.md
+++ b/compliance/aws/missing_scps/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.4
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.1.3
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/aws/missing_scps/aws_missing_scps.pt
+++ b/compliance/aws/missing_scps/aws_missing_scps.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "medium"
 default_frequency "daily"
 info(
-  version: "3.1.3",
+  version: "3.1.4",
   provider: "AWS",
   service: "Organization",
   policy_set: "",
@@ -273,6 +273,8 @@ script "js_filter_accounts", type: "javascript" do
   parameters "ds_org_accounts_with_policies", "ds_service_control_policies", "ds_applied_policy", "param_policy_names", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_policy_names = _.compact(_.map(param_policy_names, function(item) { return item.trim() }))
   csv_message = param_incident_csv == "false" ? "" : "Incident table CSV file has been attached to emails for this incident."
 
   policies_to_check = _.filter(ds_service_control_policies, function(policy) {

--- a/compliance/aws/rds_backup/CHANGELOG.md
+++ b/compliance/aws/rds_backup/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.2.0
 
 - Added a region-error-reporting incident that alerts if the policy is unable to retrieve RDS instance data from one or more AWS regions due to permission or configuration errors.

--- a/compliance/aws/rds_backup/aws_rds_backup.pt
+++ b/compliance/aws/rds_backup/aws_rds_backup.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "medium"
 default_frequency "weekly"
 info(
-  version: "3.2.0",
+  version: "3.2.1",
   provider: "AWS",
   service: "RDS",
   policy_set: "",
@@ -587,6 +587,8 @@ script "js_rds_instances", type: "javascript" do
   parameters "ds_rds_instances_set", "ds_resource_tags", "ds_aws_instance_size_map", "ds_aws_account", "ds_applied_policy", "param_exclusion_tags", "param_exclusion_tags_boolean", "param_backup_retention_period", "param_backup_window", "param_backup_settings"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/compliance/aws/untagged_resources/CHANGELOG.md
+++ b/compliance/aws/untagged_resources/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.0.4
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v6.0.3
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/compliance/aws/untagged_resources/aws_untagged_resources.pt
+++ b/compliance/aws/untagged_resources/aws_untagged_resources.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.0.3",
+  version: "6.0.4",
   provider: "AWS",
   service: "Compute",
   policy_set: "Untagged Resources",
@@ -640,6 +640,8 @@ script "js_aws_resources", type:"javascript" do
   parameters "region", "param_resource_types"
   result "request"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_resource_types = _.compact(_.map(param_resource_types, function(item) { return item.trim() }))
   var request = {
     auth: "auth_aws",
     pagination: "pagination_aws_tagging",
@@ -670,6 +672,8 @@ script "js_aws_resources_missing_tags", type:"javascript" do
   parameters "ds_aws_resources", "ds_aws_account", "ds_tag_dimensions", "param_tags", "param_tags_boolean", "param_consider_tag_dimensions", "param_report_types"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_tags = _.compact(_.map(param_tags, function(item) { return item.trim() }))
   result = []
 
   comparators = _.map(param_tags, function(item) {
@@ -796,6 +800,8 @@ script "js_missing_tags_incident", type:"javascript" do
   parameters "ds_aws_resources_missing_tags", "ds_aws_account", "ds_applied_policy", "ds_recommendation_resources_total_savings", "ds_currency", "param_tags", "param_tags_boolean", "param_include_savings", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_tags = _.compact(_.map(param_tags, function(item) { return item.trim() }))
   csv_message = param_incident_csv == "false" ? "" : "Incident table CSV file has been attached to emails for this incident."
 
   recommendations_id = {}

--- a/compliance/azure/advisor_carbon/CHANGELOG.md
+++ b/compliance/azure/advisor_carbon/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.4.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/azure/advisor_carbon/azure_advisor_carbon.pt
+++ b/compliance/azure/advisor_carbon/azure_advisor_carbon.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.1",
+  version: "0.4.2",
   provider: "Azure",
   service: "All",
   policy_set: "Sustainability",
@@ -229,6 +229,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -311,6 +313,8 @@ script "js_azure_advisor_recs_region_filtered", type: "javascript" do
   parameters "ds_azure_advisor_recs", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_advisor_recs, function(vm) {
       include_rec = _.contains(param_regions_list, vm['region'])
@@ -331,6 +335,8 @@ script "js_azure_advisor_recs_rg_filtered", type: "javascript" do
   parameters "ds_azure_advisor_recs_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
   if (param_resource_groups_list.length > 0) {
     result = _.filter(ds_azure_advisor_recs_region_filtered, function(resource) {
       rg = resource['resourceGroup']

--- a/compliance/azure/ahub_manual/CHANGELOG.md
+++ b/compliance/azure/ahub_manual/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.3.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.3.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry.pt
+++ b/compliance/azure/ahub_manual/azure_ahub_utilization_with_manual_entry.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Compliance"
 default_frequency "weekly"
 info(
-  version: "4.3.2",
+  version: "4.3.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "Hybrid Use Benefit",
@@ -255,6 +255,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -332,6 +334,8 @@ script "js_azure_instances_tag_filtered", type: "javascript" do
   parameters "ds_azure_instances", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -408,6 +412,8 @@ script "js_azure_instances_region_filtered", type: "javascript" do
   parameters "ds_azure_instances_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_instances_tag_filtered, function(vm) {
       include_vm = _.contains(param_regions_list, vm['region'])
@@ -432,6 +438,8 @@ script "js_azure_instances_rg_filtered", type: "javascript" do
   parameters "azure_instances_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(azure_instances_region_filtered, function(resource) {
         rg = resource['resourceGroup']

--- a/compliance/azure/azure_disallowed_regions/CHANGELOG.md
+++ b/compliance/azure/azure_disallowed_regions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.4.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.4.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/azure/azure_disallowed_regions/azure_disallowed_regions.pt
+++ b/compliance/azure/azure_disallowed_regions/azure_disallowed_regions.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.4.1",
+  version: "4.4.2",
   provider: "Azure",
   service: "Compute",
   policy_set: "Disallowed Regions",
@@ -256,6 +256,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -363,6 +365,8 @@ script "js_azure_instances_region_filtered", type: "javascript" do
   parameters "ds_azure_instances_tag_filtered", "param_regions_disallow_or_allow", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_instances_tag_filtered, function(vm) {
       include_vm = _.contains(param_regions_list, vm['region'])
@@ -387,6 +391,8 @@ script "js_azure_instances_rg_filtered", type: "javascript" do
   parameters "ds_azure_instances_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_azure_instances_region_filtered, function(resource) {
         rg = resource['resourceGroup']
@@ -417,6 +423,8 @@ script "js_instances_in_bad_regions", type: "javascript" do
   parameters "ds_azure_instances_rg_filtered", "ds_applied_policy", "param_regions_disallow_or_allow", "param_regions_list", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   var csv_message = param_incident_csv == "false" ? "" : " Incident table CSV file has been attached to emails for this incident."
 
   result = []

--- a/compliance/azure/azure_policy_audit/CHANGELOG.md
+++ b/compliance/azure/azure_policy_audit/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.2.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/azure/azure_policy_audit/azure_policy_audit.pt
+++ b/compliance/azure/azure_policy_audit/azure_policy_audit.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "medium"
 default_frequency "daily"
 info(
-  version: "3.2.1",
+  version: "3.2.2",
   provider: "Azure",
   service: "Identity & Access Management",
   policy_set: "Identity & Access Management",
@@ -203,6 +203,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -302,6 +304,8 @@ script "js_azure_policy_assignments_enriched", type: "javascript" do
   parameters "ds_azure_policy_definitions", "ds_azure_policy_assignments", "param_policy_names"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_policy_names = _.compact(_.map(param_policy_names, function(item) { return item.trim() }))
   // Create a list of policy assignments with policy definition metadata integrated into it
   definitions_object = {}
 
@@ -358,6 +362,8 @@ script "js_audit_results", type: "javascript" do
   parameters "ds_azure_subscriptions_filtered", "ds_azure_policy_assignments_enriched", "ds_applied_policy", "param_policy_names", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_policy_names = _.compact(_.map(param_policy_names, function(item) { return item.trim() }))
   csv_message = param_incident_csv == "false" ? "" : "Incident table CSV file has been attached to emails for this incident."
 
   // Sort assignments by subscription for easy iteration later

--- a/compliance/azure/azure_untagged_resources/CHANGELOG.md
+++ b/compliance/azure/azure_untagged_resources/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.0.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v5.0.2
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/compliance/azure/azure_untagged_resources/untagged_resources.pt
+++ b/compliance/azure/azure_untagged_resources/untagged_resources.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.0.2",
+  version: "5.0.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "Untagged Resources",
@@ -308,6 +308,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -430,6 +432,8 @@ script "js_azure_resources_region_filtered", type: "javascript" do
   parameters "ds_azure_resources", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_resources, function(resource) {
       include_resource = _.contains(param_regions_list, resource['region'])
@@ -450,6 +454,8 @@ script "js_azure_resources_type_filtered", type: "javascript" do
   parameters "ds_azure_resources_region_filtered", "ds_azure_resource_types", "param_resourcetypes_allow_or_deny", "param_resourcetypes_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_resourcetypes_list = _.compact(_.map(param_resourcetypes_list, function(item) { return item.trim() }))
   if (param_resourcetypes_list.length > 0) {
     result = _.filter(ds_azure_resources_region_filtered, function(resource) {
       resourcetypes_list = _.map(param_resourcetypes_list, function(type) {
@@ -476,6 +482,8 @@ script "js_azure_resources_rg_filtered", type: "javascript" do
   parameters "ds_azure_resources_type_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_azure_resources_type_filtered, function(resource) {
         rg = resource['resourceGroup']
@@ -506,6 +514,8 @@ script "js_azure_resources_missing_tags", type: "javascript" do
   parameters "ds_azure_subscriptions_with_tags", "ds_azure_resource_groups", "ds_azure_resources_rg_filtered", "ds_tag_dimensions", "param_tags", "param_tags_boolean", "param_report_types", "param_consider_tag_dimensions"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_tags = _.compact(_.map(param_tags, function(item) { return item.trim() }))
   result = []
 
   comparators = _.map(param_tags, function(item) {
@@ -656,6 +666,8 @@ script "js_missing_tags_incident", type: "javascript" do
   parameters "ds_azure_resources_missing_tags", "ds_applied_policy", "ds_azure_api_versions", "param_tags", "param_tags_boolean", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_tags = _.compact(_.map(param_tags, function(item) { return item.trim() }))
   csv_message = param_incident_csv == "false" ? "" : "Incident table CSV file has been attached to emails for this incident."
 
   result = _.map(ds_azure_resources_missing_tags, function(resource) {

--- a/compliance/azure/azure_untagged_vms/CHANGELOG.md
+++ b/compliance/azure/azure_untagged_vms/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.0.4
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v2.0.3
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/compliance/azure/azure_untagged_vms/untagged_vms.pt
+++ b/compliance/azure/azure_untagged_vms/untagged_vms.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "2.0.3",
+  version: "2.0.4",
   provider: "Azure",
   service: "Compute",
   policy_set: "Untagged Resources",
@@ -292,6 +292,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -364,6 +366,8 @@ script "js_azure_instances_region_filtered", type: "javascript" do
   parameters "ds_azure_instances", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_instances, function(vm) {
       include_vm = _.contains(param_regions_list, vm['region'])
@@ -388,6 +392,8 @@ script "js_azure_instances_rg_filtered", type: "javascript" do
   parameters "ds_azure_instances_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_azure_instances_region_filtered, function(resource) {
         rg = resource['resourceGroup']
@@ -418,6 +424,8 @@ script "js_azure_instances_missing_tags", type: "javascript" do
   parameters "ds_azure_instances_rg_filtered", "ds_tag_dimensions", "param_tags", "param_tags_boolean", "param_consider_tag_dimensions"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_tags = _.compact(_.map(param_tags, function(item) { return item.trim() }))
   result = []
 
   comparators = _.map(param_tags, function(item) {
@@ -516,6 +524,8 @@ script "js_missing_tags_incident", type: "javascript" do
   parameters "ds_azure_instances_missing_tags", "ds_applied_policy", "param_tags", "param_tags_boolean", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_tags = _.compact(_.map(param_tags, function(item) { return item.trim() }))
   csv_message = param_incident_csv == "false" ? "" : "Incident table CSV file has been attached to emails for this incident."
 
   result = _.map(ds_azure_instances_missing_tags, function(instance) {

--- a/compliance/azure/compliance_score/CHANGELOG.md
+++ b/compliance/azure/compliance_score/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/azure/compliance_score/azure_regulatory_compliance_report.pt
+++ b/compliance/azure/compliance_score/azure_regulatory_compliance_report.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "medium"
 default_frequency "daily"
 info(
-  version: "3.1.1",
+  version: "3.1.2",
   provider: "Azure",
   service: "",
   policy_set: "",
@@ -177,6 +177,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])

--- a/compliance/azure/deprecated_storage_accounts/CHANGELOG.md
+++ b/compliance/azure/deprecated_storage_accounts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.4.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/azure/deprecated_storage_accounts/azure_deprecated_storage_accounts.pt
+++ b/compliance/azure/deprecated_storage_accounts/azure_deprecated_storage_accounts.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.2",
+  version: "0.4.3",
   provider: "Azure",
   service: "Storage Accounts",
   policy_set: "Deprecated Storage Accounts",
@@ -337,6 +337,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -428,6 +430,8 @@ script "js_storage_accounts_tag_filtered", type: "javascript" do
   parameters "ds_storage_accounts", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -504,6 +508,8 @@ script "js_storage_accounts_region_filtered", type: "javascript" do
   parameters "ds_storage_accounts_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_storage_accounts_tag_filtered, function(resource) {
       include_resource = _.contains(param_regions_list, resource['region'])
@@ -525,6 +531,8 @@ script "js_storage_accounts_rg_filtered", type: "javascript" do
   parameters "ds_storage_accounts_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
   if (param_resource_groups_list.length > 0) {
     result = _.filter(ds_storage_accounts_region_filtered, function(resource) {
       rg = resource['resourceGroup']


### PR DESCRIPTION
### Description

One of several PRs focused on sanitizing inputs for PT parameters. This is to prevent users from breaking policy template execution because they entered a parameter incorrectly, such as putting whitespace at the beginning or end of the value.

Also corrects some Dangerfile-reported issues with the touched PTs.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
