### PR TITLE
POL-1826 Parameter Sanitization: Policy Templates #12

### DIFF
--- a/operational/aws/long_running_instances/CHANGELOG.md
+++ b/operational/aws/long_running_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.3.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v5.3.0
 
 - Added a region-error-reporting incident that alerts if the policy is unable to retrieve EC2 instance data from one or more AWS regions due to permission or configuration errors.

--- a/operational/aws/long_running_instances/long_running_instances.pt
+++ b/operational/aws/long_running_instances/long_running_instances.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.3.0",
+  version: "5.3.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Long Running Instances",
@@ -565,6 +565,8 @@ script "js_instances", type: "javascript" do
   parameters "ds_instance_sets", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/operational/aws/overutilized_ec2_instances/CHANGELOG.md
+++ b/operational/aws/overutilized_ec2_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.3.0
 
 - Added a region-error-reporting incident that alerts if the policy is unable to retrieve EC2 instance data from one or more AWS regions due to permission or configuration errors.

--- a/operational/aws/overutilized_ec2_instances/aws_overutilized_ec2.pt
+++ b/operational/aws/overutilized_ec2_instances/aws_overutilized_ec2.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "0.3.0",
+  version: "0.3.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Overutilized Compute Instances",
@@ -689,6 +689,8 @@ script "js_instances", type: "javascript" do
   parameters "ds_instance_sets", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/operational/aws/scheduled_ec2_events/CHANGELOG.md
+++ b/operational/aws/scheduled_ec2_events/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.2.1
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.2.0
 
 - Added a region-error-reporting incident that alerts if the policy is unable to retrieve EC2 instance data from one or more AWS regions due to permission or configuration errors.

--- a/operational/aws/scheduled_ec2_events/aws_scheduled_ec2_events.pt
+++ b/operational/aws/scheduled_ec2_events/aws_scheduled_ec2_events.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "medium"
 default_frequency "weekly"
 info(
-  version: "4.2.0",
+  version: "4.2.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "",
@@ -445,6 +445,8 @@ script "js_instances", type: "javascript" do
   parameters "ds_instance_sets", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }

--- a/operational/aws/tag_cardinality/CHANGELOG.md
+++ b/operational/aws/tag_cardinality/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.3.4
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.3.3
 
 - Improved the policy's reliability when checking which AWS regions it can access, making it less likely to fail to run due to expected access restrictions in certain regions

--- a/operational/aws/tag_cardinality/aws_tag_cardinality.pt
+++ b/operational/aws/tag_cardinality/aws_tag_cardinality.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "3.3.3",
+  version: "3.3.4",
   provider: "AWS",
   service: "Tags",
   policy_set: "Tag Cardinality",

--- a/operational/aws/tag_cardinality/aws_tag_cardinality_meta_parent.pt
+++ b/operational/aws/tag_cardinality/aws_tag_cardinality_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "3.3.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.3.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -352,6 +352,9 @@ script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_dimension_filter_includes = _.compact(_.map(param_dimension_filter_includes, function(item) { return item.trim() }))
+  param_dimension_filter_excludes = _.compact(_.map(param_dimension_filter_excludes, function(item) { return item.trim() }))
 
   billing_centers_formatted = []
 
@@ -1042,7 +1045,6 @@ script "js_ds_tag_report_combined_incidents", type: "javascript" do
 EOS
 end
 
-
 ###############################################################################
 # Policy
 ###############################################################################
@@ -1287,7 +1289,6 @@ end
 ###############################################################################
 # Escalations
 ###############################################################################
-
 
 # Used only for emailing the combined child incident if so desired
 escalation "esc_email" do

--- a/operational/aws/total_instance_usage_forecast/CHANGELOG.md
+++ b/operational/aws/total_instance_usage_forecast/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.1.8
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v1.1.7
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/aws/total_instance_usage_forecast/aws_total_instance_usage_forecast.pt
+++ b/operational/aws/total_instance_usage_forecast/aws_total_instance_usage_forecast.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "1.1.7",
+  version: "1.1.8",
   provider: "AWS",
   service: "Compute",
   policy_set: "Usage Report",
