### PR TITLE
SQ-28381 Policy Sanitization Fix

### DIFF
--- a/.github/agents/policy-dev.agent.md
+++ b/.github/agents/policy-dev.agent.md
@@ -482,6 +482,33 @@ Two mechanisms, depending on how the parameter is consumed:
 
 **Example:** See "Common JavaScript Patterns - Parameter Sanitization" in `data/agent/code_examples.txt`.
 
+> **⚠️ Critical gotcha - never reference a Category B wrapper datasource bare inside a `join([...])` array.** The DSL's `join()` function statically requires its array argument to be "array of strings." Literal strings, built-in variables (`rs_org_id`, `policy_id`), and `$param_x` (a declared `type "string"` parameter) all satisfy that check. A Category B wrapper datasource's `result` is produced by a plain `run_script` with no declared field/type, so the engine treats it as an **untyped/"unknown"** value - mixing it bare into a `join([...])` array with literal strings makes the whole array "array of unknown," and `join()` fails at evaluation time with an error like:
+>
+> ```text
+> invalid argument in join(array,""): first argument must be an array of
+> strings, got array of unknown
+> ```
+>
+> This is a *runtime evaluation* error, not a parse error - `fpt check` will **not** catch it; it only surfaces when the policy is actually applied. It affects `join([...])` used for `host`, `path`, `query`, and `body` values alike.
+>
+> **The fix:** have the wrapper script return a keyed object instead of a bare scalar, then access it with `val()` at every `join([...])` call site (this exact pattern - a `run_script`-only datasource returning an object, consumed via `val($ds_x, "field")` inside `join([...])` - is already proven throughout the catalog, e.g. `val($ds_dates, "period")` in `cost/flexera/cco/fixed_cost_cbi/fixed_cost_cbi.pt`):
+>
+> ```javascript
+> script "js_cbi_endpoint", type: "javascript" do
+>   parameters "param_cbi_endpoint"
+>   result "result"
+>   code <<-'EOS'
+>   result = { value: param_cbi_endpoint.trim() }
+> EOS
+> end
+> ```
+>
+> ```text
+> path join(["/some/path/", val($ds_cbi_endpoint, "value"), "/execute"])
+> ```
+>
+> A bare `$ds_x` reference works fine when it is the **entire** value of a DSL field with nothing else to combine (e.g. `host $ds_kubecost_host`) - the failure is specific to embedding it alongside literal strings inside `join([...])`. When in doubt, always use the object+`val()` form for any Category B wrapper that feeds into a `join([...])` call, even if only one element in the array.
+
 **Architectural exception - "action-only" parameters used exclusively inside `run`/`define` Cloud Workflow blocks** (e.g. `param_tags_to_add`, `param_labels_to_add`, `param_new_name`, `param_new_description`, `param_schedule`, `param_target_bucket`): these cannot be sanitized with either mechanism above. `run "define_name", data, $param_x, ...` invocation lines only ever accept raw `$param_x` references (or reserved words/built-ins) - never a `$ds_x` datasource reference - and `define` blocks have no string-manipulation function equivalent to JavaScript's `.trim()`. Since there is no script in the chain to insert a trim into and no way to substitute a sanitized datasource value into `run`, leave these parameters untrimmed. This is a confirmed language limitation, not an oversight - do not attempt to work around it (for example, by adding a no-op script) purely to satisfy a sanitization audit. `param_aws_account_number` (used only inside `credentials do ... aws_account_number $param_x end` blocks) falls into the same category for the same reason.
 
 **Exclusion - parameters with `allowed_values` or `allowed_pattern`:** Do NOT sanitize any parameter that declares an `allowed_values` or `allowed_pattern` field, even if it is a `string` or `list` type that would otherwise qualify for trimming. Both fields are validated and enforced by the policy engine itself before the template's own code ever runs - `allowed_values` restricts the user to a fixed, exact-match dropdown of choices (no free-text entry is possible), and `allowed_pattern` already enforces a specific format via regex. Adding a `.trim()` wrapper (or a `ds_x`/`js_x` datasource pair) for these parameters is redundant, adds unnecessary complexity, and provides no real protection since malformed/padded input can never reach the template in the first place. This applies regardless of which mechanism (Category A inline trim or Category B wrapper datasource) would otherwise be used. Common examples that must NOT be wrapped: `param_incident_csv` (`allowed_values "true", "false"`), `param_azure_endpoint` (`allowed_values "management.azure.com", "management.chinacloudapi.cn"`), and `param_exclusion_tags_boolean` (`allowed_values "Any", "All"`).

