### PR TITLE
POL-1826 Parameter Sanitization: Policy Templates #5

### DIFF
--- a/cost/aws/s3_bucket_size/CHANGELOG.md
+++ b/cost/aws/s3_bucket_size/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.0.6
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.0.5
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/aws/s3_bucket_size/aws_bucket_size.pt
+++ b/cost/aws/s3_bucket_size/aws_bucket_size.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "medium"
 default_frequency "weekly"
 info(
-  version: "4.0.5",
+  version: "4.0.6",
   provider: "AWS",
   service: "Storage",
   policy_set: "",
@@ -453,6 +453,8 @@ script "js_aws_buckets_tag_filtered", type: "javascript" do
   parameters "ds_aws_buckets_with_tags", "ds_aws_buckets_region_filtered", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   // Logic to ensure any buckets skipped because of a 404 response due to no tags
   // are still included in the final result
   tagged_bucket_list = _.map(ds_aws_buckets_with_tags, function(bucket) {

--- a/cost/aws/s3_lifecycle/CHANGELOG.md
+++ b/cost/aws/s3_lifecycle/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.7
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.2.6
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/aws/s3_lifecycle/aws_s3_lifecycle.pt
+++ b/cost/aws/s3_lifecycle/aws_s3_lifecycle.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "medium"
 default_frequency "weekly"
 info(
-  version: "0.2.6",
+  version: "0.2.7",
   provider: "AWS",
   service: "Storage",
   policy_set: "",
@@ -445,6 +445,8 @@ script "js_aws_buckets_tag_filtered", type: "javascript" do
   parameters "ds_aws_buckets_with_tags", "ds_aws_buckets_region_filtered", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   // Logic to ensure any buckets skipped because of a 404 response due to no tags
   // are still included in the final result
   tagged_bucket_list = _.map(ds_aws_buckets_with_tags, function(bucket) {

--- a/cost/aws/s3_multipart_uploads/CHANGELOG.md
+++ b/cost/aws/s3_multipart_uploads/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.7
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.2.6
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/aws/s3_multipart_uploads/aws_s3_multipart_uploads.pt
+++ b/cost/aws/s3_multipart_uploads/aws_s3_multipart_uploads.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.6",
+  version: "0.2.7",
   provider: "AWS",
   service: "Storage",
   policy_set: "",
@@ -463,6 +463,8 @@ script "js_aws_buckets_tag_filtered", type: "javascript" do
   parameters "ds_aws_buckets_with_tags", "ds_aws_buckets_region_filtered", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   // Logic to ensure any buckets skipped because of a 404 response due to no tags
   // are still included in the final result
   tagged_bucket_list = _.map(ds_aws_buckets_with_tags, function(bucket) {

--- a/cost/aws/s3_storage_policy/CHANGELOG.md
+++ b/cost/aws/s3_storage_policy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.2.10
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.2.9
 
 - Replaced non-ASCII punctuation (em dashes, curly quotes, etc.) with standard ASCII equivalents for consistent rendering in the Flexera UI. No functional changes.

--- a/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check.pt
+++ b/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "medium"
 default_frequency "weekly"
 info(
-  version: "4.2.9",
+  version: "4.2.10",
   provider: "AWS",
   service: "Storage",
   policy_set: "Object Store Optimization",
@@ -538,6 +538,8 @@ script "js_aws_buckets_tag_filtered", type: "javascript" do
   parameters "ds_aws_buckets_with_tags", "ds_aws_buckets_region_filtered", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   // Logic to ensure any buckets skipped because of a 404 response due to no tags
   // are still included in the final result
   tagged_bucket_list = _.map(ds_aws_buckets_with_tags, function(bucket) {

--- a/cost/aws/savings_plan/purchase_analysis/CHANGELOG.md
+++ b/cost/aws/savings_plan/purchase_analysis/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.2.2
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/aws/savings_plan/purchase_analysis/CHANGELOG.md
+++ b/cost/aws/savings_plan/purchase_analysis/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.2.3
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Fixed `run_script` parameter ordering in the analysis start and incident datasources.
 
 ## v0.2.2
 

--- a/cost/aws/savings_plan/purchase_analysis/aws_sp_purchase_analysis.pt
+++ b/cost/aws/savings_plan/purchase_analysis/aws_sp_purchase_analysis.pt
@@ -350,7 +350,7 @@ end
 
 datasource "ds_start_analysis" do
   request do
-    run_script $js_start_analysis, $ds_aws_account, $param_scope, $param_analysis_type, $param_days, $param_payment_option, $param_term, $param_savings_plan_type, $param_hourly_commitment, $param_target_coverage, $ds_region, $param_instance_family, $param_offering_id
+    run_script $js_start_analysis, $ds_aws_account, $ds_region, $param_scope, $param_analysis_type, $param_days, $param_payment_option, $param_term, $param_savings_plan_type, $param_hourly_commitment, $param_target_coverage, $param_instance_family, $param_offering_id
   end
   result do
     encoding "json"
@@ -361,7 +361,7 @@ datasource "ds_start_analysis" do
 end
 
 script "js_start_analysis", type: "javascript" do
-  parameters "ds_aws_account", "param_scope", "param_analysis_type", "param_days", "param_payment_option", "param_term", "param_savings_plan_type", "param_hourly_commitment", "param_target_coverage", "ds_region", "param_instance_family", "param_offering_id"
+  parameters "ds_aws_account", "ds_region", "param_scope", "param_analysis_type", "param_days", "param_payment_option", "param_term", "param_savings_plan_type", "param_hourly_commitment", "param_target_coverage", "param_instance_family", "param_offering_id"
   result "request"
   code <<-'EOS'
   // Remove any leading/trailing whitespace the user may have accidentally entered
@@ -610,11 +610,11 @@ EOS
 end
 
 datasource "ds_analysis_incident" do
-  run_script $js_analysis_incident, $ds_collect_analysis, $ds_currency, $ds_conditional_currency_conversion, $ds_aws_account, $ds_applied_policy, $param_scope, $param_analysis_type, $param_days, $param_payment_option, $param_term, $param_savings_plan_type, $param_hourly_commitment, $param_target_coverage, $ds_region, $param_instance_family, $param_offering_id, $param_incident_csv
+  run_script $js_analysis_incident, $ds_collect_analysis, $ds_currency, $ds_conditional_currency_conversion, $ds_aws_account, $ds_applied_policy, $ds_region, $param_scope, $param_analysis_type, $param_days, $param_payment_option, $param_term, $param_savings_plan_type, $param_hourly_commitment, $param_target_coverage, $param_instance_family, $param_offering_id, $param_incident_csv
 end
 
 script "js_analysis_incident", type: "javascript" do
-  parameters "ds_collect_analysis", "ds_currency", "ds_conditional_currency_conversion", "ds_aws_account", "ds_applied_policy", "param_scope", "param_analysis_type", "param_days", "param_payment_option", "param_term", "param_savings_plan_type", "param_hourly_commitment", "param_target_coverage", "ds_region", "param_instance_family", "param_offering_id", "param_incident_csv"
+  parameters "ds_collect_analysis", "ds_currency", "ds_conditional_currency_conversion", "ds_aws_account", "ds_applied_policy", "ds_region", "param_scope", "param_analysis_type", "param_days", "param_payment_option", "param_term", "param_savings_plan_type", "param_hourly_commitment", "param_target_coverage", "param_instance_family", "param_offering_id", "param_incident_csv"
   result "result"
   code <<-'EOS'
   // Remove any leading/trailing whitespace the user may have accidentally entered

--- a/cost/aws/savings_plan/purchase_analysis/aws_sp_purchase_analysis.pt
+++ b/cost/aws/savings_plan/purchase_analysis/aws_sp_purchase_analysis.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "0.2.2",
+  version: "0.2.3",
   provider: "AWS",
   service: "Compute",
   policy_set: "Savings Plans",
@@ -179,6 +179,18 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_region" do
+  run_script $js_region, $param_region
+end
+
+script "js_region", type: "javascript" do
+  parameters "param_region"
+  result "result"
+  code <<-'EOS'
+  result = param_region.trim()
+EOS
+end
+
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
@@ -338,7 +350,7 @@ end
 
 datasource "ds_start_analysis" do
   request do
-    run_script $js_start_analysis, $ds_aws_account, $param_scope, $param_analysis_type, $param_days, $param_payment_option, $param_term, $param_savings_plan_type, $param_hourly_commitment, $param_target_coverage, $param_region, $param_instance_family, $param_offering_id
+    run_script $js_start_analysis, $ds_aws_account, $param_scope, $param_analysis_type, $param_days, $param_payment_option, $param_term, $param_savings_plan_type, $param_hourly_commitment, $param_target_coverage, $ds_region, $param_instance_family, $param_offering_id
   end
   result do
     encoding "json"
@@ -349,9 +361,12 @@ datasource "ds_start_analysis" do
 end
 
 script "js_start_analysis", type: "javascript" do
-  parameters "ds_aws_account", "param_scope", "param_analysis_type", "param_days", "param_payment_option", "param_term", "param_savings_plan_type", "param_hourly_commitment", "param_target_coverage", "param_region", "param_instance_family", "param_offering_id"
+  parameters "ds_aws_account", "param_scope", "param_analysis_type", "param_days", "param_payment_option", "param_term", "param_savings_plan_type", "param_hourly_commitment", "param_target_coverage", "ds_region", "param_instance_family", "param_offering_id"
   result "request"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_instance_family = param_instance_family.trim()
+  param_offering_id = param_offering_id.trim()
   option_table = {
     "No Upfront": "NO_UPFRONT",
     "Partial Upfront": "PARTIAL_UPFRONT",
@@ -419,7 +434,7 @@ script "js_start_analysis", type: "javascript" do
     body_fields["CommitmentPurchaseAnalysisConfiguration"]["SavingsPlansPurchaseAnalysisConfiguration"]["SavingsPlansTargetCoverage"] = param_target_coverage
   }
 
-  if (param_region) { body_fields["CommitmentPurchaseAnalysisConfiguration"]["SavingsPlansPurchaseAnalysisConfiguration"]["SavingsPlansToAdd"][0]["Region"] = param_region }
+  if (ds_region) { body_fields["CommitmentPurchaseAnalysisConfiguration"]["SavingsPlansPurchaseAnalysisConfiguration"]["SavingsPlansToAdd"][0]["Region"] = ds_region }
   if (param_instance_family) { body_fields["CommitmentPurchaseAnalysisConfiguration"]["SavingsPlansPurchaseAnalysisConfiguration"]["SavingsPlansToAdd"][0]["InstanceFamily"] = param_instance_family }
   if (param_offering_id) { body_fields["CommitmentPurchaseAnalysisConfiguration"]["SavingsPlansPurchaseAnalysisConfiguration"]["SavingsPlansToAdd"][0]["OfferingId"] = param_offering_id }
 
@@ -595,13 +610,16 @@ EOS
 end
 
 datasource "ds_analysis_incident" do
-  run_script $js_analysis_incident, $ds_collect_analysis, $ds_currency, $ds_conditional_currency_conversion, $ds_aws_account, $ds_applied_policy, $param_scope, $param_analysis_type, $param_days, $param_payment_option, $param_term, $param_savings_plan_type, $param_hourly_commitment, $param_target_coverage, $param_region, $param_instance_family, $param_offering_id, $param_incident_csv
+  run_script $js_analysis_incident, $ds_collect_analysis, $ds_currency, $ds_conditional_currency_conversion, $ds_aws_account, $ds_applied_policy, $param_scope, $param_analysis_type, $param_days, $param_payment_option, $param_term, $param_savings_plan_type, $param_hourly_commitment, $param_target_coverage, $ds_region, $param_instance_family, $param_offering_id, $param_incident_csv
 end
 
 script "js_analysis_incident", type: "javascript" do
-  parameters "ds_collect_analysis", "ds_currency", "ds_conditional_currency_conversion", "ds_aws_account", "ds_applied_policy", "param_scope", "param_analysis_type", "param_days", "param_payment_option", "param_term", "param_savings_plan_type", "param_hourly_commitment", "param_target_coverage", "param_region", "param_instance_family", "param_offering_id", "param_incident_csv"
+  parameters "ds_collect_analysis", "ds_currency", "ds_conditional_currency_conversion", "ds_aws_account", "ds_applied_policy", "param_scope", "param_analysis_type", "param_days", "param_payment_option", "param_term", "param_savings_plan_type", "param_hourly_commitment", "param_target_coverage", "ds_region", "param_instance_family", "param_offering_id", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_instance_family = param_instance_family.trim()
+  param_offering_id = param_offering_id.trim()
   // Used for formatting numbers to look pretty
   function formatNumber(number, separator) {
     formatted_number = "0"
@@ -681,7 +699,7 @@ script "js_analysis_incident", type: "javascript" do
 
   if (param_analysis_type == "Custom Commitment") { message.push("- Hourly Commitment: ", param_hourly_commitment, "\n") }
   if (param_analysis_type == "Target Average Coverage") { message.push("- Target Coverage Percentage: ", param_target_coverage, "%\n") }
-  if (param_region) { message.push("- Region: ", param_region, "\n") }
+  if (ds_region) { message.push("- Region: ", ds_region, "\n") }
   if (param_instance_family) { message.push("- Instance Family: ", param_instance_family, "\n") }
   if (param_offering_id) { message.push("- Offering ID: ", param_offering_id, "\n") }
 
@@ -727,7 +745,7 @@ script "js_analysis_incident", type: "javascript" do
     service: service_table[param_savings_plan_type],
     scope: param_scope,
     hourly_commitment: param_hourly_commitment,
-    region: param_region,
+    region: ds_region,
     instance_family: param_instance_family,
     offering_id: param_offering_id,
     policy_name: ds_applied_policy['name'],

--- a/cost/aws/savings_realized/CHANGELOG.md
+++ b/cost/aws/savings_realized/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.0.10
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.0.9
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/aws/savings_realized/aws_savings_realized.pt
+++ b/cost/aws/savings_realized/aws_savings_realized.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "monthly"
 info(
-  version: "4.0.9",
+  version: "4.0.10",
   provider: "AWS",
   service: "Compute",
   policy_set: "Reserved Instance",
@@ -163,6 +163,8 @@ script "js_billing_centers_filtered", type: "javascript" do
   parameters "ds_billing_centers", "param_bc_allow_or_deny", "param_bc_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_bc_list = _.compact(_.map(param_bc_list, function(item) { return item.trim() }))
   allow_deny_test = { "Allow": true, "Deny": false }
 
   if (param_bc_list.length > 0) {

--- a/cost/aws/schedule_instance/CHANGELOG.md
+++ b/cost/aws/schedule_instance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v8.1.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v8.1.0
 
 - Added a region error-reporting check that surfaces a clear incident when the policy is unable to access one or more AWS regions, instead of silently omitting data from those regions.

--- a/cost/aws/schedule_instance/aws_schedule_instance.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "15 minutes"
 info(
-  version: "8.1.0",
+  version: "8.1.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Schedule Instance",
@@ -140,6 +140,18 @@ end
 ###############################################################################
 # Datasources & Scripts
 ###############################################################################
+
+datasource "ds_tag_schedule" do
+  run_script $js_tag_schedule, $param_tag_schedule
+end
+
+script "js_tag_schedule", type: "javascript" do
+  parameters "param_tag_schedule"
+  result "result"
+  code <<-'EOS'
+  result = param_tag_schedule.trim()
+EOS
+end
 
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
@@ -696,7 +708,7 @@ datasource "ds_instance_sets" do
     query 'Action', 'DescribeInstances'
     query 'Version', '2016-11-15'
     query "Filter.1.Name", "tag-key"
-    query "Filter.1.Value.1", $param_tag_schedule
+    query "Filter.1.Value.1", $ds_tag_schedule
     header 'User-Agent', 'RS Policies'
     header 'Content-Type', 'text/xml'
   end
@@ -733,6 +745,8 @@ script "js_instances", type: "javascript" do
   parameters "ds_instance_sets", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -813,11 +827,11 @@ EOS
 end
 
 datasource "ds_instances_with_schedule" do
-  run_script $js_instances_with_schedule, $ds_instances, $ds_aws_account, $ds_applied_policy, $param_tag_schedule
+  run_script $js_instances_with_schedule, $ds_instances, $ds_aws_account, $ds_applied_policy, $ds_tag_schedule
 end
 
 script "js_instances_with_schedule", type: "javascript" do
-  parameters "ds_instances", "ds_aws_account", "ds_applied_policy", "param_tag_schedule"
+  parameters "ds_instances", "ds_aws_account", "ds_applied_policy", "ds_tag_schedule"
   result "result"
   code <<-'EOS'
   result = []
@@ -841,7 +855,7 @@ script "js_instances_with_schedule", type: "javascript" do
         tags.push(item['key'] + '=' + item['value'])
 
         if (item['key'].toLowerCase() == 'name') { resourceName = item['value'] }
-        if (item['key'] == param_tag_schedule)   { schedule = item['value']     }
+        if (item['key'] == ds_tag_schedule)   { schedule = item['value']     }
       })
     }
 
@@ -977,6 +991,8 @@ script "js_instances_schedule_result_action_start", type: "javascript" do
   parameters "ds_instances_schedule_result", "param_enforce_schedules", "param_tag_schedule_action"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_tag_schedule_action = param_tag_schedule_action.trim()
   var result = []
   var enforce_schedule_enabled = param_enforce_schedules == "Yes"
   // Force Action is a static string unless force action is enabled
@@ -1049,6 +1065,8 @@ script "js_instances_schedule_result_action_stop", type: "javascript" do
   parameters "ds_instances_schedule_result", "param_enforce_schedules", "param_tag_schedule_action"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_tag_schedule_action = param_tag_schedule_action.trim()
   var result = []
   var enforce_schedule_enabled = param_enforce_schedules == "Yes"
   // Force Action is a static string unless force action is enabled
@@ -1445,7 +1463,7 @@ The following AWS Instances are scheduled to stop now:
     detail_template <<-'EOS'
 **Policy Applied in Account: {{ rs_project_name }} (Account ID: {{ rs_project_id }}) within Org: {{ rs_org_name }} (Org ID: {{ rs_org_id }})**
 
-The following AWS Scheduled Instances have tag `{{ parameters.param_tag_schedule }}` and will be automatically started and stopped on a schedule.
+The following AWS Scheduled Instances have tag `{{ parameters.ds_tag_schedule }}` and will be automatically started and stopped on a schedule.
     EOS
     # Policy check fails and incident is created only if data is not empty and the Parent Policy has not been terminated
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))

--- a/cost/aws/superseded_ebs_volumes/CHANGELOG.md
+++ b/cost/aws/superseded_ebs_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.7.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v6.7.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
+++ b/cost/aws/superseded_ebs_volumes/aws_superseded_ebs_volumes.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "6.7.0",
+  version: "6.7.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Inefficient Disk Usage",
@@ -640,6 +640,8 @@ script "js_volumes_tag_filtered", type: "javascript" do
   parameters "ds_volumes", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   gp2_volumes = _.reject(ds_volumes, function(volume) {
     return volume['volumeType'] != 'gp2'
   })

--- a/cost/aws/superseded_instances/CHANGELOG.md
+++ b/cost/aws/superseded_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.3.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.3.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/aws/superseded_instances/aws_superseded_instances.pt
+++ b/cost/aws/superseded_instances/aws_superseded_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.3.0",
+  version: "3.3.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Superseded Compute Instances",
@@ -644,6 +644,8 @@ script "js_instances", type: "javascript" do
   parameters "ds_instance_sets", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/cost/aws/superseded_rds_instances/CHANGELOG.md
+++ b/cost/aws/superseded_rds_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.2.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/aws/superseded_rds_instances/aws_superseded_rds_instances.pt
+++ b/cost/aws/superseded_rds_instances/aws_superseded_rds_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "0.2.0",
+  version: "0.2.1",
   provider: "AWS",
   service: "RDS",
   policy_set: "Superseded Compute Instances",
@@ -736,6 +736,8 @@ script "js_rds_instances", type: "javascript" do
   parameters "ds_rds_instances_set", "ds_resource_tags", "ds_aws_instance_type_map", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   result = []
 
   comparators = _.map(param_exclusion_tags, function(item) {

--- a/cost/aws/unused_albs/CHANGELOG.md
+++ b/cost/aws/unused_albs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.5.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/aws/unused_albs/aws_unused_albs.pt
+++ b/cost/aws/unused_albs/aws_unused_albs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.0",
+  version: "0.5.1",
   provider: "AWS",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -624,6 +624,8 @@ script "js_albs_tag_filtered", type: "javascript" do
   parameters "ds_albs_age_filtered", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/cost/aws/unused_clbs/CHANGELOG.md
+++ b/cost/aws/unused_clbs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.7.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v6.7.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/aws/unused_clbs/aws_unused_clbs.pt
+++ b/cost/aws/unused_clbs/aws_unused_clbs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.7.0",
+  version: "6.7.1",
   provider: "AWS",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -571,6 +571,8 @@ script "js_clbs_tag_filtered", type: "javascript" do
   parameters "ds_clbs", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/cost/aws/unused_ip_addresses/CHANGELOG.md
+++ b/cost/aws/unused_ip_addresses/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v9.5.6
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v9.5.5
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
+++ b/cost/aws/unused_ip_addresses/aws_unused_ip_addresses.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "9.5.5",
+  version: "9.5.6",
   provider: "AWS",
   service: "Compute",
   policy_set: "Unused IP Addresses",
@@ -566,6 +566,8 @@ script "js_ip_addresses_filtered", type: "javascript" do
   parameters "ds_ip_addresses", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/cost/aws/unused_nlbs/CHANGELOG.md
+++ b/cost/aws/unused_nlbs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.5.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/aws/unused_nlbs/aws_unused_nlbs.pt
+++ b/cost/aws/unused_nlbs/aws_unused_nlbs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.0",
+  version: "0.5.1",
   provider: "AWS",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -624,6 +624,8 @@ script "js_nlbs_tag_filtered", type: "javascript" do
   parameters "ds_nlbs_age_filtered", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/cost/azure/advisor_compute/CHANGELOG.md
+++ b/cost/azure/advisor_compute/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.5.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/azure/advisor_compute/azure_advisor_compute.pt
+++ b/cost/azure/advisor_compute/azure_advisor_compute.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.0",
+  version: "0.5.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -325,6 +325,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -457,6 +459,8 @@ script "js_azure_instances_tag_filtered", type: "javascript" do
   parameters "ds_azure_instances_with_status", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -533,6 +537,8 @@ script "js_azure_instances_region_filtered", type: "javascript" do
   parameters "ds_azure_instances_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_instances_tag_filtered, function(vm) {
       include_vm = _.contains(param_regions_list, vm['region'])
@@ -600,6 +606,8 @@ script "js_azure_instances_rg_filtered", type: "javascript" do
   parameters "ds_azure_instances_status_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_azure_instances_status_filtered, function(resource) {
         rg = resource['resourceGroup']

--- a/cost/azure/blob_storage_optimization/CHANGELOG.md
+++ b/cost/azure/blob_storage_optimization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.2.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.2.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/blob_storage_optimization/azure_blob_storage_optimization.pt
+++ b/cost/azure/blob_storage_optimization/azure_blob_storage_optimization.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.2.2",
+  version: "4.2.3",
   provider: "Azure",
   service: "Storage",
   policy_set: "Object Store Optimization",
@@ -290,6 +290,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -360,6 +362,8 @@ script "js_azure_storage_accounts_tag_filtered", type: "javascript" do
   parameters "ds_azure_storage_accounts", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -436,6 +440,8 @@ script "js_azure_storage_accounts_region_filtered", type: "javascript" do
   parameters "ds_azure_storage_accounts_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_storage_accounts_tag_filtered, function(account) {
       include_account = _.contains(param_regions_list, account['region'])
@@ -462,6 +468,8 @@ script "js_azure_storage_accounts_name_filtered", type: "javascript" do
   parameters "ds_azure_storage_accounts_region_filtered", "param_storage_account_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_storage_account_list = _.compact(_.map(param_storage_account_list, function(item) { return item.trim() }))
   if (param_storage_account_list.length > 0) {
     result = _.filter(ds_azure_storage_accounts_region_filtered, function(account) {
       return _.contains(param_storage_account_list, account['name'])
@@ -558,6 +566,8 @@ script "js_azure_blobs_rg_filtered", type: "javascript" do
   parameters "ds_azure_blobs_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_azure_blobs_filtered, function(resource) {
         rg = resource['resourceGroup']

--- a/cost/azure/cheaper_regions/CHANGELOG.md
+++ b/cost/azure/cheaper_regions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.2.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v1.2.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/cheaper_regions/azure_cheaper_regions.pt
+++ b/cost/azure/cheaper_regions/azure_cheaper_regions.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "1.2.2",
+  version: "1.2.3",
   provider: "Azure",
   service: "All",
   policy_set: "Cheaper Regions",
@@ -250,6 +250,8 @@ script "js_billing_centers_filtered", type: "javascript" do
   parameters "ds_billing_centers", "param_bc_allow_or_deny", "param_bc_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_bc_list = _.compact(_.map(param_bc_list, function(item) { return item.trim() }))
   allow_deny_test = { "Allow": true, "Deny": false }
 
   if (param_bc_list.length > 0) {
@@ -448,6 +450,8 @@ script "js_cheaper_regions", type: "javascript" do
   parameters "ds_regions_sorted", "ds_currency", "param_regions_allow_or_deny", "param_regions_list", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   result = _.filter(ds_regions_sorted, function(item) {
     return typeof(item['cheaper']) == 'string' && item['cheaper'] != ''
   })


### PR DESCRIPTION
### Description

One of several PRs focused on sanitizing inputs for PT parameters. This is to prevent users from breaking policy template execution because they entered a parameter incorrectly, such as putting whitespace at the beginning or end of the value.

Also corrects some Dangerfile-reported issues with the touched PTs.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
