### PR TITLE
POL-1826 Parameter Sanitization: Policy Templates #4

### DIFF
--- a/cost/aws/ec2_compute_optimizer/CHANGELOG.md
+++ b/cost/aws/ec2_compute_optimizer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.7.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.7.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/aws/ec2_compute_optimizer/aws_ec2_compute_optimizer.pt
+++ b/cost/aws/ec2_compute_optimizer/aws_ec2_compute_optimizer.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.7.0",
+  version: "0.7.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -466,6 +466,8 @@ script "js_instances", type: "javascript" do
   parameters "ds_instance_sets", "ds_aws_gpu_table", "param_exclusion_tags", "param_exclusion_tags_boolean", "param_recommendations_gpu"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/cost/aws/eks_without_spot/CHANGELOG.md
+++ b/cost/aws/eks_without_spot/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.3.0
 
 - Added a region error-reporting check that surfaces a clear incident when the policy is unable to access one or more AWS regions, instead of silently omitting data from those regions.

--- a/cost/aws/eks_without_spot/aws_eks_without_spot.pt
+++ b/cost/aws/eks_without_spot/aws_eks_without_spot.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.0",
+  version: "0.3.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Autoscaling",
@@ -464,6 +464,8 @@ script "js_eks_clusters_tag_filtered", type: "javascript" do
   parameters "ds_eks_clusters", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/cost/aws/extended_support/CHANGELOG.md
+++ b/cost/aws/extended_support/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.3.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v1.3.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/aws/extended_support/aws_extended_support.pt
+++ b/cost/aws/extended_support/aws_extended_support.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "1.3.0",
+  version: "1.3.1",
   provider: "AWS",
   service: "All",
   policy_set: "Deprecated Resources",