--- a/cost/oracle/advisor_lifecycle_mgmt/CHANGELOG.md
+++ b/cost/oracle/advisor_lifecycle_mgmt/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.2
+
+- Fixed a bug introduced in v0.3.1 where the policy would fail to evaluate with an "invalid argument in join" error due to how the primary region parameter was sanitized.
+
 ## v0.3.1
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/cost/oracle/advisor_lifecycle_mgmt/oracle_advisor_lifecycle_mgmt.pt
+++ b/cost/oracle/advisor_lifecycle_mgmt/oracle_advisor_lifecycle_mgmt.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.1",
+  version: "0.3.2",
   provider: "Oracle",
   service: "Storage",
   policy_set: "",
@@ -148,7 +148,7 @@ script "js_primary_region", type: "javascript" do
   parameters "param_primary_region"
   result "result"
   code <<-'EOS'
-  result = param_primary_region.trim()
+  result = { value: param_primary_region.trim() }
 EOS
 end
 
@@ -279,7 +279,7 @@ datasource "ds_oci_recommendation_list" do
   request do
     auth $auth_oracle
     pagination $pagination_oracle
-    host join(["optimizer.", $ds_primary_region, ".oci.oraclecloud.com"])
+    host join(["optimizer.", val($ds_primary_region, "value"), ".oci.oraclecloud.com"])
     path "/20200606/recommendations"
     query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"
@@ -329,7 +329,7 @@ datasource "ds_oci_recommendation_actions" do
     auth $auth_oracle
     pagination $pagination_oracle
     verb "POST"
-    host join(["optimizer.", $ds_primary_region, ".oci.oraclecloud.com"])
+    host join(["optimizer.", val($ds_primary_region, "value"), ".oci.oraclecloud.com"])
     path "/20200606/actions/filterResourceActions"
     query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"

--- a/cost/oracle/advisor_rightsize_autodbs/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_autodbs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.3
+
+- Fixed a bug introduced in v0.3.1 where the policy would fail to evaluate with an "invalid argument in join" error due to how the primary region parameter was sanitized.
+
 ## v0.3.2
 
 - Fixed an issue where the reported CPU utilization could incorrectly appear blank for databases with zero average or p95 utilization.

--- a/cost/oracle/advisor_rightsize_autodbs/oracle_advisor_rightsize_autodbs.pt
+++ b/cost/oracle/advisor_rightsize_autodbs/oracle_advisor_rightsize_autodbs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.2",
+  version: "0.3.3",
   provider: "Oracle",
   service: "Database",
   policy_set: "Rightsize Database Instances",
@@ -141,7 +141,7 @@ script "js_primary_region", type: "javascript" do
   parameters "param_primary_region"
   result "result"
   code <<-'EOS'
-  result = param_primary_region.trim()
+  result = { value: param_primary_region.trim() }
 EOS
 end
 
@@ -272,7 +272,7 @@ datasource "ds_oci_recommendation_list" do
   request do
     auth $auth_oracle
     pagination $pagination_oracle
-    host join(["optimizer.", $ds_primary_region, ".oci.oraclecloud.com"])
+    host join(["optimizer.", val($ds_primary_region, "value"), ".oci.oraclecloud.com"])
     path "/20200606/recommendations"
     query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"
@@ -322,7 +322,7 @@ datasource "ds_oci_recommendation_actions" do
     auth $auth_oracle
     pagination $pagination_oracle
     verb "POST"
-    host join(["optimizer.", $ds_primary_region, ".oci.oraclecloud.com"])
+    host join(["optimizer.", val($ds_primary_region, "value"), ".oci.oraclecloud.com"])
     path "/20200606/actions/filterResourceActions"
     query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"

--- a/cost/oracle/advisor_rightsize_basedbs/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_basedbs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.2
+
+- Fixed a bug introduced in v0.3.1 where the policy would fail to evaluate with an "invalid argument in join" error due to how the primary region parameter was sanitized.
+
 ## v0.3.1
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/cost/oracle/advisor_rightsize_basedbs/oracle_advisor_rightsize_basedbs.pt
+++ b/cost/oracle/advisor_rightsize_basedbs/oracle_advisor_rightsize_basedbs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.1",
+  version: "0.3.2",
   provider: "Oracle",
   service: "Database",
   policy_set: "Rightsize Database Instances",
@@ -141,7 +141,7 @@ script "js_primary_region", type: "javascript" do
   parameters "param_primary_region"
   result "result"
   code <<-'EOS'
-  result = param_primary_region.trim()
+  result = { value: param_primary_region.trim() }
 EOS
 end
 
@@ -272,7 +272,7 @@ datasource "ds_oci_recommendation_list" do
   request do
     auth $auth_oracle
     pagination $pagination_oracle
