### PR TITLE
POL-1841 Content-Type Update

### DIFF
--- a/.github/agents/policy-dev.agent.md
+++ b/.github/agents/policy-dev.agent.md
@@ -896,6 +896,10 @@ More broadly, avoid all non-ASCII punctuation and special Unicode characters in 
 
 This rule also applies to all other output you produce: READMEs, CHANGELOGs, and any other files in this repository should not contain em dashes or other non-ASCII punctuation.
 
+### Content-Type Header Casing
+
+**Always write the `Content-Type` header with this exact casing - never `content-type`, `content-Type`, or `Content-type`.** This applies everywhere a `Content-Type` header key appears in a `.pt` file: `header "Content-Type", ...` declarations in `datasource request` blocks, `headers: { "Content-Type": ... }` maps passed to `http_request` (and similar) calls in Cloud Workflow `define` blocks, and any JSON/JavaScript object literal that sets this header. The policy engine defaults to a `Content-Type` of `text/plain`, and that default is only correctly masked when the header key matches the exact `Content-Type` casing - `content-type` (or any other casing) does not reliably override it. When writing new templates or editing existing ones, check for and correct any lowercase or mis-cased `content-type` header keys you encounter, even outside the immediate scope of the requested change.
+
 ### No Alignment Padding
 
 Do **not** pad field names or object keys with extra spaces to visually align values into columns. Use a single space after the field name / colon only.

