### PR TITLE
POL-1826 Parameter Sanitization: Policy Templates #11

### DIFF
--- a/cost/turbonomics/allocate_virtual_machines_recommendations/azure/CHANGELOG.md
+++ b/cost/turbonomics/allocate_virtual_machines_recommendations/azure/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.3.9
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v2.3.8
 
 - Added `hash_exclude` for volatile savings and utilization fields so that recalculated estimates alone no longer cause incidents to be treated as changed/reopened.

--- a/cost/turbonomics/allocate_virtual_machines_recommendations/azure/turbonomics_allocate_virtual_machines.pt
+++ b/cost/turbonomics/allocate_virtual_machines_recommendations/azure/turbonomics_allocate_virtual_machines.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.3.8",
+  version: "2.3.9",
   provider: "Azure",
   source: "Turbonomic",
   service: "Compute",
@@ -73,10 +73,34 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_turbonomic_audience" do
+  run_script $js_turbonomic_audience, $param_turbonomic_audience
+end
+
+script "js_turbonomic_audience", type: "javascript" do
+  parameters "param_turbonomic_audience"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_audience.trim()
+EOS
+end
+
+datasource "ds_turbonomic_host" do
+  run_script $js_turbonomic_host, $param_turbonomic_host
+end
+
+script "js_turbonomic_host", type: "javascript" do
+  parameters "param_turbonomic_host"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_host.trim()
+EOS
+end
+
 #get turbonomic token
 datasource "ds_get_turbonomic_token" do
   request do
-    run_script $js_get_turbonomic_token, $param_turbonomic_host, $param_turbonomic_audience
+    run_script $js_get_turbonomic_token, $ds_turbonomic_host, $ds_turbonomic_audience
   end
   result do
     encoding "json"
@@ -87,7 +111,7 @@ end
 #get turbonomic recommendation data
 datasource "ds_get_turbonomics_recommendations" do
   request do
-    run_script $js_get_turbonomics_recommendations, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_host
+    run_script $js_get_turbonomics_recommendations, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_host
   end
   result do
     encoding "json"
@@ -113,7 +137,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_host
+    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_host
   end
   result do
     encoding "json"
@@ -128,7 +152,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_action_details" do
   request do
-    run_script $js_get_action_details, val($ds_get_turbonomic_token, "access_token"), $ds_get_turbonomics_recommendations, $param_turbonomic_host
+    run_script $js_get_action_details, val($ds_get_turbonomic_token, "access_token"), $ds_get_turbonomics_recommendations, $ds_turbonomic_host
   end
   result do
     encoding "json"
@@ -161,14 +185,14 @@ end
 
 ##script using acquired turbonomic token and pulls hard coded scalable vm data
 script "js_get_turbonomics_recommendations", type: "javascript" do