@@ -262,6 +262,8 @@ script "js_filtered_bcs", type: "javascript" do
   parameters "ds_billing_centers", "param_billing_centers"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_billing_centers = _.compact(_.map(param_billing_centers, function(item) { return item.trim() }))
   if (param_billing_centers.length == 0) {
     result = _.filter(ds_billing_centers, function(bc) {
       return bc['parent_id'] == null || bc['parent_id'] == undefined
@@ -450,6 +452,9 @@ script "js_flexera_cco_data_filtered", type: "javascript" do
   parameters "ds_flexera_cco_data", "ds_regions_table", "param_accounts_allow_or_deny", "param_accounts_list", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_accounts_list = _.compact(_.map(param_accounts_list, function(item) { return item.trim() }))
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   allow_deny_test = { "Allow": true, "Deny": false }
 
   if (param_accounts_list.length > 0) {
@@ -507,6 +512,8 @@ script "js_regions", type: "javascript" do
   parameters "ds_describe_regions", "param_regions_list", "param_regions_allow_or_deny"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   allow_deny_test = { "Allow": true, "Deny": false }
 
   if (param_regions_list.length > 0) {
@@ -547,6 +554,8 @@ script "js_identify_errors", type: "javascript" do
   parameters "ds_regions", "ds_region_check", "ds_applied_policy", "param_regions_allow_or_deny", "param_regions_list"
   result "errors"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   var errors = []
 
   if (ds_regions.length > 0) {
@@ -895,6 +904,8 @@ script "js_all_extended_support_resources", type: "javascript" do
   parameters "ds_rds_instances", "ds_rds_tags", "ds_eks_clusters", "ds_elasticache_clusters", "ds_elasticache_tags", "ds_aws_extended_support_dates", "ds_flexera_cco_data_filtered", "ds_cloud_vendor_accounts", "ds_currency", "ds_regions_table", "param_upcoming_days", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   result = []
 
   var today = new Date()

--- a/cost/aws/idle_fsx/CHANGELOG.md
+++ b/cost/aws/idle_fsx/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.3.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/aws/idle_fsx/aws_idle_fsx.pt
+++ b/cost/aws/idle_fsx/aws_idle_fsx.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.0",
+  version: "0.3.1",
   provider: "AWS",
   service: "Storage",
   policy_set: "Unused Storage",
@@ -559,6 +559,8 @@ script "js_aws_fsx_instances_tag_filtered", type: "javascript" do
   parameters "ds_aws_fsx_instances", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   // Normalize tags so they aren't awkwardly stored the way AWS stores them
   fsx_instances = _.map(ds_aws_fsx_instances, function(item) {
     new_item = {}

--- a/cost/aws/idle_lambda_functions/CHANGELOG.md
+++ b/cost/aws/idle_lambda_functions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.2.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/aws/idle_lambda_functions/aws_idle_lambda_functions.pt
+++ b/cost/aws/idle_lambda_functions/aws_idle_lambda_functions.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.0",
+  version: "0.2.1",
   provider: "AWS",
   service: "PaaS",
   policy_set: "Idle Lambda Functions",
@@ -588,6 +588,8 @@ script "js_aws_lambda_functions_tag_filtered", type: "javascript" do
   parameters "ds_aws_lambda_functions_with_tags", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/cost/aws/idle_nat_gateways/CHANGELOG.md
+++ b/cost/aws/idle_nat_gateways/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.4.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/aws/idle_nat_gateways/aws_idle_nat_gateways.pt
+++ b/cost/aws/idle_nat_gateways/aws_idle_nat_gateways.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.0",
+  version: "0.4.1",
   provider: "AWS",
   service: "Network",
   policy_set: "Idle NAT Gateways",
@@ -569,6 +569,8 @@ script "js_gateways_tag_filtered", type: "javascript" do
   parameters "ds_gateways", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/cost/aws/idle_sagemaker_endpoints/CHANGELOG.md
+++ b/cost/aws/idle_sagemaker_endpoints/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.2.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/aws/idle_sagemaker_endpoints/aws_idle_sagemaker_endpoints.pt
+++ b/cost/aws/idle_sagemaker_endpoints/aws_idle_sagemaker_endpoints.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.0",
+  version: "0.2.1",
   provider: "AWS",
   service: "SageMaker",
   policy_set: "Idle SageMaker Endpoints",
@@ -659,6 +659,8 @@ script "js_sagemaker_endpoints_tag_filtered", type: "javascript" do
   parameters "ds_sagemaker_endpoints_with_tags", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/cost/aws/instance_cost_per_hour/CHANGELOG.md
+++ b/cost/aws/instance_cost_per_hour/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.8
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.2.7
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/aws/instance_cost_per_hour/aws_instance_cost_per_hour.pt
+++ b/cost/aws/instance_cost_per_hour/aws_instance_cost_per_hour.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "monthly"
 info(
-  version: "0.2.7",
+  version: "0.2.8",
   provider: "AWS",
   service: "Compute",
   policy_set: "Unit Economics",
@@ -163,6 +163,8 @@ script "js_billing_centers_filtered", type: "javascript" do
   parameters "ds_billing_centers", "param_bc_allow_or_deny", "param_bc_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_bc_list = _.compact(_.map(param_bc_list, function(item) { return item.trim() }))
   allow_deny_test = { "Allow": true, "Deny": false }
 
   if (param_bc_list.length > 0) {

--- a/cost/aws/object_storage_optimization/CHANGELOG.md
+++ b/cost/aws/object_storage_optimization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.0.15
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.0.14
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.0.14",
+  version: "4.0.15",
   provider: "AWS",
   service: "Storage",
   policy_set: "Object Store Optimization",
@@ -285,6 +285,8 @@ script "js_aws_buckets_name_filtered", type: "javascript" do
   parameters "ds_get_aws_buckets", "param_bucket_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_bucket_list = _.compact(_.map(param_bucket_list, function(item) { return item.trim() }))
   if (param_bucket_list.length > 0) {
     result = _.filter(ds_get_aws_buckets, function(bucket) {
       return _.contains(param_bucket_list, bucket['name'])

--- a/cost/aws/old_snapshots/CHANGELOG.md
+++ b/cost/aws/old_snapshots/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v8.7.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v8.7.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
+++ b/cost/aws/old_snapshots/aws_delete_old_snapshots.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "8.7.0",
+  version: "8.7.1",
   provider: "AWS",
   service: "Storage",
   policy_set: "Old Snapshots",
@@ -740,6 +740,9 @@ script "js_snapshots_combined", type: "javascript" do
   parameters "ds_describe_snapshots", "ds_describe_db_snapshots", "ds_describe_db_cluster_snapshots", "param_exclusion_tags", "param_exclusion_tags_boolean", "param_exclusion_types", "param_exclusion_description", "param_exclusion_services"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
+  param_exclusion_description = _.compact(_.map(param_exclusion_description, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/cost/aws/reserved_instances/expiration/CHANGELOG.md
+++ b/cost/aws/reserved_instances/expiration/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.4
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.1.3
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/aws/reserved_instances/expiration/aws_reserved_instance_expiration.pt
+++ b/cost/aws/reserved_instances/expiration/aws_reserved_instance_expiration.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "medium"
 default_frequency "daily"
 info(
-  version: "3.1.3",
+  version: "3.1.4",
   provider: "AWS",
   service: "Compute",
   policy_set: "Reserved Instances",
@@ -170,6 +170,8 @@ script "js_billing_centers_filtered", type: "javascript" do
   parameters "ds_billing_centers", "param_bc_allow_or_deny", "param_billing_centers"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_billing_centers = _.compact(_.map(param_billing_centers, function(item) { return item.trim() }))
   allow_deny_test = { "Allow": true, "Deny": false }
 
   if (param_billing_centers.length > 0) {

--- a/cost/aws/reserved_instances/utilization/CHANGELOG.md
+++ b/cost/aws/reserved_instances/utilization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.4
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.1.3
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/aws/reserved_instances/utilization/utilization_ris.pt
+++ b/cost/aws/reserved_instances/utilization/utilization_ris.pt
@@ -8,7 +8,7 @@ severity "high"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "3.1.3",
+  version: "3.1.4",
   provider: "AWS",
   service: "Compute",
   policy_set: "Reserved Instances",
@@ -171,6 +171,8 @@ script "js_billing_centers_filtered", type: "javascript" do
   parameters "ds_billing_centers", "param_bc_allow_or_deny", "param_billing_centers"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_billing_centers = _.compact(_.map(param_billing_centers, function(item) { return item.trim() }))
   allow_deny_test = { "Allow": true, "Deny": false }
 
   if (param_billing_centers.length > 0) {

--- a/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/rightsize_ebs_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.6.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/aws/rightsize_ebs_volumes/aws_rightsize_ebs_volumes.pt
+++ b/cost/aws/rightsize_ebs_volumes/aws_rightsize_ebs_volumes.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.6.0",
+  version: "0.6.1",
   provider: "AWS",
   service: "EBS",
   policy_set: "Unused Volumes",
@@ -718,6 +718,8 @@ script "js_volumes_type_filtered", type: "javascript" do
   parameters "ds_volumes_list", "param_exclusion_types"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_types = _.compact(_.map(param_exclusion_types, function(item) { return item.trim() }))
   exclusion_types = _.map(param_exclusion_types, function(item) { return item.toLowerCase().trim() })
 
   result = _.reject(ds_volumes_list, function(volume) {
@@ -734,6 +736,8 @@ script "js_volumes_tag_filtered", type: "javascript" do
   parameters "ds_volumes_type_filtered", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/cost/aws/rightsize_ec2_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_ec2_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.8.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v5.8.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances.pt
+++ b/cost/aws/rightsize_ec2_instances/aws_rightsize_ec2_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "5.8.0",
+  version: "5.8.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -748,6 +748,8 @@ script "js_instances", type: "javascript" do
   parameters "ds_instance_sets", "ds_aws_instance_types_map", "param_exclusion_tags", "param_exclusion_tags_boolean", "param_filter_gpu"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/cost/aws/rightsize_ec2_instances_cross_family/CHANGELOG.md
+++ b/cost/aws/rightsize_ec2_instances_cross_family/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.2.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/aws/rightsize_ec2_instances_cross_family/aws_rightsize_ec2_instances_cross_family.pt
+++ b/cost/aws/rightsize_ec2_instances_cross_family/aws_rightsize_ec2_instances_cross_family.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "0.2.0",
+  version: "0.2.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -707,6 +707,8 @@ script "js_instances", type: "javascript" do
   parameters "ds_instance_sets", "ds_aws_instance_types_map", "param_exclusion_tags", "param_exclusion_tags_boolean", "param_filter_gpu"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/cost/aws/rightsize_elasticache/CHANGELOG.md
+++ b/cost/aws/rightsize_elasticache/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.6.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/aws/rightsize_elasticache/aws_rightsize_elasticache.pt
+++ b/cost/aws/rightsize_elasticache/aws_rightsize_elasticache.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.6.0",
+  version: "0.6.1",
   provider: "AWS",
   service: "Database",
   policy_set: "Rightsize Database Instances",
@@ -763,6 +763,8 @@ script "js_elasticache_clusters_tag_filtered", type: "javascript" do
   parameters "ds_elasticache_clusters_with_tags", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/cost/aws/rightsize_rds_instances/CHANGELOG.md
+++ b/cost/aws/rightsize_rds_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.12.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v5.12.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
+++ b/cost/aws/rightsize_rds_instances/aws_rightsize_rds_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "5.12.0",
+  version: "5.12.1",
   provider: "AWS",
   service: "RDS",
   policy_set: "Rightsize Database Instances",
@@ -906,6 +906,8 @@ script "js_rds_instances", type: "javascript" do
   parameters "ds_rds_instances_set", "ds_resource_tags", "ds_aws_instance_type_map", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/cost/aws/rightsize_redshift/CHANGELOG.md
+++ b/cost/aws/rightsize_redshift/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.4.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/aws/rightsize_redshift/aws_rightsize_redshift.pt
+++ b/cost/aws/rightsize_redshift/aws_rightsize_redshift.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.0",
+  version: "0.4.1",
   provider: "AWS",
   service: "Database",
   policy_set: "Rightsize Database Instances",
@@ -615,6 +615,8 @@ script "js_redshift_clusters_tag_filtered", type: "javascript" do
   parameters "ds_redshift_clusters_resize_filtered", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }


### PR DESCRIPTION
### Description

One of several PRs focused on sanitizing inputs for PT parameters. This is to prevent users from breaking policy template execution because they entered a parameter incorrectly, such as putting whitespace at the beginning or end of the value.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
