### PR TITLE
POL-1826 Parameter Sanitization: Policy Templates #9

### DIFF
--- a/.dangerfile/policy_tests.rb
+++ b/.dangerfile/policy_tests.rb
@@ -1213,7 +1213,7 @@ end
 def policy_run_script_incorrect_order?(file, file_lines)
   puts Time.now.strftime("%H:%M:%S.%L") + " *** Testing whether Policy Template file has any scripts with parameters in the wrong order..."
 
-  fail_message = ""
+  found_calls = []
   ds_name = nil
 
   file_lines.each_with_index do |line, index|
@@ -1264,9 +1264,26 @@ def policy_run_script_incorrect_order?(file, file_lines)
           val_index = index if parameter.start_with?("val(")
         end
       end
-    end
 
-    fail_message += "Line #{line_number}: #{ds_name} / run_script #{script_name}\n" if disordered
+      found_calls << { line_number: line_number, ds_name: ds_name, script_name: script_name, disordered: disordered }
+    end
+  end
+
+  # If the same script is invoked more than once, and at least one of those invocations is
+  # correctly ordered, treat every invocation of that script as correct. A "disordered"
+  # reading on a sibling call in this situation is only an artifact of that call passing a
+  # raw value (e.g. a hardcoded lookback of 3 for a baseline comparison) in the same
+  # argument slot where another call passes a $param/$ds/constant, not an actual structural
+  # reordering bug — the argument's position, and thus the script's interpretation of it,
+  # is unchanged between calls.
+  calls_by_script = found_calls.group_by { |call| call[:script_name] }
+
+  fail_message = ""
+  found_calls.each do |call|
+    next unless call[:disordered]
+    next if calls_by_script[call[:script_name]].any? { |c| !c[:disordered] }
+
+    fail_message += "Line #{call[:line_number]}: #{call[:ds_name]} / run_script #{call[:script_name]}\n"
   end
 
   fail_message = "[[Info](https://github.com/flexera-public/policy_templates/blob/master/STYLE_GUIDE.md#scripts)] run_script statements found whose parameters are not in the correct order. run_script parameters should be in the following order: script, val(iter_item, *string*), datasources, parameters, variables, raw values:\n\n" + fail_message if !fail_message.empty?