@@ -198,6 +198,8 @@ script "js_billing_centers_filtered", type: "javascript" do
   parameters "ds_billing_centers", "param_bc_allow_or_deny", "param_bc_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_bc_list = _.compact(_.map(param_bc_list, function(item) { return item.trim() }))
   allow_deny_test = { "Allow": true, "Deny": false }
 
   if (param_bc_list.length > 0) {
@@ -280,6 +282,8 @@ script "js_usage_data", type: "javascript" do
   parameters "start_date", "end_date", "ds_billing_centers_filtered", "param_regions_allow_or_deny", "param_regions_list", "rs_org_id", "rs_optima_host"
   result "request"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   // Generate region filters if applicable
   region_filters = []
 

--- a/operational/aws/total_instance_usage_report/CHANGELOG.md
+++ b/operational/aws/total_instance_usage_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.1.7
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v1.1.6
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/aws/total_instance_usage_report/aws_total_instance_usage_report.pt
+++ b/operational/aws/total_instance_usage_report/aws_total_instance_usage_report.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "1.1.6",
+  version: "1.1.7",
   provider: "AWS",
   service: "Compute",
   policy_set: "Usage Report",
@@ -188,6 +188,8 @@ script "js_billing_centers_filtered", type: "javascript" do
   parameters "ds_billing_centers", "param_bc_allow_or_deny", "param_bc_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_bc_list = _.compact(_.map(param_bc_list, function(item) { return item.trim() }))
   allow_deny_test = { "Allow": true, "Deny": false }
 
   if (param_bc_list.length > 0) {
@@ -236,6 +238,8 @@ script "js_usage_data", type: "javascript" do
   parameters "ds_billing_centers_filtered", "param_regions_allow_or_deny", "param_regions_list", "param_months_back", "rs_org_id", "rs_optima_host"
   result "request"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   // Get Start and End dates
   start_date = new Date()
   start_date.setMonth(start_date.getMonth() - param_months_back)
@@ -431,6 +435,8 @@ script "js_chart_creation", type: "javascript" do
   parameters "ds_instance_units_per_family", "ds_applied_policy", "param_regions_allow_or_deny", "param_regions_list", "param_unit_time", "param_unit_instance", "param_months_back"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   instance_unit = { "Normalized Units (NFUs)": "NFU", "vCPUs": "vCPU", "Memory (GiB)": "Memory (GiB)" }
 
   // Get list of months from data and create chart X axis labels

--- a/operational/azure/aks_nodepools_without_autoscaling/CHANGELOG.md
+++ b/operational/azure/aks_nodepools_without_autoscaling/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.3.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.3.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/azure/aks_nodepools_without_autoscaling/aks_nodepools_without_autoscaling.pt
+++ b/operational/azure/aks_nodepools_without_autoscaling/aks_nodepools_without_autoscaling.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "daily"
 info(
-  version: "3.3.2",
+  version: "3.3.3",
   provider: "Azure",
   service: "AKS",
   policy_set: "",
@@ -246,6 +246,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -316,6 +318,8 @@ script "js_aks_clusters_tag_filtered", type: "javascript" do
   parameters "ds_aks_clusters", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -392,6 +396,8 @@ script "js_aks_clusters_region_filtered", type: "javascript" do
   parameters "ds_aks_clusters_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_aks_clusters_tag_filtered, function(vm) {
       include_cluster = _.contains(param_regions_list, vm['region'])
@@ -416,6 +422,8 @@ script "js_aks_clusters_rg_filtered", type: "javascript" do
   parameters "ds_aks_clusters_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
   if (param_resource_groups_list.length > 0) {
     result = _.filter(ds_aks_clusters_region_filtered, function(resource) {
       rg = resource['resourceGroup']

--- a/operational/azure/aks_nodepools_without_zero_autoscaling/CHANGELOG.md
+++ b/operational/azure/aks_nodepools_without_zero_autoscaling/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.4.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.4.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/azure/aks_nodepools_without_zero_autoscaling/aks_nodepools_without_zero_autoscaling.pt
+++ b/operational/azure/aks_nodepools_without_zero_autoscaling/aks_nodepools_without_zero_autoscaling.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "daily"
 info(
-  version: "3.4.2",
+  version: "3.4.3",
   provider: "Azure",
   service: "AKS",
   policy_set: "",
@@ -246,6 +246,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -316,6 +318,8 @@ script "js_aks_clusters_tag_filtered", type: "javascript" do
   parameters "ds_aks_clusters", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -392,6 +396,8 @@ script "js_aks_clusters_region_filtered", type: "javascript" do
   parameters "ds_aks_clusters_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_aks_clusters_tag_filtered, function(vm) {
       include_cluster = _.contains(param_regions_list, vm['region'])
@@ -416,6 +422,8 @@ script "js_aks_clusters_rg_filtered", type: "javascript" do
   parameters "ds_aks_clusters_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
   if (param_resource_groups_list.length > 0) {
     result = _.filter(ds_aks_clusters_region_filtered, function(resource) {
       rg = resource['resourceGroup']

--- a/operational/azure/azure_certificates/CHANGELOG.md
+++ b/operational/azure/azure_certificates/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.3.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.3.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/azure/azure_certificates/azure_certificates.pt
+++ b/operational/azure/azure_certificates/azure_certificates.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "daily"
 info(
-  version: "4.3.2",
+  version: "4.3.3",
   provider: "Azure",
   service: "PaaS",
   policy_set: "Expiring Certificates",
@@ -264,6 +264,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -342,6 +344,8 @@ script "js_azure_certificates_tag_filtered", type: "javascript" do
   parameters "ds_azure_certificates", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -418,6 +422,8 @@ script "js_azure_certificates_region_filtered", type: "javascript" do
   parameters "ds_azure_certificates_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_certificates_tag_filtered, function(resource) {
       include_resource = _.contains(param_regions_list, resource['region'])
@@ -438,6 +444,8 @@ script "js_azure_certificates_rg_filtered", type: "javascript" do
   parameters "ds_azure_certificates_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
   if (param_resource_groups_list.length > 0) {
     result = _.filter(ds_azure_certificates_region_filtered, function(resource) {
       rg = resource['resourceGroup']

--- a/operational/azure/azure_long_running_instances/CHANGELOG.md
+++ b/operational/azure/azure_long_running_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.4.4
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v6.4.3
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
+++ b/operational/azure/azure_long_running_instances/azure_long_running_instances.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.4.3",
+  version: "6.4.4",
   provider: "Azure",
   service: "Compute",
   policy_set: "Long Running Instances",
@@ -365,6 +365,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -488,6 +490,8 @@ script "js_azure_instances_tag_filtered", type: "javascript" do
   parameters "ds_azure_instances_running", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -564,6 +568,8 @@ script "js_azure_instances_region_filtered", type: "javascript" do
   parameters "ds_azure_instances_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_instances_tag_filtered, function(instance) {
       include_instance = _.contains(param_regions_list, instance['region'])
@@ -588,6 +594,8 @@ script "js_azure_instances_rg_filtered", type: "javascript" do
   parameters "ds_azure_instances_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_azure_instances_region_filtered, function(resource) {
         rg = resource['resourceGroup']

--- a/operational/azure/byol_report/CHANGELOG.md
+++ b/operational/azure/byol_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.2
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.5.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/azure/byol_report/azure_byol_report.pt
+++ b/operational/azure/byol_report/azure_byol_report.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "0.5.1",
+  version: "0.5.2",
   provider: "Azure",
   service: "Compute",
   policy_set: "Hybrid Use Benefit",
@@ -341,6 +341,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -480,6 +482,8 @@ script "js_cco_data_region_filtered", type: "javascript" do
   parameters "ds_cco_data", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_cco_data, function(vm) {
       include_vm = _.contains(param_regions_list, vm['region'])

--- a/operational/azure/compute_poweredoff_report/CHANGELOG.md
+++ b/operational/azure/compute_poweredoff_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.5.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/azure/compute_poweredoff_report/azure_compute_poweredoff_report.pt
+++ b/operational/azure/compute_poweredoff_report/azure_compute_poweredoff_report.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "0.5.2",
+  version: "0.5.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "",
@@ -366,6 +366,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -498,6 +500,8 @@ script "js_azure_instances_tag_filtered", type: "javascript" do
   parameters "ds_azure_instances_with_status", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -574,6 +578,8 @@ script "js_azure_instances_region_filtered", type: "javascript" do
   parameters "ds_azure_instances_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_instances_tag_filtered, function(vm) {
       include_vm = _.contains(param_regions_list, vm['region'])
@@ -641,6 +647,8 @@ script "js_azure_instances_rg_filtered", type: "javascript" do
   parameters "ds_azure_instances_status_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
   if (param_resource_groups_list.length > 0) {
     result = _.filter(ds_azure_instances_status_filtered, function(resource) {
       rg = resource['resourceGroup']

--- a/operational/azure/overutilized_compute_instances/CHANGELOG.md
+++ b/operational/azure/overutilized_compute_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.4
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v0.4.3
 
 - Minor code formatting cleanup. No functional or user-facing changes.

--- a/operational/azure/overutilized_compute_instances/azure_compute_overutilized.pt
+++ b/operational/azure/overutilized_compute_instances/azure_compute_overutilized.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.3",
+  version: "0.4.4",
   provider: "Azure",
   service: "Compute",
   policy_set: "Overutilized Compute Instances",
@@ -448,6 +448,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -585,6 +587,8 @@ script "js_azure_instances_tag_filtered", type: "javascript" do
   parameters "ds_azure_instances_with_status", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -661,6 +665,8 @@ script "js_azure_instances_region_filtered", type: "javascript" do
   parameters "ds_azure_instances_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_instances_tag_filtered, function(vm) {
       include_vm = _.contains(param_regions_list, vm['region'])
@@ -681,6 +687,8 @@ script "js_azure_instances_rg_filtered", type: "javascript" do
   parameters "ds_azure_instances_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_azure_instances_region_filtered, function(resource) {
         rg = resource['resourceGroup']

--- a/operational/azure/tag_cardinality/CHANGELOG.md
+++ b/operational/azure/tag_cardinality/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.3.4
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v3.3.3
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/azure/tag_cardinality/azure_tag_cardinality.pt
+++ b/operational/azure/tag_cardinality/azure_tag_cardinality.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "3.3.3",
+  version: "3.3.4",
   provider: "Azure",
   service: "Tags",
   policy_set: "Tag Cardinality",
@@ -203,6 +203,8 @@ script "js_azure_subscriptions_tagless_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions_tagless", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions_tagless, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -298,6 +300,8 @@ script "js_azure_resources_region_filtered", type: "javascript" do
   parameters "ds_azure_resources", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_resources, function(vm) {
       include_vm = _.contains(param_regions_list, vm['region'])

--- a/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
+++ b/operational/azure/tag_cardinality/azure_tag_cardinality_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "3.3.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.3.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"
@@ -368,6 +368,9 @@ script "js_make_billing_center_request", type: "javascript" do
   parameters "rs_org_id", "rs_optima_host", "billing_centers_unformatted", "param_dimension_filter_includes", "param_dimension_filter_excludes"
   result "request"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_dimension_filter_includes = _.compact(_.map(param_dimension_filter_includes, function(item) { return item.trim() }))
+  param_dimension_filter_excludes = _.compact(_.map(param_dimension_filter_excludes, function(item) { return item.trim() }))
 
   billing_centers_formatted = []
 
@@ -1064,7 +1067,6 @@ script "js_ds_tag_report_combined_incidents", type: "javascript" do
 EOS
 end
 
-
 ###############################################################################
 # Policy
 ###############################################################################
@@ -1309,7 +1311,6 @@ end
 ###############################################################################
 # Escalations
 ###############################################################################
-
 
 # Used only for emailing the combined child incident if so desired
 escalation "esc_email" do

--- a/operational/azure/total_instance_usage_report/CHANGELOG.md
+++ b/operational/azure/total_instance_usage_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.13
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v1.0.12
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt
+++ b/operational/azure/total_instance_usage_report/azure_total_instance_usage_report.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "monthly"
 info(
-  version: "1.0.12",
+  version: "1.0.13",
   provider: "Azure",
   service: "Compute",
   policy_set: "Usage Report",
@@ -188,6 +188,8 @@ script "js_billing_centers_filtered", type: "javascript" do
   parameters "ds_billing_centers", "param_bc_allow_or_deny", "param_bc_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_bc_list = _.compact(_.map(param_bc_list, function(item) { return item.trim() }))
   allow_deny_test = { "Allow": true, "Deny": false }
 
   if (param_bc_list.length > 0) {
@@ -236,6 +238,8 @@ script "js_usage_data", type: "javascript" do
   parameters "ds_billing_centers_filtered", "param_regions_allow_or_deny", "param_regions_list", "param_months_back", "rs_org_id", "rs_optima_host"
   result "request"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   // Get Start and End dates
   start_date = new Date()
   start_date.setMonth(start_date.getMonth() - param_months_back)
@@ -457,6 +461,8 @@ script "js_chart_creation", type: "javascript" do
   parameters "ds_instance_units_per_family", "ds_applied_policy", "param_regions_allow_or_deny", "param_regions_list", "param_unit_time", "param_unit_instance", "param_months_back"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   instance_unit = { "Normalized Instance Count": "Count", "vCPUs": "vCPU", "Memory (GiB)": "Memory (GiB)" }
 
   // Get list of months from data and create chart X axis labels

--- a/operational/azure/vms_without_managed_disks/CHANGELOG.md
+++ b/operational/azure/vms_without_managed_disks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.3.3
+
+- Added input sanitization to trim leading and trailing whitespace from string and list parameter values.
+
 ## v4.3.2
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks.pt
+++ b/operational/azure/vms_without_managed_disks/azure_vms_without_managed_disks.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.3.2",
+  version: "4.3.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "",
@@ -246,6 +246,8 @@ script "js_azure_subscriptions_filtered", type: "javascript" do
   parameters "ds_azure_subscriptions", "param_subscriptions_allow_or_deny", "param_subscriptions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_subscriptions_list = _.compact(_.map(param_subscriptions_list, function(item) { return item.trim() }))
   if (param_subscriptions_list.length > 0) {
     result = _.filter(ds_azure_subscriptions, function(subscription) {
       include_subscription = _.contains(param_subscriptions_list, subscription['id']) || _.contains(param_subscriptions_list, subscription['name'])
@@ -319,6 +321,8 @@ script "js_azure_instances_tag_filtered", type: "javascript" do
   parameters "ds_azure_instances", "param_exclusion_tags", "param_exclusion_tags_boolean"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_exclusion_tags = _.compact(_.map(param_exclusion_tags, function(item) { return item.trim() }))
   comparators = _.map(param_exclusion_tags, function(item) {
     if (item.indexOf('==') != -1) {
       return { comparison: '==', key: item.split('==')[0], value: item.split('==')[1], string: item }
@@ -395,6 +399,8 @@ script "js_azure_instances_region_filtered", type: "javascript" do
   parameters "ds_azure_instances_tag_filtered", "param_regions_allow_or_deny", "param_regions_list"
   result "result"
   code <<-'EOS'
+  // Remove any leading/trailing whitespace the user may have accidentally entered
+  param_regions_list = _.compact(_.map(param_regions_list, function(item) { return item.trim() }))
   if (param_regions_list.length > 0) {
     result = _.filter(ds_azure_instances_tag_filtered, function(vm) {
       include_vm = _.contains(param_regions_list, vm['region'])
@@ -419,6 +425,8 @@ script "js_azure_instances_rg_filtered", type: "javascript" do
   parameters "ds_azure_instances_region_filtered", "param_resource_groups_allow_or_deny", "param_resource_groups_list"
   result "result"
   code <<-'EOS'
+    // Remove any leading/trailing whitespace the user may have accidentally entered
+    param_resource_groups_list = _.compact(_.map(param_resource_groups_list, function(item) { return item.trim() }))
     if (param_resource_groups_list.length > 0) {
       result = _.filter(ds_azure_instances_region_filtered, function(resource) {
         rg = resource['resourceGroup']


### PR DESCRIPTION
### Description

One of several PRs focused on sanitizing inputs for PT parameters. This is to prevent users from breaking policy template execution because they entered a parameter incorrectly, such as putting whitespace at the beginning or end of the value.

Also corrects some Dangerfile-reported issues with the touched PTs.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
