### PR TITLE
POL-1826 Parameter Sanitization: Policy Templates #3

### DIFF
--- a/compliance/azure/instances_without_fnm_agent/CHANGELOG.md
+++ b/compliance/azure/instances_without_fnm_agent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.3.4
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.3.3
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent.pt
+++ b/compliance/azure/instances_without_fnm_agent/azure_instances_not_running_flexnet_inventory_agent.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Compliance"
 default_frequency "weekly"
 info(
-  version: "4.3.3",
+  version: "4.3.4",
   provider: "Azure",
   service: "Compute",
   policy_set: "Instances not running FlexNet Inventory Agent",
@@ -123,6 +123,18 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_report_id" do
+  run_script $js_report_id, $param_report_id
+end
+
+script "js_report_id", type: "javascript" do
+  parameters "param_report_id"
+  result "result"
+  code <<-'EOS'
+  result = param_report_id.trim()
+EOS
+end
+
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
@@ -203,6 +215,8 @@ script "js_filtered_subscriptions", type: "javascript" do
   parameters "ds_subscriptions", "param_subscriptions_list"
   result "results"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   var results = []
   if ( param_subscriptions_list.length != 0){
     results = []
@@ -247,18 +261,18 @@ datasource "ds_list_virtual_machines" do
 end
 
 datasource "ds_fnms_report_api_body" do
-  run_script $js_fnms_report_api_body, $param_report_id
+  run_script $js_fnms_report_api_body, $ds_report_id
 end
 
 script "js_fnms_report_api_body", type: "javascript" do
-  parameters "param_report_id"
+  parameters "ds_report_id"
   result "result"
   code <<-'EOS'
   body = [
     "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n",
     "  <soap:Body>\n",
     "    <tem:GetCustomView>\n",
-    "      <tem:customViewID>", param_report_id, "</tem:customViewID>\n",
+    "      <tem:customViewID>", ds_report_id, "</tem:customViewID>\n",
     "      <tem:rowLimit>100000</tem:rowLimit>\n",
     "   </tem:GetCustomView>\n",
     "  </soap:Body>\n",
@@ -297,6 +311,8 @@ script "js_formatted_instances", type: "javascript" do
   parameters "ds_list_virtual_machines", "ds_fnms_report", "param_exclusion_tag_key", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tag_key = param_exclusion_tag_key.trim()
   csv_message = param_incident_csv == "false" ? "" : "Incident table CSV file has been attached to emails for this incident."
 
   var result = [];

--- a/compliance/flexera/cco/billing_center_access_report/CHANGELOG.md
+++ b/compliance/flexera/cco/billing_center_access_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2.4
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.2.3
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/flexera/cco/billing_center_access_report/bc_access_report.pt
+++ b/compliance/flexera/cco/billing_center_access_report/bc_access_report.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "daily"
 info(
-  version: "3.2.3",
+  version: "3.2.4",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -155,6 +155,8 @@ script "js_billing_centers_filtered", type: "javascript" do
   parameters "ds_billing_centers", "param_billing_centers"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_billing_centers = _.compact(_.map(param_billing_centers, function(item) { return item.trim() }))
   if (param_billing_centers.length > 0) {
     result = _.filter(ds_billing_centers, function(bc) {
       return _.contains(param_billing_centers, bc['id']) || _.contains(param_billing_centers, bc['name'])

--- a/compliance/flexera/iam/iam_explicit_user_roles/CHANGELOG.md
+++ b/compliance/flexera/iam/iam_explicit_user_roles/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.0.8
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.0.7
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/flexera/iam/iam_explicit_user_roles/flexera_iam_explicit_user_roles.pt
+++ b/compliance/flexera/iam/iam_explicit_user_roles/flexera_iam_explicit_user_roles.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "medium"
 default_frequency "daily"
 info(
-  version: "4.0.7",
+  version: "4.0.8",
   provider: "Flexera",
   service: "Identity & Access Management",
   policy_set: "Identity & Access Management",
@@ -166,6 +166,8 @@ script "js_bad_users", type: "javascript" do
   parameters "ds_users", "ds_access_rules", "ds_applied_policy", "param_role_ignorelist"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_role_ignorelist = _.compact(_.map(param_role_ignorelist, function(item) { return item.trim() }))
   relevant_rules = _.filter(ds_access_rules, function(rule) {
     return _.contains(param_role_ignorelist, rule['roleId']) == false && _.contains(param_role_ignorelist, rule['roleName']) == false && _.contains(param_role_ignorelist, rule['roleDisplayName']) == false && rule['subjectKind'] == 'iam:user'
   })

--- a/compliance/github/available_seats/CHANGELOG.md
+++ b/compliance/github/available_seats/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/github/available_seats/available_seats.pt
+++ b/compliance/github/available_seats/available_seats.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Compliance"
 default_frequency "weekly"
 info(
-  version: "3.1.1",
+  version: "3.1.2",
   provider: "GitHub",
   service: "Git",
   policy_set: "",
@@ -170,7 +170,9 @@ end
 script "js_org_list", type: "javascript" do
   parameters "param_orgs"
   result "result"
-  code "result = param_orgs"
+  code <<-'EOS'
+  result = _.compact(_.map(param_orgs, function(item) { return item.trim() }))
+EOS
 end
 
 datasource "ds_github_orgs" do

--- a/compliance/github/outside_collaborators/CHANGELOG.md
+++ b/compliance/github/outside_collaborators/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/github/outside_collaborators/outside_collaborators.pt
+++ b/compliance/github/outside_collaborators/outside_collaborators.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Compliance"
 default_frequency "weekly"
 info(
-  version: "3.1.1",
+  version: "3.1.2",
   provider: "GitHub",
   service: "Git",
   policy_set: "",
@@ -177,7 +177,9 @@ end
 script "js_org_list", type: "javascript" do
   parameters "param_orgs"
   result "result"
-  code "result = param_orgs"
+  code <<-'EOS'
+  result = _.compact(_.map(param_orgs, function(item) { return item.trim() }))
+EOS
 end
 
 datasource "ds_github_orgs" do
@@ -242,6 +244,8 @@ script "js_github_org_repos_filtered", type: "javascript" do
   parameters "ds_github_org_repos", "param_repos_allow_or_deny", "param_repos_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_repos_list = _.compact(_.map(param_repos_list, function(item) { return item.trim() }))
   if (param_repos_list.length > 0) {
     result = _.filter(ds_github_org_repos, function(repo) {
       include_repo = _.contains(param_repos_list, repo['name'])
@@ -301,6 +305,8 @@ script "js_invalid_collaborators", type: "javascript" do
   parameters "ds_github_org_collaborators", "ds_applied_policy", "param_user_allowlist", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_user_allowlist = _.compact(_.map(param_user_allowlist, function(item) { return item.trim() }))
   users_cleaned = _.map(ds_github_org_collaborators, function(user) {
     org_name = encodeURI(user["org_name"])
     q_param = encodeURI("repo:" + user["org_name"] + "/" + user["repo_name"])

--- a/compliance/github/repository_admin_team/CHANGELOG.md
+++ b/compliance/github/repository_admin_team/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/github/repository_admin_team/repository_admin_team.pt
+++ b/compliance/github/repository_admin_team/repository_admin_team.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Compliance"
 default_frequency "weekly"
 info(
-  version: "3.1.1",
+  version: "3.1.2",
   provider: "GitHub",
   service: "Git",
   policy_set: "",
@@ -169,7 +169,9 @@ end
 script "js_org_list", type: "javascript" do
   parameters "param_orgs"
   result "result"
-  code "result = param_orgs"
+  code <<-'EOS'
+  result = _.compact(_.map(param_orgs, function(item) { return item.trim() }))
+EOS
 end
 
 datasource "ds_github_orgs" do
@@ -234,6 +236,8 @@ script "js_github_org_repos_filtered", type: "javascript" do
   parameters "ds_github_org_repos", "param_repos_allow_or_deny", "param_repos_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_repos_list = _.compact(_.map(param_repos_list, function(item) { return item.trim() }))
   if (param_repos_list.length > 0) {
     result = _.filter(ds_github_org_repos, function(repo) {
       include_repo = _.contains(param_repos_list, repo['name'])

--- a/compliance/github/repository_branch_protection/CHANGELOG.md
+++ b/compliance/github/repository_branch_protection/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/github/repository_branch_protection/repository_branch_protection.pt
+++ b/compliance/github/repository_branch_protection/repository_branch_protection.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Compliance"
 default_frequency "weekly"
 info(
-  version: "3.1.1",
+  version: "3.1.2",
   provider: "GitHub",
   service: "Git",
   policy_set: "",
@@ -232,7 +232,9 @@ end
 script "js_org_list", type: "javascript" do
   parameters "param_orgs"
   result "result"
-  code "result = param_orgs"
+  code <<-'EOS'
+  result = _.compact(_.map(param_orgs, function(item) { return item.trim() }))
+EOS
 end
 
 datasource "ds_github_orgs" do
@@ -297,6 +299,8 @@ script "js_github_org_repos_filtered", type: "javascript" do
   parameters "ds_github_org_repos", "param_repos_allow_or_deny", "param_repos_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_repos_list = _.compact(_.map(param_repos_list, function(item) { return item.trim() }))
   if (param_repos_list.length > 0) {
     result = _.filter(ds_github_org_repos, function(repo) {
       include_repo = _.contains(param_repos_list, repo['name'])
@@ -317,6 +321,9 @@ script "js_github_query", type: "javascript" do
   parameters "param_orgs", "param_branches"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_orgs = _.compact(_.map(param_orgs, function(item) { return item.trim() }))
+  param_branches = _.compact(_.map(param_branches, function(item) { return item.trim() }))
   org_names = _.map(param_orgs, function(org) { return 'org:' + org }).join(' ')
 
   branch_names = _.map(param_branches, function(branch) {
@@ -441,6 +448,8 @@ script "js_invalid_repo_branches", type: "javascript" do
   parameters "ds_github_repos_combined", "param_branches", "param_include_default_branch", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_branches = _.compact(_.map(param_branches, function(item) { return item.trim() }))
   result = []
 
   _.each(ds_github_repos_combined, function(repo) {

--- a/compliance/github/repository_naming/CHANGELOG.md
+++ b/compliance/github/repository_naming/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/github/repository_naming/repository_naming.pt
+++ b/compliance/github/repository_naming/repository_naming.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Compliance"
 default_frequency "weekly"
 info(
-  version: "3.1.1",
+  version: "3.1.2",
   provider: "GitHub",
   service: "Git",
   policy_set: "",
@@ -177,7 +177,9 @@ end
 script "js_org_list", type: "javascript" do
   parameters "param_orgs"
   result "result"
-  code "result = param_orgs"
+  code <<-'EOS'
+  result = _.compact(_.map(param_orgs, function(item) { return item.trim() }))
+EOS
 end
 
 datasource "ds_github_orgs" do
@@ -242,6 +244,8 @@ script "js_github_org_repos_filtered", type: "javascript" do
   parameters "ds_github_org_repos", "param_repos_allow_or_deny", "param_repos_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_repos_list = _.compact(_.map(param_repos_list, function(item) { return item.trim() }))
   if (param_repos_list.length > 0) {
     result = _.filter(ds_github_org_repos, function(repo) {
       include_repo = _.contains(param_repos_list, repo['name'])
@@ -262,6 +266,8 @@ script "js_invalid_repos", type: "javascript" do
   parameters "ds_github_org_repos_filtered", "ds_applied_policy", "param_repo_regex", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_repo_regex = param_repo_regex.trim()
   invalid_repos = _.reject(ds_github_org_repos_filtered, function(repo) {
     return repo['name'].match(param_repo_regex)
   })

--- a/compliance/github/repository_size/CHANGELOG.md
+++ b/compliance/github/repository_size/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/github/repository_size/repository_size.pt
+++ b/compliance/github/repository_size/repository_size.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Compliance"
 default_frequency "weekly"
 info(
-  version: "3.1.1",
+  version: "3.1.2",
   provider: "GitHub",
   service: "Git",
   policy_set: "",
@@ -187,7 +187,9 @@ end
 script "js_org_list", type: "javascript" do
   parameters "param_orgs"
   result "result"
-  code "result = param_orgs"
+  code <<-'EOS'
+  result = _.compact(_.map(param_orgs, function(item) { return item.trim() }))
+EOS
 end
 
 datasource "ds_github_orgs" do
@@ -253,6 +255,8 @@ script "js_github_org_repos_filtered", type: "javascript" do
   parameters "ds_github_org_repos", "param_repos_allow_or_deny", "param_repos_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_repos_list = _.compact(_.map(param_repos_list, function(item) { return item.trim() }))
   if (param_repos_list.length > 0) {
     result = _.filter(ds_github_org_repos, function(repo) {
       include_repo = _.contains(param_repos_list, repo['name'])

--- a/compliance/github/toplevel_teams/CHANGELOG.md
+++ b/compliance/github/toplevel_teams/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/github/toplevel_teams/toplevel_teams.pt
+++ b/compliance/github/toplevel_teams/toplevel_teams.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Compliance"
 default_frequency "weekly"
 info(
-  version: "3.1.1",
+  version: "3.1.2",
   provider: "GitHub",
   service: "Git",
   policy_set: "",
@@ -160,7 +160,9 @@ end
 script "js_org_list", type: "javascript" do
   parameters "param_orgs"
   result "result"
-  code "result = param_orgs"
+  code <<-'EOS'
+  result = _.compact(_.map(param_orgs, function(item) { return item.trim() }))
+EOS
 end
 
 datasource "ds_github_orgs" do
@@ -226,6 +228,8 @@ script "js_invalid_teams", type: "javascript" do
   parameters "ds_org_teams", "ds_applied_policy", "param_allowed_teams", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_allowed_teams = _.compact(_.map(param_allowed_teams, function(item) { return item.trim() }))
   invalid_teams = _.reject(ds_org_teams, function(team) {
     return typeof(team["parent"]) == "string" || _.contains(param_allowed_teams, team["name"])
   })

--- a/compliance/google/long_stopped_instances/CHANGELOG.md
+++ b/compliance/google/long_stopped_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.3.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.3.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/compliance/google/long_stopped_instances/google_long_stopped_instances.pt
+++ b/compliance/google/long_stopped_instances/google_long_stopped_instances.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.3.1",
+  version: "4.3.2",
   provider: "Google",
   service: "Compute",
   policy_set: "Long Stopped Instances",
@@ -380,6 +380,8 @@ script "js_google_projects_filtered", type: "javascript" do
   parameters "ds_google_projects", "param_projects_allow_or_deny", "param_projects_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_projects_list = _.compact(_.map(param_projects_list, function(item) { return item.trim() }))
   if (param_projects_list.length > 0) {
     result = _.filter(ds_google_projects, function(project) {
       include_project = _.contains(param_projects_list, project['id']) || _.contains(param_projects_list, project['name'])
@@ -479,6 +481,8 @@ script "js_instances_label_filtered", type: "javascript" do
   parameters "ds_instances", "param_exclusion_labels", "param_exclusion_labels_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_labels = _.compact(_.map(param_exclusion_labels, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_labels, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -556,6 +560,8 @@ script "js_instances_region_filtered", type: "javascript" do
   parameters "ds_instances_label_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_instances_label_filtered, function(instance) {
       include_instance = _.contains(param_regions_list, instance['region'])

--- a/compliance/google/unlabeled_resources/CHANGELOG.md
+++ b/compliance/google/unlabeled_resources/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.0.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v5.0.2
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/compliance/google/unlabeled_resources/unlabeled_resources.pt
+++ b/compliance/google/unlabeled_resources/unlabeled_resources.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.0.2",
+  version: "5.0.3",
   provider: "Google",
   service: "Compute",
   policy_set: "Untagged Resources",
@@ -390,6 +390,8 @@ script "js_google_projects_filtered", type: "javascript" do
   parameters "ds_google_projects", "param_projects_allow_or_deny", "param_projects_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_projects_list = _.compact(_.map(param_projects_list, function(item) { return item.trim() }))
   if (param_projects_list.length > 0) {
     result = _.filter(ds_google_projects, function(project) {
       include_project = _.contains(param_projects_list, project['id']) || _.contains(param_projects_list, project['name'])
@@ -854,6 +856,8 @@ script "js_google_resources_missing_labels", type: "javascript" do
   parameters "ds_google_resources", "ds_applied_policy", "ds_tag_dimensions", "param_labels", "param_labels_boolean", "param_consider_tag_dimensions"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_labels = _.compact(_.map(param_labels, function(item) { return item.trim() }))
   result = []
 
   comparators = _.map(param_labels, function(item) {
@@ -952,6 +956,8 @@ script "js_missing_labels_incident", type: "javascript" do
   parameters "ds_google_resources_missing_labels", "ds_applied_policy", "param_labels", "param_labels_boolean", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_labels = _.compact(_.map(param_labels, function(item) { return item.trim() }))
   csv_message = param_incident_csv == "false" ? "" : "Incident table CSV file has been attached to emails for this incident."
 
   resource_mapping = {

--- a/cost/alibaba/alibaba_cbi/CHANGELOG.md
+++ b/cost/alibaba/alibaba_cbi/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.7
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.1.6
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/alibaba/alibaba_cbi/CHANGELOG.md
+++ b/cost/alibaba/alibaba_cbi/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.1.7
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Fixed `run_script` parameter ordering in the incident datasource.
 
 ## v0.1.6
 

--- a/cost/alibaba/alibaba_cbi/alibaba_cbi.pt
+++ b/cost/alibaba/alibaba_cbi/alibaba_cbi.pt
@@ -567,11 +567,11 @@ EOS
 end
 
 datasource "ds_incident" do
-  run_script $js_incident, $ds_cbi_commit_bill_upload, $ds_applied_policy, $param_account_id, $param_region, $ds_bucket, $param_path
+  run_script $js_incident, $ds_cbi_commit_bill_upload, $ds_applied_policy, $ds_bucket, $param_account_id, $param_region, $param_path
 end
 
 script "js_incident", type: "javascript" do
-  parameters "ds_cbi_commit_bill_upload", "ds_applied_policy", "param_account_id", "param_region", "ds_bucket", "param_path"
+  parameters "ds_cbi_commit_bill_upload", "ds_applied_policy", "ds_bucket", "param_account_id", "param_region", "param_path"
   result "result"
   code <<-'EOS'
   // Remove any leading/trailing whitespace the user may have accidentally entered

--- a/cost/alibaba/alibaba_cbi/alibaba_cbi.pt
+++ b/cost/alibaba/alibaba_cbi/alibaba_cbi.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.1.6",
+  version: "0.1.7",
   provider: "Alibaba",
   service: "Common Bill Ingestion",
   policy_set: "Common Bill Ingestion",
@@ -123,6 +123,18 @@ end
 ###############################################################################
 # Datasources & Scripts
 ###############################################################################
+
+datasource "ds_bucket" do
+  run_script $js_bucket, $param_bucket
+end
+
+script "js_bucket", type: "javascript" do
+  parameters "param_bucket"
+  result "result"
+  code <<-'EOS'
+  result = param_bucket.trim()
+EOS
+end
 
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
@@ -443,7 +455,7 @@ end
 datasource "ds_cost_reports" do
   iterate $ds_dates_list
   request do
-    run_script $js_cost_reports, val(iter_item, "date"), $param_bucket, $param_path, $param_region, $param_account_id
+    run_script $js_cost_reports, val(iter_item, "date"), $ds_bucket, $param_path, $param_region, $param_account_id
   end
   result do
     encoding "text"
@@ -451,15 +463,18 @@ datasource "ds_cost_reports" do
 end
 
 script "js_cost_reports", type: "javascript" do
-  parameters "date", "param_bucket", "param_path", "param_region", "param_account_id"
+  parameters "date", "ds_bucket", "param_path", "param_region", "param_account_id"
   result "request"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_path = param_path.trim()
+  param_account_id = param_account_id.trim()
   root_path = param_path.replace(/\/$/, '')
   if (root_path != '' && root_path.indexOf("/") != 0) { root_path = [ "/", root_path ].join('') }
 
   var request = {
     auth: "auth_alibaba",
-    host: [ param_bucket, ".", param_region, ".aliyuncs.com" ].join(''),
+    host: [ ds_bucket, ".", param_region, ".aliyuncs.com" ].join(''),
     path: [ root_path, "/", param_account_id, "_BillingItemDetail_", date ].join(''),
     ignore_status: [404]
   }
@@ -552,13 +567,16 @@ EOS
 end
 
 datasource "ds_incident" do
-  run_script $js_incident, $ds_cbi_commit_bill_upload, $ds_applied_policy, $param_account_id, $param_region, $param_bucket, $param_path
+  run_script $js_incident, $ds_cbi_commit_bill_upload, $ds_applied_policy, $param_account_id, $param_region, $ds_bucket, $param_path
 end
 
 script "js_incident", type: "javascript" do
-  parameters "ds_cbi_commit_bill_upload", "ds_applied_policy", "param_account_id", "param_region", "param_bucket", "param_path"
+  parameters "ds_cbi_commit_bill_upload", "ds_applied_policy", "param_account_id", "param_region", "ds_bucket", "param_path"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_account_id = param_account_id.trim()
+  param_path = param_path.trim()
   result = [{
     policy_name: ds_applied_policy['name'],
     id: ds_cbi_commit_bill_upload['id'],
@@ -569,7 +587,7 @@ script "js_incident", type: "javascript" do
     billingPeriod: ds_cbi_commit_bill_upload['billingPeriod'],
     account_id: param_account_id,
     region: param_region,
-    bucket: param_bucket,
+    bucket: ds_bucket,
     path: param_path
   }]
 EOS

--- a/cost/aws/asg_recommendations/CHANGELOG.md
+++ b/cost/aws/asg_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.2.0
 
 - Fixed a bug where the policy would fail entirely for any Auto Scaling Group using a `MixedInstancesPolicy` with more than one instance type override. The policy now correctly captures all configured instance types for mixed-instance ASGs instead of assuming there is only one.

--- a/cost/aws/asg_recommendations/aws_asg_recommendations.pt
+++ b/cost/aws/asg_recommendations/aws_asg_recommendations.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.0",
+  version: "0.2.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Auto Scaling Recommendations",
@@ -544,6 +544,8 @@ script "js_aws_asgs_filtered", type: "javascript" do
   parameters "ds_aws_asgs_raw", "param_stats_lookback", "param_min_age_days", "param_exclusion_tags", "param_exclusion_tags_boolean", "param_findings"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   // If only finding #4 (group metrics disabled) is selected, no per-ASG metric/activity
   // data is needed. Skip the downstream API calls entirely.
   needs_metrics = _.contains(param_findings, "Fixed-size ASG") || _.contains(param_findings, "Never Moved Off Floor") || _.contains(param_findings, "Over-provisioned Floor")
@@ -960,6 +962,8 @@ script "js_asg_processed", type: "javascript" do
   parameters "ds_aws_asgs_raw", "ds_aws_scaling_policies", "ds_aws_scaling_activities", "ds_cloudwatch_data_sorted", "ds_instance_costs_grouped", "param_stats_lookback", "param_min_age_days", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   // Build tag-exclusion comparators (standard catalog pattern)
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) { return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item } }

--- a/cost/aws/burstable_ec2_instances/CHANGELOG.md
+++ b/cost/aws/burstable_ec2_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.6.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.6.0
 
 - Added a region error-reporting check that surfaces a clear incident when the policy is unable to access one or more AWS regions, instead of silently omitting data from those regions.

--- a/cost/aws/burstable_ec2_instances/aws_burstable_ec2_instances.pt
+++ b/cost/aws/burstable_ec2_instances/aws_burstable_ec2_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "monthly"
 info(
-  version: "4.6.0",
+  version: "4.6.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Burstable Compute Instances",
@@ -479,6 +479,8 @@ script "js_instances", type: "javascript" do
   parameters "ds_instance_sets", "ds_aws_instance_types", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/cost/aws/cheaper_regions/CHANGELOG.md
+++ b/cost/aws/cheaper_regions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.2.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v1.2.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/aws/cheaper_regions/aws_cheaper_regions.pt
+++ b/cost/aws/cheaper_regions/aws_cheaper_regions.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "1.2.2",
+  version: "1.2.3",
   provider: "AWS",
   service: "All",
   policy_set: "Cheaper Regions",
@@ -250,6 +250,8 @@ script "js_billing_centers_filtered", type: "javascript" do
   parameters "ds_billing_centers", "param_bc_allow_or_deny", "param_bc_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_bc_list = _.compact(_.map(param_bc_list, function(item) { return item.trim() }))
   allow_deny_test = { "Allow": true, "Deny": false }
 
   if (param_bc_list.length > 0) {
@@ -438,6 +440,8 @@ script "js_cheaper_regions", type: "javascript" do
   parameters "ds_regions_sorted", "ds_currency", "param_regions_allow_or_deny", "param_regions_list", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   result = _.filter(ds_regions_sorted, function(item) {
     return typeof(item['cheaper']) == 'string' && item['cheaper'] != ''
   })


### PR DESCRIPTION
### Description

One of several PRs focused on sanitizing inputs for PT parameters. This is to prevent users from breaking policy template execution because they entered a parameter incorrectly, such as putting whitespace at the beginning or end of the value.

Also corrects some Dangerfile-reported issues with the touched PTs.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