-  parameters "access_token", "param_turbonomic_host"
+  parameters "access_token", "ds_turbonomic_host"
   result "request"
   code <<-'EOS'
   //replace cookie every day this is run
     var request = {
       verb: "POST",
       pagination: "pagination_turbonomic",
-      host: param_turbonomic_host,
+      host: ds_turbonomic_host,
       path: "/api/v3/markets/Market/actions",
       body_fields: {
         "actionStateList": ["READY", "ACCEPTED", "QUEUED", "IN_PROGRESS"],
@@ -191,12 +215,12 @@ end
 
 ## verified that discovered is the only one we need
 script "js_get_business_units", type: "javascript" do
-  parameters "access_token", "param_turbonomic_host"
+  parameters "access_token", "ds_turbonomic_host"
   result "request"
   code <<-'EOS'
   //replace cookie every day this is run
     var request = {
-      host: param_turbonomic_host,
+      host: ds_turbonomic_host,
       path: "/api/v3/businessunits",
       query_params: {
         "cloud_type": "AZURE",
@@ -211,7 +235,7 @@ EOS
 end
 
 script "js_get_action_details", type: "javascript" do
-  parameters  "access_token", "ds_get_turbonomics_recommendations", "param_turbonomic_host"
+  parameters  "access_token", "ds_get_turbonomics_recommendations", "ds_turbonomic_host"
   result "request"
   code <<-'EOS'
   //replace cookie every day this is run
@@ -221,7 +245,7 @@ script "js_get_action_details", type: "javascript" do
     })
     var request = {
       verb: "POST",
-      host: param_turbonomic_host,
+      host: ds_turbonomic_host,
       path: "/api/v3/actions/details",
       body_fields: {
         "uuids": uuids,

--- a/cost/turbonomics/allocate_virtual_machines_recommendations/google/CHANGELOG.md
+++ b/cost/turbonomics/allocate_virtual_machines_recommendations/google/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.3.10
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v2.3.9
 
 - Added `hash_exclude` for volatile savings and utilization fields so that recalculated estimates alone no longer cause incidents to be treated as changed/reopened.

--- a/cost/turbonomics/allocate_virtual_machines_recommendations/google/turbonomics_allocate_virtual_machines.pt
+++ b/cost/turbonomics/allocate_virtual_machines_recommendations/google/turbonomics_allocate_virtual_machines.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "2.3.9",
+  version: "2.3.10",
   provider: "Google",
   source: "Turbonomic",
   service: "Compute",
@@ -73,10 +73,34 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_turbonomic_audience" do
+  run_script $js_turbonomic_audience, $param_turbonomic_audience
+end
+
+script "js_turbonomic_audience", type: "javascript" do
+  parameters "param_turbonomic_audience"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_audience.trim()
+EOS
+end
+
+datasource "ds_turbonomic_host" do
+  run_script $js_turbonomic_host, $param_turbonomic_host
+end
+
+script "js_turbonomic_host", type: "javascript" do
+  parameters "param_turbonomic_host"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_host.trim()
+EOS
+end
+
 #get turbonomic token
 datasource "ds_get_turbonomic_token" do
   request do
-    run_script $js_get_turbonomic_token, $param_turbonomic_host, $param_turbonomic_audience
+    run_script $js_get_turbonomic_token, $ds_turbonomic_host, $ds_turbonomic_audience
   end
   result do
     encoding "json"
@@ -87,7 +111,7 @@ end
 #get turbonomic recommendation data
 datasource "ds_get_turbonomics_recommendations" do
   request do
-    run_script $js_get_turbonomics_recommendations, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_host
+    run_script $js_get_turbonomics_recommendations, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_host
   end
   result do
     encoding "json"
@@ -113,7 +137,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_host
+    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_host
   end
   result do
     encoding "json"
@@ -128,7 +152,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_action_details" do
   request do
-    run_script $js_get_action_details, val($ds_get_turbonomic_token, "access_token"), $ds_get_turbonomics_recommendations, $param_turbonomic_host
+    run_script $js_get_action_details, val($ds_get_turbonomic_token, "access_token"), $ds_get_turbonomics_recommendations, $ds_turbonomic_host
   end
   result do
     encoding "json"
@@ -161,14 +185,14 @@ end
 
 ##script using a manually acquired turbonomic cookie and pulls hard coded scalable vm data
 script "js_get_turbonomics_recommendations", type: "javascript" do
-  parameters "access_token", "param_turbonomic_host"
+  parameters "access_token", "ds_turbonomic_host"
   result "request"
   code <<-'EOS'
   //replace cookie every day this is run
     var request = {
       verb: "POST",
       pagination: "pagination_turbonomic",
-      host: param_turbonomic_host,
+      host: ds_turbonomic_host,
       path: "/api/v3/markets/Market/actions",
       body_fields: {
         "actionStateList": ["READY", "ACCEPTED", "QUEUED", "IN_PROGRESS"],
@@ -191,12 +215,12 @@ end
 
 ## verified that discovered is the only one we need
 script "js_get_business_units", type: "javascript" do
-  parameters "access_token", "param_turbonomic_host"
+  parameters "access_token", "ds_turbonomic_host"
   result "request"
   code <<-'EOS'
   //replace cookie every day this is run
     var request = {
-      host: param_turbonomic_host,
+      host: ds_turbonomic_host,
       path: "/api/v3/businessunits",
       query_params: {
         "cloud_type": "GCP",
@@ -211,7 +235,7 @@ EOS
 end
 
 script "js_get_action_details", type: "javascript" do
-  parameters "access_token", "ds_get_turbonomics_recommendations", "param_turbonomic_host"
+  parameters "access_token", "ds_get_turbonomics_recommendations", "ds_turbonomic_host"
   result "request"
   code <<-'EOS'
   //replace cookie every day this is run
@@ -221,7 +245,7 @@ script "js_get_action_details", type: "javascript" do
     })
     var request = {
       verb: "POST",
-      host: param_turbonomic_host,
+      host: ds_turbonomic_host,
       path: "/api/v3/actions/details",
       body_fields: {
         "uuids": uuids,

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.10
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.3.9
 
 - Added `hash_exclude` for volatile savings and utilization fields so that recalculated estimates alone no longer cause incidents to be treated as changed/reopened.

--- a/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/aws/turbonomics_buy_reserved_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.3.9",
+  version: "0.3.10",
   provider: "AWS",
   source: "Turbonomic",
   service: "Usage Discount",
@@ -73,10 +73,34 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_turbonomic_audience" do
+  run_script $js_turbonomic_audience, $param_turbonomic_audience
+end
+
+script "js_turbonomic_audience", type: "javascript" do
+  parameters "param_turbonomic_audience"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_audience.trim()
+EOS
+end
+
+datasource "ds_turbonomic_host" do
+  run_script $js_turbonomic_host, $param_turbonomic_host
+end
+
+script "js_turbonomic_host", type: "javascript" do
+  parameters "param_turbonomic_host"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_host.trim()
+EOS
+end
+
 #get turbonomic token
 datasource "ds_get_turbonomic_token" do
   request do
-    run_script $js_get_turbonomic_token, $param_turbonomic_host, $param_turbonomic_audience
+    run_script $js_get_turbonomic_token, $ds_turbonomic_host, $ds_turbonomic_audience
   end
   result do
     encoding "json"
@@ -87,7 +111,7 @@ end
 #get turbonomic recommendation data
 datasource "ds_get_turbonomic_recommendations" do
   request do
-    run_script $js_get_turbonomic_recommendations, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_host
+    run_script $js_get_turbonomic_recommendations, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_host
   end
   result do
     encoding "json"
@@ -119,7 +143,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_host
+    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_host
   end
   result do
     encoding "json"
@@ -132,12 +156,12 @@ datasource "ds_get_business_units" do
 end
 
 datasource "ds_filtered_turbonomic_recommendations" do
-  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $ds_get_action_details, $param_turbonomic_host
+  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $ds_get_action_details, $ds_turbonomic_host
 end
 
 datasource "ds_get_action_details" do
   request do
-    run_script $js_get_action_details, val($ds_get_turbonomic_token, "access_token"), $ds_get_turbonomic_recommendations, $param_turbonomic_host
+    run_script $js_get_action_details, val($ds_get_turbonomic_token, "access_token"), $ds_get_turbonomic_recommendations, $ds_turbonomic_host
   end
   result do
     encoding "json"
@@ -166,13 +190,13 @@ end
 
 ##script using acquired turbonomic token and pulls hard coded purchasable ri data
 script "js_get_turbonomic_recommendations", type: "javascript" do
-  parameters "access_token", "param_turbonomic_host"
+  parameters "access_token", "ds_turbonomic_host"
   result "request"
   code <<-'EOS'
   var request = {
       verb: "POST",
       pagination: "pagination_turbonomic",
-      host: param_turbonomic_host,
+      host: ds_turbonomic_host,
       path: "/api/v3/markets/Market/actions",
       body_fields: {
           "actionStateList": ["READY", "ACCEPTED", "QUEUED", "IN_PROGRESS"],
@@ -195,11 +219,11 @@ end
 
 ## verified that discovered is the only one we need
 script "js_get_business_units", type: "javascript" do
-  parameters  "access_token", "param_turbonomic_host"
+  parameters  "access_token", "ds_turbonomic_host"
   result "request"
   code <<-'EOS'
   var request = {
-      host: param_turbonomic_host,
+      host: ds_turbonomic_host,
       path: "/api/v3/businessunits",
       query_params: {
           "cloud_type": "AWS",
@@ -214,7 +238,7 @@ EOS
 end
 
 script "js_filtered_turbonomic_recommendations", type: "javascript" do
-  parameters "ds_get_turbonomic_recommendations", "ds_get_business_units", "ds_get_action_details", "param_turbonomic_host"
+  parameters "ds_get_turbonomic_recommendations", "ds_get_business_units", "ds_get_action_details", "ds_turbonomic_host"
   result "result"
   code <<-'EOS'
     instances = []
@@ -283,7 +307,7 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
                         ri.riUtilization = Number(ri.coupons.value * 100 / ri.coupons.capacity.avg).toFixed(2)
                       }
                     }
-                    ri.url = "Buy AWS RI: " + ri.resourceType  + " || https://" + param_turbonomic_host + "/app/index.html#/view/main/action/" + ri.uuid
+                    ri.url = "Buy AWS RI: " + ri.resourceType  + " || https://" + ds_turbonomic_host + "/app/index.html#/view/main/action/" + ri.uuid
                     instances.push(ri)
                 }
             }
@@ -304,7 +328,7 @@ EOS
 end
 
 script "js_get_action_details", type: "javascript" do
-  parameters "access_token", "ds_get_turbonomic_recommendations","param_turbonomic_host"
+  parameters "access_token", "ds_get_turbonomic_recommendations","ds_turbonomic_host"
   result "request"
   code <<-'EOS'
     var uuids = []
@@ -313,7 +337,7 @@ script "js_get_action_details", type: "javascript" do
     })
     var request = {
       verb: "POST",
-      host: param_turbonomic_host,
+      host: ds_turbonomic_host,
       path: "/api/v3/actions/details",
       body_fields: {
         "uuids": uuids,

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/CHANGELOG.md
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.10
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.3.9
 
 - Added `hash_exclude` for volatile savings and utilization fields so that recalculated estimates alone no longer cause incidents to be treated as changed/reopened.

--- a/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
+++ b/cost/turbonomics/buy_reserved_instances_recommendations/azure/turbonomics_buy_reserved_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.3.9",
+  version: "0.3.10",
   provider: "Azure",
   source: "Turbonomic",
   service: "Usage Discount",
@@ -73,10 +73,34 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_turbonomic_audience" do
+  run_script $js_turbonomic_audience, $param_turbonomic_audience
+end
+
+script "js_turbonomic_audience", type: "javascript" do
+  parameters "param_turbonomic_audience"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_audience.trim()
+EOS
+end
+
+datasource "ds_turbonomic_host" do
+  run_script $js_turbonomic_host, $param_turbonomic_host
+end
+
+script "js_turbonomic_host", type: "javascript" do
+  parameters "param_turbonomic_host"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_host.trim()
+EOS
+end
+
 #get turbonomic token
 datasource "ds_get_turbonomic_token" do
   request do
-    run_script $js_get_turbonomic_token, $param_turbonomic_host, $param_turbonomic_audience
+    run_script $js_get_turbonomic_token, $ds_turbonomic_host, $ds_turbonomic_audience
   end
   result do
     encoding "json"
@@ -87,7 +111,7 @@ end
 #get turbonomic recommendation data
 datasource "ds_get_turbonomic_recommendations" do
   request do
-    run_script $js_get_turbonomic_recommendations, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_host
+    run_script $js_get_turbonomic_recommendations, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_host
   end
   result do
     encoding "json"
@@ -117,7 +141,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_host
+    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_host
   end
   result do
     encoding "json"
@@ -150,13 +174,13 @@ end
 
 ##script using a acquired turbonomic token and pulls hard coded purchasable ri data
 script "js_get_turbonomic_recommendations", type: "javascript" do
-  parameters "access_token", "param_turbonomic_host"
+  parameters "access_token", "ds_turbonomic_host"
   result "request"
   code <<-'EOS'
   var request = {
       verb: "POST",
       pagination: "pagination_turbonomic",
-      host: param_turbonomic_host,
+      host: ds_turbonomic_host,
       path: "/api/v3/markets/Market/actions",
       body_fields: {
           "actionStateList": ["READY", "ACCEPTED", "QUEUED", "IN_PROGRESS"],
@@ -179,11 +203,11 @@ end
 
 ## verified that discovered is the only one we need
 script "js_get_business_units", type: "javascript" do
-  parameters "access_token", "param_turbonomic_host"
+  parameters "access_token", "ds_turbonomic_host"
   result "request"
   code <<-'EOS'
   var request = {
-      host: param_turbonomic_host,
+      host: ds_turbonomic_host,
       path: "/api/v3/businessunits",
       query_params: {
           "cloud_type": "AZURE",
@@ -200,7 +224,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_action_details" do
   request do
-    run_script $js_get_action_details, val($ds_get_turbonomic_token, "access_token"), $ds_get_turbonomic_recommendations, $param_turbonomic_host
+    run_script $js_get_action_details, val($ds_get_turbonomic_token, "access_token"), $ds_get_turbonomic_recommendations, $ds_turbonomic_host
   end
   result do
     encoding "json"
@@ -235,7 +259,7 @@ script "js_get_action_details", type: "javascript" do
 end
 
 datasource "ds_filtered_turbonomic_recommendations" do
-  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $ds_get_action_details, $param_turbonomic_host
+  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $ds_get_action_details, $ds_turbonomic_host
 end
 
 script "js_filtered_turbonomic_recommendations", type: "javascript" do

--- a/cost/turbonomics/delete_unattached_volumes/aws/CHANGELOG.md
+++ b/cost/turbonomics/delete_unattached_volumes/aws/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.6.10
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Fixed `run_script` parameter order for the business units and filtered recommendations scripts (datasources before parameters).
 
 ## v0.6.9
 

--- a/cost/turbonomics/delete_unattached_volumes/aws/CHANGELOG.md
+++ b/cost/turbonomics/delete_unattached_volumes/aws/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.10
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.6.9
 
 - Added `hash_exclude` for volatile savings and utilization fields so that recalculated estimates alone no longer cause incidents to be treated as changed/reopened.

--- a/cost/turbonomics/delete_unattached_volumes/aws/turbonomics_delete_virtual_volumes.pt
+++ b/cost/turbonomics/delete_unattached_volumes/aws/turbonomics_delete_virtual_volumes.pt
@@ -164,7 +164,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $param_provider, $ds_turbonomic_host
+    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_host, $param_provider
   end
   result do
     encoding "json"
@@ -177,7 +177,7 @@ datasource "ds_get_business_units" do
 end
 
 datasource "ds_filtered_turbonomics_recommendations" do
-  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_business_units, $param_days_unattached, $param_provider, $ds_turbonomic_host
+  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_business_units, $ds_turbonomic_host, $param_days_unattached, $param_provider
 end
 
 ###############################################################################
@@ -234,7 +234,7 @@ end
 
 ## verified that discovered is the only one we need
 script "js_get_business_units", type: "javascript" do
-  parameters "access_token", "param_provider", "ds_turbonomic_host"
+  parameters "access_token", "ds_turbonomic_host", "param_provider"
   result "request"
   code <<-'EOS'
     var providers = {
@@ -258,7 +258,7 @@ EOS
 end
 
 script "js_filtered_turbonomics_recommendations", type: "javascript" do
-  parameters "ds_get_turbonomics_recommendations", "ds_get_business_units", "param_days_unattached", "param_provider", "ds_turbonomic_host"
+  parameters "ds_get_turbonomics_recommendations", "ds_get_business_units", "ds_turbonomic_host", "param_days_unattached", "param_provider"
   result "result"
   code <<-'EOS'
     instances = []

--- a/cost/turbonomics/delete_unattached_volumes/aws/turbonomics_delete_virtual_volumes.pt
+++ b/cost/turbonomics/delete_unattached_volumes/aws/turbonomics_delete_virtual_volumes.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.6.9",
+  version: "0.6.10",
   provider: "AWS",
   source: "Turbonomic",
   service: "Storage",
@@ -93,10 +93,34 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_turbonomic_audience" do
+  run_script $js_turbonomic_audience, $param_turbonomic_audience
+end
+
+script "js_turbonomic_audience", type: "javascript" do
+  parameters "param_turbonomic_audience"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_audience.trim()
+EOS
+end
+
+datasource "ds_turbonomic_host" do
+  run_script $js_turbonomic_host, $param_turbonomic_host
+end
+
+script "js_turbonomic_host", type: "javascript" do
+  parameters "param_turbonomic_host"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_host.trim()
+EOS
+end
+
 #get turbonomic token
 datasource "ds_get_turbonomic_token" do
   request do
-    run_script $js_get_turbonomic_token, $param_turbonomic_host, $param_turbonomic_audience
+    run_script $js_get_turbonomic_token, $ds_turbonomic_host, $ds_turbonomic_audience
   end
   result do
     encoding "json"
@@ -107,7 +131,7 @@ end
 #get turbonomic recommendation data
 datasource "ds_get_turbonomics_recommendations" do
   request do
-    run_script $js_get_turbonomics_recommendations, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_host
+    run_script $js_get_turbonomics_recommendations, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_host
   end
   result do
     encoding "json"
@@ -140,7 +164,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $param_provider, $param_turbonomic_host
+    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $param_provider, $ds_turbonomic_host
   end
   result do
     encoding "json"
@@ -153,7 +177,7 @@ datasource "ds_get_business_units" do
 end
 
 datasource "ds_filtered_turbonomics_recommendations" do
-  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_business_units, $param_days_unattached, $param_provider, $param_turbonomic_host
+  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_business_units, $param_days_unattached, $param_provider, $ds_turbonomic_host
 end
 
 ###############################################################################
@@ -181,13 +205,13 @@ end
 
 ##script using a acquired turbonomic token and pulls hard coded unused volume data
 script "js_get_turbonomics_recommendations", type: "javascript" do
-  parameters "access_token", "param_turbonomic_host"
+  parameters "access_token", "ds_turbonomic_host"
   result "request"
   code <<-'EOS'
     var request = {
       verb: "POST",
       pagination: "pagination_turbonomic",
-      host: param_turbonomic_host,
+      host: ds_turbonomic_host,
       path: "/api/v3/markets/Market/actions",
       body_fields: {
         "actionStateList": ["READY", "ACCEPTED", "QUEUED", "IN_PROGRESS"],
@@ -210,7 +234,7 @@ end
 
 ## verified that discovered is the only one we need
 script "js_get_business_units", type: "javascript" do
-  parameters "access_token", "param_provider", "param_turbonomic_host"
+  parameters "access_token", "param_provider", "ds_turbonomic_host"
   result "request"
   code <<-'EOS'
     var providers = {
@@ -219,7 +243,7 @@ script "js_get_business_units", type: "javascript" do
       "GCP Project": "GCP",
     }
     var request = {
-      host: param_turbonomic_host,
+      host: ds_turbonomic_host,
       path: "/api/v3/businessunits",
       query_params: {
         "cloud_type": providers[param_provider],
@@ -234,7 +258,7 @@ EOS
 end
 
 script "js_filtered_turbonomics_recommendations", type: "javascript" do
-  parameters "ds_get_turbonomics_recommendations", "ds_get_business_units", "param_days_unattached", "param_provider", "param_turbonomic_host"
+  parameters "ds_get_turbonomics_recommendations", "ds_get_business_units", "param_days_unattached", "param_provider", "ds_turbonomic_host"
   result "result"
   code <<-'EOS'
     instances = []
@@ -306,7 +330,7 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
         }
         volume.savings = (Math.round(volume.savings * 730 * 1000) / 1000)
         monthlySavings = monthlySavings + volume.savings
-        volume.url = "System name: " + volume.resourceName  + " || https://" + param_turbonomic_host + "/app/index.html#/view/main/action/" + volume.uuid
+        volume.url = "System name: " + volume.resourceName  + " || https://" + ds_turbonomic_host + "/app/index.html#/view/main/action/" + volume.uuid
         instances.push(volume)
       }
     })

--- a/cost/turbonomics/delete_unattached_volumes/azure/CHANGELOG.md
+++ b/cost/turbonomics/delete_unattached_volumes/azure/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.10
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.5.9
 
 - Added `hash_exclude` for volatile savings and utilization fields so that recalculated estimates alone no longer cause incidents to be treated as changed/reopened.

--- a/cost/turbonomics/delete_unattached_volumes/azure/CHANGELOG.md
+++ b/cost/turbonomics/delete_unattached_volumes/azure/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.5.10
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Fixed `run_script` parameter order for the business units and filtered recommendations scripts (datasources before parameters).
 
 ## v0.5.9
 

--- a/cost/turbonomics/delete_unattached_volumes/azure/turbonomics_delete_virtual_volumes.pt
+++ b/cost/turbonomics/delete_unattached_volumes/azure/turbonomics_delete_virtual_volumes.pt
@@ -165,7 +165,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $param_provider, $ds_turbonomic_host
+    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_host, $param_provider
   end
   result do
     encoding "json"
@@ -178,7 +178,7 @@ datasource "ds_get_business_units" do
 end
 
 datasource "ds_filtered_turbonomics_recommendations" do
-  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_business_units, $param_days_unattached, $param_provider, $ds_turbonomic_host
+  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_business_units, $ds_turbonomic_host, $param_days_unattached, $param_provider
 end
 
 ##script retrieves an OAuth2 token from the Turbonomic API
@@ -230,7 +230,7 @@ end
 
 ## verified that discovered is the only one we need
 script "js_get_business_units", type: "javascript" do
-  parameters "access_token", "param_provider", "ds_turbonomic_host"
+  parameters "access_token", "ds_turbonomic_host", "param_provider"
   result "request"
   code <<-'EOS'
     var providers = {
@@ -254,7 +254,7 @@ EOS
 end
 
 script "js_filtered_turbonomics_recommendations", type: "javascript" do
-  parameters "ds_get_turbonomics_recommendations", "ds_get_business_units", "param_days_unattached", "param_provider", "ds_turbonomic_host"
+  parameters "ds_get_turbonomics_recommendations", "ds_get_business_units", "ds_turbonomic_host", "param_days_unattached", "param_provider"
   result "result"
   code <<-'EOS'
     instances = []

--- a/cost/turbonomics/delete_unattached_volumes/azure/turbonomics_delete_virtual_volumes.pt
+++ b/cost/turbonomics/delete_unattached_volumes/azure/turbonomics_delete_virtual_volumes.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.5.9",
+  version: "0.5.10",
   provider: "Azure",
   source: "Turbonomic",
   service: "Storage",
@@ -94,10 +94,34 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_turbonomic_audience" do
+  run_script $js_turbonomic_audience, $param_turbonomic_audience
+end
+
+script "js_turbonomic_audience", type: "javascript" do
+  parameters "param_turbonomic_audience"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_audience.trim()
+EOS
+end
+
+datasource "ds_turbonomic_host" do
+  run_script $js_turbonomic_host, $param_turbonomic_host
+end
+
+script "js_turbonomic_host", type: "javascript" do
+  parameters "param_turbonomic_host"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_host.trim()
+EOS
+end
+
 #get turbonomic token
 datasource "ds_get_turbonomic_token" do
   request do
-    run_script $js_get_turbonomic_token, $param_turbonomic_host, $param_turbonomic_audience
+    run_script $js_get_turbonomic_token, $ds_turbonomic_host, $ds_turbonomic_audience
   end
   result do
     encoding "json"
@@ -108,7 +132,7 @@ end
 #get turbonomic recommendation data
 datasource "ds_get_turbonomics_recommendations" do
   request do
-    run_script $js_get_turbonomics_recommendations, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_host
+    run_script $js_get_turbonomics_recommendations, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_host
   end
   result do
     encoding "json"
@@ -141,7 +165,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $param_provider, $param_turbonomic_host
+    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $param_provider, $ds_turbonomic_host
   end
   result do
     encoding "json"
@@ -154,7 +178,7 @@ datasource "ds_get_business_units" do
 end
 
 datasource "ds_filtered_turbonomics_recommendations" do
-  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_business_units, $param_days_unattached, $param_provider, $param_turbonomic_host
+  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_business_units, $param_days_unattached, $param_provider, $ds_turbonomic_host
 end
 
 ##script retrieves an OAuth2 token from the Turbonomic API
@@ -178,13 +202,13 @@ end
 
 ##script using a acquired turbonomic token and pulls hard coded unused volume data
 script "js_get_turbonomics_recommendations", type: "javascript" do
-  parameters "access_token", "param_turbonomic_host"
+  parameters "access_token", "ds_turbonomic_host"
   result "request"
   code <<-'EOS'
     var request = {
       verb: "POST",
       pagination: "pagination_turbonomic",
-      host: param_turbonomic_host,
+      host: ds_turbonomic_host,
       path: "/api/v3/markets/Market/actions",
       body_fields: {
         "actionStateList": ["READY", "ACCEPTED", "QUEUED", "IN_PROGRESS"],
@@ -206,7 +230,7 @@ end
 
 ## verified that discovered is the only one we need
 script "js_get_business_units", type: "javascript" do
-  parameters "access_token", "param_provider", "param_turbonomic_host"
+  parameters "access_token", "param_provider", "ds_turbonomic_host"
   result "request"
   code <<-'EOS'
     var providers = {
@@ -215,7 +239,7 @@ script "js_get_business_units", type: "javascript" do
       "GCP Project": "GCP",
     }
     var request = {
-      host: param_turbonomic_host,
+      host: ds_turbonomic_host,
       path: "/api/v3/businessunits",
       query_params: {
         "cloud_type": providers[param_provider],
@@ -230,7 +254,7 @@ EOS
 end
 
 script "js_filtered_turbonomics_recommendations", type: "javascript" do
-  parameters "ds_get_turbonomics_recommendations", "ds_get_business_units", "param_days_unattached", "param_provider", "param_turbonomic_host"
+  parameters "ds_get_turbonomics_recommendations", "ds_get_business_units", "param_days_unattached", "param_provider", "ds_turbonomic_host"
   result "result"
   code <<-'EOS'
     instances = []
@@ -302,7 +326,7 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
         }
         volume.savings = (Math.round(volume.savings * 730 * 1000) / 1000)
         monthlySavings = monthlySavings + volume.savings
-        volume.url = "System name: " + volume.resourceName  + " || https://" + param_turbonomic_host + "/app/index.html#/view/main/action/" + volume.uuid
+        volume.url = "System name: " + volume.resourceName  + " || https://" + ds_turbonomic_host + "/app/index.html#/view/main/action/" + volume.uuid
         instances.push(volume)
       }
     })

--- a/cost/turbonomics/delete_unattached_volumes/google/CHANGELOG.md
+++ b/cost/turbonomics/delete_unattached_volumes/google/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.6.10
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Fixed `run_script` parameter order for the business units and filtered recommendations scripts (datasources before parameters).
 
 ## v0.6.9
 

--- a/cost/turbonomics/delete_unattached_volumes/google/CHANGELOG.md
+++ b/cost/turbonomics/delete_unattached_volumes/google/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.10
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.6.9
 
 - Added `hash_exclude` for volatile savings and utilization fields so that recalculated estimates alone no longer cause incidents to be treated as changed/reopened.

--- a/cost/turbonomics/delete_unattached_volumes/google/turbonomics_delete_virtual_volumes.pt
+++ b/cost/turbonomics/delete_unattached_volumes/google/turbonomics_delete_virtual_volumes.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.6.9",
+  version: "0.6.10",
   provider: "Google",
   source: "Turbonomic",
   service: "Storage",
@@ -94,10 +94,34 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_turbonomic_audience" do
+  run_script $js_turbonomic_audience, $param_turbonomic_audience
+end
+
+script "js_turbonomic_audience", type: "javascript" do
+  parameters "param_turbonomic_audience"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_audience.trim()
+EOS
+end
+
+datasource "ds_turbonomic_host" do
+  run_script $js_turbonomic_host, $param_turbonomic_host
+end
+
+script "js_turbonomic_host", type: "javascript" do
+  parameters "param_turbonomic_host"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_host.trim()
+EOS
+end
+
 #get turbonomic token
 datasource "ds_get_turbonomic_token" do
   request do
-    run_script $js_get_turbonomic_token, $param_turbonomic_host, $param_turbonomic_audience
+    run_script $js_get_turbonomic_token, $ds_turbonomic_host, $ds_turbonomic_audience
   end
   result do
     encoding "json"
@@ -108,7 +132,7 @@ end
 #get turbonomic recommendation data
 datasource "ds_get_turbonomics_recommendations" do
   request do
-    run_script $js_get_turbonomics_recommendations, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_host
+    run_script $js_get_turbonomics_recommendations, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_host
   end
   result do
     encoding "json"
@@ -141,7 +165,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $param_provider, $param_turbonomic_host
+    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $param_provider, $ds_turbonomic_host
   end
   result do
     encoding "json"
@@ -154,7 +178,7 @@ datasource "ds_get_business_units" do
 end
 
 datasource "ds_filtered_turbonomics_recommendations" do
-  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_business_units, $param_days_unattached, $param_provider, $param_turbonomic_host
+  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_business_units, $param_days_unattached, $param_provider, $ds_turbonomic_host
 end
 
 ##script retrieves an OAuth2 token from the Turbonomic API
@@ -178,13 +202,13 @@ end
 
 ##script using acquired turbonomic token and pulls hard coded unused volume data
 script "js_get_turbonomics_recommendations", type: "javascript" do
-  parameters "access_token", "param_turbonomic_host"
+  parameters "access_token", "ds_turbonomic_host"
   result "request"
   code <<-'EOS'
     var request = {
       verb: "POST",
       pagination: "pagination_turbonomic",
-      host: param_turbonomic_host,
+      host: ds_turbonomic_host,
       path: "/api/v3/markets/Market/actions",
       body_fields: {
         "actionStateList": ["READY", "ACCEPTED", "QUEUED", "IN_PROGRESS"],
@@ -207,7 +231,7 @@ end
 
 ## verified that discovered is the only one we need
 script "js_get_business_units", type: "javascript" do
-  parameters "access_token", "param_provider", "param_turbonomic_host"
+  parameters "access_token", "param_provider", "ds_turbonomic_host"
   result "request"
   code <<-'EOS'
     var providers = {
@@ -216,7 +240,7 @@ script "js_get_business_units", type: "javascript" do
       "GCP Project": "GCP",
     }
     var request = {
-      host: param_turbonomic_host,
+      host: ds_turbonomic_host,
       path: "/api/v3/businessunits",
       query_params: {
         "cloud_type": providers[param_provider],
@@ -231,7 +255,7 @@ EOS
 end
 
 script "js_filtered_turbonomics_recommendations", type: "javascript" do
-  parameters "ds_get_turbonomics_recommendations", "ds_get_business_units", "param_days_unattached", "param_provider", "param_turbonomic_host"
+  parameters "ds_get_turbonomics_recommendations", "ds_get_business_units", "param_days_unattached", "param_provider", "ds_turbonomic_host"
   result "result"
   code <<-'EOS'
     instances = []
@@ -303,7 +327,7 @@ script "js_filtered_turbonomics_recommendations", type: "javascript" do
         }
         volume.savings = (Math.round(volume.savings * 730 * 1000) / 1000)
         monthlySavings = monthlySavings + volume.savings
-        volume.url = "System name: " + volume.resourceName  + " || https://" + param_turbonomic_host + "/app/index.html#/view/main/action/" + volume.uuid
+        volume.url = "System name: " + volume.resourceName  + " || https://" + ds_turbonomic_host + "/app/index.html#/view/main/action/" + volume.uuid
         instances.push(volume)
       }
     })

--- a/cost/turbonomics/delete_unattached_volumes/google/turbonomics_delete_virtual_volumes.pt
+++ b/cost/turbonomics/delete_unattached_volumes/google/turbonomics_delete_virtual_volumes.pt
@@ -165,7 +165,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $param_provider, $ds_turbonomic_host
+    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_host, $param_provider
   end
   result do
     encoding "json"
@@ -178,7 +178,7 @@ datasource "ds_get_business_units" do
 end
 
 datasource "ds_filtered_turbonomics_recommendations" do
-  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_business_units, $param_days_unattached, $param_provider, $ds_turbonomic_host
+  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_business_units, $ds_turbonomic_host, $param_days_unattached, $param_provider
 end
 
 ##script retrieves an OAuth2 token from the Turbonomic API
@@ -231,7 +231,7 @@ end
 
 ## verified that discovered is the only one we need
 script "js_get_business_units", type: "javascript" do
-  parameters "access_token", "param_provider", "ds_turbonomic_host"
+  parameters "access_token", "ds_turbonomic_host", "param_provider"
   result "request"
   code <<-'EOS'
     var providers = {
@@ -255,7 +255,7 @@ EOS
 end
 
 script "js_filtered_turbonomics_recommendations", type: "javascript" do
-  parameters "ds_get_turbonomics_recommendations", "ds_get_business_units", "param_days_unattached", "param_provider", "ds_turbonomic_host"
+  parameters "ds_get_turbonomics_recommendations", "ds_get_business_units", "ds_turbonomic_host", "param_days_unattached", "param_provider"
   result "result"
   code <<-'EOS'
     instances = []

--- a/cost/turbonomics/rightsize_databases_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_databases_recommendations/aws/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.4.10
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Fixed `run_script` parameter order for the filtered recommendations script (datasources before parameters).
 
 ## v0.4.9
 

--- a/cost/turbonomics/rightsize_databases_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_databases_recommendations/aws/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.10
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.4.9
 
 - Added `hash_exclude` for volatile savings and utilization fields so that recalculated estimates alone no longer cause incidents to be treated as changed/reopened.

--- a/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
+++ b/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.4.9",
+  version: "0.4.10",
   source: "Turbonomic",
   service: "Usage Discount",
   provider: "AWS",
@@ -84,10 +84,34 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_turbonomic_audience" do
+  run_script $js_turbonomic_audience, $param_turbonomic_audience
+end
+
+script "js_turbonomic_audience", type: "javascript" do
+  parameters "param_turbonomic_audience"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_audience.trim()
+EOS
+end
+
+datasource "ds_turbonomic_host" do
+  run_script $js_turbonomic_host, $param_turbonomic_host
+end
+
+script "js_turbonomic_host", type: "javascript" do
+  parameters "param_turbonomic_host"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_host.trim()
+EOS
+end
+
 #get turbonomic token
 datasource "ds_get_turbonomic_token" do
   request do
-    run_script $js_get_turbonomic_token, $param_turbonomic_host, $param_turbonomic_audience
+    run_script $js_get_turbonomic_token, $ds_turbonomic_host, $ds_turbonomic_audience
   end
   result do
     encoding "json"
@@ -97,7 +121,7 @@ end
 
 datasource "ds_get_turbonomic_recommendations" do
   request do
-    run_script $js_get_turbonomic_recommendations, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_host
+    run_script $js_get_turbonomic_recommendations, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_host
   end
   result do
     encoding "json"
@@ -171,7 +195,7 @@ end
 
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_host, $param_provider
+    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_host, $param_provider
   end
   result do
     encoding "json"
@@ -214,7 +238,7 @@ script "js_get_business_units", type: "javascript" do
 end
 
 datasource "ds_filtered_turbonomic_recommendations" do
-  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $param_provider, $param_turbonomic_host
+  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $param_provider, $ds_turbonomic_host
 end
 
 script "js_filtered_turbonomic_recommendations", type: "javascript" do
@@ -323,7 +347,7 @@ end
 datasource "ds_get_projected_statistics" do
   iterate $ds_filtered_recommendations
   request do
-    run_script $js_get_projected_statistics, iter_item, $param_turbonomic_host, val($ds_get_turbonomic_token, "access_token")
+    run_script $js_get_projected_statistics, iter_item, $ds_turbonomic_host, val($ds_get_turbonomic_token, "access_token")
   end
   result do
     encoding "json"
@@ -343,7 +367,7 @@ end
 datasource "ds_get_current_statistics" do
   iterate $ds_filtered_recommendations
   request do
-    run_script $js_get_projected_statistics, iter_item, $param_turbonomic_host, val($ds_get_turbonomic_token, "access_token")
+    run_script $js_get_projected_statistics, iter_item, $ds_turbonomic_host, val($ds_get_turbonomic_token, "access_token")
   end
   result do
     encoding "json"

--- a/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
+++ b/cost/turbonomics/rightsize_databases_recommendations/aws/turbonomics_rightsize_databases_recommendations.pt
@@ -238,11 +238,11 @@ script "js_get_business_units", type: "javascript" do
 end
 
 datasource "ds_filtered_turbonomic_recommendations" do
-  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $param_provider, $ds_turbonomic_host
+  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $ds_turbonomic_host, $param_provider
 end
 
 script "js_filtered_turbonomic_recommendations", type: "javascript" do
-  parameters "ds_get_turbonomic_recommendations", "ds_get_business_units", "param_provider", "turbonomic_endpoint"
+  parameters "ds_get_turbonomic_recommendations", "ds_get_business_units", "turbonomic_endpoint", "param_provider"
   result "result"
   code <<-'EOS'
     instances = []

--- a/cost/turbonomics/rightsize_databases_recommendations/azure/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_databases_recommendations/azure/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.5.10
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Fixed `run_script` parameter order for the filtered recommendations script (datasources before parameters).
 
 ## v0.5.9
 

--- a/cost/turbonomics/rightsize_databases_recommendations/azure/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_databases_recommendations/azure/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.10
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.5.9
 
 - Added `hash_exclude` for volatile savings and utilization fields so that recalculated estimates alone no longer cause incidents to be treated as changed/reopened.

--- a/cost/turbonomics/rightsize_databases_recommendations/azure/turbonomics_rightsize_databases_recommendations.pt
+++ b/cost/turbonomics/rightsize_databases_recommendations/azure/turbonomics_rightsize_databases_recommendations.pt
@@ -238,11 +238,11 @@ script "js_get_business_units", type: "javascript" do
 end
 
 datasource "ds_filtered_turbonomic_recommendations" do
-  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $param_provider, $ds_turbonomic_endpoint
+  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $ds_turbonomic_endpoint, $param_provider
 end
 
 script "js_filtered_turbonomic_recommendations", type: "javascript" do
-  parameters "ds_get_turbonomic_recommendations", "ds_get_business_units", "param_provider", "turbonomic_endpoint"
+  parameters "ds_get_turbonomic_recommendations", "ds_get_business_units", "turbonomic_endpoint", "param_provider"
   result "result"
   code <<-'EOS'
     instances = []

--- a/cost/turbonomics/rightsize_databases_recommendations/azure/turbonomics_rightsize_databases_recommendations.pt
+++ b/cost/turbonomics/rightsize_databases_recommendations/azure/turbonomics_rightsize_databases_recommendations.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.5.9",
+  version: "0.5.10",
   source: "Turbonomic",
   service: "Usage Discount",
   provider: "Azure",
@@ -84,10 +84,34 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_turbonomic_audience" do
+  run_script $js_turbonomic_audience, $param_turbonomic_audience
+end
+
+script "js_turbonomic_audience", type: "javascript" do
+  parameters "param_turbonomic_audience"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_audience.trim()
+EOS
+end
+
+datasource "ds_turbonomic_endpoint" do
+  run_script $js_turbonomic_endpoint, $param_turbonomic_endpoint
+end
+
+script "js_turbonomic_endpoint", type: "javascript" do
+  parameters "param_turbonomic_endpoint"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_endpoint.trim()
+EOS
+end
+
 #get turbonomic token
 datasource "ds_get_turbonomic_token" do
   request do
-    run_script $js_get_turbonomic_token, $param_turbonomic_endpoint, $param_turbonomic_audience
+    run_script $js_get_turbonomic_token, $ds_turbonomic_endpoint, $ds_turbonomic_audience
   end
   result do
     encoding "json"
@@ -116,7 +140,7 @@ end
 
 datasource "ds_get_turbonomic_recommendations" do
   request do
-    run_script $js_get_turbonomic_recommendations, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_endpoint
+    run_script $js_get_turbonomic_recommendations, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_endpoint
   end
   result do
     encoding "json"
@@ -171,7 +195,7 @@ end
 
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_endpoint, $param_provider
+    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_endpoint, $param_provider
   end
   result do
     encoding "json"
@@ -214,7 +238,7 @@ script "js_get_business_units", type: "javascript" do
 end
 
 datasource "ds_filtered_turbonomic_recommendations" do
-  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $param_provider, $param_turbonomic_endpoint
+  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $param_provider, $ds_turbonomic_endpoint
 end
 
 script "js_filtered_turbonomic_recommendations", type: "javascript" do
@@ -337,7 +361,7 @@ end
 
 datasource "ds_get_pricing_model" do
   request do
-    run_script $js_get_pricing_model, val($ds_get_turbonomic_token, "access_token"), $ds_only_uuids, $param_turbonomic_endpoint
+    run_script $js_get_pricing_model, val($ds_get_turbonomic_token, "access_token"), $ds_only_uuids, $ds_turbonomic_endpoint
   end
   result do
     encoding "json"
@@ -373,7 +397,7 @@ end
 datasource "ds_get_projected_statistics" do
   iterate $ds_filtered_recommendations
   request do
-    run_script $js_get_projected_statistics, val($ds_get_turbonomic_token, "access_token"), iter_item, $ds_get_pricing_model, $param_turbonomic_endpoint
+    run_script $js_get_projected_statistics, val($ds_get_turbonomic_token, "access_token"), iter_item, $ds_get_pricing_model, $ds_turbonomic_endpoint
   end
   result do
     encoding "json"
@@ -393,7 +417,7 @@ end
 datasource "ds_get_current_statistics" do
   iterate $ds_filtered_recommendations
   request do
-    run_script $js_get_projected_statistics, val($ds_get_turbonomic_token, "access_token"), iter_item, $ds_get_pricing_model, $param_turbonomic_endpoint
+    run_script $js_get_projected_statistics, val($ds_get_turbonomic_token, "access_token"), iter_item, $ds_get_pricing_model, $ds_turbonomic_endpoint
   end
   result do
     encoding "json"

--- a/cost/turbonomics/rightsize_databases_recommendations/google/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_databases_recommendations/google/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.5.10
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Fixed `run_script` parameter order for the filtered recommendations script (datasources before parameters).
 
 ## v0.5.9
 

--- a/cost/turbonomics/rightsize_databases_recommendations/google/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_databases_recommendations/google/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.10
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.5.9
 
 - Added `hash_exclude` for volatile savings and utilization fields so that recalculated estimates alone no longer cause incidents to be treated as changed/reopened.

--- a/cost/turbonomics/rightsize_databases_recommendations/google/turbonomics_rightsize_databases_recommendations.pt
+++ b/cost/turbonomics/rightsize_databases_recommendations/google/turbonomics_rightsize_databases_recommendations.pt
@@ -239,11 +239,11 @@ script "js_get_business_units", type: "javascript" do
 end
 
 datasource "ds_filtered_turbonomic_recommendations" do
-  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $param_provider, $ds_turbonomic_endpoint
+  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $ds_turbonomic_endpoint, $param_provider
 end
 
 script "js_filtered_turbonomic_recommendations", type: "javascript" do
-  parameters "ds_get_turbonomic_recommendations", "ds_get_business_units", "param_provider", "turbonomic_endpoint"
+  parameters "ds_get_turbonomic_recommendations", "ds_get_business_units", "turbonomic_endpoint", "param_provider"
   result "result"
   code <<-'EOS'
     instances = []

--- a/cost/turbonomics/rightsize_databases_recommendations/google/turbonomics_rightsize_databases_recommendations.pt
+++ b/cost/turbonomics/rightsize_databases_recommendations/google/turbonomics_rightsize_databases_recommendations.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.5.9",
+  version: "0.5.10",
   source: "Turbonomic",
   service: "Usage Discount",
   provider: "Google",
@@ -85,10 +85,34 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_turbonomic_audience" do
+  run_script $js_turbonomic_audience, $param_turbonomic_audience
+end
+
+script "js_turbonomic_audience", type: "javascript" do
+  parameters "param_turbonomic_audience"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_audience.trim()
+EOS
+end
+
+datasource "ds_turbonomic_endpoint" do
+  run_script $js_turbonomic_endpoint, $param_turbonomic_endpoint
+end
+
+script "js_turbonomic_endpoint", type: "javascript" do
+  parameters "param_turbonomic_endpoint"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_endpoint.trim()
+EOS
+end
+
 #get turbonomic token
 datasource "ds_get_turbonomic_token" do
   request do
-    run_script $js_get_turbonomic_token, $param_turbonomic_endpoint, $param_turbonomic_audience
+    run_script $js_get_turbonomic_token, $ds_turbonomic_endpoint, $ds_turbonomic_audience
   end
   result do
     encoding "json"
@@ -117,7 +141,7 @@ end
 
 datasource "ds_get_turbonomic_recommendations" do
   request do
-    run_script $js_get_turbonomic_recommendations, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_endpoint
+    run_script $js_get_turbonomic_recommendations, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_endpoint
   end
   result do
     encoding "json"
@@ -172,7 +196,7 @@ end
 
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_endpoint, $param_provider
+    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_endpoint, $param_provider
   end
   result do
     encoding "json"
@@ -215,7 +239,7 @@ script "js_get_business_units", type: "javascript" do
 end
 
 datasource "ds_filtered_turbonomic_recommendations" do
-  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $param_provider, $param_turbonomic_endpoint
+  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $param_provider, $ds_turbonomic_endpoint
 end
 
 script "js_filtered_turbonomic_recommendations", type: "javascript" do
@@ -322,7 +346,7 @@ end
 datasource "ds_get_projected_statistics" do
   iterate $ds_filtered_recommendations
   request do
-    run_script $js_get_projected_statistics, iter_item, $param_turbonomic_endpoint, val($ds_get_turbonomic_token, "access_token")
+    run_script $js_get_projected_statistics, iter_item, $ds_turbonomic_endpoint, val($ds_get_turbonomic_token, "access_token")
   end
   result do
     encoding "json"
@@ -342,7 +366,7 @@ end
 datasource "ds_get_current_statistics" do
   iterate $ds_filtered_recommendations
   request do
-    run_script $js_get_projected_statistics, iter_item, $param_turbonomic_endpoint, val($ds_get_turbonomic_token, "access_token")
+    run_script $js_get_projected_statistics, iter_item, $ds_turbonomic_endpoint, val($ds_get_turbonomic_token, "access_token")
   end
   result do
     encoding "json"

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/aws/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.4.10
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Fixed `run_script` parameter order for the filtered recommendations script (datasources before parameters).
 
 ## v0.4.9
 

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/aws/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.10
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.4.9
 
 - Added `hash_exclude` for volatile savings and utilization fields so that recalculated estimates alone no longer cause incidents to be treated as changed/reopened.

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/aws/turbonomics_rightsize_virtual_volumes_recommendations.pt
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/aws/turbonomics_rightsize_virtual_volumes_recommendations.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.4.9",
+  version: "0.4.10",
   source: "Turbonomic",
   service: "Usage Discount",
   provider: "AWS",
@@ -84,10 +84,34 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_turbonomic_audience" do
+  run_script $js_turbonomic_audience, $param_turbonomic_audience
+end
+
+script "js_turbonomic_audience", type: "javascript" do
+  parameters "param_turbonomic_audience"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_audience.trim()
+EOS
+end
+
+datasource "ds_turbonomic_endpoint" do
+  run_script $js_turbonomic_endpoint, $param_turbonomic_endpoint
+end
+
+script "js_turbonomic_endpoint", type: "javascript" do
+  parameters "param_turbonomic_endpoint"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_endpoint.trim()
+EOS
+end
+
 #get turbonomic token
 datasource "ds_get_turbonomic_token" do
   request do
-    run_script $js_get_turbonomic_token, $param_turbonomic_endpoint, $param_turbonomic_audience
+    run_script $js_get_turbonomic_token, $ds_turbonomic_endpoint, $ds_turbonomic_audience
   end
   result do
     encoding "json"
@@ -97,7 +121,7 @@ end
 
 datasource "ds_get_turbonomic_recommendations" do
   request do
-    run_script $js_get_turbonomic_recommendations, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_endpoint
+    run_script $js_get_turbonomic_recommendations, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_endpoint
   end
   result do
     encoding "json"
@@ -126,7 +150,7 @@ end
 
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_endpoint, $param_provider
+    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_endpoint, $param_provider
   end
   result do
     encoding "json"
@@ -139,13 +163,13 @@ datasource "ds_get_business_units" do
 end
 
 datasource "ds_filtered_turbonomic_recommendations" do
-  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $param_provider, $param_turbonomic_endpoint
+  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $param_provider, $ds_turbonomic_endpoint
 end
 
 datasource "ds_get_stats" do
   iterate $ds_filtered_turbonomic_recommendations
   request do
-    run_script $js_get_stats, val($ds_get_turbonomic_token, "access_token"), iter_item, $param_turbonomic_endpoint
+    run_script $js_get_stats, val($ds_get_turbonomic_token, "access_token"), iter_item, $ds_turbonomic_endpoint
   end
   result do
     encoding "json"

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/aws/turbonomics_rightsize_virtual_volumes_recommendations.pt
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/aws/turbonomics_rightsize_virtual_volumes_recommendations.pt
@@ -163,7 +163,7 @@ datasource "ds_get_business_units" do
 end
 
 datasource "ds_filtered_turbonomic_recommendations" do
-  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $param_provider, $ds_turbonomic_endpoint
+  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $ds_turbonomic_endpoint, $param_provider
 end
 
 datasource "ds_get_stats" do
@@ -263,7 +263,7 @@ script "js_get_business_units", type: "javascript" do
 end
 
 script "js_filtered_turbonomic_recommendations", type: "javascript" do
-  parameters "ds_get_turbonomic_recommendations", "ds_get_business_units", "param_provider", "param_turbonomic_host"
+  parameters "ds_get_turbonomic_recommendations", "ds_get_business_units", "param_turbonomic_host", "param_provider"
   result "result"
   code <<-'EOS'
     instances = []

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/azure/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/azure/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.4.10
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Fixed `run_script` parameter order for the filtered recommendations script (datasources before parameters).
 
 ## v0.4.9
 

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/azure/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/azure/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.10
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.4.9
 
 - Added `hash_exclude` for volatile savings and utilization fields so that recalculated estimates alone no longer cause incidents to be treated as changed/reopened.

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/azure/turbonomics_rightsize_virtual_volumes_recommendations.pt
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/azure/turbonomics_rightsize_virtual_volumes_recommendations.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.4.9",
+  version: "0.4.10",
   source: "Turbonomic",
   service: "Usage Discount",
   provider: "Azure",
@@ -84,10 +84,34 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_turbonomic_audience" do
+  run_script $js_turbonomic_audience, $param_turbonomic_audience
+end
+
+script "js_turbonomic_audience", type: "javascript" do
+  parameters "param_turbonomic_audience"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_audience.trim()
+EOS
+end
+
+datasource "ds_turbonomic_endpoint" do
+  run_script $js_turbonomic_endpoint, $param_turbonomic_endpoint
+end
+
+script "js_turbonomic_endpoint", type: "javascript" do
+  parameters "param_turbonomic_endpoint"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_endpoint.trim()
+EOS
+end
+
 #get turbonomic token
 datasource "ds_get_turbonomic_token" do
   request do
-    run_script $js_get_turbonomic_token, $param_turbonomic_endpoint, $param_turbonomic_audience
+    run_script $js_get_turbonomic_token, $ds_turbonomic_endpoint, $ds_turbonomic_audience
   end
   result do
     encoding "json"
@@ -97,7 +121,7 @@ end
 
 datasource "ds_get_turbonomic_recommendations" do
   request do
-    run_script $js_get_turbonomic_recommendations, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_endpoint
+    run_script $js_get_turbonomic_recommendations, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_endpoint
   end
   result do
     encoding "json"
@@ -126,7 +150,7 @@ end
 
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_endpoint, $param_provider
+    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_endpoint, $param_provider
   end
   result do
     encoding "json"
@@ -139,13 +163,13 @@ datasource "ds_get_business_units" do
 end
 
 datasource "ds_filtered_turbonomic_recommendations" do
-  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $param_provider, $param_turbonomic_endpoint
+  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $param_provider, $ds_turbonomic_endpoint
 end
 
 datasource "ds_get_stats" do
   iterate $ds_filtered_turbonomic_recommendations
   request do
-    run_script $js_get_stats, iter_item, $param_turbonomic_endpoint, val($ds_get_turbonomic_token, "access_token")
+    run_script $js_get_stats, iter_item, $ds_turbonomic_endpoint, val($ds_get_turbonomic_token, "access_token")
   end
   result do
     encoding "json"

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/azure/turbonomics_rightsize_virtual_volumes_recommendations.pt
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/azure/turbonomics_rightsize_virtual_volumes_recommendations.pt
@@ -163,7 +163,7 @@ datasource "ds_get_business_units" do
 end
 
 datasource "ds_filtered_turbonomic_recommendations" do
-  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $param_provider, $ds_turbonomic_endpoint
+  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_business_units, $ds_turbonomic_endpoint, $param_provider
 end
 
 datasource "ds_get_stats" do
@@ -263,7 +263,7 @@ script "js_get_business_units", type: "javascript" do
 end
 
 script "js_filtered_turbonomic_recommendations", type: "javascript" do
-  parameters "ds_get_turbonomic_recommendations", "ds_get_business_units", "param_provider", "param_turbonomic_host"
+  parameters "ds_get_turbonomic_recommendations", "ds_get_business_units", "param_turbonomic_host", "param_provider"
   result "result"
   code <<-'EOS'
     instances = []

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/google/CHANGELOG.md
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/google/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.9
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.4.8
 
 - Added `hash_exclude` for volatile savings and utilization fields so that recalculated estimates alone no longer cause incidents to be treated as changed/reopened.

--- a/cost/turbonomics/rightsize_virtual_volumes_recommendations/google/turbonomics_rightsize_virtual_volumes_recommendations.pt
+++ b/cost/turbonomics/rightsize_virtual_volumes_recommendations/google/turbonomics_rightsize_virtual_volumes_recommendations.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.4.8",
+  version: "0.4.9",
   source: "Turbonomic",
   service: "Usage Discount",
   provider: "Google",
@@ -85,10 +85,34 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_turbonomic_audience" do
+  run_script $js_turbonomic_audience, $param_turbonomic_audience
+end
+
+script "js_turbonomic_audience", type: "javascript" do
+  parameters "param_turbonomic_audience"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_audience.trim()
+EOS
+end
+
+datasource "ds_turbonomic_endpoint" do
+  run_script $js_turbonomic_endpoint, $param_turbonomic_endpoint
+end
+
+script "js_turbonomic_endpoint", type: "javascript" do
+  parameters "param_turbonomic_endpoint"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_endpoint.trim()
+EOS
+end
+
 #get turbonomic token
 datasource "ds_get_turbonomic_token" do
   request do
-    run_script $js_get_turbonomic_token, $param_turbonomic_endpoint, $param_turbonomic_audience
+    run_script $js_get_turbonomic_token, $ds_turbonomic_endpoint, $ds_turbonomic_audience
   end
   result do
     encoding "json"
@@ -98,7 +122,7 @@ end
 
 datasource "ds_get_turbonomic_recommendations" do
   request do
-    run_script $js_get_turbonomic_recommendations, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_endpoint
+    run_script $js_get_turbonomic_recommendations, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_endpoint
   end
   result do
     encoding "json"
@@ -122,7 +146,7 @@ end
 
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_endpoint, $param_provider
+    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_endpoint, $param_provider
   end
   result do
     encoding "json"

--- a/cost/turbonomics/scale_virtual_machines_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/aws/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.10
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.6.9
 
 - Added `hash_exclude` for volatile savings and utilization fields so that recalculated estimates alone no longer cause incidents to be treated as changed/reopened.

--- a/cost/turbonomics/scale_virtual_machines_recommendations/aws/CHANGELOG.md
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/aws/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.6.10
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Fixed `run_script` parameter order for the filtered recommendations script (datasources before parameters).
 
 ## v0.6.9
 

--- a/cost/turbonomics/scale_virtual_machines_recommendations/aws/turbonomics_scale_virtual_machines.pt
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/aws/turbonomics_scale_virtual_machines.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.6.9",
+  version: "0.6.10",
   provider: "AWS",
   source: "Turbonomic",
   service: "Compute",
@@ -83,10 +83,34 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_turbonomic_audience" do
+  run_script $js_turbonomic_audience, $param_turbonomic_audience
+end
+
+script "js_turbonomic_audience", type: "javascript" do
+  parameters "param_turbonomic_audience"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_audience.trim()
+EOS
+end
+
+datasource "ds_turbonomic_endpoint" do
+  run_script $js_turbonomic_endpoint, $param_turbonomic_endpoint
+end
+
+script "js_turbonomic_endpoint", type: "javascript" do
+  parameters "param_turbonomic_endpoint"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_endpoint.trim()
+EOS
+end
+
 #get turbonomic token
 datasource "ds_get_turbonomic_token" do
   request do
-    run_script $js_get_turbonomic_token, $param_turbonomic_endpoint, $param_turbonomic_audience
+    run_script $js_get_turbonomic_token, $ds_turbonomic_endpoint, $ds_turbonomic_audience
   end
   result do
     encoding "json"
@@ -97,7 +121,7 @@ end
 #get turbonomic recommendation data
 datasource "ds_get_turbonomic_recommendations" do
   request do
-    run_script $js_get_turbonomic_recommendations, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_endpoint
+    run_script $js_get_turbonomic_recommendations, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_endpoint
   end
   result do
     encoding "json"
@@ -125,7 +149,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_action_details" do
   request do
-    run_script $js_get_action_details, val($ds_get_turbonomic_token, "access_token"), $ds_get_turbonomic_recommendations, $param_turbonomic_endpoint
+    run_script $js_get_action_details, val($ds_get_turbonomic_token, "access_token"), $ds_get_turbonomic_recommendations, $ds_turbonomic_endpoint
   end
   result do
     encoding "json"
@@ -136,7 +160,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_endpoint, $param_provider
+    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_endpoint, $param_provider
   end
   result do
     encoding "json"
@@ -149,13 +173,13 @@ datasource "ds_get_business_units" do
 end
 
 datasource "ds_filtered_turbonomic_recommendations" do
-  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_action_details, $ds_get_business_units, $param_provider, $param_turbonomic_endpoint
+  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_action_details, $ds_get_business_units, $param_provider, $ds_turbonomic_endpoint
 end
 
 datasource "ds_get_stats" do
   iterate $ds_filtered_turbonomic_recommendations
   request do
-    run_script $js_get_stats, iter_item, $param_turbonomic_endpoint, val($ds_get_turbonomic_token, "access_token")
+    run_script $js_get_stats, iter_item, $ds_turbonomic_endpoint, val($ds_get_turbonomic_token, "access_token")
   end
   result do
     encoding "json"
@@ -270,7 +294,7 @@ EOS
 end
 
 script "js_filtered_turbonomic_recommendations", type: "javascript" do
-  parameters "ds_get_turbonomic_recommendations", "ds_get_action_details", "ds_get_business_units", "param_provider", "param_turbonomic_endpoint"
+  parameters "ds_get_turbonomic_recommendations", "ds_get_action_details", "ds_get_business_units", "param_provider", "ds_turbonomic_endpoint"
   result "result"
   code <<-'EOS'
     var instances = []
@@ -349,7 +373,7 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
         }
         vm.savings = (Math.round(vm.savings * 730 * 1000 * (vm.uptime/100)) / 1000)
         monthlySavings = monthlySavings + vm.savings
-        vm.url = "System name: " + vm.resourceName  + " || https://" + param_turbonomic_endpoint + "/app/index.html#/view/main/action/" + vm.urlUUID
+        vm.url = "System name: " + vm.resourceName  + " || https://" + ds_turbonomic_endpoint + "/app/index.html#/view/main/action/" + vm.urlUUID
         vm.resourceType = vm.currentResourceType
         instances.push(vm)
       }

--- a/cost/turbonomics/scale_virtual_machines_recommendations/aws/turbonomics_scale_virtual_machines.pt
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/aws/turbonomics_scale_virtual_machines.pt
@@ -173,7 +173,7 @@ datasource "ds_get_business_units" do
 end
 
 datasource "ds_filtered_turbonomic_recommendations" do
-  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_action_details, $ds_get_business_units, $param_provider, $ds_turbonomic_endpoint
+  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_action_details, $ds_get_business_units, $ds_turbonomic_endpoint, $param_provider
 end
 
 datasource "ds_get_stats" do
@@ -294,7 +294,7 @@ EOS
 end
 
 script "js_filtered_turbonomic_recommendations", type: "javascript" do
-  parameters "ds_get_turbonomic_recommendations", "ds_get_action_details", "ds_get_business_units", "param_provider", "ds_turbonomic_endpoint"
+  parameters "ds_get_turbonomic_recommendations", "ds_get_action_details", "ds_get_business_units", "ds_turbonomic_endpoint", "param_provider"
   result "result"
   code <<-'EOS'
     var instances = []

--- a/cost/turbonomics/scale_virtual_machines_recommendations/azure/CHANGELOG.md
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/azure/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.10
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.6.9
 
 - Added `hash_exclude` for volatile savings and utilization fields so that recalculated estimates alone no longer cause incidents to be treated as changed/reopened.

--- a/cost/turbonomics/scale_virtual_machines_recommendations/azure/CHANGELOG.md
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/azure/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.6.10
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Fixed `run_script` parameter order for the filtered recommendations script (datasources before parameters).
 
 ## v0.6.9
 

--- a/cost/turbonomics/scale_virtual_machines_recommendations/azure/turbonomics_scale_virtual_machines.pt
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/azure/turbonomics_scale_virtual_machines.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.6.9",
+  version: "0.6.10",
   provider: "Azure",
   source: "Turbonomic",
   service: "Compute",
@@ -83,10 +83,34 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_turbonomic_audience" do
+  run_script $js_turbonomic_audience, $param_turbonomic_audience
+end
+
+script "js_turbonomic_audience", type: "javascript" do
+  parameters "param_turbonomic_audience"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_audience.trim()
+EOS
+end
+
+datasource "ds_turbonomic_endpoint" do
+  run_script $js_turbonomic_endpoint, $param_turbonomic_endpoint
+end
+
+script "js_turbonomic_endpoint", type: "javascript" do
+  parameters "param_turbonomic_endpoint"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_endpoint.trim()
+EOS
+end
+
 #get turbonomic token
 datasource "ds_get_turbonomic_token" do
   request do
-    run_script $js_get_turbonomic_token, $param_turbonomic_endpoint, $param_turbonomic_audience
+    run_script $js_get_turbonomic_token, $ds_turbonomic_endpoint, $ds_turbonomic_audience
   end
   result do
     encoding "json"
@@ -116,7 +140,7 @@ end
 #get turbonomic recommendation data
 datasource "ds_get_turbonomics_recommendations" do
   request do
-    run_script $js_get_turbonomics_recommendations, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_endpoint
+    run_script $js_get_turbonomics_recommendations, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_endpoint
   end
   result do
     encoding "json"
@@ -173,7 +197,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_action_details" do
   request do
-    run_script $js_get_action_details, val($ds_get_turbonomic_token, "access_token"), $ds_get_turbonomics_recommendations, $param_turbonomic_endpoint
+    run_script $js_get_action_details, val($ds_get_turbonomic_token, "access_token"), $ds_get_turbonomics_recommendations, $ds_turbonomic_endpoint
   end
   result do
     encoding "json"
@@ -208,7 +232,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_endpoint, $param_provider
+    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_endpoint, $param_provider
   end
   result do
     encoding "json"
@@ -246,7 +270,7 @@ script "js_get_business_units", type: "javascript" do
 end
 
 datasource "ds_filtered_turbonomics_recommendations" do
-  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_action_details, $ds_get_business_units, $param_provider, $param_turbonomic_endpoint
+  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_action_details, $ds_get_business_units, $param_provider, $ds_turbonomic_endpoint
 end
 
 script "js_filtered_turbonomics_recommendations", type: "javascript" do
@@ -386,7 +410,7 @@ end
 datasource "ds_get_projected_statistics" do
   iterate $ds_filtered_recommendations
   request do
-    run_script $js_get_projected_statistics, iter_item, $param_turbonomic_endpoint, val($ds_get_turbonomic_token, "access_token")
+    run_script $js_get_projected_statistics, iter_item, $ds_turbonomic_endpoint, val($ds_get_turbonomic_token, "access_token")
   end
   result do
     encoding "json"
@@ -403,7 +427,7 @@ end
 datasource "ds_get_current_statistics" do
   iterate $ds_filtered_recommendations
   request do
-    run_script $js_get_projected_statistics, iter_item, $param_turbonomic_endpoint, val($ds_get_turbonomic_token, "access_token")
+    run_script $js_get_projected_statistics, iter_item, $ds_turbonomic_endpoint, val($ds_get_turbonomic_token, "access_token")
   end
   result do
     encoding "json"

--- a/cost/turbonomics/scale_virtual_machines_recommendations/azure/turbonomics_scale_virtual_machines.pt
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/azure/turbonomics_scale_virtual_machines.pt
@@ -270,11 +270,11 @@ script "js_get_business_units", type: "javascript" do
 end
 
 datasource "ds_filtered_turbonomics_recommendations" do
-  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_action_details, $ds_get_business_units, $param_provider, $ds_turbonomic_endpoint
+  run_script $js_filtered_turbonomics_recommendations, $ds_get_turbonomics_recommendations, $ds_get_action_details, $ds_get_business_units, $ds_turbonomic_endpoint, $param_provider
 end
 
 script "js_filtered_turbonomics_recommendations", type: "javascript" do
-  parameters "ds_get_turbonomics_recommendations", "ds_get_action_details", "ds_get_business_units", "param_provider", "turbonomic_endpoint"
+  parameters "ds_get_turbonomics_recommendations", "ds_get_action_details", "ds_get_business_units", "turbonomic_endpoint", "param_provider"
   result "result"
   code <<-'EOS'
     instances = []

--- a/cost/turbonomics/scale_virtual_machines_recommendations/google/CHANGELOG.md
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/google/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.7.10
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+- Fixed `run_script` parameter order for the filtered recommendations script (datasources before parameters).
 
 ## v0.7.9
 

--- a/cost/turbonomics/scale_virtual_machines_recommendations/google/CHANGELOG.md
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/google/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.7.10
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.7.9
 
 - Added `hash_exclude` for volatile savings and utilization fields so that recalculated estimates alone no longer cause incidents to be treated as changed/reopened.

--- a/cost/turbonomics/scale_virtual_machines_recommendations/google/turbonomics_scale_virtual_machines.pt
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/google/turbonomics_scale_virtual_machines.pt
@@ -173,7 +173,7 @@ datasource "ds_get_action_details" do
 end
 
 datasource "ds_filtered_turbonomic_recommendations" do
-  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_action_details, $ds_get_business_units, $param_provider, $ds_turbonomic_endpoint
+  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_action_details, $ds_get_business_units, $ds_turbonomic_endpoint, $param_provider
 end
 
 datasource "ds_get_stats" do
@@ -294,7 +294,7 @@ EOS
 end
 
 script "js_filtered_turbonomic_recommendations", type: "javascript" do
-  parameters "ds_get_turbonomic_recommendations", "ds_get_action_details", "ds_get_business_units", "param_provider", "ds_turbonomic_endpoint"
+  parameters "ds_get_turbonomic_recommendations", "ds_get_action_details", "ds_get_business_units", "ds_turbonomic_endpoint", "param_provider"
   result "result"
   code <<-'EOS'
     var instances = []

--- a/cost/turbonomics/scale_virtual_machines_recommendations/google/turbonomics_scale_virtual_machines.pt
+++ b/cost/turbonomics/scale_virtual_machines_recommendations/google/turbonomics_scale_virtual_machines.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "0.7.9",
+  version: "0.7.10",
   provider: "Google",
   source: "Turbonomic",
   service: "Compute",
@@ -83,10 +83,34 @@ end
 # Datasources & Scripts
 ###############################################################################
 
+datasource "ds_turbonomic_audience" do
+  run_script $js_turbonomic_audience, $param_turbonomic_audience
+end
+
+script "js_turbonomic_audience", type: "javascript" do
+  parameters "param_turbonomic_audience"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_audience.trim()
+EOS
+end
+
+datasource "ds_turbonomic_endpoint" do
+  run_script $js_turbonomic_endpoint, $param_turbonomic_endpoint
+end
+
+script "js_turbonomic_endpoint", type: "javascript" do
+  parameters "param_turbonomic_endpoint"
+  result "result"
+  code <<-'EOS'
+  result = param_turbonomic_endpoint.trim()
+EOS
+end
+
 #get turbonomic token
 datasource "ds_get_turbonomic_token" do
   request do
-    run_script $js_get_turbonomic_token, $param_turbonomic_endpoint, $param_turbonomic_audience
+    run_script $js_get_turbonomic_token, $ds_turbonomic_endpoint, $ds_turbonomic_audience
   end
   result do
     encoding "json"
@@ -97,7 +121,7 @@ end
 #get turbonomic recommendation data
 datasource "ds_get_turbonomic_recommendations" do
   request do
-    run_script $js_get_turbonomic_recommendations, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_endpoint
+    run_script $js_get_turbonomic_recommendations, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_endpoint
   end
   result do
     encoding "json"
@@ -125,7 +149,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_business_units" do
   request do
-    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $param_turbonomic_endpoint, $param_provider
+    run_script $js_get_business_units, val($ds_get_turbonomic_token, "access_token"), $ds_turbonomic_endpoint, $param_provider
   end
   result do
     encoding "json"
@@ -140,7 +164,7 @@ end
 ##this will potentially be a lot of calls. how to make this more performant
 datasource "ds_get_action_details" do
   request do
-    run_script $js_get_action_details, val($ds_get_turbonomic_token, "access_token"), $ds_get_turbonomic_recommendations, $param_turbonomic_endpoint
+    run_script $js_get_action_details, val($ds_get_turbonomic_token, "access_token"), $ds_get_turbonomic_recommendations, $ds_turbonomic_endpoint
   end
   result do
     encoding "json"
@@ -149,13 +173,13 @@ datasource "ds_get_action_details" do
 end
 
 datasource "ds_filtered_turbonomic_recommendations" do
-  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_action_details, $ds_get_business_units, $param_provider, $param_turbonomic_endpoint
+  run_script $js_filtered_turbonomic_recommendations, $ds_get_turbonomic_recommendations, $ds_get_action_details, $ds_get_business_units, $param_provider, $ds_turbonomic_endpoint
 end
 
 datasource "ds_get_stats" do
   iterate $ds_filtered_turbonomic_recommendations
   request do
-    run_script $js_get_stats, iter_item, $param_turbonomic_endpoint, val($ds_get_turbonomic_token, "access_token")
+    run_script $js_get_stats, iter_item, $ds_turbonomic_endpoint, val($ds_get_turbonomic_token, "access_token")
   end
   result do
     encoding "json"
@@ -270,7 +294,7 @@ EOS
 end
 
 script "js_filtered_turbonomic_recommendations", type: "javascript" do
-  parameters "ds_get_turbonomic_recommendations", "ds_get_action_details", "ds_get_business_units", "param_provider", "param_turbonomic_endpoint"
+  parameters "ds_get_turbonomic_recommendations", "ds_get_action_details", "ds_get_business_units", "param_provider", "ds_turbonomic_endpoint"
   result "result"
   code <<-'EOS'
     var instances = []
@@ -349,7 +373,7 @@ script "js_filtered_turbonomic_recommendations", type: "javascript" do
         }
         vm.savings = (Math.round(vm.savings * 730 * 1000 * (vm.uptime/100)) / 1000)
         monthlySavings = monthlySavings + vm.savings
-        vm.url = "System name: " + vm.resourceName  + " || https://" + param_turbonomic_endpoint + "/app/index.html#/view/main/action/" + vm.urlUUID
+        vm.url = "System name: " + vm.resourceName  + " || https://" + ds_turbonomic_endpoint + "/app/index.html#/view/main/action/" + vm.urlUUID
         vm.resourceType = vm.currentResourceType
         instances.push(vm)
       }

--- a/operational/aws/ec2_stopped_report/CHANGELOG.md
+++ b/operational/aws/ec2_stopped_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.4.0
 
 - Added a region-error-reporting incident that alerts if the policy is unable to retrieve EC2 instance data from one or more AWS regions due to permission or configuration errors.

--- a/operational/aws/ec2_stopped_report/aws_ec2_stopped_report.pt
+++ b/operational/aws/ec2_stopped_report/aws_ec2_stopped_report.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "0.4.0",
+  version: "0.4.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "",
@@ -520,6 +520,8 @@ script "js_instances", type: "javascript" do
   parameters "ds_instance_sets", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/operational/aws/lambda_functions_with_high_error_rate/CHANGELOG.md
+++ b/operational/aws/lambda_functions_with_high_error_rate/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.2.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v5.2.0
 
 - Added a region-error-reporting incident that alerts if the policy is unable to retrieve Lambda function data from one or more AWS regions due to permission or configuration errors.

--- a/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate.pt
+++ b/operational/aws/lambda_functions_with_high_error_rate/lambda_functions_with_high_error_rate.pt
@@ -8,7 +8,7 @@ severity "high"
 category "Operational"
 default_frequency "hourly"
 info(
-  version: "5.2.0",
+  version: "5.2.1",
   provider: "AWS",
   service: "PaaS",
   policy_set: "Lambda",
@@ -464,6 +464,8 @@ script "js_aws_lambda_functions_tag_filtered", type: "javascript" do
   parameters "ds_aws_lambda_functions_with_tags", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/operational/aws/lambda_provisioned_concurrency/CHANGELOG.md
+++ b/operational/aws/lambda_provisioned_concurrency/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.3.0
 
 - Added a region-error-reporting incident that alerts if the policy is unable to retrieve Lambda function data from one or more AWS regions due to permission or configuration errors.

--- a/operational/aws/lambda_provisioned_concurrency/aws_lambda_provisioned_concurrency.pt
+++ b/operational/aws/lambda_provisioned_concurrency/aws_lambda_provisioned_concurrency.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.0",
+  version: "0.3.1",
   provider: "AWS",
   service: "PaaS",
   policy_set: "Lambda",
@@ -443,6 +443,8 @@ script "js_functions_tag_filtered", type: "javascript" do
   parameters "ds_functions_with_tags", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }


### PR DESCRIPTION
### Description

One of several PRs focused on sanitizing inputs for PT parameters. This is to prevent users from breaking policy template execution because they entered a parameter incorrectly, such as putting whitespace at the beginning or end of the value.

Also corrects some Dangerfile-reported issues with the touched PTs.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
