### PR TITLE
POL-1834 AWS Reserved Instances Coverage: Support for Additional Services

### DIFF
--- a/cost/aws/reserved_instances/coverage/CHANGELOG.md
+++ b/cost/aws/reserved_instances/coverage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.0
+
+- Added support for ElastiCache, OpenSearch Service, Redshift, and Relational Database Service.
+
 ## v3.0.7
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/cost/aws/reserved_instances/coverage/README.md
+++ b/cost/aws/reserved_instances/coverage/README.md
@@ -8,7 +8,9 @@ This policy template uses the [AWS Billing and Cost Management API](https://docs
 
 - *Email Addresses* - Email addresses of the recipients you wish to notify when new incidents are created.
 - *Account Number* - The Account number for use with the AWS STS Cross Account Role. Leave blank when using AWS IAM Access key and secret. It only needs to be passed when the desired AWS account is different than the one associated with the Flexera One credential. [More information is available in our documentation.](https://docs.flexera.com/flexera-one/automation/automation-administration/managing-credentials-for-policy-access-to-external-systems/provider-specific-credentials#aws)
+- *Service* - AWS services to provide coverage information for.
 - *Look Back Period (Days)* - Number of days in the past to assess AWS Reserved Instances coverage. Coverage will be assessed from this point in time until today.
+- *Attach CSV To Incident Email* - Whether or not to attach the results as a CSV file to the incident email.
 
 ## Policy Actions
 

--- a/cost/aws/reserved_instances/coverage/reserved_instance_coverage.pt
+++ b/cost/aws/reserved_instances/coverage/reserved_instance_coverage.pt
@@ -156,7 +156,7 @@ script "js_services", type: "javascript" do
     "Relational Database Service (RDS)": "Amazon Relational Database Service",
     "ElastiCache": "Amazon ElastiCache",
     "Redshift": "Amazon Redshift",
-    "Elasticsearch Service (ES)": "Amazon OpenSearch Service"
+    "OpenSearch Service (ES)": "Amazon OpenSearch Service"
   }
 
   result = _.map(param_service, function(service) {
@@ -204,7 +204,7 @@ script "js_reservations_coverage", type: "javascript" do
       "Filter": {
         "Dimensions": {
           "Key": "SERVICE",
-          "Values": [ iter_item ]
+          "Values": [ service ]
         }
       }
     }
@@ -226,16 +226,20 @@ script "js_coverage_report", type: "javascript" do
   start_date.setDate(start_date.getDate() - param_lookback)
   start_date = start_date.toISOString().split('T')[0]
 
+  function roundValue(number) { return Math.round(number * 1000) / 1000 }
+
   result = _.map(ds_reservations_coverage, function(item) {
-    service: item['service'],
-    total_coverage_hours_percentage: item['total_coverage_hours_percentage'],
-    total_on_demand_hours: item['total_on_demand_hours'],
-    total_reserved_hours: item['total_reserved_hours'],
-    total_running_hours: item['total_running_hours'],
-    start_date: start_date,
-    end_date: end_date,
-    policy_name: ds_applied_policy['name'],
-    lookback_period: param_lookback
+    return {
+      service: item['service'],
+      total_coverage_hours_percentage: roundValue(item['total_coverage_hours_percentage']),
+      total_on_demand_hours: roundValue(item['total_on_demand_hours']),
+      total_reserved_hours: roundValue(item['total_reserved_hours']),
+      total_running_hours: roundValue(item['total_running_hours']),
+      start_date: start_date,
+      end_date: end_date,
+      policy_name: ds_applied_policy['name'],
+      lookback_period: param_lookback
+    }
   })
 EOS
 end

--- a/cost/aws/reserved_instances/coverage/reserved_instance_coverage.pt
+++ b/cost/aws/reserved_instances/coverage/reserved_instance_coverage.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.0.7",
+  version: "3.1.0",
   provider: "AWS",
   service: "Compute",
   policy_set: "Reserved Instances",
@@ -43,6 +43,24 @@ parameter "param_lookback" do
   min_value 7
   max_value 365
   default 7
+end
+
+parameter "param_service" do
+  type "list"
+  category "Reservation Settings"
+  label "Service"
+  description "AWS services to provide coverage information for."
+  allowed_values ["ElastiCache", "Elastic Compute Cloud (EC2)", "OpenSearch Service (ES)", "Redshift", "Relational Database Service (RDS)"]
+  default ["Elastic Compute Cloud (EC2)"]
+end
+
+parameter "param_incident_csv" do
+  type "string"
+  category "Incident Settings"
+  label "Attach CSV To Incident Email"
+  description "Whether or not to attach the results as a CSV file to the incident email."
+  allowed_values "true", "false"
+  default "false"
 end
 
 ###############################################################################
@@ -125,9 +143,32 @@ datasource "ds_applied_policy" do
   end
 end
 
+datasource "ds_services" do
+  run_script $js_services, $param_service
+end
+
+script "js_services", type: "javascript" do
+  parameters "param_service"
+  result "result"
+  code <<-'EOS'
+  service_table = {
+    "Elastic Compute Cloud (EC2)": "Amazon Elastic Compute Cloud - Compute",
+    "Relational Database Service (RDS)": "Amazon Relational Database Service",
+    "ElastiCache": "Amazon ElastiCache",
+    "Redshift": "Amazon Redshift",
+    "Elasticsearch Service (ES)": "Amazon OpenSearch Service"
+  }
+
+  result = _.map(param_service, function(service) {
+    return service_table[service]
+  })
+EOS
+end
+
 datasource "ds_reservations_coverage" do
+  iterate $ds_services
   request do
-    run_script $js_reservations_coverage, $param_lookback
+    run_script $js_reservations_coverage, $param_lookback, iter_item
   end
   result do
     encoding "json"
@@ -135,11 +176,12 @@ datasource "ds_reservations_coverage" do
     field "total_on_demand_hours", jmes_path(response, "Total.CoverageHours.OnDemandHours")
     field "total_reserved_hours", jmes_path(response, "Total.CoverageHours.ReservedHours")
     field "total_running_hours", jmes_path(response, "Total.CoverageHours.TotalRunningHours")
+    field "service", iter_item
   end
 end
 
 script "js_reservations_coverage", type: "javascript" do
-  parameters "param_lookback"
+  parameters "param_lookback", "service"
   result "request"
   code <<-'EOS'
   end_date = new Date().toISOString().split('T')[0]
@@ -157,7 +199,15 @@ script "js_reservations_coverage", type: "javascript" do
       "X-Amz-Target": "AWSInsightsIndexService.GetReservationCoverage",
       "Content-Type": "application/x-amz-json-1.1",
     },
-    body_fields: { "TimePeriod": { "Start": start_date, "End": end_date } }
+    body_fields: {
+      "TimePeriod": { "Start": start_date, "End": end_date },
+      "Filter": {
+        "Dimensions": {
+          "Key": "SERVICE",
+          "Values": [ iter_item ]
+        }
+      }
+    }
   }
 EOS
 end