-    host join(["optimizer.", $ds_primary_region, ".oci.oraclecloud.com"])
+    host join(["optimizer.", val($ds_primary_region, "value"), ".oci.oraclecloud.com"])
     path "/20200606/recommendations"
     query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"
@@ -322,7 +322,7 @@ datasource "ds_oci_recommendation_actions" do
     auth $auth_oracle
     pagination $pagination_oracle
     verb "POST"
-    host join(["optimizer.", $ds_primary_region, ".oci.oraclecloud.com"])
+    host join(["optimizer.", val($ds_primary_region, "value"), ".oci.oraclecloud.com"])
     path "/20200606/actions/filterResourceActions"
     query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"

--- a/cost/oracle/advisor_rightsize_lbs/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_lbs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.2
+
+- Fixed a bug introduced in v0.3.1 where the policy would fail to evaluate with an "invalid argument in join" error due to how the primary region parameter was sanitized.
+
 ## v0.3.1
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/cost/oracle/advisor_rightsize_lbs/oracle_advisor_rightsize_lbs.pt
+++ b/cost/oracle/advisor_rightsize_lbs/oracle_advisor_rightsize_lbs.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.1",
+  version: "0.3.2",
   provider: "Oracle",
   service: "Network",
   policy_set: "Unused Load Balancers",
@@ -141,7 +141,7 @@ script "js_primary_region", type: "javascript" do
   parameters "param_primary_region"
   result "result"
   code <<-'EOS'
-  result = param_primary_region.trim()
+  result = { value: param_primary_region.trim() }
 EOS
 end
 
@@ -272,7 +272,7 @@ datasource "ds_oci_recommendation_list" do
   request do
     auth $auth_oracle
     pagination $pagination_oracle
-    host join(["optimizer.", $ds_primary_region, ".oci.oraclecloud.com"])
+    host join(["optimizer.", val($ds_primary_region, "value"), ".oci.oraclecloud.com"])
     path "/20200606/recommendations"
     query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"
@@ -322,7 +322,7 @@ datasource "ds_oci_recommendation_actions" do
     auth $auth_oracle
     pagination $pagination_oracle
     verb "POST"
-    host join(["optimizer.", $ds_primary_region, ".oci.oraclecloud.com"])
+    host join(["optimizer.", val($ds_primary_region, "value"), ".oci.oraclecloud.com"])
     path "/20200606/actions/filterResourceActions"
     query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"

--- a/cost/oracle/advisor_rightsize_vms/CHANGELOG.md
+++ b/cost/oracle/advisor_rightsize_vms/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.2
+
+- Fixed a bug introduced in v0.4.1 where the policy would fail to evaluate with an "invalid argument in join" error due to how the primary region parameter was sanitized.
+
 ## v0.4.1
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/cost/oracle/advisor_rightsize_vms/oracle_advisor_rightsize_vms.pt
+++ b/cost/oracle/advisor_rightsize_vms/oracle_advisor_rightsize_vms.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.1",
+  version: "0.4.2",
   provider: "Oracle",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -168,7 +168,7 @@ script "js_primary_region", type: "javascript" do
   parameters "param_primary_region"
   result "result"
   code <<-'EOS'
-  result = param_primary_region.trim()
+  result = { value: param_primary_region.trim() }
 EOS
 end
 
@@ -299,7 +299,7 @@ datasource "ds_oci_recommendation_list" do
   request do
     auth $auth_oracle
     pagination $pagination_oracle
-    host join(["optimizer.", $ds_primary_region, ".oci.oraclecloud.com"])
+    host join(["optimizer.", val($ds_primary_region, "value"), ".oci.oraclecloud.com"])
     path "/20200606/recommendations"
     query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"
@@ -350,7 +350,7 @@ datasource "ds_oci_recommendation_actions" do
     auth $auth_oracle
     pagination $pagination_oracle
     verb "POST"
-    host join(["optimizer.", $ds_primary_region, ".oci.oraclecloud.com"])
+    host join(["optimizer.", val($ds_primary_region, "value"), ".oci.oraclecloud.com"])
     path "/20200606/actions/filterResourceActions"
     query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"

--- a/cost/oracle/advisor_unattached_volumes/CHANGELOG.md
+++ b/cost/oracle/advisor_unattached_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.2
+
+- Fixed a bug introduced in v0.3.1 where the policy would fail to evaluate with an "invalid argument in join" error due to how the primary region parameter was sanitized.
+
 ## v0.3.1
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/cost/oracle/advisor_unattached_volumes/oracle_advisor_unattached_volumes.pt
+++ b/cost/oracle/advisor_unattached_volumes/oracle_advisor_unattached_volumes.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.1",
+  version: "0.3.2",
   provider: "Oracle",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -150,7 +150,7 @@ script "js_primary_region", type: "javascript" do
   parameters "param_primary_region"
   result "result"
   code <<-'EOS'
