### PR TITLE
POL-1828 AWS S3 Buckets Without Lifecycle Configuration: Bug Fix

### DIFF
--- a/cost/aws/s3_lifecycle/CHANGELOG.md
+++ b/cost/aws/s3_lifecycle/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.8
+
+- Fixed bug where the policy would fail with a `'resource' is not defined` error whenever the `Exclusion Tags` parameter was used.
+
 ## v0.2.7
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/cost/aws/s3_lifecycle/aws_s3_lifecycle.pt
+++ b/cost/aws/s3_lifecycle/aws_s3_lifecycle.pt
@@ -490,7 +490,7 @@ script "js_aws_buckets_tag_filtered", type: "javascript" do
   })
 
   if (param_exclusion_tags.length > 0) {
-    result = _.filter(aws_buckets, function(bucket) {
+    result = _.reject(aws_buckets, function(bucket) {
       resource_tags = {}
 
       if (typeof(bucket['tags']) == 'object') {

--- a/cost/aws/s3_lifecycle/aws_s3_lifecycle.pt
+++ b/cost/aws/s3_lifecycle/aws_s3_lifecycle.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "medium"
 default_frequency "weekly"
 info(
-  version: "0.2.7",
+  version: "0.2.8",
   provider: "AWS",
   service: "Storage",
   policy_set: "",
@@ -493,8 +493,8 @@ script "js_aws_buckets_tag_filtered", type: "javascript" do
     result = _.filter(aws_buckets, function(bucket) {
       resource_tags = {}
 
-      if (typeof(resource['tags']) == 'object') {
-        _.each(resource['tags'], function(tag) {
+      if (typeof(bucket['tags']) == 'object') {
+        _.each(bucket['tags'], function(tag) {
           resource_tags[tag['key']] = tag['value']
         })
       }

--- a/cost/aws/s3_lifecycle/aws_s3_lifecycle_meta_parent.pt
+++ b/cost/aws/s3_lifecycle/aws_s3_lifecycle_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.2.7", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.8", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/s3_multipart_uploads/CHANGELOG.md
+++ b/cost/aws/s3_multipart_uploads/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.8
+
+- Fixed bug where the "Exclusion Tags" parameter incorrectly included matching resources in the results instead of excluding them, and fixed a related error that occurred whenever any exclusion tag was entered.
+
 ## v0.2.7
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/cost/aws/s3_multipart_uploads/aws_s3_multipart_uploads.pt
+++ b/cost/aws/s3_multipart_uploads/aws_s3_multipart_uploads.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.7",
+  version: "0.2.8",
   provider: "AWS",
   service: "Storage",
   policy_set: "",
@@ -508,11 +508,11 @@ script "js_aws_buckets_tag_filtered", type: "javascript" do
   })
 
   if (param_exclusion_tags.length > 0) {
-    result = _.filter(aws_buckets, function(bucket) {
+    result = _.reject(aws_buckets, function(bucket) {
       resource_tags = {}
 
-      if (typeof(resource['tags']) == 'object') {
-        _.each(resource['tags'], function(tag) {
+      if (typeof(bucket['tags']) == 'object') {
+        _.each(bucket['tags'], function(tag) {
           resource_tags[tag['key']] = tag['value']
         })
       }

--- a/cost/aws/s3_multipart_uploads/aws_s3_multipart_uploads_meta_parent.pt
+++ b/cost/aws/s3_multipart_uploads/aws_s3_multipart_uploads_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "0.2.7", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.8", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/s3_storage_policy/CHANGELOG.md
+++ b/cost/aws/s3_storage_policy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.2.11
+
+- Fixed bug where the "Exclusion Tags" parameter incorrectly included matching resources in the results instead of excluding them, and fixed a related error that occurred whenever any exclusion tag was entered.
+
 ## v4.2.10
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check.pt
+++ b/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "medium"
 default_frequency "weekly"
 info(
-  version: "4.2.10",
+  version: "4.2.11",
   provider: "AWS",
   service: "Storage",
   policy_set: "Object Store Optimization",
@@ -583,11 +583,11 @@ script "js_aws_buckets_tag_filtered", type: "javascript" do
   })
 
   if (param_exclusion_tags.length > 0) {
-    result = _.filter(aws_buckets, function(bucket) {
+    result = _.reject(aws_buckets, function(bucket) {
       resource_tags = {}
 
-      if (typeof(resource['tags']) == 'object') {
-        _.each(resource['tags'], function(tag) {
+      if (typeof(bucket['tags']) == 'object') {
+        _.each(bucket['tags'], function(tag) {
           resource_tags[tag['key']] = tag['value']
         })
       }

--- a/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check_meta_parent.pt
+++ b/cost/aws/s3_storage_policy/aws_s3_bucket_policy_check_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "4.2.10", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.2.11", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"


### PR DESCRIPTION
### Description

AWS S3 Buckets Without Lifecycle Configuration - Fixed bug where the policy would fail with a `'resource' is not defined` error whenever the `Exclusion Tags` parameter was used.

Also fixed bugs in this and two other policy templates related to the tag filtering not working correctly.

### Link to Example Applied Policy

https://app.flexera.com/orgs/6/automation/applied-policies/projects/7954?policyId=6a8f3d1e30ae6a2d17bf6332

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
