### PR TITLE
POL-1836 Currency Conversion Fixes

### DIFF
--- a/automation/flexera/spot/container_cost_visibility/CHANGELOG.md
+++ b/automation/flexera/spot/container_cost_visibility/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.6
+
+- Fixed an issue where applying adjustments could fail with a "415 Unsupported Media Type" error due to the casing of the `Content-Type` header.
+
 ## v0.1.5
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/automation/flexera/spot/container_cost_visibility/flexera_spot_container_cost_visibility.pt
+++ b/automation/flexera/spot/container_cost_visibility/flexera_spot_container_cost_visibility.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "monthly"
 info(
-  version: "0.1.5",
+  version: "0.1.6",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Container Cost Visibility",
@@ -654,7 +654,7 @@ datasource "ds_apply_adjustments" do
     verb "PUT"
     host rs_optima_host
     path join(["/bill-analysis/orgs/", rs_org_id, "/adjustments/"])
-    header "content-type", "application/json"
+    header "Content-Type", "application/json"
     header "User-Agent", "RS Policies"
     body val(iter_item, "payload")
   end

--- a/cost/flexera/cco/currency_conversion/CHANGELOG.md
+++ b/cost/flexera/cco/currency_conversion/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v5.1.6
 
 - Fixed an issue where applying adjustments could fail with a "415 Unsupported Media Type" error due to the casing of the `Content-Type` header.
-- Fixed an issue where the incident name showed "<no value>" instead of the currency codes.
+- Fixed an issue where the incident name showed `<no value>` instead of the currency codes.
 - Fixed an issue where the incident detail showed "[object Object]" instead of the month for each exchange rate.
 
 ## v5.1.5

--- a/cost/flexera/cco/currency_conversion/CHANGELOG.md
+++ b/cost/flexera/cco/currency_conversion/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed an issue where applying adjustments could fail with a "415 Unsupported Media Type" error due to the casing of the `Content-Type` header.
 - Fixed an issue where the incident name showed "<no value>" instead of the currency codes.
+- Fixed an issue where the incident detail showed "[object Object]" instead of the month for each exchange rate.
 
 ## v5.1.5
 

--- a/cost/flexera/cco/currency_conversion/CHANGELOG.md
+++ b/cost/flexera/cco/currency_conversion/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v5.1.6
+
+- Fixed an issue where applying adjustments could fail with a "415 Unsupported Media Type" error due to the casing of the `Content-Type` header.
+- Fixed an issue where the incident name showed "<no value>" instead of the currency codes.
+
 ## v5.1.5
 
 - Fixed an issue where the policy could fail with a "must be a string" error when requesting exchange rates due to how the currency parameters were sanitized.

--- a/cost/flexera/cco/currency_conversion/currency_conversion.pt
+++ b/cost/flexera/cco/currency_conversion/currency_conversion.pt
@@ -8,7 +8,7 @@ severity "low"
 default_frequency "monthly"
 category "Cost"
 info(
-  version: "5.1.5",
+  version: "5.1.6",
   provider: "Flexera",
   service: "Cloud Cost Optimization",
   policy_set: "Cloud Cost Optimization",
@@ -563,7 +563,7 @@ datasource "ds_new_adjustments" do
     verb "PUT"
     host rs_optima_host
     path join(["/bill-analysis/orgs/", rs_org_id, "/adjustments/"])
-    header "content-type", "application/json"
+    header "Content-Type", "application/json"
     header "User-Agent", "RS Policies"
     body val(iter_item, "list")
   end
@@ -580,7 +580,7 @@ end
 
 policy "pol_currency_conversion" do
   validate_each $ds_new_adjustments do
-    summary_template "Currency Conversion - {{ parameters.ds_currency_from.value }} to {{ parameters.ds_currency_to.value }} - {{ with index data 0 }}{{ .dimension }}{{ end }}"
+    summary_template "Currency Conversion - {{ parameters.param_currency_from }} to {{ parameters.param_currency_to }} - {{ with index data 0 }}{{ .dimension }}{{ end }}"
     detail_template "{{ with index data 0 }}{{ .message }}{{ end }}"
     check eq(0, 1)
   end

--- a/cost/flexera/cco/currency_conversion/currency_conversion.pt
+++ b/cost/flexera/cco/currency_conversion/currency_conversion.pt
@@ -483,7 +483,7 @@ script "js_updated_adjustments", type: "javascript" do
       }
 
       // Store rule information for incident
-      message_rules.push(date + ": " + conversion_rate.toString())
+      message_rules.push(date['current'] + ": " + conversion_rate.toString())
 
       // Incorporate the new rule into the existing rule set if necessary
       adjustment_list = [ currency_conversion_rule ]


### PR DESCRIPTION
### Description

- Fixed `415 Unsupported Media Type` when applying adjustments - lowercase `content-type` header didn't override the engine's default `text/plain`, so both were sent. Same fix applied to Container Cost Visibility (unverified, but identical code).
- Fixed incident name showing `<no value>` instead of the currency codes - `summary_template` referenced a datasource via the `parameters` namespace.
- Fixed incident detail showing `[object Object]` instead of the month - concatenated the month loop variable instead of `date['current']`.

Versions bumped: Currency Conversion 5.1.6, Container Cost Visibility 0.1.6.

### Link to Example Applied Policy

<!-- your applied policy URL -->
https://app.flexera.eu/orgs/34134/automation/applied-policies/projects/135606?policyId=6aa2a6b984ca1cca92a58672
https://app.flexera.com/orgs/30105/automation/applied-policies/projects/133807?policyId=6aa2a90cd7c30be12dc6140f

### Contribution Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD

### Other Notes

Potential Platform question: whether Optima's media-type validation for the Adjustments API (or more broadly) has changed recently.