-  result = param_primary_region.trim()
+  result = { value: param_primary_region.trim() }
 EOS
 end
 
@@ -281,7 +281,7 @@ datasource "ds_oci_recommendation_list" do
   request do
     auth $auth_oracle
     pagination $pagination_oracle
-    host join(["optimizer.", $ds_primary_region, ".oci.oraclecloud.com"])
+    host join(["optimizer.", val($ds_primary_region, "value"), ".oci.oraclecloud.com"])
     path "/20200606/recommendations"
     query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"
@@ -333,7 +333,7 @@ datasource "ds_oci_recommendation_actions" do
     auth $auth_oracle
     pagination $pagination_oracle
     verb "POST"
-    host join(["optimizer.", $ds_primary_region, ".oci.oraclecloud.com"])
+    host join(["optimizer.", val($ds_primary_region, "value"), ".oci.oraclecloud.com"])
     path "/20200606/actions/filterResourceActions"
     query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"

--- a/data/agent/code_examples.txt
+++ b/data/agent/code_examples.txt
@@ -310,6 +310,14 @@ end
 # free-text parameters; never wrap a parameter that has `allowed_values`/`allowed_pattern`
 # (see exception below). Name the wrapper datasource/script by dropping the `param_`
 # prefix (ds_cbi_endpoint / js_cbi_endpoint) - never ds_param_cbi_endpoint / js_param_cbi_endpoint.
+#
+# IMPORTANT: the script must return a keyed object ({ value: ... }), NOT a bare scalar.
+# If this datasource is ever combined with literal strings inside a DSL `join([...])`
+# call (for a `host`/`path`/`query`/`body` value), a bare scalar result causes a runtime
+# "invalid argument in join(array,''): ... got array of unknown" evaluation error that
+# `fpt check` will NOT catch (see the Parameter Sanitization warning in policy-dev.agent.md).
+# Always access the wrapper via val($ds_x, "value") at the join() call site, e.g.:
+#   path join(["/some/path/", val($ds_cbi_endpoint, "value"), "/execute"])
 
 datasource "ds_cbi_endpoint" do
   run_script $js_cbi_endpoint, $param_cbi_endpoint
@@ -319,7 +327,7 @@ script "js_cbi_endpoint", type: "javascript" do
   parameters "param_cbi_endpoint"
   result "result"
   code <<-'EOS'
-  result = param_cbi_endpoint.trim()
+  result = { value: param_cbi_endpoint.trim() }
 EOS
 end
 

