### PR TITLE
POL-1833 Savings Plan Policies: Parameter Fix

### DIFF
--- a/cost/aws/savings_plan/expiration/CHANGELOG.md
+++ b/cost/aws/savings_plan/expiration/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2.1
+
+- Added `Account Number` parameter to support meta policies. Basic functionality unchanged.
+
 ## v3.2.0
 
 - Added support for meta parent policy. Basic functionality unchanged.

--- a/cost/aws/savings_plan/expiration/README.md
+++ b/cost/aws/savings_plan/expiration/README.md
@@ -9,6 +9,7 @@ This policy template reports on any AWS Savings Plans that have expired or are a
 This policy template has the following input parameters:
 
 - *Email Addresses* - enter the number of days you want before the Savings Plan expires.
+- *Account Number* - The Account number for use with the AWS STS Cross Account Role. Leave blank when using AWS IAM Access key and secret. It only needs to be passed when the desired AWS account is different than the one associated with the Flexera One credential. [More information is available in our documentation.](https://docs.flexera.com/flexera-one/automation/automation-administration/managing-credentials-for-policy-access-to-external-systems/provider-specific-credentials#aws)
 - *Days Until Expiration* - The number of days until expiration to include a Savings Plan in the report. Set to '0' to only report expired Savings Plans.
 - *Attach CSV To Incident Email* - Whether or not to attach the results as a CSV file to the incident email.
 - *Incident Table Rows for Email Body (#)* - The number of results to include in the incident table in the incident email. Set to '0' to not show an incident table at all, and '100000' to include all results. Does not impact attached CSV files or the incident as presented in Flexera One.

--- a/cost/aws/savings_plan/expiration/aws_savings_plan_expiration.pt
+++ b/cost/aws/savings_plan/expiration/aws_savings_plan_expiration.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "medium"
 default_frequency "daily"
 info(
-  version: "3.2.0",
+  version: "3.2.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Savings Plans",
@@ -25,6 +25,14 @@ parameter "param_email" do
   label "Email Addresses"
   description "A list of email addresses to notify."
   default []
+end
+
+parameter "param_aws_account_number" do
+  type "string"
+  category "Policy Settings"
+  label "Account Number"
+  description "Leave blank; this is for automated use with Meta Policies. See README for more details."
+  default ""
 end
 
 parameter "param_days_expiration" do

--- a/cost/aws/savings_plan/expiration/aws_savings_plan_expiration_meta_parent.pt
+++ b/cost/aws/savings_plan/expiration/aws_savings_plan_expiration_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "3.2.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.2.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/savings_plan/utilization/CHANGELOG.md
+++ b/cost/aws/savings_plan/utilization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.2.1
+
+- Added `Account Number` parameter to support meta policies. Basic functionality unchanged.
+
 ## v4.2.0
 
 - Added support for meta parent policy. Basic functionality unchanged.

--- a/cost/aws/savings_plan/utilization/README.md
+++ b/cost/aws/savings_plan/utilization/README.md
@@ -12,6 +12,7 @@ This Policy Template leverages the [AWS Savings Plans Utilization API](https://d
 ## Input Parameters
 
 - *Email Addresses* - Email addresses of the recipients you wish to notify when new incidents are created.
+- *Account Number* - The Account number for use with the AWS STS Cross Account Role. Leave blank when using AWS IAM Access key and secret. It only needs to be passed when the desired AWS account is different than the one associated with the Flexera One credential. [More information is available in our documentation.](https://docs.flexera.com/flexera-one/automation/automation-administration/managing-credentials-for-policy-access-to-external-systems/provider-specific-credentials#aws)
 - *Look Back Period (Days)* - Specify the number of days of past usage to analyze.
 - *Utilization Threshold* - Specify the minimum Savings Plan Utilization threshold as a percentage that should result in an alert.
 - *Savings Plan ARNs* - The unique Amazon Resource Names (ARNs) for particular Savings Plans to report on. Leave blank to report on all Savings Plans.

--- a/cost/aws/savings_plan/utilization/aws_savings_plan_utilization.pt
+++ b/cost/aws/savings_plan/utilization/aws_savings_plan_utilization.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "Cost"
 default_frequency "monthly"
 info(
-  version: "4.2.0",
+  version: "4.2.1",
   provider: "AWS",
   service: "Compute",
   policy_set: "Savings Plans",
@@ -25,6 +25,14 @@ parameter "param_email" do
   label "Email Addresses"
   description "A list of email addresses to notify."
   default []
+end
+
+parameter "param_aws_account_number" do
+  type "string"
+  category "Policy Settings"
+  label "Account Number"
+  description "Leave blank; this is for automated use with Meta Policies. See README for more details."
+  default ""
 end
 
 parameter "param_savings_threshold" do

--- a/cost/aws/savings_plan/utilization/aws_savings_plan_utilization_meta_parent.pt
+++ b/cost/aws/savings_plan/utilization/aws_savings_plan_utilization_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "4.2.0", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.2.1", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"


### PR DESCRIPTION
### Description

Two policy templates recently had meta parent functionality enabled but were missing the AWS account number parameter. This PR fixes that.

### Link to Example Applied Policy

<!-- URL to the Applied Policy that was used for dev/testing below -->
<!-- This can be helpful for a reviewer to validate the changes proposed resulted in the expected behavior. If you do not have access or ability to apply the policy template, please mention this in your PR description.-->

### Contribution Check List

- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
