### PR TITLE
POL-1826 Parameter Sanitization: Policy Templates #7

### DIFF
--- a/cost/azure/rightsize_postgresql_flexible/CHANGELOG.md
+++ b/cost/azure/rightsize_postgresql_flexible/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.2.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/azure/rightsize_postgresql_flexible/azure_rightsize_postgresql_flexible.pt
+++ b/cost/azure/rightsize_postgresql_flexible/azure_rightsize_postgresql_flexible.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.0",
+  version: "0.2.1",
   provider: "Azure",
   service: "PostgreSQL",
   policy_set: "Rightsize Database Instances",
@@ -448,6 +448,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -541,6 +543,8 @@ script "js_azure_postgresql_tag_filtered", type: "javascript" do
   parameters "ds_azure_postgresql_system_filtered", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -617,6 +621,8 @@ script "js_azure_postgresql_region_filtered", type: "javascript" do
   parameters "ds_azure_postgresql_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_postgresql_tag_filtered, function(resource) {
       include_resource = _.contains(param_regions_list, resource['region'])
@@ -637,6 +643,8 @@ script "js_azure_postgresql_rg_filtered", type: "javascript" do
   parameters "azure_postgresql_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
   if (param_resource_groups_list.length > 0) {
     result = _.filter(azure_postgresql_region_filtered, function(resource) {
       rg = resource['resourceGroup']

--- a/cost/azure/rightsize_postgresql_single/CHANGELOG.md
+++ b/cost/azure/rightsize_postgresql_single/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.2.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/azure/rightsize_postgresql_single/azure_rightsize_postgresql_single.pt
+++ b/cost/azure/rightsize_postgresql_single/azure_rightsize_postgresql_single.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.0",
+  version: "0.2.1",
   provider: "Azure",
   service: "PostgreSQL",
   policy_set: "Rightsize Database Instances",
@@ -448,6 +448,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -541,6 +543,8 @@ script "js_azure_postgresql_tag_filtered", type: "javascript" do
   parameters "ds_azure_postgresql_system_filtered", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -617,6 +621,8 @@ script "js_azure_postgresql_region_filtered", type: "javascript" do
   parameters "ds_azure_postgresql_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_postgresql_tag_filtered, function(resource) {
       include_resource = _.contains(param_regions_list, resource['region'])
@@ -637,6 +643,8 @@ script "js_azure_postgresql_rg_filtered", type: "javascript" do
   parameters "azure_postgresql_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
   if (param_resource_groups_list.length > 0) {
     result = _.filter(azure_postgresql_region_filtered, function(resource) {
       rg = resource['resourceGroup']

--- a/cost/azure/rightsize_sql_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_sql_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.4.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v6.4.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.4.0",
+  version: "6.4.1",
   provider: "Azure",
   service: "SQL",
   policy_set: "Rightsize Database Instances",
@@ -464,6 +464,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -614,6 +616,8 @@ script "js_azure_sql_databases_tag_filtered", type: "javascript" do
   parameters "ds_azure_sql_databases_system_filtered", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -690,6 +694,8 @@ script "js_azure_sql_databases_region_filtered", type: "javascript" do
   parameters "ds_azure_sql_databases_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_sql_databases_tag_filtered, function(db) {
       include_db = _.contains(param_regions_list, db['region'])
@@ -714,6 +720,8 @@ script "js_azure_sql_databases_rg_filtered", type: "javascript" do
   parameters "ds_azure_sql_databases_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_azure_sql_databases_region_filtered, function(resource) {
         rg = resource['resourceGroup']

--- a/cost/azure/rightsize_sql_storage/CHANGELOG.md
+++ b/cost/azure/rightsize_sql_storage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.5.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/azure/rightsize_sql_storage/azure_rightsize_sql_storage.pt
+++ b/cost/azure/rightsize_sql_storage/azure_rightsize_sql_storage.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.0",
+  version: "0.5.1",
   provider: "Azure",
   service: "SQL",
   policy_set: "Rightsize Database Instances",
@@ -393,6 +393,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -556,6 +558,8 @@ script "js_azure_sql_databases_tag_filtered", type: "javascript" do
   parameters "ds_azure_sql_databases_system_filtered", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -632,6 +636,8 @@ script "js_azure_sql_databases_region_filtered", type: "javascript" do
   parameters "ds_azure_sql_databases_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_sql_databases_tag_filtered, function(ip) {
       include_db = _.contains(param_regions_list, db['region'])
@@ -656,6 +662,8 @@ script "js_azure_sql_databases_rg_filtered", type: "javascript" do
   parameters "ds_azure_sql_databases_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_azure_sql_databases_region_filtered, function(resource) {
         rg = resource['resourceGroup']

--- a/cost/azure/rightsize_synapse_sql_pools/CHANGELOG.md
+++ b/cost/azure/rightsize_synapse_sql_pools/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## v0.4.3
-
-- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
-
 ## v0.5.1
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/cost/azure/rightsize_synapse_sql_pools/CHANGELOG.md
+++ b/cost/azure/rightsize_synapse_sql_pools/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.4.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
+## v0.5.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.5.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/azure/rightsize_synapse_sql_pools/azure_rightsize_synapse_sql_pools.pt
+++ b/cost/azure/rightsize_synapse_sql_pools/azure_rightsize_synapse_sql_pools.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.0",
+  version: "0.5.1",
   provider: "Azure",
   service: "SQL",
   policy_set: "Rightsize Synapse SQL Pools",
@@ -422,6 +422,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     if (param_subscriptions_allow_or_deny == "Deny") {
         result = _.filter(ds_azure_subscriptions, function (s) {
@@ -507,6 +509,8 @@ script "js_azure_synapse_sql_pools_tag_filtered", type: "javascript" do
   parameters "ds_azure_synapse_sql_pools", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -602,6 +606,8 @@ script "js_azure_synapse_sql_pools_region_filtered", type: "javascript" do
   parameters "ds_azure_synapse_sql_pools_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_synapse_sql_pools_tag_filtered, function(pool) {
       include_pool = _.contains(param_regions_list, pool['region'])
@@ -626,6 +632,8 @@ script "js_azure_synapse_sql_pools_rg_filtered", type: "javascript" do
   parameters "ds_azure_synapse_sql_pools_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_azure_synapse_sql_pools_region_filtered, function(resource) {
         rg = resource['resourceGroup']

--- a/cost/azure/rightsize_synapse_sql_pools/azure_rightsize_synapse_sql_pools_meta_parent.pt
+++ b/cost/azure/rightsize_synapse_sql_pools/azure_rightsize_synapse_sql_pools_meta_parent.pt
@@ -7,7 +7,7 @@ category "Meta"
 default_frequency "15 minutes"
 info(
   provider: "Azure",
-  version: "0.4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.4.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
 )
 
 ##############################################################################
@@ -374,6 +374,9 @@ script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
   code <<-EOS
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_dimension_filter_includes = _.compact(_.map(param_dimension_filter_includes, function(item) { return item.trim() }))
+  param_dimension_filter_excludes = _.compact(_.map(param_dimension_filter_excludes, function(item) { return item.trim() }))
 
   billing_centers_formatted = []
 

--- a/cost/azure/savings_plan/recommendations/CHANGELOG.md
+++ b/cost/azure/savings_plan/recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.8.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.8.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/azure/savings_plan/recommendations/azure_savings_plan_recommendations.pt
+++ b/cost/azure/savings_plan/recommendations/azure_savings_plan_recommendations.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.8.0",
+  version: "3.8.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Savings Plans",
@@ -300,6 +300,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -463,6 +465,8 @@ script "js_sp_recommendations_rg_filtered", type: "javascript" do
   parameters "ds_sp_recommendations", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_sp_recommendations, function(resource) {
         rg = resource['resourceGroup']

--- a/cost/azure/savings_realized/CHANGELOG.md
+++ b/cost/azure/savings_realized/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.9.10
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.9.9
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/savings_realized/azure_savings_realized.pt
+++ b/cost/azure/savings_realized/azure_savings_realized.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "monthly"
 info(
-  version: "3.9.9",
+  version: "3.9.10",
   provider: "Azure",
   service: "Compute",
   policy_set: "Savings Realized",
@@ -236,6 +236,8 @@ script "js_filtered_bcs", type: "javascript" do
   parameters "ds_billing_centers", "param_billing_centers"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_billing_centers = _.compact(_.map(param_billing_centers, function(item) { return item.trim() }))
   if (param_billing_centers.length == 0) {
     filtered_bcs = _.filter(ds_billing_centers, function(bc) {
       return bc['parent_id'] == null || bc['parent_id'] == undefined
@@ -267,6 +269,9 @@ script "js_bill_connections", type: "javascript" do
   parameters "ds_filtered_bcs", "start_date", "end_date", "org_id", "optima_host"
   result "request"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  start_date = start_date.trim()
+  end_date = end_date.trim()
   payload = {
     "billing_center_ids": ds_filtered_bcs,
     "dimensions": [ "bill_source" ],
@@ -450,6 +455,9 @@ script "js_get_aggregated_costs", type: "javascript" do
   parameters "bill_sources", "ds_filtered_bcs", "start_date", "end_date", "org_id", "optima_host", "connection_type"
   result "request"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  start_date = start_date.trim()
+  end_date = end_date.trim()
   // Set filters based on the type of request
   if (connection_type == 'old_base') {
     filter = {

--- a/cost/azure/schedule_instance/CHANGELOG.md
+++ b/cost/azure/schedule_instance/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v7.2.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Fixed `run_script` parameter ordering for the `ds_azure_instances_tag_filtered` datasource.
+
 ## v7.2.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/schedule_instance/azure_schedule_instance.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "15 minutes"
 info(
-  version: "7.2.2",
+  version: "7.2.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "Schedule Instance",
@@ -182,6 +182,18 @@ end
 ###############################################################################
 # Datasources & Scripts
 ###############################################################################
+
+datasource "ds_tag_schedule" do
+  run_script $js_tag_schedule, $param_tag_schedule
+end
+
+script "js_tag_schedule", type: "javascript" do
+  parameters "param_tag_schedule"
+  result "result"
+  code <<-'EOS'
+  result = param_tag_schedule.trim()
+EOS
+end
 
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
@@ -471,6 +483,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -536,13 +550,15 @@ datasource "ds_azure_instances" do
 end
 
 datasource "ds_azure_instances_tag_filtered" do
-  run_script $js_azure_instances_tag_filtered, $ds_azure_instances, $param_exclusion_tags, $param_exclusion_tags_boolean, $param_tag_schedule
+  run_script $js_azure_instances_tag_filtered, $ds_azure_instances, $ds_tag_schedule, $param_exclusion_tags, $param_exclusion_tags_boolean
 end
 
 script "js_azure_instances_tag_filtered", type: "javascript" do
-  parameters "ds_azure_instances", "param_exclusion_tags", "param_exclusion_tags_boolean", "param_tag_schedule"
+  parameters "ds_azure_instances", "ds_tag_schedule", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -614,7 +630,7 @@ script "js_azure_instances_tag_filtered", type: "javascript" do
     tag_keys = []
     if (typeof(vm['tags']) == 'object') { tag_keys = _.keys(vm['tags']) }
 
-    return _.contains(tag_keys, param_tag_schedule)
+    return _.contains(tag_keys, ds_tag_schedule)
   })
 EOS
 end
@@ -627,6 +643,8 @@ script "js_azure_instances_region_filtered", type: "javascript" do
   parameters "ds_azure_instances_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_instances_tag_filtered, function(vm) {
       include_vm = _.contains(param_regions_list, vm['region'])
@@ -651,6 +669,8 @@ script "js_azure_instances_rg_filtered", type: "javascript" do
   parameters "ds_azure_instances_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_azure_instances_region_filtered, function(resource) {
         rg = resource['resourceGroup']
@@ -702,11 +722,11 @@ datasource "ds_azure_instances_with_status" do
 end
 
 datasource "ds_instances_with_schedule" do
-  run_script $js_instances_with_schedule, $ds_azure_instances_with_status, $ds_applied_policy, $ds_azure_directory, $param_tag_schedule
+  run_script $js_instances_with_schedule, $ds_azure_instances_with_status, $ds_applied_policy, $ds_azure_directory, $ds_tag_schedule
 end
 
 script "js_instances_with_schedule", type: "javascript" do
-  parameters "ds_azure_instances_with_status", "ds_applied_policy", "ds_azure_directory", "param_tag_schedule"
+  parameters "ds_azure_instances_with_status", "ds_applied_policy", "ds_azure_directory", "ds_tag_schedule"
   result "result"
   code <<-'EOS'
   result = []
@@ -729,7 +749,7 @@ script "js_instances_with_schedule", type: "javascript" do
         tags.push(key + '=' + value)
 
         // If tag is the schedule tag, set schedule var for parsing
-        if (key == param_tag_schedule) { schedule = value }
+        if (key == ds_tag_schedule) { schedule = value }
       })
     }
 
@@ -887,6 +907,8 @@ script "js_instances_schedule_result_action_start", type: "javascript" do
   parameters "ds_instances_schedule_result", "param_enforce_schedules", "param_tag_schedule_action"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_tag_schedule_action = param_tag_schedule_action.trim()
   var result = []
   var enforce_schedule_enabled = param_enforce_schedules == "Yes"
   // Force Action is a static string unless force action is enabled
@@ -959,6 +981,8 @@ script "js_instances_schedule_result_action_stop", type: "javascript" do
   parameters "ds_instances_schedule_result", "param_enforce_schedules", "param_tag_schedule_action"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_tag_schedule_action = param_tag_schedule_action.trim()
   var result = []
   var enforce_schedule_enabled = param_enforce_schedules == "Yes"
   // Force Action is a static string unless force action is enabled
@@ -1424,7 +1448,7 @@ The following Azure Instances are scheduled to stop now:
     detail_template <<-'EOS'
 **Policy Applied in Account: {{ rs_project_name }} (Account ID: {{ rs_project_id }}) within Org: {{ rs_org_name }} (Org ID: {{ rs_org_id }})**
 
-The following Azure Scheduled Instances have tag `{{ parameters.param_tag_schedule }}` and will be automatically started and stopped on a schedule.
+The following Azure Scheduled Instances have tag `{{ parameters.ds_tag_schedule }}` and will be automatically started and stopped on a schedule.
     EOS
     # Policy check fails and incident is created only if data is not empty and the Parent Policy has not been terminated
     check logic_or($ds_parent_policy_terminated, eq(val(item, "resourceID"), ""))

--- a/cost/azure/sentinel_commitment_tiers/CHANGELOG.md
+++ b/cost/azure/sentinel_commitment_tiers/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.5.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/azure/sentinel_commitment_tiers/azure_sentinel_commitment_tiers.pt
+++ b/cost/azure/sentinel_commitment_tiers/azure_sentinel_commitment_tiers.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "0.5.0",
+  version: "0.5.1",
   provider: "Azure",
   service: "Sentinel",
   policy_set: "Commitment Tiers",
@@ -347,6 +347,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
     var enabled_subscriptions = _.filter(ds_azure_subscriptions, function(sub) {
       return sub["state"] === "Enabled"
     })
@@ -638,6 +640,8 @@ script "js_workspace_ingestion_rg_filtered", type: "javascript" do
   parameters "ds_workspace_ingestion", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_workspace_ingestion, function(resource) {
         rg = resource['resourceGroup']

--- a/cost/azure/sql_servers_without_elastic_pool/CHANGELOG.md
+++ b/cost/azure/sql_servers_without_elastic_pool/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.3.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.3.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/sql_servers_without_elastic_pool/azure_sql_servers_without_elastic_pool.pt
+++ b/cost/azure/sql_servers_without_elastic_pool/azure_sql_servers_without_elastic_pool.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.3.2",
+  version: "3.3.3",
   provider: "Azure",
   service: "SQL",
   policy_set: "Database Services",
@@ -246,6 +246,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -319,6 +321,8 @@ script "js_azure_sql_servers_tag_filtered", type: "javascript" do
   parameters "ds_azure_sql_servers", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -395,6 +399,8 @@ script "js_azure_sql_servers_region_filtered", type: "javascript" do
   parameters "ds_azure_sql_servers_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_sql_servers_tag_filtered, function(ip) {
       include_db = _.contains(param_regions_list, db['region'])
@@ -419,6 +425,8 @@ script "js_azure_sql_servers_rg_filtered", type: "javascript" do
   parameters "ds_azure_sql_servers_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_azure_sql_servers_region_filtered, function(resource) {
         rg = resource['resourceGroup']

--- a/cost/azure/storage_account_lifecycle_management/CHANGELOG.md
+++ b/cost/azure/storage_account_lifecycle_management/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.3.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.3.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management.pt
+++ b/cost/azure/storage_account_lifecycle_management/storage_account_lifecycle_management.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.3.2",
+  version: "4.3.3",
   provider: "Azure",
   service: "Storage Accounts",
   policy_set: "Lifecycle Management",
@@ -246,6 +246,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -329,6 +331,8 @@ script "js_storage_accounts_tag_filtered", type: "javascript" do
   parameters "ds_storage_accounts", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -405,6 +409,8 @@ script "js_storage_accounts_region_filtered", type: "javascript" do
   parameters "ds_storage_accounts_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_storage_accounts_tag_filtered, function(resource) {
       include_resource = _.contains(param_regions_list, resource['region'])
@@ -426,6 +432,8 @@ script "js_storage_accounts_rg_filtered", type: "javascript" do
   parameters "ds_storage_accounts_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_storage_accounts_region_filtered, function(resource) {
         rg = resource['resourceGroup']

--- a/cost/azure/superseded_instances/CHANGELOG.md
+++ b/cost/azure/superseded_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.4.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.4.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/azure/superseded_instances/azure_superseded_instances.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.4.0",
+  version: "4.4.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Superseded Compute Instances",
@@ -505,6 +505,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -578,6 +580,8 @@ script "js_azure_instances_tag_filtered", type: "javascript" do
   parameters "ds_azure_instances", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -654,6 +658,8 @@ script "js_azure_instances_region_filtered", type: "javascript" do
   parameters "ds_azure_instances_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_instances_tag_filtered, function(vm) {
       include_vm = _.contains(param_regions_list, vm['region'])
@@ -678,6 +684,8 @@ script "js_azure_instances_rg_filtered", type: "javascript" do
   parameters "ds_azure_instances_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_azure_instances_region_filtered, function(resource) {
         rg = resource['resourceGroup']

--- a/cost/azure/unoptimized_web_app_scaling/CHANGELOG.md
+++ b/cost/azure/unoptimized_web_app_scaling/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.5.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/unoptimized_web_app_scaling/azure_unoptimized_web_app_scaling.pt
+++ b/cost/azure/unoptimized_web_app_scaling/azure_unoptimized_web_app_scaling.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.1",
+  version: "0.5.2",
   provider: "Azure",
   service: "PaaS",
   policy_set: "PaaS Optimization",
@@ -247,6 +247,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -323,6 +325,8 @@ script "js_azure_web_apps_region_filtered", type: "javascript" do
   parameters "ds_azure_web_apps", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     web_apps = _.filter(ds_azure_web_apps, function(resource) {
       include_resource = _.contains(param_regions_list, resource['region'])
@@ -346,6 +350,8 @@ script "js_azure_web_apps_rg_filtered", type: "javascript" do
   parameters "ds_azure_web_apps_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_azure_web_apps_region_filtered, function(resource) {
         rg = resource['resourceGroup']

--- a/cost/azure/unused_app_service_plans/CHANGELOG.md
+++ b/cost/azure/unused_app_service_plans/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.5.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/azure/unused_app_service_plans/azure_unused_app_service_plans.pt
+++ b/cost/azure/unused_app_service_plans/azure_unused_app_service_plans.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.0",
+  version: "0.5.1",
   provider: "Azure",
   service: "PaaS",
   policy_set: "PaaS Optimization",
@@ -356,6 +356,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -438,6 +440,8 @@ script "js_azure_app_service_plans_tag_filtered", type: "javascript" do
   parameters "ds_azure_app_service_plans", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -514,6 +518,8 @@ script "js_azure_app_service_plans_region_filtered", type: "javascript" do
   parameters "ds_azure_app_service_plans_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_app_service_plans_tag_filtered, function(resource) {
       include_resource = _.contains(param_regions_list, resource['region'])
@@ -534,6 +540,8 @@ script "js_azure_app_service_plans_rg_filtered", type: "javascript" do
   parameters "ds_azure_app_service_plans_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_azure_app_service_plans_region_filtered, function(resource) {
         rg = resource['resourceGroup']

--- a/cost/azure/unused_firewalls/CHANGELOG.md
+++ b/cost/azure/unused_firewalls/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.6.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/azure/unused_firewalls/azure_unused_firewalls.pt
+++ b/cost/azure/unused_firewalls/azure_unused_firewalls.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.6.0",
+  version: "0.6.1",
   provider: "Azure",
   service: "Network",
   policy_set: "Unused Firewalls",
@@ -366,6 +366,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -438,6 +440,8 @@ script "js_azure_firewalls_tag_filtered", type: "javascript" do
   parameters "ds_azure_firewalls", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -514,6 +518,8 @@ script "js_azure_firewalls_region_filtered", type: "javascript" do
   parameters "ds_azure_firewalls_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_firewalls_tag_filtered, function(resource) {
       include_resource = _.contains(param_regions_list, resource['region'])
@@ -534,6 +540,8 @@ script "js_azure_firewalls_rg_filtered", type: "javascript" do
   parameters "ds_azure_firewalls_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_azure_firewalls_region_filtered, function(resource) {
         rg = resource['resourceGroup']

--- a/cost/azure/unused_ip_addresses/CHANGELOG.md
+++ b/cost/azure/unused_ip_addresses/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v7.7.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v7.7.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/azure/unused_ip_addresses/azure_unused_ip_addresses.pt
+++ b/cost/azure/unused_ip_addresses/azure_unused_ip_addresses.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "7.7.0",
+  version: "7.7.1",
   provider: "Azure",
   service: "Compute",
   policy_set: "Unused IP Addresses",
@@ -376,6 +376,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -463,6 +465,8 @@ script "js_ip_addresses_tag_filtered", type: "javascript" do
   parameters "ds_ip_addresses_alloc_filtered", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -539,6 +543,8 @@ script "js_ip_addresses_region_filtered", type: "javascript" do
   parameters "ds_ip_addresses_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_ip_addresses_tag_filtered, function(ip) {
       include_ip = _.contains(param_regions_list, ip['region'])
@@ -563,6 +569,8 @@ script "js_ip_addresses_rg_filtered", type: "javascript" do
   parameters "ds_ip_addresses_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_ip_addresses_region_filtered, function(resource) {
         rg = resource['resourceGroup']

--- a/cost/azure/unused_load_balancers/CHANGELOG.md
+++ b/cost/azure/unused_load_balancers/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.5.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/azure/unused_load_balancers/azure_unused_load_balancers.pt
+++ b/cost/azure/unused_load_balancers/azure_unused_load_balancers.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.0",
+  version: "0.5.1",
   provider: "Azure",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -366,6 +366,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -444,6 +446,8 @@ script "js_azure_loadbalancers_tag_filtered", type: "javascript" do
   parameters "ds_azure_loadbalancers", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -520,6 +524,8 @@ script "js_azure_loadbalancers_region_filtered", type: "javascript" do
   parameters "ds_azure_loadbalancers_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_loadbalancers_tag_filtered, function(resource) {
       include_resource = _.contains(param_regions_list, resource['region'])
@@ -540,6 +546,8 @@ script "js_azure_loadbalancers_rg_filtered", type: "javascript" do
   parameters "ds_azure_loadbalancers_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_azure_loadbalancers_region_filtered, function(resource) {
         rg = resource['resourceGroup']


### PR DESCRIPTION
### Description

One of several PRs focused on sanitizing inputs for PT parameters. This is to prevent users from breaking policy template execution because they entered a parameter incorrectly, such as putting whitespace at the beginning or end of the value.

Also corrects some Dangerfile-reported issues with the touched PTs.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