--- a/operational/flexera/cco/rbd_from_csv_azure_storage/CHANGELOG.md
+++ b/operational/flexera/cco/rbd_from_csv_azure_storage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.6
+
+- Fixed a bug introduced in v0.1.5 where the policy would fail to evaluate with an "invalid argument in join" error due to how the Azure storage account and container parameters were sanitized.
+
 ## v0.1.5
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/operational/flexera/cco/rbd_from_csv_azure_storage/flexera_rbd_from_csv_azure_storage.pt
+++ b/operational/flexera/cco/rbd_from_csv_azure_storage/flexera_rbd_from_csv_azure_storage.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "daily"
 info(
-  version: "0.1.5",
+  version: "0.1.6",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Rule-Based Dimensions",
@@ -129,7 +129,7 @@ script "js_azure_container", type: "javascript" do
   parameters "param_azure_container"
   result "result"
   code <<-'EOS'
-  result = param_azure_container.trim()
+  result = { value: param_azure_container.trim() }
 EOS
 end
 
@@ -153,7 +153,7 @@ script "js_azure_storage_account", type: "javascript" do
   parameters "param_azure_storage_account"
   result "result"
   code <<-'EOS'
-  result = param_azure_storage_account.trim()
+  result = { value: param_azure_storage_account.trim() }
 EOS
 end
 
@@ -208,8 +208,8 @@ datasource "ds_azure_list_blobs" do
   request do
     auth $auth_azure_storage
     pagination $pagination_azure_xml
-    host join([$ds_azure_storage_account, ".blob.core.windows.net"])
-    path join(["/", $ds_azure_container])
+    host join([val($ds_azure_storage_account, "value"), ".blob.core.windows.net"])
+    path join(["/", val($ds_azure_container, "value")])
     query "restype", "container"
     query "comp", "list"
     query "prefix", $ds_azure_file_prefix
@@ -264,8 +264,8 @@ end
 datasource "ds_csv_raw" do
   request do
     auth $auth_azure_storage
-    host join([$ds_azure_storage_account, ".blob.core.windows.net"])
-    path join(["/", $ds_azure_container, "/", val($ds_csv_file_selected, "blob_name")])
+    host join([val($ds_azure_storage_account, "value"), ".blob.core.windows.net"])
+    path join(["/", val($ds_azure_container, "value"), "/", val($ds_csv_file_selected, "blob_name")])
     header "User-Agent", "RS Policies"
     header "x-ms-version", "2018-03-28"
   end

--- a/operational/flexera/cco/rbd_from_csv_google_storage/CHANGELOG.md
+++ b/operational/flexera/cco/rbd_from_csv_google_storage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.6
+
+- Fixed a bug introduced in v0.1.5 where the policy would fail to evaluate with an "invalid argument in join" error due to how the Google Cloud Storage bucket parameter was sanitized.
+
 ## v0.1.5
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/operational/flexera/cco/rbd_from_csv_google_storage/flexera_rbd_from_csv_google_storage.pt
+++ b/operational/flexera/cco/rbd_from_csv_google_storage/flexera_rbd_from_csv_google_storage.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "daily"
 info(
-  version: "0.1.5",
+  version: "0.1.6",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Rule-Based Dimensions",
@@ -121,7 +121,7 @@ script "js_gcs_bucket", type: "javascript" do
   parameters "param_gcs_bucket"
   result "result"
   code <<-'EOS'
-  result = param_gcs_bucket.trim()
+  result = { value: param_gcs_bucket.trim() }
 EOS
 end
 
@@ -189,7 +189,7 @@ datasource "ds_gcs_list_objects" do
     auth $auth_google
     pagination $pagination_google
     host "storage.googleapis.com"
-    path join(["/storage/v1/b/", $ds_gcs_bucket, "/o"])
+    path join(["/storage/v1/b/", val($ds_gcs_bucket, "value"), "/o"])
     query "prefix", $ds_gcs_file_prefix
     header "User-Agent", "RS Policies"
     ignore_status [403, 404]
@@ -242,7 +242,7 @@ datasource "ds_csv_raw" do
   request do
     auth $auth_google
     host "storage.googleapis.com"
-    path join(["/storage/v1/b/", $ds_gcs_bucket, "/o/", val($ds_csv_file_selected, "object_name")])
+    path join(["/storage/v1/b/", val($ds_gcs_bucket, "value"), "/o/", val($ds_csv_file_selected, "object_name")])
     query "alt", "media"
     header "User-Agent", "RS Policies"
   end

--- a/operational/flexera/cco/rbd_to_child_orgs/CHANGELOG.md
+++ b/operational/flexera/cco/rbd_to_child_orgs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.4
+
+- Fixed a bug introduced in v0.1.3 where the policy would fail to evaluate with an "invalid argument in join" error due to how the effective date parameter was sanitized.
+
 ## v0.1.3
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/operational/flexera/cco/rbd_to_child_orgs/flexera_rbd_to_child_orgs.pt
+++ b/operational/flexera/cco/rbd_to_child_orgs/flexera_rbd_to_child_orgs.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "daily"
 info(
-  version: "0.1.3",
+  version: "0.1.4",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Rule-Based Dimensions",
@@ -68,7 +68,7 @@ script "js_effective_date_input", type: "javascript" do
   parameters "param_effective_date"
   result "result"
   code <<-'EOS'
-  result = param_effective_date.trim()
+  result = { value: param_effective_date.trim() }
 EOS
 end
 
@@ -574,7 +574,7 @@ datasource "ds_child_existing_selected_rbds_with_rules" do
   request do
     auth $auth_flexera
     host val($ds_flexera_api_hosts, "flexera")
-    path join(["/finops-customizations/v1/orgs/", val(iter_item, "org_id"), "/rule-based-dimensions/", val(iter_item, "id"), "/rules/", $ds_effective_date_input])
+    path join(["/finops-customizations/v1/orgs/", val(iter_item, "org_id"), "/rule-based-dimensions/", val(iter_item, "id"), "/rules/", val($ds_effective_date_input, "value")])
     ignore_status [400, 401, 403, 404, 429]
   end
   result do

--- a/operational/flexera/fnms/schedule_fnms_reports/CHANGELOG.md
+++ b/operational/flexera/fnms/schedule_fnms_reports/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2.8
+
+- Fixed a bug introduced in v3.2.7 where the policy would fail to evaluate with an "invalid argument in join" error due to how the report ID parameter was sanitized.
+
 ## v3.2.7
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/operational/flexera/fnms/schedule_fnms_reports/schedule_fnms_report.pt
+++ b/operational/flexera/fnms/schedule_fnms_reports/schedule_fnms_report.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "3.2.7",
+  version: "3.2.8",
   provider: "Flexera",
   service: "FlexNet Manager",
   policy_set: "Schedule Report",
@@ -76,7 +76,7 @@ script "js_report_id", type: "javascript" do
   parameters "param_report_id"
   result "result"
   code <<-'EOS'
-  result = param_report_id.trim()
+  result = { value: param_report_id.trim() }
 EOS
 end
 
@@ -90,7 +90,7 @@ datasource "ds_itam_report_header" do
     path "/ManageSoftServices/ComplianceAPIService/ComplianceAPIService.asmx"
     query "orgid", to_s(rs_org_id) # Must convert rs_org_id to string otherwise query param does not get set
     header "Content-Type", "text/xml;charset=utf-8"
-    body join(['<?xml version="1.0" encoding="utf-8"?>', '<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:tem="http://tempuri.org/">', '  <soap:Body>', '    <tem:GetCustomView>', '      <tem:customViewID>', $ds_report_id, '</tem:customViewID>', '      <tem:rowLimit>100000</tem:rowLimit>', '   </tem:GetCustomView>', '  </soap:Body>', '</soap:Envelope>'])
+    body join(['<?xml version="1.0" encoding="utf-8"?>', '<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:tem="http://tempuri.org/">', '  <soap:Body>', '    <tem:GetCustomView>', '      <tem:customViewID>', val($ds_report_id, "value"), '</tem:customViewID>', '      <tem:rowLimit>100000</tem:rowLimit>', '   </tem:GetCustomView>', '  </soap:Body>', '</soap:Envelope>'])
   end
   result do
     encoding "xml"
@@ -111,7 +111,7 @@ datasource "ds_itam_report" do
     path "/ManageSoftServices/ComplianceAPIService/ComplianceAPIService.asmx"
     query "orgid", to_s(rs_org_id) # Must convert rs_org_id to string otherwise query param does not get set
     header "Content-Type", "text/xml;charset=utf-8"
-    body join(['<?xml version="1.0" encoding="utf-8"?>', '<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:tem="http://tempuri.org/">', '  <soap:Body>', '    <tem:GetCustomView>', '      <tem:customViewID>', $ds_report_id, '</tem:customViewID>', '      <tem:rowLimit>100000</tem:rowLimit>', '   </tem:GetCustomView>', '  </soap:Body>', '</soap:Envelope>'])
+    body join(['<?xml version="1.0" encoding="utf-8"?>', '<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:tem="http://tempuri.org/">', '  <soap:Body>', '    <tem:GetCustomView>', '      <tem:customViewID>', val($ds_report_id, "value"), '</tem:customViewID>', '      <tem:rowLimit>100000</tem:rowLimit>', '   </tem:GetCustomView>', '  </soap:Body>', '</soap:Envelope>'])
   end
   result do
     encoding "text"

--- a/operational/flexera/itam/schedule_itam_report/CHANGELOG.md
+++ b/operational/flexera/itam/schedule_itam_report/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.9
+
+- Fixed a bug introduced in v0.2.8 where the policy would fail to evaluate with an "invalid argument in join" error due to how the report ID parameter was sanitized.
+
 ## v0.2.8
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/operational/flexera/itam/schedule_itam_report/schedule_itam_report.pt
+++ b/operational/flexera/itam/schedule_itam_report/schedule_itam_report.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "0.2.8",
+  version: "0.2.9",
   provider: "Flexera",
   service: "IT Asset Management",
   policy_set: "Schedule Report",
@@ -90,7 +90,7 @@ script "js_report_id", type: "javascript" do
   parameters "param_report_id"
   result "result"
   code <<-'EOS'
-  result = param_report_id.trim()
+  result = { value: param_report_id.trim() }
 EOS
 end
 
@@ -147,7 +147,7 @@ datasource "ds_fnms_reports" do
     auth $auth_flexera
     pagination $pagination_itam
     host val($ds_flexera_api_hosts, "flexera")
-    path join(["/fnms/v1/orgs/", rs_org_id, "/reports/", $ds_report_id, "/execute"])
+    path join(["/fnms/v1/orgs/", rs_org_id, "/reports/", val($ds_report_id, "value"), "/execute"])
     header "Content-Type","application/json"
     header "User-Agent", "RS Policies"
   end

--- a/operational/oracle/tag_cardinality/CHANGELOG.md
+++ b/operational/oracle/tag_cardinality/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.3
+
+- Fixed a bug introduced in v0.1.2 where the policy would fail to evaluate with an "invalid argument in join" error due to how the primary region and root compartment parameters were sanitized.
+
 ## v0.1.2
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/operational/oracle/tag_cardinality/oracle_tag_cardinality.pt
+++ b/operational/oracle/tag_cardinality/oracle_tag_cardinality.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "0.1.2",
+  version: "0.1.3",
   provider: "Oracle",
   service: "Tags",
   policy_set: "Tag Cardinality",
@@ -116,7 +116,7 @@ script "js_primary_region", type: "javascript" do
   parameters "param_primary_region"
   result "result"
   code <<-'EOS'
-  result = param_primary_region.trim()
+  result = { value: param_primary_region.trim() }
 EOS
 end
 
@@ -128,7 +128,7 @@ script "js_root_compartment", type: "javascript" do
   parameters "param_root_compartment"
   result "result"
   code <<-'EOS'
-  result = param_root_compartment.trim()
+  result = { value: param_root_compartment.trim() }
 EOS
 end
 
@@ -136,7 +136,7 @@ datasource "ds_oci_compartments" do
   request do
     auth $auth_oracle
     pagination $pagination_oracle_identity
-    host join(["identity.", $ds_primary_region, ".oci.oraclecloud.com"])
+    host join(["identity.", val($ds_primary_region, "value"), ".oci.oraclecloud.com"])
     path "/20160918/compartments"
     query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"
@@ -163,7 +163,7 @@ datasource "ds_oci_tag_namespaces" do
   request do
     auth $auth_oracle
     pagination $pagination_oracle_identity
-    host join(["identity.", $ds_primary_region, ".oci.oraclecloud.com"])
+    host join(["identity.", val($ds_primary_region, "value"), ".oci.oraclecloud.com"])
     path "/20160918/tagNamespaces"
     query "compartmentId", $ds_root_compartment
     query "compartmentIdInSubtree", "true"
@@ -197,8 +197,8 @@ datasource "ds_oci_regions" do
   request do
     auth $auth_oracle
     pagination $pagination_oracle_identity
-    host join(["identity.", $ds_primary_region, ".oci.oraclecloud.com"])
-    path join(["/20160918/tenancies/", $ds_root_compartment, "/regionSubscriptions"])
+    host join(["identity.", val($ds_primary_region, "value"), ".oci.oraclecloud.com"])
+    path join(["/20160918/tenancies/", val($ds_root_compartment, "value"), "/regionSubscriptions"])
     header "User-Agent", "RS Policies"
   end
   result do

--- a/saas/okta/inactive_users/CHANGELOG.md
+++ b/saas/okta/inactive_users/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.3
+
+- Fixed a bug introduced in v3.1.2 where the policy would fail to evaluate with an "invalid argument in join" error due to how the Okta organization name parameter was sanitized.
+
 ## v3.1.2
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/saas/okta/inactive_users/okta_inactive_users.pt
+++ b/saas/okta/inactive_users/okta_inactive_users.pt
@@ -8,7 +8,7 @@ category "SaaS Management"
 severity "medium"
 default_frequency "weekly"
 info(
-  version: "3.1.2",
+  version: "3.1.3",
   provider: "Okta",
   service: "",
   policy_set: "",
@@ -101,7 +101,7 @@ script "js_okta_org_name", type: "javascript" do
   parameters "param_okta_org_name"
   result "result"
   code <<-'EOS'
-  result = param_okta_org_name.trim()
+  result = { value: param_okta_org_name.trim() }
 EOS
 end
 
@@ -165,7 +165,7 @@ end
 datasource "ds_okta_users" do
   request do
     auth $auth_okta
-    host join([$ds_okta_org_name, ".okta.com"])
+    host join([val($ds_okta_org_name, "value"), ".okta.com"])
     path "/api/v1/users"
     query "filter", 'status eq "ACTIVE"'
     query "limit", "200"

--- a/saas/servicenow/inactive_approvers/CHANGELOG.md
+++ b/saas/servicenow/inactive_approvers/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.3
+
+- Fixed a bug introduced in v3.1.2 where the policy would fail to evaluate with an "invalid argument in join" error due to how the ServiceNow instance name parameter was sanitized.
+
 ## v3.1.2
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/saas/servicenow/inactive_approvers/servicenow_inactive_approvers.pt
+++ b/saas/servicenow/inactive_approvers/servicenow_inactive_approvers.pt
@@ -8,7 +8,7 @@ category "SaaS Management"
 severity "medium"
 default_frequency "weekly"
 info(
-  version: "3.1.2",
+  version: "3.1.3",
   provider: "ServiceNow",
   service: "",
   policy_set: "",
@@ -102,7 +102,7 @@ script "js_servicenow_name", type: "javascript" do
   parameters "param_servicenow_name"
   result "result"
   code <<-'EOS'
-  result = param_servicenow_name.trim()
+  result = { value: param_servicenow_name.trim() }
 EOS
 end
 
@@ -198,7 +198,7 @@ datasource "ds_servicenow_user_roles" do
   iterate $ds_servicenow_roles
   request do
     auth $auth_servicenow
-    host join([$ds_servicenow_name, ".service-now.com"])
+    host join([val($ds_servicenow_name, "value"), ".service-now.com"])
     path "/api/now/table/sys_user_has_role"
     query "sysparm_fields", "role,sys_id,inherited,user"
     query "sysparm_query", join(["role=", val(iter_item, "sys_id")])
@@ -219,7 +219,7 @@ datasource "ds_servicenow_approver_users" do
   iterate $ds_servicenow_user_roles
   request do
     auth $auth_servicenow
-    host join([$ds_servicenow_name, ".service-now.com"])
+    host join([val($ds_servicenow_name, "value"), ".service-now.com"])
     path "/api/now/table/sys_user"
     query "sysparm_query", join(["sys_id=", val(iter_item, "user_id")])
     query "sysparm_fields", "sys_id,name,user_name,last_login_time,vip,email"
@@ -244,7 +244,7 @@ datasource "ds_approvals" do
   iterate $ds_servicenow_approver_users
   request do
     auth $auth_servicenow
-    host join([$ds_servicenow_name, ".service-now.com"])
+    host join([val($ds_servicenow_name, "value"), ".service-now.com"])
     path "/api/now/table/sysapproval_approver"
     query "sysparm_query", join(["sys_updated_by=", val(iter_item, "username")])
     query "sysparm_fields", "approver,sys_updated_on,state,sys_updated_by"

--- a/tools/catalog_management/policy_sync/CHANGELOG.md
+++ b/tools/catalog_management/policy_sync/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.0.9
+
+- Fixed a bug introduced in v3.0.8 where the policy would fail to evaluate with an "invalid argument in join" error due to how the GitHub organization, repository, branch, and active policy list path parameters were sanitized.
+
 ## v3.0.8
 
 - Trimmed leading/trailing whitespace from the `GitHub Organization Name`, `GitHub Repository Name`, `GitHub Branch Name`, and `Active Policy JSON Path` parameters to prevent accidental whitespace from causing GitHub requests to fail.

--- a/tools/catalog_management/policy_sync/policy_sync.pt
+++ b/tools/catalog_management/policy_sync/policy_sync.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "15 minutes"
 info(
-  version: "3.0.8",
+  version: "3.0.9",
   provider: "Flexera",
   service: "Policy Engine",
   policy_set: "",
@@ -94,7 +94,7 @@ script "js_github_active_list_path", type: "javascript" do
   code <<-'EOS'
   // Remove any leading/trailing whitespace the user may have accidentally entered
   param_github_active_list_path = param_github_active_list_path.trim()
-  result = param_github_active_list_path.trim()
+  result = { value: param_github_active_list_path.trim() }
 EOS
 end
 
@@ -108,7 +108,7 @@ script "js_github_branch", type: "javascript" do
   code <<-'EOS'
   // Remove any leading/trailing whitespace the user may have accidentally entered
   param_github_branch = param_github_branch.trim()
-  result = param_github_branch.trim()
+  result = { value: param_github_branch.trim() }
 EOS
 end
 
@@ -122,7 +122,7 @@ script "js_github_org", type: "javascript" do
   code <<-'EOS'
   // Remove any leading/trailing whitespace the user may have accidentally entered
   param_github_org = param_github_org.trim()
-  result = param_github_org.trim()
+  result = { value: param_github_org.trim() }
 EOS
 end
 
@@ -136,7 +136,7 @@ script "js_github_repo", type: "javascript" do
   code <<-'EOS'
   // Remove any leading/trailing whitespace the user may have accidentally entered
   param_github_repo = param_github_repo.trim()
-  result = param_github_repo.trim()
+  result = { value: param_github_repo.trim() }
 EOS
 end
 
@@ -200,7 +200,7 @@ end
 datasource "ds_active_policy_list" do
   request do
     host "raw.githubusercontent.com"
-    path join([$ds_github_org, "/", $ds_github_repo, "/", $ds_github_branch, "/", $ds_github_active_list_path])
+    path join([val($ds_github_org, "value"), "/", val($ds_github_repo, "value"), "/", val($ds_github_branch, "value"), "/", val($ds_github_active_list_path, "value")])
     header "User-Agent", "RS Policies"
   end
   result do


### PR DESCRIPTION
### Description

Fixes an issue accidentally introduced with a previous PR in a handful of PRs because datasources can't be referenced directly in a join() statement even if they contain a raw string.

Also updates the policy dev agent to fix this issue going forward with automated changes.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
