### PR TITLE
POL-1826 Parameter Sanitization: Policy Templates #10

### DIFF
--- a/cost/google/object_storage_optimization/CHANGELOG.md
+++ b/cost/google/object_storage_optimization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/google/object_storage_optimization/google_object_storage_optimization.pt
+++ b/cost/google/object_storage_optimization/google_object_storage_optimization.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.1.1",
+  version: "3.1.2",
   provider: "Google",
   service: "Storage",
   policy_set: "Object Store Optimization",
@@ -228,6 +228,8 @@ script "js_google_projects_filtered", type: "javascript" do
   parameters "ds_google_projects", "param_projects_allow_or_deny", "param_projects_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_projects_list = _.compact(_.map(param_projects_list, function(item) { return item.trim() }))
   if (param_projects_list.length > 0) {
     result = _.filter(ds_google_projects, function(project) {
       include_project = _.contains(param_projects_list, project['id']) || _.contains(param_projects_list, project['name']) || _.contains(param_projects_list, project['number'])
@@ -302,6 +304,8 @@ script "js_google_buckets_label_filtered", type: "javascript" do
   parameters "ds_google_buckets", "param_exclusion_labels", "param_exclusion_labels_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_labels = _.compact(_.map(param_exclusion_labels, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_labels, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -379,6 +383,8 @@ script "js_google_buckets_name_filtered", type: "javascript" do
   parameters "ds_google_buckets_label_filtered", "param_storage_bucket_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_storage_bucket_list = _.compact(_.map(param_storage_bucket_list, function(item) { return item.trim() }))
   if (param_storage_bucket_list.length > 0) {
     result = _.filter(ds_google_buckets_label_filtered, function(bucket) {
       return _.contains(param_storage_bucket_list, bucket['name']) || _.contains(param_storage_bucket_list, bucket['id'])

--- a/cost/google/old_snapshots/CHANGELOG.md
+++ b/cost/google/old_snapshots/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.6.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v5.6.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/google/old_snapshots/google_delete_old_snapshots.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.6.0",
+  version: "5.6.1",
   provider:"Google",
   service: "Storage",
   policy_set: "Old Snapshots",
@@ -463,6 +463,8 @@ script "js_google_projects_filtered", type: "javascript" do
   parameters "ds_google_projects", "param_projects_allow_or_deny", "param_projects_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_projects_list = _.compact(_.map(param_projects_list, function(item) { return item.trim() }))
   if (param_projects_list.length > 0) {
     result = _.filter(ds_google_projects, function(project) {
       include_project = _.contains(param_projects_list, project['id']) || _.contains(param_projects_list, project['name'])
@@ -540,6 +542,8 @@ script "js_google_snapshots_label_filtered", type: "javascript" do
   parameters "ds_google_snapshots", "param_exclusion_labels", "param_exclusion_labels_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_labels = _.compact(_.map(param_exclusion_labels, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_labels, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/cost/google/recommender/CHANGELOG.md
+++ b/cost/google/recommender/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.4.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.4.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/google/recommender/recommender.pt
+++ b/cost/google/recommender/recommender.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.4.0",
+  version: "3.4.1",
   provider: "Google",
   service: "All",
   policy_set: "Native Recommendations",
@@ -294,6 +294,8 @@ script "js_google_projects_filtered", type: "javascript" do
   parameters "ds_google_projects", "param_projects_allow_or_deny", "param_projects_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_projects_list = _.compact(_.map(param_projects_list, function(item) { return item.trim() }))
   if (param_projects_list.length > 0) {
     result = _.filter(ds_google_projects, function(project) {
       include_project = _.contains(param_projects_list, project['id']) || _.contains(param_projects_list, project['name'])
@@ -360,6 +362,8 @@ script "js_google_regions_filtered", type: "javascript" do
   parameters "ds_google_regions", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_google_regions, function(region) {
       include_region = _.contains(param_regions_list, region['id']) || _.contains(param_projects_list, region['name'])

--- a/cost/google/rightsize_cloudsql_instances/CHANGELOG.md
+++ b/cost/google/rightsize_cloudsql_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.4.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/google/rightsize_cloudsql_instances/google_rightsize_cloudsql_instances.pt
+++ b/cost/google/rightsize_cloudsql_instances/google_rightsize_cloudsql_instances.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.0",
+  version: "0.4.1",
   provider: "Google",
   service: "Compute",
   policy_set: "Rightsize Database Instances",
@@ -438,6 +438,8 @@ script "js_google_projects_filtered", type: "javascript" do
   parameters "ds_google_projects", "param_projects_allow_or_deny", "param_projects_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_projects_list = _.compact(_.map(param_projects_list, function(item) { return item.trim() }))
   if (param_projects_list.length > 0) {
     result = _.filter(ds_google_projects, function(project) {
       include_project = _.contains(param_projects_list, project['id']) || _.contains(param_projects_list, project['name'])
@@ -521,6 +523,8 @@ script "js_cloudsql_instances_label_filtered", type: "javascript" do
   parameters "ds_cloudsql_instances", "param_exclusion_labels", "param_exclusion_labels_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_labels = _.compact(_.map(param_exclusion_labels, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_labels, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -598,6 +602,8 @@ script "js_cloudsql_instances_region_filtered", type: "javascript" do
   parameters "ds_cloudsql_instances_label_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_cloudsql_instances_label_filtered, function(instance) {
       include_instance = _.contains(param_regions_list, instance['region'])

--- a/cost/google/rightsize_cloudsql_recommendations/CHANGELOG.md
+++ b/cost/google/rightsize_cloudsql_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.6.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/google/rightsize_cloudsql_recommendations/google_rightsize_cloudsql_recommendations.pt
+++ b/cost/google/rightsize_cloudsql_recommendations/google_rightsize_cloudsql_recommendations.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.6.0",
+  version: "0.6.1",
   provider: "Google",
   service: "Compute",
   policy_set: "Rightsize Database Instances",
@@ -321,6 +321,8 @@ script "js_google_projects_filtered", type: "javascript" do
   parameters "ds_google_projects", "param_projects_allow_or_deny", "param_projects_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_projects_list = _.compact(_.map(param_projects_list, function(item) { return item.trim() }))
   if (param_projects_list.length > 0) {
     result = _.filter(ds_google_projects, function(project) {
       include_project = _.contains(param_projects_list, project['id']) || _.contains(param_projects_list, project['name'])
@@ -404,6 +406,8 @@ script "js_cloudsql_instances_label_filtered", type: "javascript" do
   parameters "ds_cloudsql_instances", "param_exclusion_labels", "param_exclusion_labels_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_labels = _.compact(_.map(param_exclusion_labels, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_labels, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -481,6 +485,8 @@ script "js_cloudsql_instances_region_filtered", type: "javascript" do
   parameters "ds_cloudsql_instances_label_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_cloudsql_instances_label_filtered, function(instance) {
       include_instance = _.contains(param_regions_list, instance['region'])

--- a/cost/google/rightsize_persistent_disks/CHANGELOG.md
+++ b/cost/google/rightsize_persistent_disks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.3.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/google/rightsize_persistent_disks/google_rightsize_persistent_disks.pt
+++ b/cost/google/rightsize_persistent_disks/google_rightsize_persistent_disks.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.0",
+  version: "0.3.1",
   provider: "Google",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -418,6 +418,8 @@ script "js_google_projects_filtered", type: "javascript" do
   parameters "ds_google_projects", "param_projects_allow_or_deny", "param_projects_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_projects_list = _.compact(_.map(param_projects_list, function(item) { return item.trim() }))
   if (param_projects_list.length > 0) {
     result = _.filter(ds_google_projects, function(project) {
       include_project = _.contains(param_projects_list, project['id']) || _.contains(param_projects_list, project['name'])
@@ -484,6 +486,8 @@ script "js_zones_filtered", type: "javascript" do
   parameters "ds_zones", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_zones, function(zone) {
       include_zone = _.contains(param_regions_list, zone['region'])
@@ -543,6 +547,8 @@ script "js_disks_label_filtered", type: "javascript" do
   parameters "ds_disks", "param_exclusion_labels", "param_exclusion_labels_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_labels = _.compact(_.map(param_exclusion_labels, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_labels, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/cost/google/rightsize_vm_instances/CHANGELOG.md
+++ b/cost/google/rightsize_vm_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.4.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/google/rightsize_vm_instances/google_rightsize_vm_instances.pt
+++ b/cost/google/rightsize_vm_instances/google_rightsize_vm_instances.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.0",
+  version: "0.4.1",
   provider: "Google",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -548,6 +548,8 @@ script "js_google_projects_filtered", type: "javascript" do
   parameters "ds_google_projects", "param_projects_allow_or_deny", "param_projects_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_projects_list = _.compact(_.map(param_projects_list, function(item) { return item.trim() }))
   if (param_projects_list.length > 0) {
     result = _.filter(ds_google_projects, function(project) {
       include_project = _.contains(param_projects_list, project['id']) || _.contains(param_projects_list, project['name'])
@@ -651,6 +653,8 @@ script "js_google_vms_label_filtered", type: "javascript" do
   parameters "ds_google_vms", "param_exclusion_labels", "param_exclusion_labels_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_labels = _.compact(_.map(param_exclusion_labels, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_labels, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -728,6 +732,8 @@ script "js_google_vms_region_filtered", type: "javascript" do
   parameters "ds_google_vms_label_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_google_vms_label_filtered, function(instance) {
       include_instance = _.contains(param_regions_list, instance['region'])

--- a/cost/google/rightsize_vm_recommendations/CHANGELOG.md
+++ b/cost/google/rightsize_vm_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.5.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.5.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations.pt
+++ b/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "3.5.0",
+  version: "3.5.1",
   provider: "Google",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -431,6 +431,8 @@ script "js_google_projects_filtered", type: "javascript" do
   parameters "ds_google_projects", "param_projects_allow_or_deny", "param_projects_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_projects_list = _.compact(_.map(param_projects_list, function(item) { return item.trim() }))
   if (param_projects_list.length > 0) {
     result = _.filter(ds_google_projects, function(project) {
       include_project = _.contains(param_projects_list, project['id']) || _.contains(param_projects_list, project['name'])
@@ -580,6 +582,8 @@ script "js_instances_label_filtered", type: "javascript" do
   parameters "ds_instances", "param_exclusion_labels", "param_exclusion_labels_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_labels = _.compact(_.map(param_exclusion_labels, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_labels, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -657,6 +661,8 @@ script "js_instances_region_filtered", type: "javascript" do
   parameters "ds_instances_label_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_instances_label_filtered, function(instance) {
       include_instance = _.contains(param_regions_list, instance['region'])

--- a/cost/google/schedule_instance/CHANGELOG.md
+++ b/cost/google/schedule_instance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.1.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v6.1.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/google/schedule_instance/google_schedule_instance.pt
+++ b/cost/google/schedule_instance/google_schedule_instance.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "15 minutes"
 info(
-  version: "6.1.1",
+  version: "6.1.2",
   provider: "Google",
   service: "Compute",
   policy_set: "Schedule Instance",
@@ -272,6 +272,8 @@ script "js_google_projects_filtered", type: "javascript" do
   parameters "ds_google_projects", "param_projects_allow_or_deny", "param_projects_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_projects_list = _.compact(_.map(param_projects_list, function(item) { return item.trim() }))
   if (param_projects_list.length > 0) {
     result = _.filter(ds_google_projects, function(project) {
       include_project = _.contains(param_projects_list, project['id']) || _.contains(param_projects_list, project['name']) || _.contains(param_projects_list, project['number'])
@@ -375,6 +377,8 @@ script "js_instances_label_filtered", type: "javascript" do
   parameters "ds_instances", "param_exclusion_labels", "param_exclusion_labels_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_labels = _.compact(_.map(param_exclusion_labels, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_labels, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -452,6 +456,8 @@ script "js_instances_region_filtered", type: "javascript" do
   parameters "ds_instances_label_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_instances_label_filtered, function(instance) {
       include_instance = _.contains(param_regions_list, instance['region'])
@@ -476,6 +482,8 @@ script "js_instances_with_schedule", type: "javascript" do
   parameters "ds_instances_region_filtered", "ds_applied_policy", "ds_timezones_list", "param_label_schedule"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_label_schedule = param_label_schedule.trim()
   result = []
   now = new Date()
 
@@ -644,6 +652,8 @@ script "js_instances_schedule_result_action_start", type: "javascript" do
   parameters "ds_instances_schedule_result_with_last_action_status", "param_enforce_schedules", "param_label_schedule_action"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_label_schedule_action = param_label_schedule_action.trim()
   var result = []
   var enforce_schedule_enabled = param_enforce_schedules == "Yes"
   // Force Action is a static string unless force action is enabled
@@ -720,6 +730,8 @@ script "js_instances_schedule_result_action_stop", type: "javascript" do
   parameters "ds_instances_schedule_result_with_last_action_status", "param_enforce_schedules", "param_label_schedule_action"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_label_schedule_action = param_label_schedule_action.trim()
   var result = []
   var enforce_schedule_enabled = param_enforce_schedules == "Yes"
   // Force Action is a static string unless force action is enabled

--- a/cost/google/unused_disks/CHANGELOG.md
+++ b/cost/google/unused_disks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.4.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/google/unused_disks/google_unused_disks.pt
+++ b/cost/google/unused_disks/google_unused_disks.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.0",
+  version: "0.4.1",
   provider: "Google",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -380,6 +380,8 @@ script "js_google_projects_filtered", type: "javascript" do
   parameters "ds_google_projects", "param_projects_allow_or_deny", "param_projects_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_projects_list = _.compact(_.map(param_projects_list, function(item) { return item.trim() }))
   if (param_projects_list.length > 0) {
     result = _.filter(ds_google_projects, function(project) {
       include_project = _.contains(param_projects_list, project['id']) || _.contains(param_projects_list, project['name'])
@@ -447,6 +449,8 @@ script "js_zones_filtered", type: "javascript" do
   parameters "ds_zones", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_regions, function(zone) {
       include_zone = _.contains(param_regions_list, zone['region'])
@@ -524,6 +528,8 @@ script "js_unattached_disks_label_filtered", type: "javascript" do
   parameters "ds_unattached_disks", "param_exclusion_labels", "param_exclusion_labels_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_labels = _.compact(_.map(param_exclusion_labels, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_labels, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/cost/kubecost/cluster/CHANGELOG.md
+++ b/cost/kubecost/cluster/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.4
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.5.3
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/kubecost/cluster/kubecost_cluster_rightsizing_recommendations.pt
+++ b/cost/kubecost/cluster/kubecost_cluster_rightsizing_recommendations.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.3",
+  version: "0.5.4",
   provider: "Kubecost",
   service: "Kubernetes",
   policy_set: "Rightsize Clusters",
@@ -124,6 +124,18 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_kubecost_host" do
+  run_script $js_kubecost_host, $param_kubecost_host
+end
+
+script "js_kubecost_host", type: "javascript" do
+  parameters "param_kubecost_host"
+  result "result"
+  code <<-'EOS'
+  result = param_kubecost_host.trim()
+EOS
+end
+
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
@@ -183,7 +195,7 @@ end
 
 datasource "ds_kubecost_currency_code" do
   request do
-    host $param_kubecost_host
+    host $ds_kubecost_host
     path "/model/getConfigs"
   end
   result do
@@ -331,7 +343,7 @@ end
 
 datasource "ds_clusters" do
   request do
-    host $param_kubecost_host
+    host $ds_kubecost_host
     path "/model/savings/clusterSizingETL"
     query "minNodeCount", to_s($param_min_nodes)
     query "window", join([$param_lookback, "d"])

--- a/cost/kubecost/sizing/CHANGELOG.md
+++ b/cost/kubecost/sizing/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.6.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/kubecost/sizing/kubecost_resizing_recommendation.pt
+++ b/cost/kubecost/sizing/kubecost_resizing_recommendation.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.6.0",
+  version: "0.6.1",
   provider: "Kubecost",
   service: "Kubernetes",
   policy_set: "Rightsize Containers",
@@ -156,6 +156,18 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_kubecost_host" do
+  run_script $js_kubecost_host, $param_kubecost_host
+end
+
+script "js_kubecost_host", type: "javascript" do
+  parameters "param_kubecost_host"
+  result "result"
+  code <<-'EOS'
+  result = param_kubecost_host.trim()
+EOS
+end
+
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
@@ -215,7 +227,7 @@ end
 
 datasource "ds_kubecost_currency_code" do
   request do
-    host $param_kubecost_host
+    host $ds_kubecost_host
     path "/model/getConfigs"
   end
   result do
@@ -271,7 +283,7 @@ end
 
 datasource "ds_clusters" do
   request do
-    host $param_kubecost_host
+    host $ds_kubecost_host
     path "/model/clusterInfoMap"
   end
   result do
@@ -326,7 +338,7 @@ end
 datasource "ds_request_sizing" do
   iterate $ds_sizing_recommendation_request_list
   request do
-    host $param_kubecost_host
+    host $ds_kubecost_host
     path "/model/savings/requestSizingV2"
     query "algorithmCPU", val(iter_item, "algorithmCPU")
     query "algorithmRAM", val(iter_item, "algorithmRAM")

--- a/cost/oracle/advisor_lifecycle_mgmt/CHANGELOG.md
+++ b/cost/oracle/advisor_lifecycle_mgmt/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.3.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/oracle/advisor_lifecycle_mgmt/oracle_advisor_lifecycle_mgmt.pt
+++ b/cost/oracle/advisor_lifecycle_mgmt/oracle_advisor_lifecycle_mgmt.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.0",
+  version: "0.3.1",
   provider: "Oracle",
   service: "Storage",
   policy_set: "",
@@ -140,6 +140,30 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_primary_region" do
+  run_script $js_primary_region, $param_primary_region
+end
+
+script "js_primary_region", type: "javascript" do
+  parameters "param_primary_region"
+  result "result"
+  code <<-'EOS'
+  result = param_primary_region.trim()
+EOS
+end
+
+datasource "ds_root_compartment" do
+  run_script $js_root_compartment, $param_root_compartment
+end
+
+script "js_root_compartment", type: "javascript" do
+  parameters "param_root_compartment"
+  result "result"
+  code <<-'EOS'
+  result = param_root_compartment.trim()
+EOS
+end
+
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
@@ -255,9 +279,9 @@ datasource "ds_oci_recommendation_list" do
   request do
     auth $auth_oracle
     pagination $pagination_oracle
-    host join(["optimizer.", $param_primary_region, ".oci.oraclecloud.com"])
+    host join(["optimizer.", $ds_primary_region, ".oci.oraclecloud.com"])
     path "/20200606/recommendations"
-    query "compartmentId", $param_root_compartment
+    query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"
     header "User-Agent", "RS Policies"
   end
@@ -305,9 +329,9 @@ datasource "ds_oci_recommendation_actions" do
     auth $auth_oracle
     pagination $pagination_oracle
     verb "POST"
-    host join(["optimizer.", $param_primary_region, ".oci.oraclecloud.com"])
+    host join(["optimizer.", $ds_primary_region, ".oci.oraclecloud.com"])
     path "/20200606/actions/filterResourceActions"
-    query "compartmentId", $param_root_compartment
+    query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"
     query "includeResourceMetadata", "true"
     query "recommendationId", val(iter_item, "id")
@@ -357,6 +381,8 @@ script "js_oci_recommendation_actions_region_filtered", type: "javascript" do
   parameters "ds_oci_recommendation_actions", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_oci_recommendation_actions, function(action) {
       include_action = _.contains(param_regions_list, action['region'])
@@ -377,6 +403,8 @@ script "js_oci_recommendation_actions_namespace_filtered", type: "javascript" do
   parameters "ds_oci_recommendation_actions_region_filtered", "param_namespaces_allow_or_deny", "param_namespaces_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_namespaces_list = _.compact(_.map(param_namespaces_list, function(item) { return item.trim() }))
   if (param_namespaces_list.length > 0) {
     result = _.filter(ds_oci_recommendation_actions_region_filtered, function(action) {
       include_action = _.contains(param_namespaces_list, action['namespace'])

--- a/cost/oracle/advisor_rightsize_autodbs/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_autodbs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.3.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/oracle/advisor_rightsize_autodbs/oracle_advisor_rightsize_autodbs.pt
+++ b/cost/oracle/advisor_rightsize_autodbs/oracle_advisor_rightsize_autodbs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.0",
+  version: "0.3.1",
   provider: "Oracle",
   service: "Database",
   policy_set: "Rightsize Database Instances",
@@ -133,6 +133,30 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_primary_region" do
+  run_script $js_primary_region, $param_primary_region
+end
+
+script "js_primary_region", type: "javascript" do
+  parameters "param_primary_region"
+  result "result"
+  code <<-'EOS'
+  result = param_primary_region.trim()
+EOS
+end
+
+datasource "ds_root_compartment" do
+  run_script $js_root_compartment, $param_root_compartment
+end
+
+script "js_root_compartment", type: "javascript" do
+  parameters "param_root_compartment"
+  result "result"
+  code <<-'EOS'
+  result = param_root_compartment.trim()
+EOS
+end
+
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
@@ -248,9 +272,9 @@ datasource "ds_oci_recommendation_list" do
   request do
     auth $auth_oracle
     pagination $pagination_oracle
-    host join(["optimizer.", $param_primary_region, ".oci.oraclecloud.com"])
+    host join(["optimizer.", $ds_primary_region, ".oci.oraclecloud.com"])
     path "/20200606/recommendations"
-    query "compartmentId", $param_root_compartment
+    query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"
     header "User-Agent", "RS Policies"
   end
@@ -298,9 +322,9 @@ datasource "ds_oci_recommendation_actions" do
     auth $auth_oracle
     pagination $pagination_oracle
     verb "POST"
-    host join(["optimizer.", $param_primary_region, ".oci.oraclecloud.com"])
+    host join(["optimizer.", $ds_primary_region, ".oci.oraclecloud.com"])
     path "/20200606/actions/filterResourceActions"
-    query "compartmentId", $param_root_compartment
+    query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"
     query "includeResourceMetadata", "true"
     query "recommendationId", val(iter_item, "id")
@@ -355,6 +379,8 @@ script "js_oci_recommendation_actions_region_filtered", type: "javascript" do
   parameters "ds_oci_recommendation_actions", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_oci_recommendation_actions, function(action) {
       include_action = _.contains(param_regions_list, action['region'])

--- a/cost/oracle/advisor_rightsize_basedbs/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_basedbs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.3.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/oracle/advisor_rightsize_basedbs/oracle_advisor_rightsize_basedbs.pt
+++ b/cost/oracle/advisor_rightsize_basedbs/oracle_advisor_rightsize_basedbs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.0",
+  version: "0.3.1",
   provider: "Oracle",
   service: "Database",
   policy_set: "Rightsize Database Instances",
@@ -133,6 +133,30 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_primary_region" do
+  run_script $js_primary_region, $param_primary_region
+end
+
+script "js_primary_region", type: "javascript" do
+  parameters "param_primary_region"
+  result "result"
+  code <<-'EOS'
+  result = param_primary_region.trim()
+EOS
+end
+
+datasource "ds_root_compartment" do
+  run_script $js_root_compartment, $param_root_compartment
+end
+
+script "js_root_compartment", type: "javascript" do
+  parameters "param_root_compartment"
+  result "result"
+  code <<-'EOS'
+  result = param_root_compartment.trim()
+EOS
+end
+
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
@@ -248,9 +272,9 @@ datasource "ds_oci_recommendation_list" do
   request do
     auth $auth_oracle
     pagination $pagination_oracle
-    host join(["optimizer.", $param_primary_region, ".oci.oraclecloud.com"])
+    host join(["optimizer.", $ds_primary_region, ".oci.oraclecloud.com"])
     path "/20200606/recommendations"
-    query "compartmentId", $param_root_compartment
+    query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"
     header "User-Agent", "RS Policies"
   end
@@ -298,9 +322,9 @@ datasource "ds_oci_recommendation_actions" do
     auth $auth_oracle
     pagination $pagination_oracle
     verb "POST"
-    host join(["optimizer.", $param_primary_region, ".oci.oraclecloud.com"])
+    host join(["optimizer.", $ds_primary_region, ".oci.oraclecloud.com"])
     path "/20200606/actions/filterResourceActions"
-    query "compartmentId", $param_root_compartment
+    query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"
     query "includeResourceMetadata", "true"
     query "recommendationId", val(iter_item, "id")
@@ -355,6 +379,8 @@ script "js_oci_recommendation_actions_region_filtered", type: "javascript" do
   parameters "ds_oci_recommendation_actions", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_oci_recommendation_actions, function(action) {
       include_action = _.contains(param_regions_list, action['region'])

--- a/cost/oracle/advisor_rightsize_lbs/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_lbs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.3.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/oracle/advisor_rightsize_lbs/oracle_advisor_rightsize_lbs.pt
+++ b/cost/oracle/advisor_rightsize_lbs/oracle_advisor_rightsize_lbs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.0",
+  version: "0.3.1",
   provider: "Oracle",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -133,6 +133,30 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_primary_region" do
+  run_script $js_primary_region, $param_primary_region
+end
+
+script "js_primary_region", type: "javascript" do
+  parameters "param_primary_region"
+  result "result"
+  code <<-'EOS'
+  result = param_primary_region.trim()
+EOS
+end
+
+datasource "ds_root_compartment" do
+  run_script $js_root_compartment, $param_root_compartment
+end
+
+script "js_root_compartment", type: "javascript" do
+  parameters "param_root_compartment"
+  result "result"
+  code <<-'EOS'
+  result = param_root_compartment.trim()
+EOS
+end
+
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
@@ -248,9 +272,9 @@ datasource "ds_oci_recommendation_list" do
   request do
     auth $auth_oracle
     pagination $pagination_oracle
-    host join(["optimizer.", $param_primary_region, ".oci.oraclecloud.com"])
+    host join(["optimizer.", $ds_primary_region, ".oci.oraclecloud.com"])
     path "/20200606/recommendations"
-    query "compartmentId", $param_root_compartment
+    query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"
     header "User-Agent", "RS Policies"
   end
@@ -298,9 +322,9 @@ datasource "ds_oci_recommendation_actions" do
     auth $auth_oracle
     pagination $pagination_oracle
     verb "POST"
-    host join(["optimizer.", $param_primary_region, ".oci.oraclecloud.com"])
+    host join(["optimizer.", $ds_primary_region, ".oci.oraclecloud.com"])
     path "/20200606/actions/filterResourceActions"
-    query "compartmentId", $param_root_compartment
+    query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"
     query "includeResourceMetadata", "true"
     query "recommendationId", val(iter_item, "id")
@@ -356,6 +380,8 @@ script "js_oci_recommendation_actions_region_filtered", type: "javascript" do
   parameters "ds_oci_recommendation_actions", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_oci_recommendation_actions, function(action) {
       include_action = _.contains(param_regions_list, action['region'])

--- a/cost/oracle/advisor_rightsize_vms/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_vms/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.4.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/oracle/advisor_rightsize_vms/oracle_advisor_rightsize_vms.pt
+++ b/cost/oracle/advisor_rightsize_vms/oracle_advisor_rightsize_vms.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.0",
+  version: "0.4.1",
   provider: "Oracle",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -160,6 +160,30 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_primary_region" do
+  run_script $js_primary_region, $param_primary_region
+end
+
+script "js_primary_region", type: "javascript" do
+  parameters "param_primary_region"
+  result "result"
+  code <<-'EOS'
+  result = param_primary_region.trim()
+EOS
+end
+
+datasource "ds_root_compartment" do
+  run_script $js_root_compartment, $param_root_compartment
+end
+
+script "js_root_compartment", type: "javascript" do
+  parameters "param_root_compartment"
+  result "result"
+  code <<-'EOS'
+  result = param_root_compartment.trim()
+EOS
+end
+
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
@@ -275,9 +299,9 @@ datasource "ds_oci_recommendation_list" do
   request do
     auth $auth_oracle
     pagination $pagination_oracle
-    host join(["optimizer.", $param_primary_region, ".oci.oraclecloud.com"])
+    host join(["optimizer.", $ds_primary_region, ".oci.oraclecloud.com"])
     path "/20200606/recommendations"
-    query "compartmentId", $param_root_compartment
+    query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"
     header "User-Agent", "RS Policies"
   end
@@ -326,9 +350,9 @@ datasource "ds_oci_recommendation_actions" do
     auth $auth_oracle
     pagination $pagination_oracle
     verb "POST"
-    host join(["optimizer.", $param_primary_region, ".oci.oraclecloud.com"])
+    host join(["optimizer.", $ds_primary_region, ".oci.oraclecloud.com"])
     path "/20200606/actions/filterResourceActions"
-    query "compartmentId", $param_root_compartment
+    query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"
     query "includeResourceMetadata", "true"
     query "recommendationId", val(iter_item, "id")
@@ -397,6 +421,8 @@ script "js_oci_recommendation_actions_region_filtered", type: "javascript" do
   parameters "ds_oci_recommendation_actions", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_oci_recommendation_actions, function(action) {
       include_action = _.contains(param_regions_list, action['region'])

--- a/cost/oracle/advisor_unattached_volumes/CHANGELOG.md
+++ b/cost/oracle/advisor_unattached_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.3.0
 
 - Increased the default `Minimum Savings Threshold` from 0 to 1, so that recommendations with no meaningful savings are no longer reported by default.

--- a/cost/oracle/advisor_unattached_volumes/oracle_advisor_unattached_volumes.pt
+++ b/cost/oracle/advisor_unattached_volumes/oracle_advisor_unattached_volumes.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.0",
+  version: "0.3.1",
   provider: "Oracle",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -142,6 +142,30 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_primary_region" do
+  run_script $js_primary_region, $param_primary_region
+end
+
+script "js_primary_region", type: "javascript" do
+  parameters "param_primary_region"
+  result "result"
+  code <<-'EOS'
+  result = param_primary_region.trim()
+EOS
+end
+
+datasource "ds_root_compartment" do
+  run_script $js_root_compartment, $param_root_compartment
+end
+
+script "js_root_compartment", type: "javascript" do
+  parameters "param_root_compartment"
+  result "result"
+  code <<-'EOS'
+  result = param_root_compartment.trim()
+EOS
+end
+
 # Get region-specific Flexera API endpoints
 datasource "ds_flexera_api_hosts" do
   run_script $js_flexera_api_hosts, rs_optima_host
@@ -257,9 +281,9 @@ datasource "ds_oci_recommendation_list" do
   request do
     auth $auth_oracle
     pagination $pagination_oracle
-    host join(["optimizer.", $param_primary_region, ".oci.oraclecloud.com"])
+    host join(["optimizer.", $ds_primary_region, ".oci.oraclecloud.com"])
     path "/20200606/recommendations"
-    query "compartmentId", $param_root_compartment
+    query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"
     header "User-Agent", "RS Policies"
   end
@@ -309,9 +333,9 @@ datasource "ds_oci_recommendation_actions" do
     auth $auth_oracle
     pagination $pagination_oracle
     verb "POST"
-    host join(["optimizer.", $param_primary_region, ".oci.oraclecloud.com"])
+    host join(["optimizer.", $ds_primary_region, ".oci.oraclecloud.com"])
     path "/20200606/actions/filterResourceActions"
-    query "compartmentId", $param_root_compartment
+    query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"
     query "includeResourceMetadata", "true"
     query "recommendationId", val(iter_item, "id")
@@ -367,6 +391,8 @@ script "js_oci_recommendation_actions_region_filtered", type: "javascript" do
   parameters "ds_oci_recommendation_actions", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_oci_recommendation_actions, function(action) {
       include_action = _.contains(param_regions_list, action['region'])

--- a/cost/oracle/oracle_cbi/CHANGELOG.md
+++ b/cost/oracle/oracle_cbi/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.3.6
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Fixed `run_script` parameter order for `js_cost_object_list` (datasources before parameters).
+
 ## v3.3.5
 
 - Updated documentation link in policy description. Functionality unchanged.

--- a/cost/oracle/oracle_cbi/oracle_cbi.pt
+++ b/cost/oracle/oracle_cbi/oracle_cbi.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "15 minutes"
 info(
-  version: "3.3.5",
+  version: "3.3.6",
   provider: "Oracle",
   service: "Common Bill Ingestion",
   policy_set: "Common Bill Ingestion",
@@ -133,6 +133,42 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_bucket" do
+  run_script $js_bucket, $param_bucket
+end
+
+script "js_bucket", type: "javascript" do
+  parameters "param_bucket"
+  result "result"
+  code <<-'EOS'
+  result = param_bucket.trim()
+EOS
+end
+
+datasource "ds_cbi_endpoint" do
+  run_script $js_cbi_endpoint, $param_cbi_endpoint
+end
+
+script "js_cbi_endpoint", type: "javascript" do
+  parameters "param_cbi_endpoint"
+  result "result"
+  code <<-'EOS'
+  result = param_cbi_endpoint.trim()
+EOS
+end
+
+datasource "ds_namespace" do
+  run_script $js_namespace, $param_namespace
+end
+
+script "js_namespace", type: "javascript" do
+  parameters "param_namespace"
+  result "result"
+  code <<-'EOS'
+  result = param_namespace.trim()
+EOS
+end
+
 datasource "ds_dates" do
   run_script $js_dates, $param_billing_period, $param_specific_period
 end
@@ -164,7 +200,7 @@ datasource "ds_existing_bill_uploads" do
     auth $auth_flexera
     host rs_optima_host
     path join(["/optima/orgs/", rs_org_id, "/billUploads"])
-    query "billConnectId", $param_cbi_endpoint
+    query "billConnectId", $ds_cbi_endpoint
     query "billingPeriod", val($ds_dates, 'period')
     header "User-Agent", "RS Policies"
     header "allow_redirects", "False"
@@ -267,7 +303,7 @@ datasource "ds_create_bill_upload" do
     path join(["/optima/orgs/", rs_org_id, "/billUploads"])
     header "User-Agent", "RS Policies"
     header "allow_redirects", "False"
-    body_field "billConnectId", $param_cbi_endpoint
+    body_field "billConnectId", $ds_cbi_endpoint
     body_field "billingPeriod", val($ds_dates, 'period')
   end
   result do
@@ -307,7 +343,7 @@ end
 
 datasource "ds_cost_object_list" do
   request do
-    run_script $js_cost_object_list, $param_region, $param_namespace, $param_bucket, $param_prefix
+    run_script $js_cost_object_list, $ds_namespace, $ds_bucket, $param_region, $param_prefix
   end
   result do
     encoding "json"
@@ -322,9 +358,11 @@ datasource "ds_cost_object_list" do
 end
 
 script "js_cost_object_list", type: "javascript" do
-  parameters "param_region", "param_namespace", "param_bucket", "param_prefix"
+  parameters "ds_namespace", "ds_bucket", "param_region", "param_prefix"
   result "request"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_prefix = param_prefix.trim()
   query_params = { fields: "name,etag,md5,timeCreated,timeModified" }
   if (param_prefix != "") { query_params["prefix"] = param_prefix }
 
@@ -332,7 +370,7 @@ script "js_cost_object_list", type: "javascript" do
     auth: "auth_oracle",
     pagination: "pagination_oracle",
     host: [ "objectstorage.", param_region, ".oraclecloud.com" ].join(''),
-    path: [ "/n/", param_namespace, "/b/", param_bucket, "/o/" ].join(''),
+    path: [ "/n/", ds_namespace, "/b/", ds_bucket, "/o/" ].join(''),
     query_params: query_params
   }
 EOS
@@ -382,7 +420,7 @@ datasource "ds_cost_objects" do
   request do
     auth $auth_oracle
     host join(["objectstorage.", $param_region, ".oraclecloud.com"])
-    path join(["/n/", $param_namespace, "/b/", $param_bucket, "/o/", val(iter_item, "name")])
+    path join(["/n/", $ds_namespace, "/b/", $ds_bucket, "/o/", val(iter_item, "name")])
     header "User-Agent", "RS Policies"
   end
   result do

--- a/cost/turbonomics/allocate_virtual_machines_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/allocate_virtual_machines_recommendations/aws/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.3.9
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v2.3.8
 
 - Added `hash_exclude` for volatile savings and utilization fields so that recalculated estimates alone no longer cause incidents to be treated as changed/reopened.

--- a/cost/turbonomics/allocate_virtual_machines_recommendations/aws/turbonomics_allocate_virtual_machines.pt
+++ b/cost/turbonomics/allocate_virtual_machines_recommendations/aws/turbonomics_allocate_virtual_machines.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.3.8",
+  version: "2.3.9",
   provider: "AWS",
   source: "Turbonomic",
   service: "Compute",
@@ -73,10 +73,34 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_turbonomic_audience" do
+  run_script $js_turbonomic_audience, $param_turbonomic_audience
+end
+
+script "js_turbonomic_audience", type: "javascript" do
+  parameters "param_turbonomic_audience"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_audience.trim()
+EOS
+end
+
+datasource "ds_turbonomic_host" do
+  run_script $js_turbonomic_host, $param_turbonomic_host
+end
+
+script "js_turbonomic_host", type: "javascript" do
+  parameters "param_turbonomic_host"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_host.trim()
+EOS
+end
+
 #get turbonomic token
 datasource "ds_get_turbonomic_token" do
   request do
-    run_script $js_get_turbonomic_token, $param_turbonomic_host, $param_turbonomic_audience
+    run_script $js_get_turbonomic_token, $ds_turbonomic_host, $ds_turbonomic_audience
   end
   result do
     encoding "json"
@@ -87,7 +111,7 @@ end
 #get turbonomic recommendation data
 datasource "ds_get_turbonomics_recommendations" do
   request do
-    run_script $js_get_turbonomics_recommendations, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_host
+    run_script $js_get_turbonomics_recommendations, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_host
   end
   result do
     encoding "json"
@@ -113,7 +137,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_host
+    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_host
   end
   result do
     encoding "json"
@@ -128,7 +152,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_action_details" do
   request do
-    run_script $js_get_action_details, val($ds_get_turbonomic_token, "access_token"), $ds_get_turbonomics_recommendations, $param_turbonomic_host
+    run_script $js_get_action_details, val($ds_get_turbonomic_token, "access_token"), $ds_get_turbonomics_recommendations, $ds_turbonomic_host
   end
   result do
     encoding "json"
@@ -161,13 +185,13 @@ end
 
 ##script using a acquired turbonomic token and pulls hard coded scalable vm data
 script "js_get_turbonomics_recommendations", type: "javascript" do
-  parameters "access_token", "param_turbonomic_host"
+  parameters "access_token", "ds_turbonomic_host"
   result "request"
   code <<-'EOS'
     var request = {
       verb: "POST",
       pagination: "pagination_turbonomic",
-      host: param_turbonomic_host,
+      host: ds_turbonomic_host,
       path: "/api/v3/markets/Market/actions",
       body_fields: {
         "actionStateList": ["READY", "ACCEPTED", "QUEUED", "IN_PROGRESS"],
@@ -190,11 +214,11 @@ end
 
 ## verified that discovered is the only one we need
 script "js_get_business_units", type: "javascript" do
-  parameters "access_token", "param_turbonomic_host"
+  parameters "access_token", "ds_turbonomic_host"
   result "request"
   code <<-'EOS'
     var request = {
-      host: param_turbonomic_host,
+      host: ds_turbonomic_host,
       path: "/api/v3/businessunits",
       query_params: {
         "cloud_type": "AWS",
@@ -209,7 +233,7 @@ EOS
 end
 
 script "js_get_action_details", type: "javascript" do
-  parameters "access_token", "ds_get_turbonomics_recommendations", "param_turbonomic_host"
+  parameters "access_token", "ds_get_turbonomics_recommendations", "ds_turbonomic_host"
   result "request"
   code <<-'EOS'
     var uuids = []
@@ -218,7 +242,7 @@ script "js_get_action_details", type: "javascript" do
     })
     var request = {
       verb: "POST",
-      host: param_turbonomic_host,
+      host: ds_turbonomic_host,
       path: "/api/v3/actions/details",
       body_fields: {
         "uuids": uuids,


### PR DESCRIPTION
### Description

One of several PRs focused on sanitizing inputs for PT parameters. This is to prevent users from breaking policy template execution because they entered a parameter incorrectly, such as putting whitespace at the beginning or end of the value.

Also corrects some Dangerfile-reported issues with the touched PTs.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