--- a/cost/flexera/cco/new_usage/CHANGELOG.md
+++ b/cost/flexera/cco/new_usage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.5
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.1.4
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/flexera/cco/new_usage/new_usage.pt
+++ b/cost/flexera/cco/new_usage/new_usage.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "3.1.4",
+  version: "3.1.5",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -196,6 +196,8 @@ script "js_billing_centers_filtered", type: "javascript" do
   parameters "ds_billing_centers", "param_bc_allow_or_deny", "param_bc_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_bc_list = _.compact(_.map(param_bc_list, function(item) { return item.trim() }))
   allow_deny_test = { "Allow": true, "Deny": false }
 
   if (param_bc_list.length > 0) {
@@ -246,6 +248,8 @@ script "js_dimension", type: "javascript" do
   parameters "ds_dimensions_list", "param_dimension"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_dimension = param_dimension.trim()
   result = _.find(ds_dimensions_list, function(item) { return item['id'] == param_dimension })
 
   // If user-specified dimension isn't a valid dimension ID, check for name instead

--- a/cost/flexera/cco/percentage_cost_cbi/CHANGELOG.md
+++ b/cost/flexera/cco/percentage_cost_cbi/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.5
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.1.4
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/flexera/cco/percentage_cost_cbi/percentage_cost_cbi.pt
+++ b/cost/flexera/cco/percentage_cost_cbi/percentage_cost_cbi.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.1.4",
+  version: "0.1.5",
   provider: "Flexera",
   service: "Common Bill Ingestion",
   policy_set: "Common Bill Ingestion",
@@ -269,6 +269,8 @@ script "js_filters", type: "javascript" do
   parameters "ds_dimensions", "param_filters"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_filters = _.compact(_.map(param_filters, function(item) { return item.trim() }))
   result = []
 
   _.each(param_filters, function(item) {
@@ -322,6 +324,8 @@ script "js_cbi_endpoint_id", type: "javascript" do
   parameters "param_cbi_endpoint", "param_cbi_cloud_vendor"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_cbi_cloud_vendor = param_cbi_cloud_vendor.trim()
   result = param_cbi_endpoint
 
   if (param_cbi_endpoint == "") {
@@ -364,6 +368,8 @@ script "js_to_create_bill_connect", type: "javascript" do
   parameters "ds_existing_bill_connects", "ds_cbi_endpoint_id", "param_cbi_cloud_vendor"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_cbi_cloud_vendor = param_cbi_cloud_vendor.trim()
   result = []
 
   existing_bill_connect = _.find(ds_existing_bill_connects, function(connect) {
@@ -618,6 +624,15 @@ script "js_cost_csv", type: "javascript" do
   parameters "ds_dates", "ds_currency", "ds_calculated_spend", "param_metadata_cloud_vendor_account_id", "param_metadata_cloud_vendor_account_name", "param_metadata_category", "param_metadata_service", "param_metadata_region", "param_metadata_resourcetype", "param_metadata_instancetype", "param_metadata_lineitemtype", "param_metadata_tags", "param_amortization"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_metadata_cloud_vendor_account_id = param_metadata_cloud_vendor_account_id.trim()
+  param_metadata_cloud_vendor_account_name = param_metadata_cloud_vendor_account_name.trim()
+  param_metadata_category = param_metadata_category.trim()
+  param_metadata_service = param_metadata_service.trim()
+  param_metadata_region = param_metadata_region.trim()
+  param_metadata_resourcetype = param_metadata_resourcetype.trim()
+  param_metadata_instancetype = param_metadata_instancetype.trim()
+  param_metadata_tags = _.compact(_.map(param_metadata_tags, function(item) { return item.trim() }))
   // Set static field values. These will be the same for every entry in the CSV file
   CloudVendorAccountID = param_metadata_cloud_vendor_account_id.trim().replace(/,/g, '_')
   CloudVendorAccountName = param_metadata_cloud_vendor_account_name.trim().replace(/,/g, '_')
@@ -853,6 +868,8 @@ script "js_incident", type: "javascript" do
   parameters "ds_filters", "ds_cbi_commit_bill_upload", "ds_applied_policy", "ds_cost_csv", "ds_calculated_spend", "param_percentage", "param_cbi_cloud_vendor"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_cbi_cloud_vendor = param_cbi_cloud_vendor.trim()
   filters = _.map(ds_filters, function(filter) {
     return [ filter["dimension"]["name"], filter["value"] ].join('=')
   }).join(", ")

--- a/cost/flexera/cco/scheduled_report_markupsdowns/CHANGELOG.md
+++ b/cost/flexera/cco/scheduled_report_markupsdowns/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.0.5
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v2.0.4
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/flexera/cco/scheduled_report_markupsdowns/scheduled_report_markpsdowns.pt
+++ b/cost/flexera/cco/scheduled_report_markupsdowns/scheduled_report_markpsdowns.pt
@@ -12,7 +12,8 @@ info(
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
-  publish: "false"
+  publish: "false",
+  hide_skip_approvals: "true"
 )
 
 ###############################################################################

--- a/cost/flexera/cco/scheduled_report_markupsdowns/scheduled_report_markpsdowns.pt
+++ b/cost/flexera/cco/scheduled_report_markupsdowns/scheduled_report_markpsdowns.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "monthly"
 info(
-  version: "2.0.4",
+  version: "2.0.5",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -247,6 +247,8 @@ script "js_previous_month_costs", type: "javascript" do
   parameters "ds_billing_centers", "param_billing_centers", "param_cost_metric", "param_markUD_Percentage", "rs_org_id", "rs_optima_host"
   result "request"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_billing_centers = _.compact(_.map(param_billing_centers, function(item) { return item.trim() }))
   var range = "monthly";
   var scale = "previous";
 

--- a/cost/flexera/cco/scheduled_report_unallocated/CHANGELOG.md
+++ b/cost/flexera/cco/scheduled_report_unallocated/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.3.5
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Added a link to docs.flexera.com in the `short_description`.
 
 ## v0.3.4
 

--- a/cost/flexera/cco/scheduled_report_unallocated/CHANGELOG.md
+++ b/cost/flexera/cco/scheduled_report_unallocated/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.5
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.3.4
 
 - Updated heredocs in policy template code to conform to best practices. Functionality unchanged.

--- a/cost/flexera/cco/scheduled_report_unallocated/scheduled_report_unallocated.pt
+++ b/cost/flexera/cco/scheduled_report_unallocated/scheduled_report_unallocated.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "monthly"
 info(
-  version: "0.3.4",
+  version: "0.3.5",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -112,6 +112,8 @@ script "js_cost_dimensions", type:"javascript" do
   parameters "ds_get_dimensions", "param_cost_dimensions"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_cost_dimensions = _.compact(_.map(param_cost_dimensions, function(item) { return item.trim() }))
   dimension_ids = _.pluck(ds_get_dimensions, 'id')
   dimension_names = _.pluck(ds_get_dimensions, 'name')
 
@@ -228,6 +230,8 @@ script "js_cost_request_params", type:"javascript" do
   parameters "param_cost_time_period", "param_cost_filters"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_cost_filters = param_cost_filters.trim()
   now = new Date()
   result = { filter: null }
   if (param_cost_filters.length > 0) { result['filter'] = JSON.parse(param_cost_filters) }

--- a/cost/flexera/cco/scheduled_report_unallocated/scheduled_report_unallocated.pt
+++ b/cost/flexera/cco/scheduled_report_unallocated/scheduled_report_unallocated.pt
@@ -1,7 +1,7 @@
 name "Scheduled Report for Unallocated Costs"
 rs_pt_ver 20180301
 type "policy"
-short_description "This policy allows you to set up scheduled reports that will provide summaries of cloud cost that are unallocated for the dimensions you specify, delivered to any email addresses you specify.  See [README](https://github.com/flexera-public/policy_templates/tree/master/cost/flexera/cco/scheduled_report_unallocated/) for more details"
+short_description "This policy allows you to set up scheduled reports that will provide summaries of cloud cost that are unallocated for the dimensions you specify, delivered to any email addresses you specify. See [README](https://github.com/flexera-public/policy_templates/tree/master/cost/flexera/cco/scheduled_report_unallocated/) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera-one/automation/) to learn more."
 long_description ""
 doc_link "https://github.com/flexera-public/policy_templates/tree/master/cost/flexera/cco/scheduled_report_unallocated/"
 severity "low"

--- a/cost/flexera/cco/scheduled_reports/CHANGELOG.md
+++ b/cost/flexera/cco/scheduled_reports/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.1.4
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.1.3
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/flexera/cco/scheduled_reports/CHANGELOG.md
+++ b/cost/flexera/cco/scheduled_reports/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v4.1.4
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Renamed `policyName` to `policy_name` in the generated report data and `summary_template`/`detail_template` references to follow the standard naming convention.
 
 ## v4.1.3
 

--- a/cost/flexera/cco/scheduled_reports/scheduled_report.pt
+++ b/cost/flexera/cco/scheduled_reports/scheduled_report.pt
@@ -1160,7 +1160,7 @@ script "js_generated_report", type: "javascript" do
     reportData: ds_collated_data,
     dataPresent: ds_collated_data.length,
     graphDimension: ds_graph_dimension['name'],
-    policyName: ds_applied_policy['name'],
+    policy_name: ds_applied_policy['name'],
     today: new Date().toLocaleDateString('en-us', { year: 'numeric', month: 'long', day: 'numeric'}),
     domain: ds_flexera_domain,
     filterMessage: filterMessage,
@@ -1175,9 +1175,9 @@ end
 
 policy "pol_scheduled_report" do
   validate $ds_generated_report do
-    summary_template "{{ data.policyName }}: {{ rs_org_name }} (Organization ID: {{ rs_org_id }})"
+    summary_template "{{ data.policy_name }}: {{ rs_org_name }} (Organization ID: {{ rs_org_id }})"
     detail_template <<-'EOS'
-# {{ data.policyName }}: {{ rs_org_name }} (Organization ID: {{ rs_org_id }})
+# {{ data.policy_name }}: {{ rs_org_name }} (Organization ID: {{ rs_org_id }})
 **Date Created:** {{ data.today }}
 
 **Date Range (Months):** {{ parameters.param_date_range }}
@@ -1228,9 +1228,9 @@ For more information on this report, please view the [README](https://github.com
   end
 
   validate $ds_generated_report do
-    summary_template "Cost Alert for {{ data.policyName }}: {{ rs_org_name }} (Organization ID: {{ rs_org_id }})"
+    summary_template "Cost Alert for {{ data.policy_name }}: {{ rs_org_name }} (Organization ID: {{ rs_org_id }})"
     detail_template <<-'EOS'
-# Cost Alert for {{ data.policyName }}: {{ rs_org_name }} (Organization ID: {{ rs_org_id }})
+# Cost Alert for {{ data.policy_name }}: {{ rs_org_name }} (Organization ID: {{ rs_org_id }})
 **Date Created:** {{ data.today }}\\
 **Date Range (Months):** {{ parameters.param_date_range }}\\
 **Billing Term:** {{ parameters.param_billing_term }}\\

--- a/cost/flexera/cco/scheduled_reports/scheduled_report.pt
+++ b/cost/flexera/cco/scheduled_reports/scheduled_report.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "monthly"
 info(
-  version: "4.1.3",
+  version: "4.1.4",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -356,6 +356,8 @@ script "js_graph_dimension", type: "javascript" do
   parameters "ds_cost_dimension_table", "ds_data_tables", "param_dimension_graph", "param_dimension_graph_custom"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_dimension_graph_custom = param_dimension_graph_custom.trim()
   result = { id: "category", name: "Category" }
 
   if (param_dimension_graph == 'Custom') {
@@ -413,6 +415,8 @@ script "js_filtered_bcs", type: "javascript" do
   parameters "ds_billing_centers", "param_billing_centers"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_billing_centers = _.compact(_.map(param_billing_centers, function(item) { return item.trim() }))
   if (param_billing_centers.length > 0) {
     result = _.filter(ds_billing_centers, function(bc) {
       return _.contains(param_billing_centers, bc['name']) || _.contains(param_billing_centers, bc['name'].toLowerCase()) || _.contains(param_billing_centers, bc['id'])
@@ -952,6 +956,8 @@ script "js_generated_report", type: "javascript" do
   parameters "ds_collated_data", "ds_graph_dimension", "ds_data_tables", "ds_currency", "ds_applied_policy", "ds_flexera_domain", "param_cost_metric", "param_date_range", "param_billing_term", "param_billing_centers", "param_dimension_filter", "param_dimension_filter_boolean", "param_percent_change_threshold", "param_dimension_graph_value_count"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_billing_centers = _.compact(_.map(param_billing_centers, function(item) { return item.trim() }))
   // Prepare date information for later use
   now = new Date()
   currentMonth = now.toISOString().split('-')[0] + '-' + now.toISOString().split('-')[1]

--- a/cost/flexera/msp/master_org_cost_policy/CHANGELOG.md
+++ b/cost/flexera/msp/master_org_cost_policy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.0.6
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v2.0.5
 
 - Updated heredocs in policy template code to conform to best practices. Functionality unchanged.

--- a/cost/flexera/msp/master_org_cost_policy/CHANGELOG.md
+++ b/cost/flexera/msp/master_org_cost_policy/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.0.6
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Added a link to docs.flexera.com in the `short_description`.
 
 ## v2.0.5
 

--- a/cost/flexera/msp/master_org_cost_policy/master_org_cost_policy.pt
+++ b/cost/flexera/msp/master_org_cost_policy/master_org_cost_policy.pt
@@ -10,7 +10,7 @@ We recommend running this policy on a weekly cadence and applying it to your mas
 _Note 1: The last 3 days of data in the current week or month will contain incomplete data._
 _Note 2: The account you apply the policy to is unimportant as Flexera CCO metrics are scoped to the Org._
 _Note 3: If excluding orgs is needed use only either 'Excluded Organizations' or 'Exclucded organizations IDs' parameter, not both._
-See [README](https://github.com/flexera-public/policy_templates/tree/master/cost/flexera/msp/master_org_cost_policy) for more details"
+See [README](https://github.com/flexera-public/policy_templates/tree/master/cost/flexera/msp/master_org_cost_policy) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera-one/automation/) to learn more."
 long_description ""
 doc_link "https://github.com/flexera-public/policy_templates/tree/master/cost/flexera/msp/master_org_cost_policy"
 severity "low"

--- a/cost/flexera/msp/master_org_cost_policy/master_org_cost_policy.pt
+++ b/cost/flexera/msp/master_org_cost_policy/master_org_cost_policy.pt
@@ -17,7 +17,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "2.0.5",
+  version: "2.0.6",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Managed Service Provider",
@@ -137,6 +137,9 @@ script "js_filtered_user_organizations", type: "javascript" do
   parameters "ds_current_user_organizations", "param_exclude_organizations", "param_exclude_organizations_ids"
   result "results"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclude_organizations = _.compact(_.map(param_exclude_organizations, function(item) { return item.trim() }))
+  param_exclude_organizations_ids = _.compact(_.map(param_exclude_organizations_ids, function(item) { return item.trim() }))
   var results = _.reject(ds_current_user_organizations, function(org){
     return _.contains(param_exclude_organizations, org["name"])
   })

--- a/cost/flexera/msp/master_org_cost_policy/master_org_cost_policy.pt
+++ b/cost/flexera/msp/master_org_cost_policy/master_org_cost_policy.pt
@@ -21,7 +21,8 @@ info(
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Managed Service Provider",
-  publish: "false"
+  publish: "false",
+  hide_skip_approvals: "true"
 )
 
 ###############################################################################

--- a/cost/flexera/msp/master_org_cost_policy_currency/CHANGELOG.md
+++ b/cost/flexera/msp/master_org_cost_policy_currency/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.0.6
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v2.0.5
 
 - Updated heredocs in policy template code to conform to best practices. Functionality unchanged.

--- a/cost/flexera/msp/master_org_cost_policy_currency/CHANGELOG.md
+++ b/cost/flexera/msp/master_org_cost_policy_currency/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.0.6
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Added a link to docs.flexera.com in the `short_description`.
 
 ## v2.0.5
 

--- a/cost/flexera/msp/master_org_cost_policy_currency/master_org_cost_policy_currency.pt
+++ b/cost/flexera/msp/master_org_cost_policy_currency/master_org_cost_policy_currency.pt
@@ -10,7 +10,7 @@ We recommend running this policy on a weekly cadence and applying it to your mas
 _Note 1: The last 3 days of data in the current week or month will contain incomplete data._
 _Note 2: The account you apply the policy to is unimportant as Flexera CCO metrics are scoped to the Org._
 _Note 3: Exchange rates are calculated at execution time using [https://exchangeratesapi.io/](https://exchangeratesapi.io/)._
-See [README](https://github.com/flexera-public/policy_templates/tree/master/cost/flexera/msp/master_org_cost_policy_currency) for more details"
+See [README](https://github.com/flexera-public/policy_templates/tree/master/cost/flexera/msp/master_org_cost_policy_currency) and [docs.flexera.com/flexera/EN/Automation](https://docs.flexera.com/flexera-one/automation/) to learn more."
 long_description ""
 doc_link "https://github.com/flexera-public/policy_templates/tree/master/cost/flexera/msp/master_org_cost_policy_currency"
 severity "low"

--- a/cost/flexera/msp/master_org_cost_policy_currency/master_org_cost_policy_currency.pt
+++ b/cost/flexera/msp/master_org_cost_policy_currency/master_org_cost_policy_currency.pt
@@ -17,7 +17,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "2.0.5",
+  version: "2.0.6",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Managed Service Provider",
@@ -136,6 +136,8 @@ script "js_filtered_rejected_organizations", type: "javascript" do
   parameters "ds_current_user_organizations", "param_exclude_organizations"
   result "results"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_exclude_organizations = _.compact(_.map(param_exclude_organizations, function(item) { return item.trim() }))
     var results = _.reject(ds_current_user_organizations, function(org){
       return _.contains(param_exclude_organizations, org["name"])
     })

--- a/cost/flexera/msp/master_org_cost_policy_currency/master_org_cost_policy_currency.pt
+++ b/cost/flexera/msp/master_org_cost_policy_currency/master_org_cost_policy_currency.pt
@@ -21,7 +21,8 @@ info(
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Managed Service Provider",
-  publish: "false"
+  publish: "false",
+  hide_skip_approvals: "true"
 )
 
 ###############################################################################

--- a/cost/flexera/spot/ocean_recommendations/CHANGELOG.md
+++ b/cost/flexera/spot/ocean_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.5.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/flexera/spot/ocean_recommendations/spot_ocean_recommendations.pt
+++ b/cost/flexera/spot/ocean_recommendations/spot_ocean_recommendations.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "daily"
 info(
-  version: "0.5.0",
+  version: "0.5.1",
   provider: "Flexera",
   service: "Kubernetes",
   policy_set: "Rightsize Containers",
@@ -222,6 +222,8 @@ script "js_spotinst_accounts_filtered", type: "javascript" do
   parameters "ds_spotinst_accounts", "param_spotinst_accounts_allow_or_deny", "param_spotinst_accounts_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_spotinst_accounts_list = _.compact(_.map(param_spotinst_accounts_list, function(item) { return item.trim() }))
   if (param_spotinst_accounts_list.length > 0) {
     result = _.filter(ds_spotinst_accounts, function(subscription) {
       include = _.contains(param_spotinst_accounts_list, subscription['account']['accountId']) || _.contains(param_spotinst_accounts_list, subscription['account']['name'])

--- a/cost/google/cheaper_regions/CHANGELOG.md
+++ b/cost/google/cheaper_regions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.2.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v1.2.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/google/cheaper_regions/google_cheaper_regions.pt
+++ b/cost/google/cheaper_regions/google_cheaper_regions.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "1.2.2",
+  version: "1.2.3",
   provider: "Google",
   service: "All",
   policy_set: "Cheaper Regions",
@@ -250,6 +250,8 @@ script "js_billing_centers_filtered", type: "javascript" do
   parameters "ds_billing_centers", "param_bc_allow_or_deny", "param_bc_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_bc_list = _.compact(_.map(param_bc_list, function(item) { return item.trim() }))
   allow_deny_test = { "Allow": true, "Deny": false }
 
   if (param_bc_list.length > 0) {
@@ -446,6 +448,8 @@ script "js_cheaper_regions", type: "javascript" do
   parameters "ds_regions_sorted", "ds_currency", "param_regions_allow_or_deny", "param_regions_list", "param_incident_csv"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   result = _.filter(ds_regions_sorted, function(item) {
     return typeof(item['cheaper']) == 'string' && item['cheaper'] != ''
   })

--- a/cost/google/cloud_run_anomaly_detection/CHANGELOG.md
+++ b/cost/google/cloud_run_anomaly_detection/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.4.0
 
 - Added error incident if no Google projects are returned by the credential, to alert users to potential permission issues.

--- a/cost/google/cloud_storage_lifecycle/CHANGELOG.md
+++ b/cost/google/cloud_storage_lifecycle/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.4.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/google/cloud_storage_lifecycle/google_cloud_storage_lifecycle.pt
+++ b/cost/google/cloud_storage_lifecycle/google_cloud_storage_lifecycle.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.1",
+  version: "0.4.2",
   provider: "Google",
   service: "Storage",
   policy_set: "",
@@ -234,6 +234,8 @@ script "js_google_projects_filtered", type: "javascript" do
   parameters "ds_google_projects", "param_projects_allow_or_deny", "param_projects_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_projects_list = _.compact(_.map(param_projects_list, function(item) { return item.trim() }))
   if (param_projects_list.length > 0) {
     result = _.filter(ds_google_projects, function(project) {
       include_project = _.contains(param_projects_list, project['id']) || _.contains(param_projects_list, project['name'])
@@ -308,6 +310,8 @@ script "js_google_buckets_label_filtered", type: "javascript" do
   parameters "ds_google_buckets", "param_exclusion_labels", "param_exclusion_labels_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_labels = _.compact(_.map(param_exclusion_labels, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_labels, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/cost/google/cud_expiration/CHANGELOG.md
+++ b/cost/google/cud_expiration/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.3.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.3.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/google/cud_expiration/google_cud_expiration_report.pt
+++ b/cost/google/cud_expiration/google_cud_expiration_report.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "3.3.1",
+  version: "3.3.2",
   provider: "Google",
   service: "Compute",
   policy_set: "Committed Use Discount",
@@ -243,6 +243,8 @@ script "js_google_projects_filtered", type: "javascript" do
   parameters "ds_google_projects", "param_projects_allow_or_deny", "param_projects_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_projects_list = _.compact(_.map(param_projects_list, function(item) { return item.trim() }))
   if (param_projects_list.length > 0) {
     result = _.filter(ds_google_projects, function(project) {
       include_project = _.contains(param_projects_list, project['id']) || _.contains(param_projects_list, project['name'])
@@ -315,6 +317,8 @@ script "js_google_cuds_regions_filtered", type: "javascript" do
   parameters "ds_google_cuds", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_google_cuds, function(cud) {
       include_cud = _.contains(param_regions_list, cud['region'])

--- a/cost/google/cud_recommendations/CHANGELOG.md
+++ b/cost/google/cud_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.9.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.9.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/google/cud_recommendations/google_committed_use_discount_recommendations.pt
+++ b/cost/google/cud_recommendations/google_committed_use_discount_recommendations.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.9.0",
+  version: "4.9.1",
   provider: "Google",
   service: "Compute",
   recommendation_type: "Rate Reduction",
@@ -313,6 +313,8 @@ script "js_google_projects_filtered", type: "javascript" do
   parameters "ds_google_projects", "param_projects_allow_or_deny", "param_projects_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_projects_list = _.compact(_.map(param_projects_list, function(item) { return item.trim() }))
   if (param_projects_list.length > 0) {
     result = _.filter(ds_google_projects, function(project) {
       include_project = _.contains(param_projects_list, project['id']) || _.contains(param_projects_list, project['name'])
@@ -337,6 +339,8 @@ script "js_no_projects_error", type: "javascript" do
   parameters "ds_google_projects", "ds_applied_policy", "param_recommendation_scope", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   result = []
 
   var policy_name = "Google Policy"
@@ -385,6 +389,8 @@ script "js_google_regions_filtered", type: "javascript" do
   parameters "ds_google_regions", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_google_regions, function(region) {
       include_region = _.contains(param_regions_list, region['region'])
@@ -517,6 +523,8 @@ script "js_billing_account_recommender_requests", type: "javascript" do
   parameters "ds_google_billing_accounts", "ds_google_regions_filtered", "ds_recommender_requests", "param_recommendation_scope", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   result = []
 
   if (param_recommendation_scope != "Project") {

--- a/cost/google/cud_report/CHANGELOG.md
+++ b/cost/google/cud_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.3.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.3.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/google/cud_report/google_committed_use_discount_report.pt
+++ b/cost/google/cud_report/google_committed_use_discount_report.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "3.3.1",
+  version: "3.3.2",
   provider: "Google",
   service: "Compute",
   policy_set: "Committed Use Discount",
@@ -243,6 +243,8 @@ script "js_google_projects_filtered", type: "javascript" do
   parameters "ds_google_projects", "param_projects_allow_or_deny", "param_projects_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_projects_list = _.compact(_.map(param_projects_list, function(item) { return item.trim() }))
   if (param_projects_list.length > 0) {
     result = _.filter(ds_google_projects, function(project) {
       include_project = _.contains(param_projects_list, project['id']) || _.contains(param_projects_list, project['name'])
@@ -315,6 +317,8 @@ script "js_google_cuds_regions_filtered", type: "javascript" do
   parameters "ds_google_cuds", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_google_cuds, function(cud) {
       include_cud = _.contains(param_regions_list, cud['region'])

--- a/cost/google/extended_support/CHANGELOG.md
+++ b/cost/google/extended_support/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.3.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/google/extended_support/google_extended_support.pt
+++ b/cost/google/extended_support/google_extended_support.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.0",
+  version: "0.3.1",
   provider: "Google",
   service: "All",
   policy_set: "Deprecated Resources",
@@ -349,6 +349,8 @@ script "js_google_projects_filtered", type: "javascript" do
   parameters "ds_google_projects", "param_projects_allow_or_deny", "param_projects_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_projects_list = _.compact(_.map(param_projects_list, function(item) { return item.trim() }))
   if (param_projects_list.length > 0) {
     result = _.filter(ds_google_projects, function(project) {
       var include_project = _.contains(param_projects_list, project['id']) || _.contains(param_projects_list, project['name'])
@@ -386,6 +388,8 @@ script "js_identify_errors", type: "javascript" do
   parameters "ds_google_projects_filtered", "ds_project_check", "ds_applied_policy", "param_projects_allow_or_deny", "param_projects_list"
   result "errors"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_projects_list = _.compact(_.map(param_projects_list, function(item) { return item.trim() }))
   var errors = []
 
   if (ds_google_projects_filtered.length > 0) {
@@ -485,6 +489,8 @@ script "js_gke_clusters_filtered", type: "javascript" do
   parameters "ds_gke_clusters", "ds_google_extended_support_dates", "param_upcoming_days", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   var today = new Date()
   today.setHours(0, 0, 0, 0)
   var today_ms = today.getTime()
@@ -572,6 +578,8 @@ script "js_cloudsql_instances_filtered", type: "javascript" do
   parameters "ds_cloudsql_instances", "ds_google_extended_support_dates", "param_upcoming_days", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   var today = new Date()
   today.setHours(0, 0, 0, 0)
   var today_ms = today.getTime()
@@ -634,6 +642,8 @@ script "js_all_extended_support_resources", type: "javascript" do
   parameters "ds_gke_clusters_filtered", "ds_cloudsql_instances_filtered", "ds_google_extended_support_dates", "ds_cloud_vendor_accounts", "ds_currency", "param_upcoming_days", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   result = []
 
   var today = new Date()

--- a/cost/google/idle_ip_address_recommendations/CHANGELOG.md
+++ b/cost/google/idle_ip_address_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.6.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.6.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.6.0",
+  version: "4.6.1",
   provider: "Google",
   service: "Compute",
   policy_set: "Unused IP Addresses",
@@ -312,6 +312,8 @@ script "js_google_projects_filtered", type: "javascript" do
   parameters "ds_google_projects", "param_projects_allow_or_deny", "param_projects_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_projects_list = _.compact(_.map(param_projects_list, function(item) { return item.trim() }))
   if (param_projects_list.length > 0) {
     result = _.filter(ds_google_projects, function(project) {
       include_project = _.contains(param_projects_list, project['id']) || _.contains(param_projects_list, project['name'])
@@ -376,6 +378,8 @@ script "js_ip_addresses_region_filtered", type: "javascript" do
   parameters "ds_ip_address_lists", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   result = []
 
   _.each(ds_ip_address_lists, function(ip_list) {
@@ -423,6 +427,8 @@ script "js_ip_addresses", type: "javascript" do
   parameters "ds_ip_addresses_region_filtered", "param_exclusion_labels", "param_exclusion_labels_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_labels = _.compact(_.map(param_exclusion_labels, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_labels, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/cost/google/idle_persistent_disk_recommendations/CHANGELOG.md
+++ b/cost/google/idle_persistent_disk_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.6.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.6.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.6.0",
+  version: "4.6.1",
   provider: "Google",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -441,6 +441,8 @@ script "js_google_projects_filtered", type: "javascript" do
   parameters "ds_google_projects", "param_projects_allow_or_deny", "param_projects_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_projects_list = _.compact(_.map(param_projects_list, function(item) { return item.trim() }))
   if (param_projects_list.length > 0) {
     result = _.filter(ds_google_projects, function(project) {
       include_project = _.contains(param_projects_list, project['id']) || _.contains(param_projects_list, project['name'])
@@ -565,6 +567,8 @@ script "js_disks_label_filtered", type: "javascript" do
   parameters "ds_disks", "param_exclusion_labels", "param_exclusion_labels_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_labels = _.compact(_.map(param_exclusion_labels, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_labels, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -642,6 +646,8 @@ script "js_disks_region_filtered", type: "javascript" do
   parameters "ds_disks_label_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_disks_label_filtered, function(disk) {
       include_disk = _.contains(param_regions_list, disk['region'])

--- a/cost/google/idle_vertex_ai_endpoints/CHANGELOG.md
+++ b/cost/google/idle_vertex_ai_endpoints/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.2.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/google/idle_vertex_ai_endpoints/google_idle_vertex_ai_endpoints.pt
+++ b/cost/google/idle_vertex_ai_endpoints/google_idle_vertex_ai_endpoints.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.0",
+  version: "0.2.1",
   provider: "Google",
   service: "AI and Machine Learning",
   policy_set: "Idle Vertex AI Endpoints",
@@ -352,6 +352,8 @@ script "js_google_projects_filtered", type: "javascript" do
   parameters "ds_google_projects", "param_projects_allow_or_deny", "param_projects_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_projects_list = _.compact(_.map(param_projects_list, function(item) { return item.trim() }))
   if (param_projects_list.length > 0) {
     result = _.filter(ds_google_projects, function(project) {
       include_project = _.contains(param_projects_list, project['id']) || _.contains(param_projects_list, project['name'])
@@ -554,6 +556,8 @@ script "js_vertex_ai_endpoints_region_filtered", type: "javascript" do
   parameters "ds_vertex_ai_endpoints_processed", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_vertex_ai_endpoints_processed, function(ep) {
       include_ep = _.contains(param_regions_list, ep['region'])
@@ -575,6 +579,8 @@ script "js_vertex_ai_endpoints_filtered", type: "javascript" do
   parameters "ds_vertex_ai_endpoints_region_filtered", "param_exclusion_labels", "param_exclusion_labels_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_labels = _.compact(_.map(param_exclusion_labels, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_labels, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/cost/google/instance_cost_per_hour/CHANGELOG.md
+++ b/cost/google/instance_cost_per_hour/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/google/instance_cost_per_hour/google_instance_cost_per_hour.pt
+++ b/cost/google/instance_cost_per_hour/google_instance_cost_per_hour.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "monthly"
 info(
-  version: "0.1.1",
+  version: "0.1.2",
   provider: "Google",
   service: "Compute",
   policy_set: "Unit Economics",
@@ -163,6 +163,8 @@ script "js_billing_centers_filtered", type: "javascript" do
   parameters "ds_billing_centers", "param_bc_allow_or_deny", "param_bc_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_bc_list = _.compact(_.map(param_bc_list, function(item) { return item.trim() }))
   allow_deny_test = { "Allow": true, "Deny": false }
 
   if (param_bc_list.length > 0) {


### PR DESCRIPTION
### Description

One of several PRs focused on sanitizing inputs for PT parameters. This is to prevent users from breaking policy template execution because they entered a parameter incorrectly, such as putting whitespace at the beginning or end of the value.

Also corrects some Dangerfile-reported issues with the touched PTs.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