@@ -176,16 +226,17 @@ script "js_coverage_report", type: "javascript" do
   start_date.setDate(start_date.getDate() - param_lookback)
   start_date = start_date.toISOString().split('T')[0]
 
-  result = [{
-    total_coverage_hours_percentage: ds_reservations_coverage['total_coverage_hours_percentage'],
-    total_on_demand_hours: ds_reservations_coverage['total_on_demand_hours'],
-    total_reserved_hours: ds_reservations_coverage['total_reserved_hours'],
-    total_running_hours: ds_reservations_coverage['total_running_hours'],
+  result = _.map(ds_reservations_coverage, function(item) {
+    service: item['service'],
+    total_coverage_hours_percentage: item['total_coverage_hours_percentage'],
+    total_on_demand_hours: item['total_on_demand_hours'],
+    total_reserved_hours: item['total_reserved_hours'],
+    total_running_hours: item['total_running_hours'],
     start_date: start_date,
     end_date: end_date,
     policy_name: ds_applied_policy['name'],
     lookback_period: param_lookback
-  }]
+  })
 EOS
 end
 
@@ -199,16 +250,14 @@ policy "pol_coverage_report" do
     detail_template <<-'EOS'
 # AWS Reserved Instances Coverage Report
 ## Date Range: {{ with index data 0 }}{{ .start_date }}{{ end }} -> {{ with index data 0 }}{{ .end_date }}{{ end }}
-
-**Coverage:** {{ with index data 0 }}{{ .total_coverage_hours_percentage }}{{ end }}%\n
-**On Demand Hours:** {{ with index data 0 }}{{ .total_on_demand_hours }}{{ end }}\n
-**Reserved Hours:** {{ with index data 0 }}{{ .total_reserved_hours }}{{ end }}\n
-**Total Running Hours:** {{ with index data 0 }}{{ .total_running_hours }}{{ end }}\n
 EOS
-    check eq(0, 1)
+    check eq(val(item, "service"), "")
     escalate $esc_email
     export do
       resource_level false
+      field "service" do
+        label "Service"
+      end
       field "total_coverage_hours_percentage" do
         label "Coverage (%)"
       end
@@ -239,5 +288,10 @@ escalation "esc_email" do
   automatic true
   label "Send Email"
   description "Send incident email"
-  email $param_email
+  email $param_email do
+    attach_export_table $param_incident_csv
+    # body_table_max_rows: No need for a parameter.
+    # Incident will never have more than 5 rows anyway.
+    body_table_max_rows 50
+  end
 end

--- a/cost/aws/reserved_instances/coverage/reserved_instance_coverage.pt
+++ b/cost/aws/reserved_instances/coverage/reserved_instance_coverage.pt
@@ -168,7 +168,7 @@ end
 datasource "ds_reservations_coverage" do
   iterate $ds_services
   request do
-    run_script $js_reservations_coverage, $param_lookback, iter_item
+    run_script $js_reservations_coverage, iter_item, $param_lookback
   end
   result do
     encoding "json"
@@ -181,7 +181,7 @@ datasource "ds_reservations_coverage" do
 end
 
 script "js_reservations_coverage", type: "javascript" do
-  parameters "param_lookback", "service"
+  parameters "service", "param_lookback"
   result "request"
   code <<-'EOS'
   end_date = new Date().toISOString().split('T')[0]


### PR DESCRIPTION
### Description

Adds support for ElastiCache, OpenSearch Service, Redshift, and Relational Database Service to the `AWS Reserved Instances Coverage` policy template. Previously, this policy template only reported on EC2.

### Link to Example Applied Policy

https://app.flexera.com/orgs/27018/automation/applied-policies/projects/113453?policyId=6a98721c880ef71321f8f442

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
