### PR TITLE
POL-1826 Parameter Sanitization: Policy Templates #8

### DIFF
--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -1637,8 +1637,6 @@ def policy_bad_comma_spacing?(file, file_lines)
   file_lines.each_with_index do |line, index|
     line_number = index + 1
     line = line.strip
-    test_line = line
-    parts = []
 
     # Skip image charts stuff
     next if line.include?("chxt=") || line.include?("chxs=") || line.include?("chco=") || line.include?("chdls=") || line.include?("chls=") || line.include?("chma=") || line.include?("chxr=") || line.include?("chg=") || line.include?("chf=")
@@ -1648,21 +1646,15 @@ def policy_bad_comma_spacing?(file, file_lines)
     next if line.match?(/\/[^\/]*,[^\/]*\/\.(test|match|exec|replace)\(/)
 
     # Strip content inside quotation marks to avoid false positives from comma-separated
-    # API parameter strings (e.g. metricnames, aggregation) and other string literal values.
-    # Lines starting with a quote are included so that JSON-style key-value pairs like
-    # `"metricnames": "Percentage CPU,Memory"` have their string values stripped correctly.
-    # A limit of -1 is passed to split so that a trailing empty string is preserved when the
-    # line ends exactly on a closing quote (Ruby's split otherwise silently drops it, which
-    # previously caused the stripping logic below to be skipped for these lines).
-    parts = line.split("\"", -1) if line.include?("\"") && !line.include?("'")
-    parts = line.split("'", -1) if !line.include?("\"") && line.include?("'") && !line.start_with?("'")
-
-    if parts.length > 2
-      test_parts = []
-      parts.each_with_index { |part, index| test_parts << part if index % 2 == 0 }
-      test_line = test_parts.join("'")
-      test_line += "'" if line.end_with?("'") || line.end_with?("\"")
-    end
+    # API parameter strings (e.g. metricnames, aggregation), Google Chart data strings
+    # (e.g. "chd=t:60,40|0,100"), and other string literal values. Both quote styles are
+    # stripped unconditionally (rather than picking a single style based on which one(s)
+    # appear on the line), so this also handles lines that mix single and double quotes
+    # (e.g. ds_x['key'] + "literal,text"), which a previous either/or split-based approach
+    # missed, causing commas inside the string to be misread as list separators. Double
+    # quotes are stripped first so that an apostrophe inside a double-quoted string (e.g.
+    # "here's a comma, and more") doesn't get mistaken for the start of a single-quoted span.
+    test_line = line.gsub(/"[^"]*"/, '""').gsub(/'[^']*'/, "''")
 
     if test_line.include?(",") && !test_line.include?("allowed_pattern") && !test_line.include?('= ","') && !test_line.include?("(',')") && !test_line.include?('(",")') && !test_line.include?("jq(") && !test_line.include?("/,/")
       if test_line.match(/,\s{2,}/) || test_line.match(/\s,/) || test_line.match(/,[^\s]/) && !(test_line.match(/\',\'/) || test_line.match(/\",\"/) || test_line.match(/\`,\`/))

--- a/cost/azure/unused_storage_accounts/CHANGELOG.md
+++ b/cost/azure/unused_storage_accounts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.5.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/azure/unused_storage_accounts/azure_unused_storage_accounts.pt
+++ b/cost/azure/unused_storage_accounts/azure_unused_storage_accounts.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "0.5.0",
+  version: "0.5.1",
   provider: "Azure",
   service: "Storage",
   policy_set: "Unused Storage Accounts",
@@ -375,6 +375,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -450,6 +452,8 @@ script "js_azure_storage_accounts_tag_filtered", type: "javascript" do
   parameters "ds_azure_storage_accounts", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -526,6 +530,8 @@ script "js_azure_storage_accounts_region_filtered", type: "javascript" do
   parameters "ds_azure_storage_accounts_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_storage_accounts_tag_filtered, function(account) {
       include_account = _.contains(param_regions_list, account['region'])
@@ -546,6 +552,8 @@ script "js_azure_storage_accounts_rg_filtered", type: "javascript" do
   parameters "ds_azure_storage_accounts_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_azure_storage_accounts_region_filtered, function(resource) {
         rg = resource['resourceGroup']

--- a/cost/azure/unused_vngs/CHANGELOG.md
+++ b/cost/azure/unused_vngs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.4.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/azure/unused_vngs/azure_unused_vngs.pt
+++ b/cost/azure/unused_vngs/azure_unused_vngs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.2",
+  version: "0.4.3",
   provider: "Azure",
   service: "Network",
   policy_set: "Unused Virtual Networks",
@@ -255,6 +255,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -332,6 +334,8 @@ script "js_azure_vngs_tag_filtered", type: "javascript" do
   parameters "ds_azure_vngs", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -408,6 +412,8 @@ script "js_azure_vngs_region_filtered", type: "javascript" do
   parameters "ds_azure_vngs_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_vngs_tag_filtered, function(resource) {
       include_resource = _.contains(param_regions_list, resource['region'])
@@ -428,6 +434,8 @@ script "js_azure_vngs_rg_filtered", type: "javascript" do
   parameters "ds_azure_vngs_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_azure_vngs_region_filtered, function(resource) {
         rg = resource['resourceGroup']

--- a/cost/azure/unused_volumes/CHANGELOG.md
+++ b/cost/azure/unused_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v8.6.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v8.6.1
 
 - Fixed bug where the `Delete Volumes` action would fail if the volume had already been deleted. The action now treats a volume that no longer exists as a successful deletion.

--- a/cost/azure/unused_volumes/azure_unused_volumes.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "8.6.1",
+  version: "8.6.2",
   provider: "Azure",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -394,6 +394,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -498,6 +500,8 @@ script "js_azure_disks_tag_filtered", type: "javascript" do
   parameters "ds_azure_disks_status_filtered", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -574,6 +578,8 @@ script "js_azure_disks_region_filtered", type: "javascript" do
   parameters "ds_azure_disks_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_disks_tag_filtered, function(disk) {
       include_disk = _.contains(param_regions_list, disk['region'])
@@ -598,6 +604,8 @@ script "js_azure_disks_rg_filtered", type: "javascript" do
   parameters "ds_azure_disks_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_azure_disks_region_filtered, function(resource) {
         rg = resource['resourceGroup']

--- a/cost/flexera/cco/budget_report_alerts/CHANGELOG.md
+++ b/cost/flexera/cco/budget_report_alerts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.7.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.7.0
 
 - Added `Include Data Table In Incident` parameter to optionally include a formatted table of the budget data in the body of the incident.

--- a/cost/flexera/cco/budget_report_alerts/budget_report_alerts.pt
+++ b/cost/flexera/cco/budget_report_alerts/budget_report_alerts.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "3.7.0",
+  version: "3.7.1",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -219,6 +219,8 @@ script "js_filters", type: "javascript" do
   parameters "ds_dimensions", "param_filter"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_filter = _.compact(_.map(param_filter, function(item) { return item.trim() }))
   result = {}
   dimensions = _.invert(ds_dimensions)
 
@@ -264,6 +266,8 @@ script "js_filtered_budgets", type: "javascript" do
   parameters "ds_budgets", "param_budget_name_id"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_budget_name_id = param_budget_name_id.trim()
   current_month = new Date().toISOString().substring(0, 7)
 
   result = _.filter(ds_budgets, function(budget) {
@@ -382,6 +386,9 @@ script "js_aggregated", type: "javascript" do
   parameters "ds_filtered_reports", "ds_currency", "ds_dimensions", "ds_billing_center_table", "param_threshold_percentage", "param_type", "param_budget_name_id", "param_filter", "param_incident_csv", "param_incident_data_table", "f1_app_host"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_budget_name_id = param_budget_name_id.trim()
+  param_filter = _.compact(_.map(param_filter, function(item) { return item.trim() }))
   function convert_bc_name(id) {
     return ds_billing_center_table[id] ? ds_billing_center_table[id] : id
   }

--- a/cost/flexera/cco/budget_v_actual_spend_report/CHANGELOG.md
+++ b/cost/flexera/cco/budget_v_actual_spend_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.7.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v2.7.2
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/cost/flexera/cco/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
+++ b/cost/flexera/cco/budget_v_actual_spend_report/budget_v_actual_spend_report.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.7.2",
+  version: "2.7.3",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -217,6 +217,8 @@ script "js_filters", type: "javascript" do
   parameters "ds_dimensions", "param_filter"
   result "results"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_filter = _.compact(_.map(param_filter, function(item) { return item.trim() }))
   var results = {}
   var ds_dimensions_inverted = _.invert(ds_dimensions);
   _.each(param_filter, function (filter_item) {
@@ -365,6 +367,8 @@ script "js_aggregated_report", type: "javascript" do
   parameters "reports", "currency_code", "currency_reference", "ds_dimensions", "filters", "ds_billing_center_table", "budget_name_id", "report_type", "param_incident_data_table", "f1_app_host"
   result "results"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  budget_name_id = budget_name_id.trim()
   function convert_bc_name(id) {
     return ds_billing_center_table[id] ? ds_billing_center_table[id] : id
   }

--- a/cost/flexera/cco/cbi_ingestion_aws_s3/CHANGELOG.md
+++ b/cost/flexera/cco/cbi_ingestion_aws_s3/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.7
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.2.6
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/flexera/cco/cbi_ingestion_aws_s3/cbi_ingestion_aws_s3.pt
+++ b/cost/flexera/cco/cbi_ingestion_aws_s3/cbi_ingestion_aws_s3.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "0.2.6",
+  version: "0.2.7",
   provider: "Flexera",
   service: "Common Bill Ingestion",
   policy_set: "Common Bill Ingestion",
@@ -120,6 +120,18 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_s3_hostname" do
+  run_script $js_s3_hostname, $param_s3_hostname
+end
+
+script "js_s3_hostname", type: "javascript" do
+  parameters "param_s3_hostname"
+  result "result"
+  code <<-'EOS'
+  result = param_s3_hostname.trim()
+EOS
+end
+
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
@@ -213,6 +225,8 @@ script "js_cbi_endpoint_id", type: "javascript" do
   parameters "param_cbi_endpoint", "param_cbi_cloud_vendor", "param_cbi_type"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_cbi_cloud_vendor = param_cbi_cloud_vendor.trim()
   result = param_cbi_endpoint
 
   if (param_cbi_endpoint == "") {
@@ -258,6 +272,8 @@ script "js_to_create_bill_connect", type: "javascript" do
   parameters "ds_existing_bill_connects", "ds_cbi_endpoint_id", "param_cbi_cloud_vendor", "param_cbi_type"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_cbi_cloud_vendor = param_cbi_cloud_vendor.trim()
   result = []
 
   existing_bill_connect = _.find(ds_existing_bill_connects, function(connect) {
@@ -430,6 +446,8 @@ script "js_cost_object_names", type: "javascript" do
   parameters "ds_dates", "param_s3_prefix", "param_granularity"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_s3_prefix = param_s3_prefix.trim()
   result = []
 
   if (param_granularity == "Monthly") {
@@ -453,7 +471,7 @@ datasource "ds_cost_objects" do
   iterate $ds_cost_object_names
   request do
     auth $auth_aws
-    host $param_s3_hostname
+    host $ds_s3_hostname
     path val(iter_item, "object")
     header "User-Agent", "RS Policies"
     ignore_status [404] # Ignore dates that have no associated file instead of failing completely
@@ -546,13 +564,15 @@ EOS
 end
 
 datasource "ds_incident" do
-  run_script $js_incident, $ds_cbi_commit_bill_upload, $ds_applied_policy, $ds_dates, $ds_cost_object_names, $param_s3_hostname, $param_s3_prefix
+  run_script $js_incident, $ds_cbi_commit_bill_upload, $ds_applied_policy, $ds_dates, $ds_cost_object_names, $ds_s3_hostname, $param_s3_prefix
 end
 
 script "js_incident", type: "javascript" do
-  parameters "ds_cbi_commit_bill_upload", "ds_applied_policy", "ds_dates", "ds_cost_object_names", "param_s3_hostname", "param_s3_prefix"
+  parameters "ds_cbi_commit_bill_upload", "ds_applied_policy", "ds_dates", "ds_cost_object_names", "ds_s3_hostname", "param_s3_prefix"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_s3_prefix = param_s3_prefix.trim()
   result = [{
     policy_name: ds_applied_policy['name'],
     id: ds_cbi_commit_bill_upload['id'],
@@ -561,7 +581,7 @@ script "js_incident", type: "javascript" do
     updatedAt: ds_cbi_commit_bill_upload['updatedAt'],
     billConnectId: ds_cbi_commit_bill_upload['billConnectId'],
     billingPeriod: ds_cbi_commit_bill_upload['billingPeriod'],
-    s3_hostname: param_s3_hostname
+    s3_hostname: ds_s3_hostname
   }]
 EOS
 end

--- a/cost/flexera/cco/cbi_ingestion_aws_s3_iterating/CHANGELOG.md
+++ b/cost/flexera/cco/cbi_ingestion_aws_s3_iterating/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.4
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.1.3
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/flexera/cco/cbi_ingestion_aws_s3_iterating/cbi_ingestion_aws_s3_iterating.pt
+++ b/cost/flexera/cco/cbi_ingestion_aws_s3_iterating/cbi_ingestion_aws_s3_iterating.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "15 minutes"
 info(
-  version: "0.1.3",
+  version: "0.1.4",
   provider: "Flexera",
   service: "Common Bill Ingestion",
   policy_set: "Common Bill Ingestion",
@@ -118,6 +118,18 @@ end
 ###############################################################################
 # Datasources & Scripts
 ###############################################################################
+
+datasource "ds_s3_hostname" do
+  run_script $js_s3_hostname, $param_s3_hostname
+end
+
+script "js_s3_hostname", type: "javascript" do
+  parameters "param_s3_hostname"
+  result "result"
+  code <<-'EOS'
+  result = param_s3_hostname.trim()
+EOS
+end
 
 datasource "ds_dates" do
   run_script $js_dates, $param_billing_period, $param_specific_period
@@ -295,7 +307,7 @@ datasource "ds_objects" do
   request do
     auth $auth_aws
     pagination $pagination_aws_s3
-    host $param_s3_hostname
+    host $ds_s3_hostname
     query "list-type", "2"
     header "User-Agent", "RS Policies"
   end
@@ -316,6 +328,8 @@ script "js_cost_object_keys", type: "javascript" do
   parameters "ds_objects", "ds_dates", "param_s3_prefix"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_s3_prefix = param_s3_prefix.trim()
   // Gather the list of objects for the current month's bill
   normed_prefix = param_s3_prefix.indexOf('/') != 0 ? param_s3_prefix : param_s3_prefix.substring(1)
 
@@ -351,7 +365,7 @@ datasource "ds_cost_objects" do
   iterate $ds_cost_object_keys_sliced
   request do
     auth $auth_aws
-    host $param_s3_hostname
+    host $ds_s3_hostname
     path join(["/", val(iter_item, "key")])
     header "User-Agent", "RS Policies"
   end

--- a/cost/flexera/cco/cbi_ingestion_azure_blob/CHANGELOG.md
+++ b/cost/flexera/cco/cbi_ingestion_azure_blob/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.7
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.2.6
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/flexera/cco/cbi_ingestion_azure_blob/cbi_ingestion_azure_blob.pt
+++ b/cost/flexera/cco/cbi_ingestion_azure_blob/cbi_ingestion_azure_blob.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "0.2.6",
+  version: "0.2.7",
   provider: "Flexera",
   service: "Common Bill Ingestion",
   policy_set: "Common Bill Ingestion",
@@ -119,6 +119,18 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_blob_hostname" do
+  run_script $js_blob_hostname, $param_blob_hostname
+end
+
+script "js_blob_hostname", type: "javascript" do
+  parameters "param_blob_hostname"
+  result "result"
+  code <<-'EOS'
+  result = param_blob_hostname.trim()
+EOS
+end
+
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
@@ -212,6 +224,8 @@ script "js_cbi_endpoint_id", type: "javascript" do
   parameters "param_cbi_endpoint", "param_cbi_cloud_vendor", "param_cbi_type"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_cbi_cloud_vendor = param_cbi_cloud_vendor.trim()
   result = param_cbi_endpoint
 
   if (param_cbi_endpoint == "") {
@@ -257,6 +271,8 @@ script "js_to_create_bill_connect", type: "javascript" do
   parameters "ds_existing_bill_connects", "ds_cbi_endpoint_id", "param_cbi_cloud_vendor", "param_cbi_type"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_cbi_cloud_vendor = param_cbi_cloud_vendor.trim()
   result = []
 
   existing_bill_connect = _.find(ds_existing_bill_connects, function(connect) {
@@ -429,6 +445,8 @@ script "js_cost_object_names", type: "javascript" do
   parameters "ds_dates", "param_blob_prefix", "param_granularity"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_blob_prefix = param_blob_prefix.trim()
   result = []
 
   if (param_granularity == "Monthly") {
@@ -452,7 +470,7 @@ datasource "ds_cost_objects" do
   iterate $ds_cost_object_names
   request do
     auth $auth_azure_storage
-    host $param_blob_hostname
+    host $ds_blob_hostname
     path val(iter_item, "object")
     header "User-Agent", "RS Policies"
     header "x-ms-version", "2025-05-05"
@@ -546,13 +564,15 @@ EOS
 end
 
 datasource "ds_incident" do
-  run_script $js_incident, $ds_cbi_commit_bill_upload, $ds_applied_policy, $ds_dates, $ds_cost_object_names, $param_blob_hostname, $param_blob_prefix
+  run_script $js_incident, $ds_cbi_commit_bill_upload, $ds_applied_policy, $ds_dates, $ds_cost_object_names, $ds_blob_hostname, $param_blob_prefix
 end
 
 script "js_incident", type: "javascript" do
-  parameters "ds_cbi_commit_bill_upload", "ds_applied_policy", "ds_dates", "ds_cost_object_names", "param_blob_hostname", "param_blob_prefix"
+  parameters "ds_cbi_commit_bill_upload", "ds_applied_policy", "ds_dates", "ds_cost_object_names", "ds_blob_hostname", "param_blob_prefix"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_blob_prefix = param_blob_prefix.trim()
   result = [{
     policy_name: ds_applied_policy['name'],
     id: ds_cbi_commit_bill_upload['id'],
@@ -561,7 +581,7 @@ script "js_incident", type: "javascript" do
     updatedAt: ds_cbi_commit_bill_upload['updatedAt'],
     billConnectId: ds_cbi_commit_bill_upload['billConnectId'],
     billingPeriod: ds_cbi_commit_bill_upload['billingPeriod'],
-    blob_hostname: param_blob_hostname
+    blob_hostname: ds_blob_hostname
   }]
 EOS
 end

--- a/cost/flexera/cco/cbi_ingestion_azure_blob_iterating/CHANGELOG.md
+++ b/cost/flexera/cco/cbi_ingestion_azure_blob_iterating/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.4
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.1.3
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/flexera/cco/cbi_ingestion_azure_blob_iterating/cbi_ingestion_azure_blob_iterating.pt
+++ b/cost/flexera/cco/cbi_ingestion_azure_blob_iterating/cbi_ingestion_azure_blob_iterating.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "15 minutes"
 info(
-  version: "0.1.3",
+  version: "0.1.4",
   provider: "Flexera",
   service: "Common Bill Ingestion",
   policy_set: "Common Bill Ingestion",
@@ -117,6 +117,30 @@ end
 ###############################################################################
 # Datasources & Scripts
 ###############################################################################
+
+datasource "ds_blob_container" do
+  run_script $js_blob_container, $param_blob_container
+end
+
+script "js_blob_container", type: "javascript" do
+  parameters "param_blob_container"
+  result "result"
+  code <<-'EOS'
+  result = param_blob_container.trim()
+EOS
+end
+
+datasource "ds_blob_hostname" do
+  run_script $js_blob_hostname, $param_blob_hostname
+end
+
+script "js_blob_hostname", type: "javascript" do
+  parameters "param_blob_hostname"
+  result "result"
+  code <<-'EOS'
+  result = param_blob_hostname.trim()
+EOS
+end
 
 datasource "ds_dates" do
   run_script $js_dates, $param_billing_period, $param_specific_period
@@ -294,8 +318,8 @@ datasource "ds_objects" do
   request do
     auth $auth_azure_storage
     pagination $pagination_azure_xml
-    host $param_blob_hostname
-    path join(["/", $param_blob_container])
+    host $ds_blob_hostname
+    path join(["/", $ds_blob_container])
     query "restype", "container"
     query "comp", "list"
     header "User-Agent", "RS Policies"
@@ -350,8 +374,8 @@ datasource "ds_cost_objects" do
   iterate $ds_cost_object_keys_sliced
   request do
     auth $auth_azure_storage
-    host $param_blob_hostname
-    path join(["/", $param_blob_container, "/", val(iter_item, "key")])
+    host $ds_blob_hostname
+    path join(["/", $ds_blob_container, "/", val(iter_item, "key")])
     header "User-Agent", "RS Policies"
     header "x-ms-version", "2025-05-05"
     ignore_status [404] # Ignore dates that have no associated file instead of failing completely

--- a/cost/flexera/cco/cbi_ingestion_google_gcs/CHANGELOG.md
+++ b/cost/flexera/cco/cbi_ingestion_google_gcs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/flexera/cco/cbi_ingestion_google_gcs/cbi_ingestion_google_gcs.pt
+++ b/cost/flexera/cco/cbi_ingestion_google_gcs/cbi_ingestion_google_gcs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "0.1.1",
+  version: "0.1.2",
   provider: "Flexera",
   service: "Common Bill Ingestion",
   policy_set: "Common Bill Ingestion",
@@ -119,6 +119,30 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_gcs_bucket" do
+  run_script $js_gcs_bucket, $param_gcs_bucket
+end
+
+script "js_gcs_bucket", type: "javascript" do
+  parameters "param_gcs_bucket"
+  result "result"
+  code <<-'EOS'
+  result = param_gcs_bucket.trim()
+EOS
+end
+
+datasource "ds_gcs_prefix" do
+  run_script $js_gcs_prefix, $param_gcs_prefix
+end
+
+script "js_gcs_prefix", type: "javascript" do
+  parameters "param_gcs_prefix"
+  result "result"
+  code <<-'EOS'
+  result = param_gcs_prefix.trim()
+EOS
+end
+
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
@@ -212,6 +236,8 @@ script "js_cbi_endpoint_id", type: "javascript" do
   parameters "param_cbi_endpoint", "param_cbi_cloud_vendor", "param_cbi_type"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_cbi_cloud_vendor = param_cbi_cloud_vendor.trim()
   result = param_cbi_endpoint
 
   if (param_cbi_endpoint == "") {
@@ -257,6 +283,8 @@ script "js_to_create_bill_connect", type: "javascript" do
   parameters "ds_existing_bill_connects", "ds_cbi_endpoint_id", "param_cbi_cloud_vendor", "param_cbi_type"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_cbi_cloud_vendor = param_cbi_cloud_vendor.trim()
   result = []
 
   existing_bill_connect = _.find(ds_existing_bill_connects, function(connect) {
@@ -422,18 +450,18 @@ EOS
 end
 
 datasource "ds_cost_object_names" do
-  run_script $js_cost_object_names, $ds_dates, $param_gcs_prefix, $param_granularity
+  run_script $js_cost_object_names, $ds_dates, $ds_gcs_prefix, $param_granularity
 end
 
 script "js_cost_object_names", type: "javascript" do
-  parameters "ds_dates", "param_gcs_prefix", "param_granularity"
+  parameters "ds_dates", "ds_gcs_prefix", "param_granularity"
   result "result"
   code <<-'EOS'
   result = []
 
   if (param_granularity == "Monthly") {
     result.push({
-      object: [ param_gcs_prefix, ds_dates["period"], ".csv" ].join('')
+      object: [ ds_gcs_prefix, ds_dates["period"], ".csv" ].join('')
     })
   } else {
     for (var i = 1; i <= 31; i++) {
@@ -441,7 +469,7 @@ script "js_cost_object_names", type: "javascript" do
       if (i < 10) { day = "0" + day }
 
       result.push({
-        object: [ param_gcs_prefix, ds_dates["period"], "-", day, ".csv" ].join('')
+        object: [ ds_gcs_prefix, ds_dates["period"], "-", day, ".csv" ].join('')
       })
     }
   }
@@ -453,7 +481,7 @@ datasource "ds_cost_objects" do
   request do
     auth $auth_google
     host "storage.googleapis.com"
-    path join(["/", $param_gcs_bucket, "/", val(iter_item, "object")])
+    path join(["/", $ds_gcs_bucket, "/", val(iter_item, "object")])
     header "User-Agent", "RS Policies"
     ignore_status [404] # Ignore dates that have no associated file instead of failing completely
   end
@@ -545,11 +573,11 @@ EOS
 end
 
 datasource "ds_incident" do
-  run_script $js_incident, $ds_cbi_commit_bill_upload, $ds_applied_policy, $ds_dates, $ds_cost_object_names, $param_gcs_bucket, $param_gcs_prefix
+  run_script $js_incident, $ds_cbi_commit_bill_upload, $ds_applied_policy, $ds_dates, $ds_cost_object_names, $ds_gcs_bucket, $ds_gcs_prefix
 end
 
 script "js_incident", type: "javascript" do
-  parameters "ds_cbi_commit_bill_upload", "ds_applied_policy", "ds_dates", "ds_cost_object_names", "param_gcs_bucket", "param_gcs_prefix"
+  parameters "ds_cbi_commit_bill_upload", "ds_applied_policy", "ds_dates", "ds_cost_object_names", "ds_gcs_bucket", "ds_gcs_prefix"
   result "result"
   code <<-'EOS'
   result = [{
@@ -560,7 +588,7 @@ script "js_incident", type: "javascript" do
     updatedAt: ds_cbi_commit_bill_upload['updatedAt'],
     billConnectId: ds_cbi_commit_bill_upload['billConnectId'],
     billingPeriod: ds_cbi_commit_bill_upload['billingPeriod'],
-    gcs_bucket: param_gcs_bucket
+    gcs_bucket: ds_gcs_bucket
   }]
 EOS
 end

--- a/cost/flexera/cco/cbi_ingestion_google_gcs_iterating/CHANGELOG.md
+++ b/cost/flexera/cco/cbi_ingestion_google_gcs_iterating/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.1.0
 
 - Initial release

--- a/cost/flexera/cco/cbi_ingestion_google_gcs_iterating/cbi_ingestion_google_gcs_iterating.pt
+++ b/cost/flexera/cco/cbi_ingestion_google_gcs_iterating/cbi_ingestion_google_gcs_iterating.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "15 minutes"
 info(
-  version: "0.1.0",
+  version: "0.1.1",
   provider: "Flexera",
   service: "Common Bill Ingestion",
   policy_set: "Common Bill Ingestion",
@@ -117,6 +117,30 @@ end
 ###############################################################################
 # Datasources & Scripts
 ###############################################################################
+
+datasource "ds_gcs_bucket" do
+  run_script $js_gcs_bucket, $param_gcs_bucket
+end
+
+script "js_gcs_bucket", type: "javascript" do
+  parameters "param_gcs_bucket"
+  result "result"
+  code <<-'EOS'
+  result = param_gcs_bucket.trim()
+EOS
+end
+
+datasource "ds_gcs_prefix" do
+  run_script $js_gcs_prefix, $param_gcs_prefix
+end
+
+script "js_gcs_prefix", type: "javascript" do
+  parameters "param_gcs_prefix"
+  result "result"
+  code <<-'EOS'
+  result = param_gcs_prefix.trim()
+EOS
+end
 
 datasource "ds_dates" do
   run_script $js_dates, $param_billing_period, $param_specific_period
@@ -295,8 +319,8 @@ datasource "ds_objects" do
     auth $auth_google
     pagination $pagination_google_gcs
     host "storage.googleapis.com"
-    path join(["/storage/v1/b/", $param_gcs_bucket, "/o"])
-    query "prefix", $param_gcs_prefix
+    path join(["/storage/v1/b/", $ds_gcs_bucket, "/o"])
+    query "prefix", $ds_gcs_prefix
     header "User-Agent", "RS Policies"
   end
   result do
@@ -349,7 +373,7 @@ datasource "ds_cost_objects" do
   request do
     auth $auth_google
     host "storage.googleapis.com"
-    path join(["/", $param_gcs_bucket, "/", val(iter_item, "key")])
+    path join(["/", $ds_gcs_bucket, "/", val(iter_item, "key")])
     header "User-Agent", "RS Policies"
     ignore_status [404] # Ignore missing files instead of failing completely
   end

--- a/cost/flexera/cco/cloud_cost_anomaly_alerts/CHANGELOG.md
+++ b/cost/flexera/cco/cloud_cost_anomaly_alerts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.1.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/flexera/cco/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
+++ b/cost/flexera/cco/cloud_cost_anomaly_alerts/cloud_cost_anomaly_alerts.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "high"
 default_frequency "daily"
 info(
-  version: "4.1.1",
+  version: "4.1.2",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -346,6 +346,9 @@ script "js_filter_dimensions", type: "javascript" do
   parameters "ds_dimensions", "ds_billing_centers", "param_dimensions", "param_dimensions_excluded"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_dimensions = _.compact(_.map(param_dimensions, function(item) { return item.trim() }))
+  param_dimensions_excluded = _.compact(_.map(param_dimensions_excluded, function(item) { return item.trim() }))
   result = { ids: [], names: [], filters: [], bc_filters: [], invalid_ids: [] }
 
   _.each(param_dimensions, function(user_input_dimension, index) {
@@ -525,6 +528,8 @@ script "js_filter_anomalies", type: "javascript" do
   parameters "ds_get_anomalies", "ds_dimensions", "ds_filter_dimensions", "ds_request_variables", "ds_billing_centers", "ds_currency", "ds_applied_policy", "param_min_spend", "param_min_spend_variance", "param_anomaly_types", "param_days", "param_dimensions", "param_cost_metric", "param_anomaly_limit", "param_anomaly_sort", "rs_org_id", "rs_project_id", "f1_app_host"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_dimensions = _.compact(_.map(param_dimensions, function(item) { return item.trim() }))
   // Helper to generate a chart URL for the moving average timeseries only
   function generateChartUrl(timeseries) {
     if (!timeseries || !timeseries.moving_average) return '';

--- a/cost/flexera/cco/currency_conversion/CHANGELOG.md
+++ b/cost/flexera/cco/currency_conversion/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v5.1.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Fixed `run_script` parameter ordering for the `ds_set_org_currency_logic` datasource.
+
 ## v5.1.2
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/flexera/cco/currency_conversion/currency_conversion.pt
+++ b/cost/flexera/cco/currency_conversion/currency_conversion.pt
@@ -8,7 +8,7 @@ severity "low"
 default_frequency "monthly"
 category "Cost"
 info(
-  version: "5.1.2",
+  version: "5.1.3",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -113,6 +113,30 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_currency_from" do
+  run_script $js_currency_from, $param_currency_from
+end
+
+script "js_currency_from", type: "javascript" do
+  parameters "param_currency_from"
+  result "result"
+  code <<-'EOS'
+  result = param_currency_from.trim()
+EOS
+end
+
+datasource "ds_currency_to" do
+  run_script $js_currency_to, $param_currency_to
+end
+
+script "js_currency_to", type: "javascript" do
+  parameters "param_currency_to"
+  result "result"
+  code <<-'EOS'
+  result = param_currency_to.trim()
+EOS
+end
+
 # Find dimension in the CCO platform based on user input
 datasource "ds_dimensions" do
   request do
@@ -166,15 +190,15 @@ end
 
 # Branching Logic: Whether or not to set the organization currency
 datasource "ds_set_org_currency_logic" do
-  run_script $js_set_org_currency_logic, $param_set_org_currency, $param_currency_to
+  run_script $js_set_org_currency_logic, $ds_currency_to, $param_set_org_currency
 end
 
 script "js_set_org_currency_logic", type: "javascript" do
-  parameters "param_set_org_currency", "param_currency_to"
+  parameters "ds_currency_to", "param_set_org_currency"
   result "result"
   code <<-'EOS'
   result = []
-  if (param_set_org_currency == "Yes") { result = [{ currency_code: param_currency_to }] }
+  if (param_set_org_currency == "Yes") { result = [{ currency_code: ds_currency_to }] }
 EOS
 end
 
@@ -200,6 +224,8 @@ script "js_month_list", type: "javascript" do
   parameters "param_backfill", "param_backfill_start_date"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_backfill_start_date = param_backfill_start_date.trim()
   // Function to take YYYY-MM formatted date and move it backwards or forwards by month
   function move_month(date_string, amount) {
     year = Number(date_string.split('-')[0])
@@ -277,8 +303,8 @@ datasource "ds_xe_exchange_rates" do
   request do
     host "api.xe-auth.flexeraeng.com"
     path "/prod/{proxy+}"
-    query "from", $param_currency_from
-    query "to", $param_currency_to
+    query "from", $ds_currency_from
+    query "to", $ds_currency_to
     query "amount", "1"
     query "year", iter_item
   end
@@ -292,15 +318,15 @@ end
 
 # Assemble exchange rates into a simple object that can be used later
 datasource "ds_exchange_rates" do
-  run_script $js_exchange_rates, $ds_xe_exchange_rates, $param_currency_to
+  run_script $js_exchange_rates, $ds_xe_exchange_rates, $ds_currency_to
 end
 
 script "js_exchange_rates", type: "javascript" do
-  parameters "ds_xe_exchange_rates", "param_currency_to"
+  parameters "ds_xe_exchange_rates", "ds_currency_to"
   result "result"
   code <<-'EOS'
   result = {}
-  currency_code = param_currency_to.toUpperCase().trim()
+  currency_code = ds_currency_to.toUpperCase().trim()
 
   _.each(ds_xe_exchange_rates, function(item) {
     year_num = item['year'].toString()
@@ -326,13 +352,15 @@ datasource "ds_current_adjustments" do
 end
 
 datasource "ds_updated_adjustments" do
-  run_script $js_updated_adjustments, $ds_exchange_rates, $ds_current_adjustments, $ds_month_list, $ds_filter_dimensions, $param_currency_from, $param_currency_to, $param_backfill_exchange_rate, $param_backfill, $param_backfill_start_date, $param_dimensions_boolean, $param_adj_bring_forward
+  run_script $js_updated_adjustments, $ds_exchange_rates, $ds_current_adjustments, $ds_month_list, $ds_filter_dimensions, $ds_currency_from, $ds_currency_to, $param_backfill_exchange_rate, $param_backfill, $param_backfill_start_date, $param_dimensions_boolean, $param_adj_bring_forward
 end
 
 script "js_updated_adjustments", type: "javascript" do
-  parameters "ds_exchange_rates", "ds_current_adjustments", "ds_month_list", "ds_filter_dimensions", "param_currency_from", "param_currency_to", "param_backfill_exchange_rate", "param_backfill", "param_backfill_start_date", "param_dimensions_boolean", "param_adj_bring_forward"
+  parameters "ds_exchange_rates", "ds_current_adjustments", "ds_month_list", "ds_filter_dimensions", "ds_currency_from", "ds_currency_to", "param_backfill_exchange_rate", "param_backfill", "param_backfill_start_date", "param_dimensions_boolean", "param_adj_bring_forward"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_backfill_start_date = param_backfill_start_date.trim()
   function generateMonths(startMonth) {
     month_list = []
 
@@ -441,7 +469,7 @@ script "js_updated_adjustments", type: "javascript" do
         {
           condition: condition,
           cost_multiplier: conversion_rate - 1,
-          label: param_currency_from + " to " + param_currency_to
+          label: ds_currency_from + " to " + ds_currency_to
         }
       ]
     }
@@ -543,7 +571,7 @@ end
 
 policy "pol_currency_conversion" do
   validate_each $ds_new_adjustments do
-    summary_template "Currency Conversion - {{ parameters.param_currency_from }} to {{ parameters.param_currency_to }} - {{ with index data 0 }}{{ .dimension }}{{ end }}"
+    summary_template "Currency Conversion - {{ parameters.ds_currency_from }} to {{ parameters.ds_currency_to }} - {{ with index data 0 }}{{ .dimension }}{{ end }}"
     detail_template "{{ with index data 0 }}{{ .message }}{{ end }}"
     check eq(0, 1)
   end

--- a/cost/flexera/cco/email_recommendations/CHANGELOG.md
+++ b/cost/flexera/cco/email_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.10.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.10.1
 
 - Added `hash_exclude` for volatile savings and utilization fields so that recalculated estimates alone no longer cause incidents to be treated as changed/reopened.

--- a/cost/flexera/cco/email_recommendations/email_recommendations.pt
+++ b/cost/flexera/cco/email_recommendations/email_recommendations.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "0.10.1",
+  version: "0.10.2",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -474,6 +474,8 @@ script "js_recommendations_filtered_account", type: "javascript" do
   parameters "ds_recommendations_filtered_vendor", "param_accounts_allow_or_deny", "param_accounts_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_accounts_list = _.compact(_.map(param_accounts_list, function(item) { return item.trim() }))
   result = _.filter(ds_recommendations_filtered_vendor, function(recommendation) {
     include_recommendation = true
 
@@ -530,6 +532,8 @@ script "js_recommendations_filtered_bc", type: "javascript" do
   parameters "ds_recommendations_filtered_dimension", "ds_billing_centers_table", "param_bc_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_bc_list = _.compact(_.map(param_bc_list, function(item) { return item.trim() }))
   result = _.filter(ds_recommendations_filtered_dimension, function(recommendation) {
     include_recommendation = true
 
@@ -594,6 +598,8 @@ script "js_recommendations_filtered_pollist", type: "javascript" do
   parameters "ds_recommendations_filtered_reclist", "param_policy_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_policy_list = _.compact(_.map(param_policy_list, function(item) { return item.trim() }))
   result = _.filter(ds_recommendations_filtered_reclist, function(recommendation) {
     include_recommendation = true
 

--- a/cost/flexera/cco/fixed_cost_cbi/CHANGELOG.md
+++ b/cost/flexera/cco/fixed_cost_cbi/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.6
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.3.5
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/flexera/cco/fixed_cost_cbi/fixed_cost_cbi.pt
+++ b/cost/flexera/cco/fixed_cost_cbi/fixed_cost_cbi.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.3.5",
+  version: "0.3.6",
   provider: "Flexera",
   service: "Common Bill Ingestion",
   policy_set: "Common Bill Ingestion",
@@ -316,6 +316,15 @@ script "js_cost_csv", type: "javascript" do
   parameters "ds_dates", "ds_currency", "param_cost_amount", "param_metadata_cloud_vendor_account_id", "param_metadata_cloud_vendor_account_name", "param_metadata_category", "param_metadata_service", "param_metadata_region", "param_metadata_resourcetype", "param_metadata_instancetype", "param_metadata_lineitemtype", "param_metadata_tags", "param_amortization"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_metadata_cloud_vendor_account_id = param_metadata_cloud_vendor_account_id.trim()
+  param_metadata_cloud_vendor_account_name = param_metadata_cloud_vendor_account_name.trim()
+  param_metadata_category = param_metadata_category.trim()
+  param_metadata_service = param_metadata_service.trim()
+  param_metadata_region = param_metadata_region.trim()
+  param_metadata_resourcetype = param_metadata_resourcetype.trim()
+  param_metadata_instancetype = param_metadata_instancetype.trim()
+  param_metadata_tags = _.compact(_.map(param_metadata_tags, function(item) { return item.trim() }))
   // Set static field values. These will be the same for every entry in the CSV file
   CloudVendorAccountID = param_metadata_cloud_vendor_account_id.trim().replace(/,/g, '_')
   CloudVendorAccountName = param_metadata_cloud_vendor_account_name.trim().replace(/,/g, '_')
@@ -405,6 +414,8 @@ script "js_cbi_endpoint_id", type: "javascript" do
   parameters "param_cbi_endpoint", "param_cbi_cloud_vendor"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_cbi_cloud_vendor = param_cbi_cloud_vendor.trim()
   result = param_cbi_endpoint
 
   if (param_cbi_endpoint == "") {
@@ -447,6 +458,8 @@ script "js_to_create_bill_connect", type: "javascript" do
   parameters "ds_existing_bill_connects", "ds_cbi_endpoint_id", "param_cbi_cloud_vendor"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_cbi_cloud_vendor = param_cbi_cloud_vendor.trim()
   result = []
 
   existing_bill_connect = _.find(ds_existing_bill_connects, function(connect) {
@@ -662,6 +675,8 @@ script "js_incident", type: "javascript" do
   parameters "ds_cbi_commit_bill_upload", "ds_applied_policy", "ds_cost_csv", "param_cost_amount", "param_cbi_cloud_vendor"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_cbi_cloud_vendor = param_cbi_cloud_vendor.trim()
   result = [{
     policy_name: ds_applied_policy['name'],
     id: ds_cbi_commit_bill_upload['id'],

--- a/cost/flexera/cco/focus_report/CHANGELOG.md
+++ b/cost/flexera/cco/focus_report/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.4
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Renamed the `policyName` field to `policy_name` and updated `summary_template` accordingly, per the standard `{{ .policy_name }}` convention.
+
 ## v0.2.3
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/flexera/cco/focus_report/focus_report.pt
+++ b/cost/flexera/cco/focus_report/focus_report.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.3",
+  version: "0.2.4",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -260,6 +260,8 @@ script "js_included_bcs", type: "javascript" do
   parameters "ds_billing_centers", "param_billing_centers"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_billing_centers = _.compact(_.map(param_billing_centers, function(item) { return item.trim() }))
   if (param_billing_centers.length > 0) {
     result = _.filter(ds_billing_centers, function(bc) {
       return _.contains(param_billing_centers, bc['id']) || _.contains(param_billing_centers, bc['name'])
@@ -343,6 +345,8 @@ script "js_flexera_costs_normalized", type: "javascript" do
   parameters "ds_flexera_costs", "ds_applied_policy", "ds_dates", "ds_currency", "ds_included_bcs", "param_amortization", "param_billing_centers", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_billing_centers = _.compact(_.map(param_billing_centers, function(item) { return item.trim() }))
   csv_message = param_incident_csv == "false" ? "" : "Incident table CSV file has been attached to emails for this incident."
 
   includedBCs = "All Billing Centers"
@@ -372,7 +376,7 @@ script "js_flexera_costs_normalized", type: "javascript" do
       serviceName: item['service'],
       usageUnit: item['usage_unit'],
       billingCurrency: ds_currency['code'],
-      policyName: ds_applied_policy['name'],
+      policy_name: ds_applied_policy['name'],
       amortization: param_amortization,
       billingPeriodStart: billingPeriodStart,
       chargePeriodStart: billingPeriodStart,
@@ -391,7 +395,7 @@ end
 
 policy "pol_flexera_focus_report" do
   validate_each $ds_flexera_costs_normalized do
-    summary_template "{{ with index data 0 }}{{ .policyName }}{{ end }} - {{ with index data 0 }}{{ .billingPeriodStart }}{{ end }} - {{ with index data 0 }}{{ .amortization }}{{ end }}"
+    summary_template "{{ with index data 0 }}{{ .policy_name }}{{ end }} - {{ with index data 0 }}{{ .billingPeriodStart }}{{ end }} - {{ with index data 0 }}{{ .amortization }}{{ end }}"
     detail_template <<-'EOS'
     Billing Centers: {{ with index data 0 }}{{ .includedBCs }}{{ end }}
 

--- a/cost/flexera/cco/forecasting/commitment_forecast/CHANGELOG.md
+++ b/cost/flexera/cco/forecasting/commitment_forecast/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.0.10
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.0.9
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/flexera/cco/forecasting/commitment_forecast/commitment_forecast.pt
+++ b/cost/flexera/cco/forecasting/commitment_forecast/commitment_forecast.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "medium"
 default_frequency "monthly"
 info(
-  version: "4.0.9",
+  version: "4.0.10",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Forecasting",
@@ -169,6 +169,8 @@ script "js_cloud_vendor", type:"javascript" do
   parameters "param_cloud_vendor"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_cloud_vendor = param_cloud_vendor.trim()
   vendor_table = {
     "aws": "AWS",
     "amazon web services": "AWS",

--- a/cost/flexera/cco/forecasting/commitment_forecast/commitment_forecast.pt
+++ b/cost/flexera/cco/forecasting/commitment_forecast/commitment_forecast.pt
@@ -469,7 +469,7 @@ script "js_chart_data", type: "javascript" do
 
   chart_type = encodeURI("cht=bhs")
   chart_size = encodeURI("chs=800x200")
-  chart_data = encodeURI("chd=t:" + ds_forecasted_spend['actual_spend'] + ",0|" + ds_forecasted_spend['forecasted_spend'] +",0|0," + ds_forecasted_spend['commitment_target'] + "|" + over_commitment_data)
+  chart_data = encodeURI("chd=t:" + ds_forecasted_spend['actual_spend'] + ",0|" + ds_forecasted_spend['forecasted_spend'] + ",0|0," + ds_forecasted_spend['commitment_target'] + "|" + over_commitment_data)
   chart_title = encodeURI("chtt=Actual+and+Forecasted+Spend+vs.+Vendor+Commitment+Spend+Target+Report")
   chart_image = encodeURI("chof=.png")
   chart_color = encodeURI("chco=4FA8E9,9EC9E9,63CED6," + over_commitment_color)

--- a/cost/flexera/cco/forecasting/straight_line_forecast/CHANGELOG.md
+++ b/cost/flexera/cco/forecasting/straight_line_forecast/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.1.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/flexera/cco/forecasting/straight_line_forecast/straight_line_forecast.pt
+++ b/cost/flexera/cco/forecasting/straight_line_forecast/straight_line_forecast.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "monthly"
 info(
-  version: "4.1.1",
+  version: "4.1.2",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Forecasting",
@@ -271,6 +271,8 @@ script "js_billing_centers_filtered", type: "javascript" do
   parameters "ds_billing_centers", "param_bc_allow_or_deny", "param_bc_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_bc_list = _.compact(_.map(param_bc_list, function(item) { return item.trim() }))
   allow_deny_test = { "Allow": true, "Deny": false }
 
   if (param_bc_list.length > 0) {
@@ -321,6 +323,8 @@ script "js_dimension", type: "javascript" do
   parameters "ds_dimensions_list", "param_dimension"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_dimension = param_dimension.trim()
   if (param_dimension == "Billing Center") {
     result = { id: "billing_center_name", name: "Billing Center" }
   } else {

--- a/cost/flexera/cco/low_usage/CHANGELOG.md
+++ b/cost/flexera/cco/low_usage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2.5
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.2.4
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/flexera/cco/low_usage/low_usage.pt
+++ b/cost/flexera/cco/low_usage/low_usage.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "3.2.4",
+  version: "3.2.5",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -263,6 +263,8 @@ script "js_billing_centers_filtered", type: "javascript" do
   parameters "ds_billing_centers", "param_bc_allow_or_deny", "param_bc_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_bc_list = _.compact(_.map(param_bc_list, function(item) { return item.trim() }))
   allow_deny_test = { "Allow": true, "Deny": false }
 
   if (param_bc_list.length > 0) {
@@ -313,6 +315,8 @@ script "js_dimension", type: "javascript" do
   parameters "ds_dimensions_list", "param_dimension"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_dimension = param_dimension.trim()
   if (param_dimension == "Billing Center") {
     result = { id: "billing_center_id", name: "Billing Center" }
   } else {

--- a/cost/flexera/cco/moving_average/CHANGELOG.md
+++ b/cost/flexera/cco/moving_average/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.1.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/flexera/cco/moving_average/moving_average.pt
+++ b/cost/flexera/cco/moving_average/moving_average.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.1.1",
+  version: "4.1.2",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "",
@@ -255,6 +255,8 @@ script "js_billing_centers_filtered", type: "javascript" do
   parameters "ds_billing_centers", "param_bc_allow_or_deny", "param_bc_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_bc_list = _.compact(_.map(param_bc_list, function(item) { return item.trim() }))
   allow_deny_test = { "Allow": true, "Deny": false }
 
   if (param_bc_list.length > 0) {
@@ -416,6 +418,8 @@ script "js_moving_average_chart", type: "javascript" do
   parameters "ds_costs_calculated", "ds_billing_centers_filtered", "ds_applied_policy", "ds_currency", "param_bc_list", "param_average_months", "param_incident_data_table", "rs_org_name"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_bc_list = _.compact(_.map(param_bc_list, function(item) { return item.trim() }))
   function format_number(number) {
     formatted_number = "0"
 


### PR DESCRIPTION
### Description

One of several PRs focused on sanitizing inputs for PT parameters. This is to prevent users from breaking policy template execution because they entered a parameter incorrectly, such as putting whitespace at the beginning or end of the value.

Also corrects some Dangerfile-reported issues with the touched PTs.

Also updates some Dangerfile testing to avoid false positives.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
