### PR TITLE
POL-1830 Budget Alerts: Currency Fixes

### DIFF
--- a/cost/flexera/cco/budget_report_alerts/CHANGELOG.md
+++ b/cost/flexera/cco/budget_report_alerts/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed the Data Table in the incident detail to consistently round currency values to two decimal places and format them using the org currency's thousands separator (e.g. `$10,345,123.33` instead of `$10345123.33456`). Negative amounts (e.g. an over-budget Remaining Amount) now display correctly (e.g. `-$500.26` instead of `$-,500.26`).
 - Fixed currency formatting in the Data Table for currencies whose thousands separator is a period (e.g. Brazilian Real) so the decimal point now correctly switches to a comma (e.g. `R$10.345.123,33` instead of the ambiguous `R$10.345.123.33`).
 - Fixed the Projected (prorated) Spend value to always be rounded to two decimal places.
+- Fixed erroneous "\n" string that would sometimes appear in incident description.
 
 ## v3.7.1
 

--- a/cost/flexera/cco/budget_report_alerts/CHANGELOG.md
+++ b/cost/flexera/cco/budget_report_alerts/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v3.7.2
+
+- Fixed the Data Table in the incident detail to consistently round currency values to two decimal places and format them using the org currency's thousands separator (e.g. `$10,345,123.33` instead of `$10345123.33456`). Negative amounts (e.g. an over-budget Remaining Amount) now display correctly (e.g. `-$500.26` instead of `$-,500.26`).
+- Fixed currency formatting in the Data Table for currencies whose thousands separator is a period (e.g. Brazilian Real) so the decimal point now correctly switches to a comma (e.g. `R$10.345.123,33` instead of the ambiguous `R$10.345.123.33`).
+- Fixed the Projected (prorated) Spend value to always be rounded to two decimal places.
+
 ## v3.7.1
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/cost/flexera/cco/budget_report_alerts/budget_report_alerts.pt
+++ b/cost/flexera/cco/budget_report_alerts/budget_report_alerts.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "3.7.1",
+  version: "3.7.2",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -393,26 +393,32 @@ script "js_aggregated", type: "javascript" do
     return ds_billing_center_table[id] ? ds_billing_center_table[id] : id
   }
 
-  function format_number(number, separator) {
-    formatted_number = "0"
+  function format_number(number, separator, symbol) {
+    // Round to 2 decimal places first, then format the sign, symbol, and digits separately so
+    // that negative values (e.g. a negative Remaining Amount) group and display correctly (e.g.
+    // "-$500.26" instead of "$-,500.26") and every value always shows exactly 2 decimal places,
+    // per local currency convention. Some currencies (e.g. BRL, ARS, CLP) use "." as the
+    // thousands separator, so the decimal point must switch to "," in that case to avoid
+    // ambiguous output like "10.345.123.33".
+    number = Math.round((number || 0) * 100) / 100
+    negative = number < 0
+    parts = Math.abs(number).toFixed(2).split(".")
+    formatted_number = parts[0]
+    decimal_point = separator == "." ? "," : "."
 
-    if (number) {
-      formatted_number = (Math.round(number * 100) / 100).toString().split(".")[0]
+    if (separator) {
+      with_separator = ""
 
-      if (separator) {
-        with_separator = ""
-
-        for (var i = 0; i < formatted_number.length; i++) {
-          if (i > 0 && (formatted_number.length - i) % 3 == 0) { with_separator += separator }
-          with_separator += formatted_number[i]
-        }
-
-        formatted_number = with_separator
+      for (var i = 0; i < formatted_number.length; i++) {
+        if (i > 0 && (formatted_number.length - i) % 3 == 0) { with_separator += separator }
+        with_separator += formatted_number[i]
       }
 
-      decimal = (Math.round(number * 100) / 100).toString().split(".")[1]
-      if (decimal) { formatted_number += "." + decimal }
+      formatted_number = with_separator
     }
+
+    formatted_number = (symbol || "") + formatted_number + decimal_point + parts[1]
+    if (negative) { formatted_number = "-" + formatted_number }
 
     return formatted_number
   }
@@ -423,10 +429,10 @@ script "js_aggregated", type: "javascript" do
 
     rows = _.map(items, function(item) {
       return "| " + item['group'] +
-        " | " + ds_currency['symbol'] + format_number(item['budgetAmount'], ds_currency['separator']) +
-        " | " + ds_currency['symbol'] + format_number(item['spendAmount'], ds_currency['separator']) +
-        " | " + ds_currency['symbol'] + format_number(item['forecastedAmount'], ds_currency['separator']) +
-        " | " + ds_currency['symbol'] + format_number(item['remaining'], ds_currency['separator']) +
+        " | " + format_number(item['budgetAmount'], ds_currency['separator'], ds_currency['symbol']) +
+        " | " + format_number(item['spendAmount'], ds_currency['separator'], ds_currency['symbol']) +
+        " | " + format_number(item['forecastedAmount'], ds_currency['separator'], ds_currency['symbol']) +
+        " | " + format_number(item['remaining'], ds_currency['separator'], ds_currency['symbol']) +
         " | " + (item['spentPercent'] || "") +
         " | " + item['details'] + " |"
     })
@@ -489,7 +495,7 @@ script "js_aggregated", type: "javascript" do
       item['monthYear'] = monthYear
       item['forecasted'] = ""
       item['currency'] = ds_currency['code']
-      item['forecastedAmount'] = item['spendAmount']
+      item['forecastedAmount'] = Math.round(item['spendAmount'] * 100) / 100
       date = new Date(item['timestamp'])
       item['date'] = date.toLocaleDateString()
       now = new Date()

--- a/cost/flexera/cco/budget_report_alerts/budget_report_alerts.pt
+++ b/cost/flexera/cco/budget_report_alerts/budget_report_alerts.pt
@@ -634,7 +634,7 @@ Cost Metric: **{{with index data 0}}{{ .metric }}{{end}}**
 Dimensions: **{{with index data 0}}{{ .dimm }}{{end}}**
 
 {{ if parameters.param_filter }}
-Target Groups: \n
+Target Groups:
 {{ range parameters.param_filter }}
   * **{{ . }}**
 {{ end }}
@@ -692,7 +692,7 @@ Cost Metric: **{{with index data 0}}{{ .metric }}{{end}}**
 Dimensions: **{{with index data 0}}{{ .dimm }}{{end}}**
 
 {{ if parameters.param_filter }}
-Target Groups: \n
+Target Groups:
 {{ range parameters.param_filter }}
   * **{{ . }}**
 {{ end }}


### PR DESCRIPTION
### Description

`Budget Alerts`
- Fixed the Data Table in the incident detail to consistently round currency values to two decimal places and format them using the org currency's thousands separator (e.g. `$10,345,123.33` instead of `$10345123.33456`). Negative amounts (e.g. an over-budget Remaining Amount) now display correctly (e.g. `-$500.26` instead of `$-,500.26`).
- Fixed currency formatting in the Data Table for currencies whose thousands separator is a period (e.g. Brazilian Real) so the decimal point now correctly switches to a comma (e.g. `R$10.345.123,33` instead of the ambiguous `R$10.345.123.33`).
- Fixed the Projected (prorated) Spend value to always be rounded to two decimal places.
- Fixed erroneous "\n" string that would sometimes appear in incident description.

### Link to Example Applied Policy

https://app.flexera.com/orgs/28010/automation/applied-policies/projects/123559?policyId=6a87529309896508691b731e

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