--- a/compliance/aws/ecs_unused/CHANGELOG.md
+++ b/compliance/aws/ecs_unused/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.2.9
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v4.2.8
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/compliance/aws/ecs_unused/aws_unused_ecs_clusters.pt
+++ b/compliance/aws/ecs_unused/aws_unused_ecs_clusters.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Compliance"
 default_frequency "weekly"
 info(
-  version: "4.2.8",
+  version: "4.2.9",
   provider: "AWS",
   service: "Compute",
   policy_set: "Unused Containers",
@@ -791,7 +791,7 @@ define delete_cluster($instance) return $response do
     href: $href,
     headers: {
       "x-amz-target": "AmazonEC2ContainerServiceV20141113.DeleteCluster",
-      "content-type": "application/x-amz-json-1.1"
+      "Content-Type": "application/x-amz-json-1.1"
     },
     body: {
       "cluster": $instance["id"]

--- a/compliance/aws/ecs_unused/aws_unused_ecs_clusters_meta_parent.pt
+++ b/compliance/aws/ecs_unused/aws_unused_ecs_clusters_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "4.2.8", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.2.9", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/compliance/aws/untagged_resources/CHANGELOG.md
+++ b/compliance/aws/untagged_resources/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.0.6
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v6.0.5
 
 - Fixed an issue where the policy could fail when account-level tag data was missing for the AWS account.

--- a/compliance/aws/untagged_resources/aws_untagged_resources.pt
+++ b/compliance/aws/untagged_resources/aws_untagged_resources.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.0.5",
+  version: "6.0.6",
   provider: "AWS",
   service: "Compute",
   policy_set: "Untagged Resources",
@@ -419,7 +419,7 @@ datasource "ds_recommendations_all" do
     path join(["/recommendations/orgs/", rs_org_id, "/recommendations"])
     query "view", "extended"
     header "Api-Version", "1.0"
-    header "content-type", "application/json"
+    header "Content-Type", "application/json"
   end
   result do
     encoding "json"
@@ -1131,7 +1131,7 @@ define tag_resource($resource, $param_tags_to_add) return $response do
     href: $href,
     headers:{
       "X-Amz-Target": "ResourceGroupsTaggingAPI_20170126.TagResources",
-      "content-type": "application/x-amz-json-1.1"
+      "Content-Type": "application/x-amz-json-1.1"
     },
     body: {
       "ResourceARNList": [ $resource["resourceID"] ],
@@ -1174,7 +1174,7 @@ define tag_account($resource, $param_tags_to_add) return $response do
     href: $href,
     headers:{
       "X-Amz-Target": "AWSOrganizationsV20161128.TagResource",
-      "content-type": "application/x-amz-json-1.1"
+      "Content-Type": "application/x-amz-json-1.1"
     },
     body: {
       "ResourceId": $resource["resourceID"],

--- a/compliance/aws/untagged_resources/aws_untagged_resources_meta_parent.pt
+++ b/compliance/aws/untagged_resources/aws_untagged_resources_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "6.0.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.0.6", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/compliance/google/long_stopped_instances/CHANGELOG.md
+++ b/compliance/google/long_stopped_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.3.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v4.3.2
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/compliance/google/long_stopped_instances/google_long_stopped_instances.pt
+++ b/compliance/google/long_stopped_instances/google_long_stopped_instances.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.3.2",
+  version: "4.3.3",
   provider: "Google",
   service: "Compute",
   policy_set: "Long Stopped Instances",
@@ -866,7 +866,7 @@ define delete_instance($instance) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 

--- a/compliance/google/long_stopped_instances/google_long_stopped_instances_meta_parent.pt
+++ b/compliance/google/long_stopped_instances/google_long_stopped_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "4.3.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.3.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/compliance/google/unlabeled_resources/CHANGELOG.md
+++ b/compliance/google/unlabeled_resources/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.0.4
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v5.0.3
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/compliance/google/unlabeled_resources/unlabeled_resources.pt
+++ b/compliance/google/unlabeled_resources/unlabeled_resources.pt
@@ -8,7 +8,7 @@ category "Compliance"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.0.3",
+  version: "5.0.4",
   provider: "Google",
   service: "Compute",
   policy_set: "Untagged Resources",
@@ -1187,7 +1187,7 @@ define label_bucket($resource, $param_labels_to_add) return $response do
     url: $url,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: {
       "labels": $labels_to_add
@@ -1225,7 +1225,7 @@ define label_project($resource, $param_labels_to_add) return $response do
     url: $url,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: {
       "labels": $labels_to_add
@@ -1263,7 +1263,7 @@ define label_resource($resource, $param_labels_to_add) return $response do
     url: $url,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: {
       "labels": $labels_to_add,

--- a/compliance/google/unlabeled_resources/unlabeled_resources_meta_parent.pt
+++ b/compliance/google/unlabeled_resources/unlabeled_resources_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "5.0.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.0.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/aws/object_storage_optimization/CHANGELOG.md
+++ b/cost/aws/object_storage_optimization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.0.16
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v4.0.15
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "4.0.15",
+  version: "4.0.16",
   provider: "AWS",
   service: "Storage",
   policy_set: "Object Store Optimization",
@@ -738,7 +738,7 @@ define update_object($object) return $response do
     href: $href,
     host: $host,
     headers: {
-      'content-type': 'application/x-amz-json-1.1',
+      'Content-Type': 'application/x-amz-json-1.1',
       'x-amz-copy-source': $copy_source,
       'x-amz-storage-class': $storage_class
     }

--- a/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
+++ b/cost/aws/object_storage_optimization/aws_object_storage_optimization_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "4.0.15", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.0.16", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "true",
   hide_skip_approvals: "true"

--- a/cost/aws/schedule_instance/CHANGELOG.md
+++ b/cost/aws/schedule_instance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v8.1.4
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v8.1.3
 
 - Fixed an issue where the policy could fail with a "must be a string" error when filtering instances by the schedule tag key due to how the tag key parameter was sanitized.

--- a/cost/aws/schedule_instance/aws_schedule_instance.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "15 minutes"
 info(
-  version: "8.1.3",
+  version: "8.1.4",
   provider: "AWS",
   service: "Compute",
   policy_set: "Schedule Instance",
@@ -1982,7 +1982,7 @@ define window_active($start_hour, $start_minute, $start_rule, $stop_hour, $stop_
     verb: "post",
     href: $href,
     host: $host,
-    headers: { "content-type": "application/json" },
+    headers: { "Content-Type": "application/json" },
     body: {
       "start_hour": $start_hour,
       "start_minute": $start_minute,

--- a/cost/aws/schedule_instance/aws_schedule_instance_meta_parent.pt
+++ b/cost/aws/schedule_instance/aws_schedule_instance_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "AWS",
-  version: "8.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "8.1.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/blob_storage_optimization/CHANGELOG.md
+++ b/cost/azure/blob_storage_optimization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.2.5
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v4.2.4
 
 - Fixed an issue where Storage Account Tags could always show as blank in the incident output, even when the storage account had tags configured.

--- a/cost/azure/blob_storage_optimization/azure_blob_storage_optimization.pt
+++ b/cost/azure/blob_storage_optimization/azure_blob_storage_optimization.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.2.4",
+  version: "4.2.5",
   provider: "Azure",
   service: "Storage",
   policy_set: "Object Store Optimization",
@@ -891,7 +891,7 @@ define update_blob($blob) return $response do
     query_strings: { "comp": "tier" },
     headers: {
       "x-ms-version": "2019-02-02",
-      "content-type": "application/json",
+      "Content-Type": "application/json",
       "x-ms-access-tier": $blob['newResourceType']
     }
   )
@@ -938,7 +938,7 @@ define delete_blob($blob) return $response do
     host: $host,
     headers: {
       "x-ms-version": "2019-02-02",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 

--- a/cost/azure/blob_storage_optimization/azure_blob_storage_optimization_meta_parent.pt
+++ b/cost/azure/blob_storage_optimization/azure_blob_storage_optimization_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "4.2.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.2.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "true",
   hide_skip_approvals: "true"

--- a/cost/azure/blob_storage_optimization/azure_blob_storage_optimization_meta_parent_rg.pt
+++ b/cost/azure/blob_storage_optimization/azure_blob_storage_optimization_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "4.2.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.2.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "true",
   hide_skip_approvals: "true"

--- a/cost/azure/data_lake_optimization/CHANGELOG.md
+++ b/cost/azure/data_lake_optimization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.5
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v0.4.4
 
 - Fixed an issue where the tags for a storage account were never included in the incident output, even when the storage account had tags configured.

--- a/cost/azure/data_lake_optimization/data_lake_optimization.pt
+++ b/cost/azure/data_lake_optimization/data_lake_optimization.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "0.4.4",
+  version: "0.4.5",
   provider: "Azure",
   service: "Storage Accounts",
   policy_set: "Data Lake Optimization",
@@ -1122,7 +1122,7 @@ define update_blob($blob) return $response do
     query_strings: { "comp": "tier" },
     headers: {
       "x-ms-version": "2019-02-02",
-      "content-type": "application/json",
+      "Content-Type": "application/json",
       "x-ms-access-tier": $blob['newResourceType']
     }
   )
@@ -1169,7 +1169,7 @@ define delete_blob($blob) return $response do
     host: $host,
     headers: {
       "x-ms-version": "2019-02-02",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 

--- a/cost/azure/data_lake_optimization/data_lake_optimization_meta_parent.pt
+++ b/cost/azure/data_lake_optimization/data_lake_optimization_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.4.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.4.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/data_lake_optimization/data_lake_optimization_meta_parent_rg.pt
+++ b/cost/azure/data_lake_optimization/data_lake_optimization_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.4.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.4.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/hybrid_use_benefit/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.7.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v5.7.2
 
 - Fixed an issue where resource hourly cost could be invalid when billing data contained zero usage hours for a virtual machine.

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "5.7.2",
+  version: "5.7.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "Hybrid Use Benefit",
@@ -1166,7 +1166,7 @@ define license_instance($instance, $param_azure_endpoint) return $response do
     },
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: {
       "properties": {

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "5.7.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.7.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent_rg.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "5.7.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.7.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/hybrid_use_benefit_linux/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit_linux/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.6.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v5.6.2
 
 - Fixed an issue where the policy could fail to complete if currency conversion data was temporarily unavailable for the organization's currency.

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "5.6.2",
+  version: "5.6.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "Hybrid Use Benefit",
@@ -1148,7 +1148,7 @@ define license_instance($instance, $param_azure_endpoint) return $response do
     },
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: {
       "properties": {

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "5.6.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.6.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent_rg.pt
+++ b/cost/azure/hybrid_use_benefit_linux/ahub_linux_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "5.6.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.6.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/hybrid_use_benefit_sql/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit_sql/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.9.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v4.9.2
 
 - Fixed an issue where the policy could fail to filter results correctly when the resource group filter parameter was used, causing an error instead of a report.

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "daily"
 info(
-  version: "4.9.2",
+  version: "4.9.3",
   provider: "Azure",
   service: "SQL",
   policy_set: "Hybrid Use Benefit",
@@ -1431,7 +1431,7 @@ define license_vm($instance, $param_azure_endpoint) return $response do
     },
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: {
       "location": $instance['region'],
@@ -1470,7 +1470,7 @@ define license_elastic_pool($instance, $param_azure_endpoint) return $response d
     },
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: {
       "properties": {
@@ -1507,7 +1507,7 @@ define license_db($instance, $param_azure_endpoint) return $response do
     },
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: {
       "properties": {
@@ -1544,7 +1544,7 @@ define license_managed_instance($instance, $param_azure_endpoint) return $respon
     },
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: {
       "properties": {

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "4.9.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.9.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent_rg.pt
+++ b/cost/azure/hybrid_use_benefit_sql/ahub_sql_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "4.9.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.9.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/rightsize_managed_sql/CHANGELOG.md
+++ b/cost/azure/rightsize_managed_sql/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.7.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v0.7.2
 
 - Fixed an issue where the region filter could exclude or include the wrong SQL Managed Instances when a region allow/deny list was configured.

--- a/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql.pt
+++ b/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.7.2",
+  version: "0.7.3",
   provider: "Azure",
   service: "SQL",
   policy_set: "Rightsize Database Instances",
@@ -1373,7 +1373,7 @@ define downsize_instance($instance, $param_azure_endpoint) return $response do
     query_strings: { "api-version": "2021-02-01-preview" },
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: {
       "sku": {
@@ -1410,7 +1410,7 @@ define delete_instance($instance, $param_azure_endpoint) return $response do
     query_strings: { "api-version": "2021-02-01-preview" },
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 

--- a/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql_meta_parent.pt
+++ b/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.7.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.7.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql_meta_parent_rg.pt
+++ b/cost/azure/rightsize_managed_sql/azure_rightsize_managed_sql_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.7.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.7.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/rightsize_mysql_flexible/CHANGELOG.md
+++ b/cost/azure/rightsize_mysql_flexible/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v0.6.2
 
 - Fixed an issue where the policy could fail to generate a report when the "Allow/Deny Regions List" filter parameter was used.

--- a/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible.pt
+++ b/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.6.2",
+  version: "0.6.3",
   provider: "Azure",
   service: "MySQL",
   policy_set: "Rightsize Database Instances",
@@ -1650,7 +1650,7 @@ define downsize_server($instance, $param_azure_endpoint) return $response do
     query_strings: { "api-version": "2023-12-30" },
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: {
       "sku": {
@@ -1700,7 +1700,7 @@ define delete_server($instance, $param_azure_endpoint) return $response do
     query_strings: { "api-version": "2023-12-30" },
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 

--- a/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible_meta_parent.pt
+++ b/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.6.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.6.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible_meta_parent_rg.pt
+++ b/cost/azure/rightsize_mysql_flexible/azure_rightsize_mysql_flexible_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.6.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.6.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/rightsize_mysql_single/CHANGELOG.md
+++ b/cost/azure/rightsize_mysql_single/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v0.6.2
 
 - Fixed an issue where applying a region filter would cause the policy to fail instead of filtering databases by region.

--- a/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single.pt
+++ b/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.6.2",
+  version: "0.6.3",
   provider: "Azure",
   service: "MySQL",
   policy_set: "Rightsize Database Instances",
@@ -1635,7 +1635,7 @@ define downsize_server($instance, $param_azure_endpoint) return $response do
     query_strings: { "api-version": "2020-01-01" },
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: {
       "sku": {
@@ -1686,7 +1686,7 @@ define delete_server($instance, $param_azure_endpoint) return $response do
     query_strings: { "api-version": "2020-01-01" },
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 

--- a/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single_meta_parent.pt
+++ b/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.6.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.6.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single_meta_parent_rg.pt
+++ b/cost/azure/rightsize_mysql_single/azure_rightsize_mysql_single_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.6.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.6.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/rightsize_postgresql_flexible/CHANGELOG.md
+++ b/cost/azure/rightsize_postgresql_flexible/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v0.2.2
 
 - Fixed an issue where the policy could fail when Azure returned no CPU or connection metrics for a server during the selected lookback window.

--- a/cost/azure/rightsize_postgresql_flexible/azure_rightsize_postgresql_flexible.pt
+++ b/cost/azure/rightsize_postgresql_flexible/azure_rightsize_postgresql_flexible.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.2",
+  version: "0.2.3",
   provider: "Azure",
   service: "PostgreSQL",
   policy_set: "Rightsize Database Instances",
@@ -1682,7 +1682,7 @@ define downsize_server($instance, $param_azure_endpoint) return $response do
     query_strings: { "api-version": "2022-12-01" },
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: {
       "sku": {
@@ -1732,7 +1732,7 @@ define delete_server($instance, $param_azure_endpoint) return $response do
     query_strings: { "api-version": "2022-12-01" },
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 

--- a/cost/azure/rightsize_postgresql_flexible/azure_rightsize_postgresql_flexible_meta_parent.pt
+++ b/cost/azure/rightsize_postgresql_flexible/azure_rightsize_postgresql_flexible_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.2.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/rightsize_postgresql_flexible/azure_rightsize_postgresql_flexible_meta_parent_rg.pt
+++ b/cost/azure/rightsize_postgresql_flexible/azure_rightsize_postgresql_flexible_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.2.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/rightsize_postgresql_single/CHANGELOG.md
+++ b/cost/azure/rightsize_postgresql_single/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v0.2.2
 
 - Fixed an issue where, with "Skip Instance Sizes" set to "Yes", a server that qualified for downsizing more than one size could cause the policy to fail to generate an incident instead of recommending the correct target size.

--- a/cost/azure/rightsize_postgresql_single/azure_rightsize_postgresql_single.pt
+++ b/cost/azure/rightsize_postgresql_single/azure_rightsize_postgresql_single.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.2",
+  version: "0.2.3",
   provider: "Azure",
   service: "PostgreSQL",
   policy_set: "Rightsize Database Instances",
@@ -1664,7 +1664,7 @@ define downsize_server($instance, $param_azure_endpoint) return $response do
     query_strings: { "api-version": "2017-12-01" },
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: {
       "sku": {
@@ -1715,7 +1715,7 @@ define delete_server($instance, $param_azure_endpoint) return $response do
     query_strings: { "api-version": "2017-12-01" },
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 

--- a/cost/azure/rightsize_postgresql_single/azure_rightsize_postgresql_single_meta_parent.pt
+++ b/cost/azure/rightsize_postgresql_single/azure_rightsize_postgresql_single_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.2.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/rightsize_postgresql_single/azure_rightsize_postgresql_single_meta_parent_rg.pt
+++ b/cost/azure/rightsize_postgresql_single/azure_rightsize_postgresql_single_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "0.2.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/rightsize_sql_instances/CHANGELOG.md
+++ b/cost/azure/rightsize_sql_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.4.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v6.4.2
 
 - Fixed an issue where the incident summary could display an invalid percentage value when there were no SQL databases found to analyze.

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "6.4.2",
+  version: "6.4.3",
   provider: "Azure",
   service: "SQL",
   policy_set: "Rightsize Database Instances",
@@ -1835,7 +1835,7 @@ define downsize_instance($instance, $param_azure_endpoint) return $response do
     query_strings: { "api-version": "2017-10-01-preview" },
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: {
       "sku": {
@@ -1886,7 +1886,7 @@ define delete_instance($instance, $param_azure_endpoint) return $response do
     query_strings: { "api-version": "2017-10-01-preview" },
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "6.4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.4.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent_rg.pt
+++ b/cost/azure/rightsize_sql_instances/azure_rightsize_sql_instances_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "6.4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.4.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/rightsize_synapse_sql_pools/CHANGELOG.md
+++ b/cost/azure/rightsize_synapse_sql_pools/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v0.5.2
 
 - Fixed an issue where the policy could fail to generate an incident for a SQL pool if one of its monitoring metrics had no data points during the analysis window.

--- a/cost/azure/rightsize_synapse_sql_pools/azure_rightsize_synapse_sql_pools.pt
+++ b/cost/azure/rightsize_synapse_sql_pools/azure_rightsize_synapse_sql_pools.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.5.2",
+  version: "0.5.3",
   provider: "Azure",
   service: "SQL",
   policy_set: "Rightsize Synapse SQL Pools",
@@ -1989,7 +1989,7 @@ define pause_instance($instance, $param_azure_endpoint) return $response do
     query_strings: { "api-version": "2021-06-01" },
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 

--- a/cost/azure/schedule_instance/CHANGELOG.md
+++ b/cost/azure/schedule_instance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v7.2.5
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v7.2.4
 
 - Fixed an issue where the policy could fail to generate an incident when the Azure directory information for the tenant was unavailable.

--- a/cost/azure/schedule_instance/azure_schedule_instance.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "15 minutes"
 info(
-  version: "7.2.4",
+  version: "7.2.5",
   provider: "Azure",
   service: "Compute",
   policy_set: "Schedule Instance",
@@ -1864,7 +1864,7 @@ define update_schedule($instance, $param_azure_endpoint, $schedule, $param_tag_s
     },
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: { "tags": $new_tags }
   )
@@ -1905,7 +1905,7 @@ define delete_schedule($instance, $param_azure_endpoint, $param_tag_schedule) re
     },
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: { "tags": $new_tags }
   )
@@ -1958,7 +1958,7 @@ define window_active($start_hour, $start_minute, $start_rule, $stop_hour, $stop_
     verb: "post",
     href: $href,
     host: $host,
-    headers: { "content-type": "application/json" },
+    headers: { "Content-Type": "application/json" },
     body: {
       "start_hour": $start_hour,
       "start_minute": $start_minute,

--- a/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "7.2.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "7.2.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/schedule_instance/azure_schedule_instance_meta_parent_rg.pt
+++ b/cost/azure/schedule_instance/azure_schedule_instance_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "7.2.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "7.2.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/superseded_instances/CHANGELOG.md
+++ b/cost/azure/superseded_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.4.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v4.4.2
 
 - Fixed an issue where non-USD users would incorrectly see a currency conversion API malfunction warning in the incident details even when currency conversion was working correctly.

--- a/cost/azure/superseded_instances/azure_superseded_instances.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.4.2",
+  version: "4.4.3",
   provider: "Azure",
   service: "Compute",
   policy_set: "Superseded Compute Instances",
@@ -1296,7 +1296,7 @@ define change_instances($data, $param_azure_endpoint) return $all_responses do
           "api-version": "2019-03-01"
         },
         headers:{
-          "content-type": "application/json"
+          "Content-Type": "application/json"
         },
         body: {
           "properties":{

--- a/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "4.4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.4.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/superseded_instances/azure_superseded_instances_meta_parent_rg.pt
+++ b/cost/azure/superseded_instances/azure_superseded_instances_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "4.4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.4.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/unused_volumes/CHANGELOG.md
+++ b/cost/azure/unused_volumes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v8.6.4
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v8.6.3
 
 - Fixed an issue where the policy could calculate an invalid unused volume percentage when filters left no Azure volumes to analyze.

--- a/cost/azure/unused_volumes/azure_unused_volumes.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "8.6.3",
+  version: "8.6.4",
   provider: "Azure",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -1247,7 +1247,7 @@ define detach_disk($item, $param_azure_endpoint) return $response do
       "api-version": "2023-07-01"
     },
     headers: {
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 
@@ -1276,7 +1276,7 @@ define detach_disk($item, $param_azure_endpoint) return $response do
       "api-version": "2023-07-01"
     },
     headers: {
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: $new_properties
   )
@@ -1298,7 +1298,7 @@ define detach_disk($item, $param_azure_endpoint) return $response do
         "api-version": "2023-04-02"
       },
       headers: {
-        "content-type": "application/json"
+        "Content-Type": "application/json"
       }
     )
 
@@ -1329,7 +1329,7 @@ define create_snapshot($item, $param_azure_endpoint) return $response do
       "api-version": "2021-12-01"
     },
     headers: {
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: {
       "location": $item["region"],

--- a/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "8.6.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "8.6.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/azure/unused_volumes/azure_unused_volumes_meta_parent_rg.pt
+++ b/cost/azure/unused_volumes/azure_unused_volumes_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "8.6.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "8.6.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/idle_ip_address_recommendations/CHANGELOG.md
+++ b/cost/google/idle_ip_address_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.6.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v4.6.2
 
 - Fixed an issue where the policy could fail to calculate savings and stop processing recommendations for a project or region if a specific idle IP address recommendation did not include cost duration information.

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.6.2",
+  version: "4.6.3",
   provider: "Google",
   service: "Compute",
   policy_set: "Unused IP Addresses",
@@ -967,7 +967,7 @@ define delete_ip_address($address) do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 

--- a/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
+++ b/cost/google/idle_ip_address_recommendations/google_idle_ip_address_recommendations_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "4.6.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.6.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/idle_persistent_disk_recommendations/CHANGELOG.md
+++ b/cost/google/idle_persistent_disk_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.6.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v4.6.2
 
 - Fixed an issue where the incident summary could display an invalid percentage value when there were no disks found to analyze.

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "4.6.2",
+  version: "4.6.3",
   provider: "Google",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -1247,7 +1247,7 @@ define snapshot_disk($disk) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: {
       name: join([$disk["resourceName"], "-final-snapshot"])
@@ -1283,7 +1283,7 @@ define get_operation_status($operation) return $response, $operation_status do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 
@@ -1306,7 +1306,7 @@ define delete_disk($disk) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 

--- a/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
+++ b/cost/google/idle_persistent_disk_recommendations/google_idle_persistent_disk_recommendations_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "4.6.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "4.6.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/object_storage_optimization/CHANGELOG.md
+++ b/cost/google/object_storage_optimization/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.4
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v3.1.3
 
 - Fixed an issue where the policy could produce an invalid percentage in the incident summary when no storage objects were returned for analysis.

--- a/cost/google/object_storage_optimization/google_object_storage_optimization.pt
+++ b/cost/google/object_storage_optimization/google_object_storage_optimization.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Cost"
 default_frequency "weekly"
 info(
-  version: "3.1.3",
+  version: "3.1.4",
   provider: "Google",
   service: "Storage",
   policy_set: "Object Store Optimization",
@@ -759,7 +759,7 @@ define update_object($object) return $response do
     href: $href,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: {
       "storageClass": $object['newResourceType']
@@ -792,7 +792,7 @@ define delete_object($object) return $response do
     href: $href,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   })
 

--- a/cost/google/object_storage_optimization/google_object_storage_optimization_meta_parent.pt
+++ b/cost/google/object_storage_optimization/google_object_storage_optimization_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "3.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.1.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "true",
   hide_skip_approvals: "true"

--- a/cost/google/old_snapshots/CHANGELOG.md
+++ b/cost/google/old_snapshots/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.6.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v5.6.2
 
 - Fixed an issue where the policy could report an invalid percentage when no snapshots were returned for analysis.

--- a/cost/google/old_snapshots/google_delete_old_snapshots.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "5.6.2",
+  version: "5.6.3",
   provider:"Google",
   service: "Storage",
   policy_set: "Old Snapshots",
@@ -1215,7 +1215,7 @@ define delete_snapshot($snapshot) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 

--- a/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
+++ b/cost/google/old_snapshots/google_delete_old_snapshots_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "5.6.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "5.6.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/rightsize_cloudsql_instances/CHANGELOG.md
+++ b/cost/google/rightsize_cloudsql_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v0.4.2
 
 - Fixed an issue where the policy could fail to run when monitoring data did not include CPU or memory utilization values for a specific Cloud SQL instance.

--- a/cost/google/rightsize_cloudsql_instances/google_rightsize_cloudsql_instances.pt
+++ b/cost/google/rightsize_cloudsql_instances/google_rightsize_cloudsql_instances.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.2",
+  version: "0.4.3",
   provider: "Google",
   service: "Compute",
   policy_set: "Rightsize Database Instances",
@@ -2018,7 +2018,7 @@ define resize_instance($instance) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: $body
   )
@@ -2052,7 +2052,7 @@ define stop_instance($instance) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: $body
   )
@@ -2075,7 +2075,7 @@ define delete_instance($instance) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 

--- a/cost/google/rightsize_cloudsql_instances/google_rightsize_cloudsql_instances_meta_parent.pt
+++ b/cost/google/rightsize_cloudsql_instances/google_rightsize_cloudsql_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "0.4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.4.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/rightsize_cloudsql_recommendations/CHANGELOG.md
+++ b/cost/google/rightsize_cloudsql_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v0.6.2
 
 - Fixed an issue where an instance that was recommended for both stopping (idle) and downsizing (underutilized) at the same time could be incorrectly reported in both incidents instead of only the idle one, resulting in duplicated savings being counted for that instance.

--- a/cost/google/rightsize_cloudsql_recommendations/google_rightsize_cloudsql_recommendations.pt
+++ b/cost/google/rightsize_cloudsql_recommendations/google_rightsize_cloudsql_recommendations.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.6.2",
+  version: "0.6.3",
   provider: "Google",
   service: "Compute",
   policy_set: "Rightsize Database Instances",
@@ -1447,7 +1447,7 @@ define resize_instance($instance) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: $body
   )
@@ -1481,7 +1481,7 @@ define stop_instance($instance) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: $body
   )
@@ -1504,7 +1504,7 @@ define delete_instance($instance) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 

--- a/cost/google/rightsize_cloudsql_recommendations/google_rightsize_cloudsql_recommendations_meta_parent.pt
+++ b/cost/google/rightsize_cloudsql_recommendations/google_rightsize_cloudsql_recommendations_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "0.6.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.6.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/rightsize_persistent_disks/CHANGELOG.md
+++ b/cost/google/rightsize_persistent_disks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v0.3.2
 
 - Fixed an issue where the policy could fail when billing data included Compute Engine charges that were not tied to a specific resource.

--- a/cost/google/rightsize_persistent_disks/google_rightsize_persistent_disks.pt
+++ b/cost/google/rightsize_persistent_disks/google_rightsize_persistent_disks.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.2",
+  version: "0.3.3",
   provider: "Google",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -1717,7 +1717,7 @@ define snapshot_disk($disk) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: {
       name: join([$disk["resourceName"], "-final-snapshot"])
@@ -1753,7 +1753,7 @@ define get_operation_status($operation) return $response, $operation_status do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 
@@ -1776,7 +1776,7 @@ define delete_disk($disk) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 

--- a/cost/google/rightsize_persistent_disks/google_rightsize_persistent_disks_meta_parent.pt
+++ b/cost/google/rightsize_persistent_disks/google_rightsize_persistent_disks_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "0.3.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.3.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/rightsize_vm_instances/CHANGELOG.md
+++ b/cost/google/rightsize_vm_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v0.4.2
 
 - Fixed an issue where missing CPU or memory statistics from Google monitoring data could cause the policy to fail instead of skipping unavailable measurements.

--- a/cost/google/rightsize_vm_instances/google_rightsize_vm_instances.pt
+++ b/cost/google/rightsize_vm_instances/google_rightsize_vm_instances.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.2",
+  version: "0.4.3",
   provider: "Google",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -2124,7 +2124,7 @@ define resize_instance($instance) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: $body
   )
@@ -2156,7 +2156,7 @@ define delete_instance($instance) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 
@@ -2178,7 +2178,7 @@ define start_instance($instance) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 
@@ -2200,7 +2200,7 @@ define stop_instance($instance) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 
@@ -2231,7 +2231,7 @@ define get_instance_state($instance) return $response, $instance_state do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 

--- a/cost/google/rightsize_vm_instances/google_rightsize_vm_instances_meta_parent.pt
+++ b/cost/google/rightsize_vm_instances/google_rightsize_vm_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "0.4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.4.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/rightsize_vm_recommendations/CHANGELOG.md
+++ b/cost/google/rightsize_vm_recommendations/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.5.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v3.5.2
 
 - Fixed an issue where the policy could fail to run if currency conversion data was unavailable for the organization's configured currency.

--- a/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations.pt
+++ b/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "3.5.2",
+  version: "3.5.3",
   provider: "Google",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -1626,7 +1626,7 @@ define resize_instance($instance) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: $body
   )
@@ -1658,7 +1658,7 @@ define delete_instance($instance) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 
@@ -1680,7 +1680,7 @@ define start_instance($instance) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 
@@ -1702,7 +1702,7 @@ define stop_instance($instance) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 
@@ -1733,7 +1733,7 @@ define get_instance_state($instance) return $response, $instance_state do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 

--- a/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
+++ b/cost/google/rightsize_vm_recommendations/google_rightsize_vm_recommendations_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "3.5.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.5.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/schedule_instance/CHANGELOG.md
+++ b/cost/google/schedule_instance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.1.4
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v6.1.3
 
 - Fixed an issue where instances with an exclusion label value that matches the specified "does not match regex" filter would be incorrectly excluded from policy evaluation instead of being retained.

--- a/cost/google/schedule_instance/google_schedule_instance.pt
+++ b/cost/google/schedule_instance/google_schedule_instance.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "15 minutes"
 info(
-  version: "6.1.3",
+  version: "6.1.4",
   provider: "Google",
   service: "Compute",
   policy_set: "Schedule Instance",
@@ -1727,7 +1727,7 @@ define update_schedule($instance, $schedule, $param_label_schedule) return $resp
     url: $url,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: {
       "labels": $new_labels,
@@ -1764,7 +1764,7 @@ define delete_schedule($instance, $param_label_schedule) return $response do
     url: $url,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: {
       "labels": $new_labels,
@@ -1791,7 +1791,7 @@ define delete_instance($instance) return $response do
     url: $url,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 
@@ -1817,7 +1817,7 @@ define window_active($start_hour, $start_minute, $start_rule, $stop_hour, $stop_
     verb: "post",
     href: $href,
     host: $host,
-    headers: { "content-type": "application/json" },
+    headers: { "Content-Type": "application/json" },
     body: {
       "start_hour": $start_hour,
       "start_minute": $start_minute,
@@ -1849,7 +1849,7 @@ define start_instance($instance) return $response do
     url: $url,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 
@@ -1892,7 +1892,7 @@ define stop_instance($instance) return $response do
     url: $url,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 
@@ -1935,7 +1935,7 @@ define get_instance_info($instance) return $response, $instance_state, $labels, 
     url: $url,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 

--- a/cost/google/schedule_instance/google_schedule_instance_meta_parent.pt
+++ b/cost/google/schedule_instance/google_schedule_instance_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "6.1.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "6.1.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/cost/google/unused_disks/CHANGELOG.md
+++ b/cost/google/unused_disks/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v0.4.2
 
 - Fixed an issue where the policy could fail with an error when the region allow/deny list parameter was used.

--- a/cost/google/unused_disks/google_unused_disks.pt
+++ b/cost/google/unused_disks/google_unused_disks.pt
@@ -8,7 +8,7 @@ category "Cost"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.4.2",
+  version: "0.4.3",
   provider: "Google",
   service: "Storage",
   policy_set: "Unused Volumes",
@@ -1048,7 +1048,7 @@ define snapshot_disk($disk) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: {
       name: join([$disk["resourceName"], "-final-snapshot"])
@@ -1084,7 +1084,7 @@ define get_operation_status($operation) return $response, $operation_status do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 
@@ -1107,7 +1107,7 @@ define delete_disk($disk) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 

--- a/cost/google/unused_disks/google_unused_disks_meta_parent.pt
+++ b/cost/google/unused_disks/google_unused_disks_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "0.4.2", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.4.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "true",
   hide_skip_approvals: "true"

--- a/operational/flexera/cco/rbds_from_csv_in_policy_template/CHANGELOG.md
+++ b/operational/flexera/cco/rbds_from_csv_in_policy_template/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.8
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v0.1.7
 
 - Fixed an issue where generating rule-based dimensions could fail with an error when the "Dimensions for Rules" parameter did not match any column in the CSV data.

--- a/operational/flexera/cco/rbds_from_csv_in_policy_template/rbds_from_csv.pt
+++ b/operational/flexera/cco/rbds_from_csv_in_policy_template/rbds_from_csv.pt
@@ -9,7 +9,7 @@ severity "low"
 default_frequency "daily"
 info(
   publish: "false",
-  version: "0.1.7",
+  version: "0.1.8",
   provider: "Flexera",
   service: "FinOps Customizations",
   policy_set: "Automation",
@@ -428,7 +428,7 @@ script "js_apply_rbds", type: "javascript" do
     path: ["/finops-customizations/v1/orgs/", rs_org_id, "/rule-based-dimensions/", id, "/rules/", dated_rules[0].effective_at].join(''),
     verb: "PUT",
     headers: {
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: JSON.stringify({ "rules": dated_rules[0].rules })
   }

--- a/operational/google/long_running_instances/CHANGELOG.md
+++ b/operational/google/long_running_instances/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.4
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v0.2.3
 
 - Fixed an issue where some virtual machines could be missed by the policy for Google projects with a large number of instances.

--- a/operational/google/long_running_instances/google_long_running_instances.pt
+++ b/operational/google/long_running_instances/google_long_running_instances.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.2.3",
+  version: "0.2.4",
   provider: "Google",
   service: "Compute",
   policy_set: "Long Running Instances",
@@ -1038,7 +1038,7 @@ define delete_instance($instance) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 

--- a/operational/google/long_running_instances/google_long_running_instances_meta_parent.pt
+++ b/operational/google/long_running_instances/google_long_running_instances_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "0.2.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.2.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/operational/google/overutilized_vms/CHANGELOG.md
+++ b/operational/google/overutilized_vms/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.4
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v0.3.3
 
 - Fixed an issue where the policy could fail to run when CPU utilization metrics were unavailable for a project.

--- a/operational/google/overutilized_vms/google_overutilized_vms.pt
+++ b/operational/google/overutilized_vms/google_overutilized_vms.pt
@@ -8,7 +8,7 @@ category "Operational"
 severity "low"
 default_frequency "weekly"
 info(
-  version: "0.3.3",
+  version: "0.3.4",
   provider: "Google",
   service: "Compute",
   policy_set: "Rightsize Compute Instances",
@@ -1126,7 +1126,7 @@ define resize_instance($instance) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: $body
   )
@@ -1158,7 +1158,7 @@ define start_instance($instance) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 
@@ -1180,7 +1180,7 @@ define stop_instance($instance) return $response do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 
@@ -1211,7 +1211,7 @@ define get_instance_state($instance) return $response, $instance_state do
     auth: $$auth_google,
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 

--- a/operational/google/overutilized_vms/google_overutilized_vms_meta_parent.pt
+++ b/operational/google/overutilized_vms/google_overutilized_vms_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Google",
-  version: "0.3.3", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "0.3.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/saas/fsm/deactivated_users/CHANGELOG.md
+++ b/saas/fsm/deactivated_users/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v3.2.2
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/saas/fsm/deactivated_users/deactivated_users.pt
+++ b/saas/fsm/deactivated_users/deactivated_users.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "SaaS Management"
 default_frequency "weekly"
 info(
-  version: "3.2.2",
+  version: "3.2.3",
   provider: "Flexera",
   service: "SaaS Manager",
   policy_set: "",
@@ -160,7 +160,7 @@ script "js_managed_apps", type: "javascript" do
     auth: "auth_flexera",
     host: ds_flexera_api_hosts["flexera"],
     path: "/saas/v1/orgs/" + rs_org_id + "/managed-apps",
-    headers: { "content-type": "application/json" },
+    headers: { "Content-Type": "application/json" },
     query_params: { "view": "extended" }
   }
 EOS
@@ -221,7 +221,7 @@ script "js_managed_apps_users", type: "javascript" do
     auth: "auth_flexera",
     host: ds_flexera_api_hosts["flexera"],
     path: "/saas/v1/orgs/" + rs_org_id + "/managed-apps/" + app_id + "/app-users",
-    headers: { "content-type": "application/json" },
+    headers: { "Content-Type": "application/json" },
     query_params: { "includeAll": "true" }
   }
 EOS

--- a/saas/fsm/deactivated_users_for_integrated_apps/CHANGELOG.md
+++ b/saas/fsm/deactivated_users_for_integrated_apps/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v3.2.2
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/saas/fsm/deactivated_users_for_integrated_apps/deactivated_users_for_integrated_apps.pt
+++ b/saas/fsm/deactivated_users_for_integrated_apps/deactivated_users_for_integrated_apps.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "SaaS Management"
 default_frequency "weekly"
 info(
-  version: "3.2.2",
+  version: "3.2.3",
   provider: "Flexera",
   service: "SaaS Manager",
   policy_set: "",
@@ -161,7 +161,7 @@ script "js_managed_apps", type: "javascript" do
     auth: "auth_flexera",
     host: ds_flexera_api_hosts["flexera"],
     path: "/saas/v1/orgs/" + rs_org_id + "/managed-apps",
-    headers: { "content-type": "application/json" },
+    headers: { "Content-Type": "application/json" },
     query_params: { "view": "extended" }
   }
 EOS
@@ -245,7 +245,7 @@ script "js_integrated_apps", type: "javascript" do
     auth: "auth_flexera",
     host: ds_flexera_api_hosts["flexera"],
     path: "/saas/v1" + app_href,
-    headers: { "content-type": "application/json" },
+    headers: { "Content-Type": "application/json" },
     query_params: { "view": "extended" }
   }
 EOS
@@ -299,7 +299,7 @@ script "js_integrated_apps_users", type: "javascript" do
     auth: "auth_flexera",
     host: ds_flexera_api_hosts["flexera"],
     path: "/saas/v1/orgs/" + rs_org_id + "/managed-apps/" + app_id + "/app-users",
-    headers: { "content-type": "application/json" },
+    headers: { "Content-Type": "application/json" },
     query_params: { "includeAll": "true" }
   }
 EOS

--- a/saas/fsm/duplicate_users/CHANGELOG.md
+++ b/saas/fsm/duplicate_users/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2.2
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v3.2.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/saas/fsm/duplicate_users/duplicate_users.pt
+++ b/saas/fsm/duplicate_users/duplicate_users.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "SaaS Management"
 default_frequency "weekly"
 info(
-  version: "3.2.1",
+  version: "3.2.2",
   provider: "Flexera",
   service: "SaaS Manager",
   policy_set: "",
@@ -143,7 +143,7 @@ script "js_managed_apps", type: "javascript" do
     auth: "auth_flexera",
     host: ds_flexera_api_hosts["flexera"],
     path: "/saas/v1/orgs/" + rs_org_id + "/managed-apps",
-    headers: { "content-type": "application/json" },
+    headers: { "Content-Type": "application/json" },
     query_params: { "view": "extended" }
   }
 EOS
@@ -195,7 +195,7 @@ script "js_managed_apps_users", type: "javascript" do
     auth: "auth_flexera",
     host: ds_flexera_api_hosts["flexera"],
     path: "/saas/v1/orgs/" + rs_org_id + "/managed-apps/" + app_id + "/app-users",
-    headers: { "content-type": "application/json" }
+    headers: { "Content-Type": "application/json" }
   }
 EOS
 end

--- a/saas/fsm/redundant_apps/CHANGELOG.md
+++ b/saas/fsm/redundant_apps/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2.2
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v3.2.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/saas/fsm/redundant_apps/fsm-redundant_apps.pt
+++ b/saas/fsm/redundant_apps/fsm-redundant_apps.pt
@@ -8,7 +8,7 @@ severity "low"
 category "SaaS Management"
 default_frequency "weekly"
 info(
-  version: "3.2.1",
+  version: "3.2.2",
   provider: "Flexera",
   service: "SaaS Manager",
   policy_set: "",
@@ -156,7 +156,7 @@ script "js_managed_apps", type: "javascript" do
     auth: "auth_flexera",
     host: ds_flexera_api_hosts["flexera"],
     path: "/saas/v1/orgs/" + rs_org_id + "/managed-apps",
-    headers: { "content-type": "application/json" },
+    headers: { "Content-Type": "application/json" },
     query_params: { "view": "extended" }
   }
 EOS

--- a/saas/fsm/renewal_reminder/CHANGELOG.md
+++ b/saas/fsm/renewal_reminder/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.3.4
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v3.3.3
 
 - Fixed an issue where the policy could fail to generate results for any application if a license term did not have a valid expiration date (such as a perpetual or evergreen license).

--- a/saas/fsm/renewal_reminder/fsm-renewal_reminder.pt
+++ b/saas/fsm/renewal_reminder/fsm-renewal_reminder.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "SaaS Management"
 default_frequency "weekly"
 info(
-  version: "3.3.3",
+  version: "3.3.4",
   provider: "Flexera",
   service: "SaaS Manager",
   policy_set: "",
@@ -215,7 +215,7 @@ script "js_managed_apps", type: "javascript" do
     auth: "auth_flexera",
     host: ds_flexera_api_hosts["flexera"],
     path: "/saas/v1/orgs/" + rs_org_id + "/managed-apps",
-    headers: { "content-type": "application/json" },
+    headers: { "Content-Type": "application/json" },
     query_params: { "view": "extended" }
   }
 EOS
@@ -266,7 +266,7 @@ script "js_managed_apps_licenses", type: "javascript" do
     auth: "auth_flexera",
     host: ds_flexera_api_hosts["flexera"],
     path: "/saas/v1/orgs/" + rs_org_id + "/managed-apps",
-    headers: { "content-type": "application/json" },
+    headers: { "Content-Type": "application/json" },
     query_params: { "view": "licenseUsage" }
   }
 EOS

--- a/saas/fsm/suspicious_users/CHANGELOG.md
+++ b/saas/fsm/suspicious_users/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2.2
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v3.2.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/saas/fsm/suspicious_users/fsm-suspicious_users.pt
+++ b/saas/fsm/suspicious_users/fsm-suspicious_users.pt
@@ -8,7 +8,7 @@ severity "high"
 default_frequency "weekly"
 category "SaaS Management"
 info(
-  version: "3.2.1",
+  version: "3.2.2",
   provider: "Flexera",
   service: "SaaS Manager",
   policy_set: "",
@@ -142,7 +142,7 @@ datasource "ds_suspicious_users" do
     query "includeUnauthorized", "true"
     query "includeUnrecognized", "true"
     query "includeRecognized", "false"
-    header "content-type", "application/json"
+    header "Content-Type", "application/json"
   end
   result do
     encoding "json"

--- a/saas/fsm/unsanctioned_apps_with_contract/CHANGELOG.md
+++ b/saas/fsm/unsanctioned_apps_with_contract/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.3.2
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v3.3.1
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/saas/fsm/unsanctioned_apps_with_contract/fsm-unsanctioned_with_contract.pt
+++ b/saas/fsm/unsanctioned_apps_with_contract/fsm-unsanctioned_with_contract.pt
@@ -8,7 +8,7 @@ severity "high"
 category "SaaS Management"
 default_frequency "weekly"
 info(
-  version: "3.3.1",
+  version: "3.3.2",
   provider: "Flexera",
   service: "SaaS Manager",
   policy_set: "",
@@ -176,7 +176,7 @@ datasource "ds_num_products" do
     auth $auth_flexera
     host val($ds_flexera_api_hosts, "fsm")
     path join(["/svc/orgs/", rs_org_id, "/managed-products"])
-    header "content-type", "application/json"
+    header "Content-Type", "application/json"
   end
   result do
     encoding "json"
@@ -207,7 +207,7 @@ script "js_products", type: "javascript" do
     auth: "auth_flexera",
     host: ds_flexera_api_hosts["fsm"],
     path: "/svc/orgs/" + rs_org_id + "/managed-products",
-    headers: { "content-type": "application/json" },
+    headers: { "Content-Type": "application/json" },
     query_params: {
       "pageSize": ds_num_products["totalItems"].toString(),
       "includeInactive": "false"
@@ -221,7 +221,7 @@ datasource "ds_num_unsanctioned" do
     auth $auth_flexera
     host val($ds_flexera_api_hosts, "fsm")
     path join(["/svc/orgs/", rs_org_id, "/financial-discovery"])
-    header "content-type", "application/json"
+    header "Content-Type", "application/json"
   end
   result do
     encoding "json"
@@ -254,7 +254,7 @@ script "js_unsanctioned", type: "javascript" do
     auth: "auth_flexera",
     host: ds_flexera_api_hosts["fsm"],
     path: "/svc/orgs/" + rs_org_id + "/financial-discovery",
-    headers: { "content-type": "application/json" },
+    headers: { "Content-Type": "application/json" },
     query_params: { "pageSize": ds_num_unsanctioned["totalItems"].toString() }
   }
 EOS

--- a/saas/fsm/unsanctioned_spend/CHANGELOG.md
+++ b/saas/fsm/unsanctioned_spend/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v3.2.2
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/saas/fsm/unsanctioned_spend/fsm-unsanctioned_spend.pt
+++ b/saas/fsm/unsanctioned_spend/fsm-unsanctioned_spend.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "SaaS Management"
 default_frequency "weekly"
 info(
-  version: "3.2.2",
+  version: "3.2.3",
   provider: "Flexera",
   service: "SaaS Manager",
   policy_set: "",
@@ -138,7 +138,7 @@ datasource "ds_num_expenses" do
     auth $auth_flexera
     host val($ds_flexera_api_hosts, "fsm")
     path join(["/svc/orgs/", rs_org_id, "/financial-discovery"])
-    header "content-type", "application/json"
+    header "Content-Type", "application/json"
   end
   result do
     encoding "json"
@@ -173,7 +173,7 @@ script "js_unsanctioned", type: "javascript" do
     auth: "auth_flexera",
     host: ds_flexera_api_hosts["fsm"],
     path: "/svc/orgs/" + rs_org_id + "/financial-discovery",
-    headers: { "content-type": "application/json" },
+    headers: { "Content-Type": "application/json" },
     query_params: { "pageSize": ds_num_expenses["totalItems"].toString() }
   }
 EOS

--- a/saas/fsm/users_by_category/CHANGELOG.md
+++ b/saas/fsm/users_by_category/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.3
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v3.1.2
 
 - Added input sanitization to trim leading and trailing whitespace from string and list parameter values.

--- a/saas/fsm/users_by_category/users_by_category.pt
+++ b/saas/fsm/users_by_category/users_by_category.pt
@@ -8,7 +8,7 @@ severity "medium"
 category "SaaS Management"
 default_frequency "weekly"
 info(
-  version: "3.1.2",
+  version: "3.1.3",
   provider: "Flexera SaaS Manager",
   service: "",
   policy_set: "",
@@ -131,7 +131,7 @@ datasource "ds_managed_products" do
     auth $auth_flexera
     host val($ds_flexera_api_hosts, "fsm")
     path join(["/svc/orgs/", rs_org_id, "/managed-products"])
-    header "content-type", "application/json"
+    header "Content-Type", "application/json"
   end
   result do
     encoding "json"
@@ -173,7 +173,7 @@ script "js_managed_product_agents", type: "javascript" do
     auth: "auth_flexera",
     host: ds_flexera_api_hosts["fsm"],
     path: "/svc/orgs/" + rs_org_id + "/managed-products/" + appId + "/managed-product-agents",
-    headers: { "content-type": "application/json" },
+    headers: { "Content-Type": "application/json" },
     query_params: { "sort": "uniqueId", "deptFilter": param_category }
   }
 EOS

--- a/security/azure/sql_publicly_accessible_managed_instance/CHANGELOG.md
+++ b/security/azure/sql_publicly_accessible_managed_instance/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.3.5
+
+- Fixed HTTP request headers to use properly-cased "Content-Type" instead of "content-type" so the policy engine correctly overrides its default content type.
+
 ## v3.3.4
 
 - Fixed an issue where the policy would fail to generate results when a region filter was configured, instead of correctly filtering the results by region.

--- a/security/azure/sql_publicly_accessible_managed_instance/sql_publicly_accessible_managed_instance.pt
+++ b/security/azure/sql_publicly_accessible_managed_instance/sql_publicly_accessible_managed_instance.pt
@@ -8,7 +8,7 @@ category "Security"
 severity "high"
 default_frequency "daily"
 info(
-  version: "3.3.4",
+  version: "3.3.5",
   provider: "Azure",
   service: "SQL",
   policy_set: "",
@@ -663,7 +663,7 @@ define disable_instance($instance, $param_azure_endpoint) return $response do
     query_strings: { "api-version": "2015-05-01-preview" },
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     },
     body: {
       "properties": {
@@ -712,7 +712,7 @@ define delete_instance($instance, $param_azure_endpoint) return $response do
     query_strings: { "api-version": "2015-05-01-preview" },
     headers: {
       "cache-control": "no-cache",
-      "content-type": "application/json"
+      "Content-Type": "application/json"
     }
   )
 

--- a/security/azure/sql_publicly_accessible_managed_instance/sql_publicly_accessible_managed_instance_meta_parent.pt
+++ b/security/azure/sql_publicly_accessible_managed_instance/sql_publicly_accessible_managed_instance_meta_parent.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "3.3.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.3.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "true",
   deprecated: "false",
   hide_skip_approvals: "true"

--- a/security/azure/sql_publicly_accessible_managed_instance/sql_publicly_accessible_managed_instance_meta_parent_rg.pt
+++ b/security/azure/sql_publicly_accessible_managed_instance/sql_publicly_accessible_managed_instance_meta_parent_rg.pt
@@ -9,7 +9,7 @@ category "Meta"
 default_frequency "hourly"
 info(
   provider: "Azure",
-  version: "3.3.4", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
+  version: "3.3.5", # This version of the Meta Parent Policy Template should match the version of the Child Policy Template as it appears in the Catalog for best reliability
   publish: "false",
   deprecated: "false",
   hide_skip_approvals: "true"


### PR DESCRIPTION
### Description

Updates all policy templates to use "Content-Type" instead of "content-type" in API request headers. This is to ensure that the policy engine properly masks the default type of "text/plain" when this header is specified explicitly in the policy template; this masking is currently case sensitive. 
