### PR TITLE
POL-1842 New Marketplace Products: Additional Fields

### DIFF
--- a/operational/aws/marketplace_new_products/CHANGELOG.md
+++ b/operational/aws/marketplace_new_products/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.0
+
+- Added `Date Purchased`, `Bill Source`, `Vendor Account`, and `Vendor Account Name` fields to the incident output.
+
 ## v0.4.5
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/aws/marketplace_new_products/README.md
+++ b/operational/aws/marketplace_new_products/README.md
@@ -2,12 +2,13 @@
 
 ## What It Does
 
-This policy compares AWS billing data from 3 days ago to billing data from a user-specified number of days ago (10 by default) to see if any new Marketplace products have been purchased since then. A list of the new products and their estimated monthly cost is raised as an incident and, optionally, emailed.
+This policy compares AWS billing data from 3 days ago to billing data from a user-specified number of days ago (10 by default) to see if any new Marketplace products have been purchased since then. A list of the new products, their purchase dates, and their estimated monthly cost is raised as an incident and, optionally, emailed.
 
 ## How It Works
 
-- The policy leverages the Flexera Cloud Cost Optimization (CCO) APIs to retrieve aggregated amortized costs. Costs are filtered for only those costs whose Bill Entity is AWS Marketplace. Results are split by the Service dimension.
-- The list of Services (analogous to the name of the product purchased on the AWS Marketplace) from 3 days ago is compared to the older list to find any new items and their cost.
+- The policy leverages the Flexera Cloud Cost Optimization (CCO) APIs to retrieve aggregated amortized costs, at a daily granularity, for every day in the Look Back Period. Costs are filtered for only those costs whose Bill Entity is AWS Marketplace. Results are split by the Service dimension.
+- The list of Services (analogous to the name of the product purchased on the AWS Marketplace) with cost 3 days ago is compared to the list of Services with cost on the first day of the Look Back Period to find any new items and their cost.
+- For each new product, the daily cost history retrieved above is used to find the earliest day within the Look Back Period that the product has cost. This date is reported as the purchase date.
 
 ### Policy Cost Reporting Details
 

--- a/operational/aws/marketplace_new_products/aws_marketplace_new_products.pt
+++ b/operational/aws/marketplace_new_products/aws_marketplace_new_products.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "0.4.5",
+  version: "1.0.0",
   provider: "AWS",
   service: "Marketplace",
   policy_set: "New Marketplace Products",
@@ -33,6 +33,7 @@ parameter "param_lookback" do
   label "Look Back Period (Days)"
   description "How far back, in days, to look at Marketplace product purchases to see if new items have been added."
   min_value 4
+  max_value 30
   default 10
 end
 
@@ -227,42 +228,35 @@ script "js_currency", type:"javascript" do
 EOS
 end
 
-datasource "ds_current_products" do
+datasource "ds_products_history" do
   request do
-    run_script $js_get_products, $ds_top_level_bcs, 3, rs_org_id, rs_optima_host
+    run_script $js_get_products_history, $ds_top_level_bcs, $param_lookback, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
     collect jmes_path(response, "rows[*]") do
       field "service", jmes_path(col_item, "dimensions.service")
+      field "bill_source", jmes_path(col_item, "dimensions.bill_source")
+      field "vendor_account", jmes_path(col_item, "dimensions.vendor_account")
+      field "vendor_account_name", jmes_path(col_item, "dimensions.vendor_account_name")
       field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
+      field "timestamp", jmes_path(col_item, "timestamp")
     end
   end
 end
 
-datasource "ds_previous_products" do
-  request do
-    run_script $js_get_products, $ds_top_level_bcs, $param_lookback, rs_org_id, rs_optima_host
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "rows[*]") do
-      field "service", jmes_path(col_item, "dimensions.service")
-      field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
-    end
-  end
-end
-
-script "js_get_products", type: "javascript" do
-  parameters "ds_top_level_bcs", "lookback", "rs_org_id", "rs_optima_host"
+script "js_get_products_history", type: "javascript" do
+  parameters "ds_top_level_bcs", "param_lookback", "rs_org_id", "rs_optima_host"
   result "request"
   code <<-'EOS'
+  // End 2 days ago (exclusive) so the range covers every day from the lookback
+  // cutoff through 3 days ago, the most recent day with reliably finalized cost data.
   end_date = new Date()
-  end_date.setDate(end_date.getDate() - (lookback - 1))
+  end_date.setDate(end_date.getDate() - 2)
   end_date = end_date.toISOString().split('T')[0]
 
   start_date = new Date()
-  start_date.setDate(start_date.getDate() - lookback)
+  start_date.setDate(start_date.getDate() - param_lookback)
   start_date = start_date.toISOString().split('T')[0]
 
   var request = {
@@ -271,7 +265,7 @@ script "js_get_products", type: "javascript" do
     verb: "POST",
     path: "/bill-analysis/orgs/" + rs_org_id + "/costs/aggregated",
     body_fields: {
-      dimensions: ["service"],
+      dimensions: ["service", "bill_source", "vendor_account", "vendor_account_name"],
       granularity: "day",
       start_at: start_date,
       end_at: end_date,
@@ -294,11 +288,11 @@ EOS
 end
 
 datasource "ds_new_products" do
-  run_script $js_new_products, $ds_current_products, $ds_previous_products, $ds_currency, $ds_applied_policy, $param_min_cost, $param_lookback, $param_incident_csv
+  run_script $js_new_products, $ds_products_history, $ds_currency, $ds_applied_policy, $param_min_cost, $param_lookback, $param_incident_csv
 end
 
 script "js_new_products", type: "javascript" do
-  parameters "ds_current_products", "ds_previous_products", "ds_currency", "ds_applied_policy", "param_min_cost", "param_lookback", "param_incident_csv"
+  parameters "ds_products_history", "ds_currency", "ds_applied_policy", "param_min_cost", "param_lookback", "param_incident_csv"
   result "result"
   code <<-'EOS'
   csv_message = param_incident_csv == "false" ? "" : "Incident table CSV file has been attached to emails for this incident."
@@ -331,21 +325,50 @@ script "js_new_products", type: "javascript" do
   result = []
   total_cost = 0.0
 
-  old_product_list = _.compact(_.uniq(_.pluck(ds_previous_products, "service")))
+  // Build the two comparison snapshot dates from the continuous daily history:
+  // "current" is 3 days ago (buffer for billing data to finalize), "previous" is
+  // the full lookback period ago. A product is new if it has cost in the current
+  // snapshot but had no cost in the previous snapshot.
+  current_date = new Date()
+  current_date.setDate(current_date.getDate() - 3)
+  current_date_str = current_date.toISOString().split('T')[0]
 
-  valid_products = _.filter(ds_current_products, function(item) {
-    return typeof(item['service']) == 'string' && item['service'] != ''
+  previous_date = new Date()
+  previous_date.setDate(previous_date.getDate() - param_lookback)
+  previous_date_str = previous_date.toISOString().split('T')[0]
+
+  function dayOf(item) {
+    return item['timestamp'] ? item['timestamp'].split('T')[0] : ''
+  }
+
+  valid_history = _.filter(ds_products_history, function(item) {
+    return typeof(item['service']) == 'string' && item['service'] != '' && dayOf(item) != ''
   })
 
-  _.each(valid_products, function(item) {
+  current_products = _.filter(valid_history, function(item) { return dayOf(item) == current_date_str })
+  previous_products = _.filter(valid_history, function(item) { return dayOf(item) == previous_date_str })
+
+  old_product_list = _.compact(_.uniq(_.pluck(previous_products, "service")))
+
+  _.each(current_products, function(item) {
     if (_.contains(old_product_list, item['service']) == false) {
       cost = item['cost'] * 365.25 / 12
 
       if (cost >= param_min_cost) {
         total_cost += cost
 
+        // Find the earliest day within the queried history where this product had
+        // any cost, this is the date the product was purchased.
+        product_history = _.filter(valid_history, function(h) { return h['service'] == item['service'] })
+        product_dates = _.sortBy(_.uniq(_.map(product_history, dayOf)), function(date) { return date })
+        date_purchased = product_dates.length > 0 ? product_dates[0] : current_date_str
+
         result.push({
           product: item['service'],
+          bill_source: item['bill_source'],
+          vendor_account: item['vendor_account'],
+          vendor_account_name: item['vendor_account_name'],
+          date_purchased: date_purchased,
           cost: Number(cost.toFixed(2)),
           currency: ds_currency['symbol'],
           policy_name: ds_applied_policy['name'],
@@ -364,10 +387,6 @@ script "js_new_products", type: "javascript" do
       formatNumber(parseFloat(total_cost).toFixed(2), ds_currency['separator'])
     ].join('')
 
-    start_date = new Date()
-    start_date.setDate(start_date.getDate() - param_lookback)
-    start_date = start_date.toISOString().split('T')[0]
-
     product_noun = "product has"
     product_adj = "This product was"
 
@@ -378,7 +397,7 @@ script "js_new_products", type: "javascript" do
 
     message = [
       result.length, " new AWS Marketplace ", product_noun, " been found. ",
-      product_adj, " not present on ", start_date, " (", param_lookback.toString(), " days ago).\n\n"
+      product_adj, " not present on ", previous_date_str, " (", param_lookback.toString(), " days ago).\n\n"
     ].join('')
 
     disclaimer = "The above settings can be modified by editing the applied policy and changing the appropriate parameters.\n\n"
@@ -406,8 +425,20 @@ policy "pol_new_products" do
     hash_exclude "total_cost", "cost", "currency"
     export do
       resource_level false
+      field "bill_source" do
+        label "Bill Source"
+      end
+      field "vendor_account" do
+        label "Vendor Account"
+      end
+      field "vendor_account_name" do
+        label "Vendor Account Name"
+      end
       field "product" do
         label "New Product"
+      end
+      field "date_purchased" do
+        label "Date Purchased"
       end
       field "cost" do
         label "Estimated Monthly Cost"

--- a/operational/aws/marketplace_new_products/aws_marketplace_new_products.pt
+++ b/operational/aws/marketplace_new_products/aws_marketplace_new_products.pt
@@ -230,7 +230,7 @@ end
 
 datasource "ds_products_history" do
   request do
-    run_script $js_get_products_history, $ds_top_level_bcs, $param_lookback, rs_org_id, rs_optima_host
+    run_script $js_products_history, $ds_top_level_bcs, $param_lookback, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -245,7 +245,7 @@ datasource "ds_products_history" do
   end
 end
 
-script "js_get_products_history", type: "javascript" do
+script "js_products_history", type: "javascript" do
   parameters "ds_top_level_bcs", "param_lookback", "rs_org_id", "rs_optima_host"
   result "request"
   code <<-'EOS'

--- a/operational/azure/marketplace_new_products/CHANGELOG.md
+++ b/operational/azure/marketplace_new_products/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.0
+
+- Added `Date Purchased`, `Bill Source`, `Vendor Account`, `Vendor Account Name`, and `Resource Group` fields to the incident output.
+
 ## v0.6.5
 
 - Updated the `ds_flexera_api_hosts` datasource to support an additional internal testing environment. No functional changes for existing users.

--- a/operational/azure/marketplace_new_products/README.md
+++ b/operational/azure/marketplace_new_products/README.md
@@ -2,13 +2,14 @@
 
 ## What It Does
 
-This policy compares Azure billing data from 3 days ago to billing data from a user-specified number of days ago (10 by default) to see if any new Marketplace products have been purchased since then. A list of the new products and their estimated monthly cost is raised as an incident and, optionally, emailed.
+This policy compares Azure billing data from 3 days ago to billing data from a user-specified number of days ago (10 by default) to see if any new Marketplace products have been purchased since then. A list of the new products, their purchase dates, and their estimated monthly cost is raised as an incident and, optionally, emailed.
 
 ## How It Works
 
-- The policy leverages the Flexera Cloud Cost Optimization (CCO) APIs to retrieve aggregated amortized costs from each Azure bill source.
+- The policy leverages the Flexera Cloud Cost Optimization (CCO) APIs to retrieve aggregated amortized costs, at a daily granularity, for every day in the Look Back Period, from each Azure bill source.
 - Costs are filtered accordingly based on the kind of Azure bill source. Old bill sources pull the `usage_type` dimension and filter by the `Microsoft.Marketplace` service, while newer bill sources pull the `resource_type` dimension and filter by `manufacturer_name` not containing the substring "Microsoft".
-- The list of products from 3 days ago is compared to the older list to find any new items and their cost.
+- The list of products with cost 3 days ago is compared to the list of products with cost on the first day of the Look Back Period to find any new items and their cost.
+- For each new product, the daily cost history retrieved above is used to find the earliest day within the Look Back Period that the product has cost. This date is reported as the purchase date.
 
 ### Policy Cost Reporting Details
 

--- a/operational/azure/marketplace_new_products/azure_marketplace_new_products.pt
+++ b/operational/azure/marketplace_new_products/azure_marketplace_new_products.pt
@@ -320,7 +320,7 @@ end
 
 datasource "ds_products_history_oldconnection" do
   request do
-    run_script $js_get_products_history_oldconnection, $ds_bill_connections_old, $ds_top_level_bcs, $param_lookback, rs_org_id, rs_optima_host
+    run_script $js_products_history_oldconnection, $ds_bill_connections_old, $ds_top_level_bcs, $param_lookback, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -336,7 +336,7 @@ datasource "ds_products_history_oldconnection" do
   end
 end
 
-script "js_get_products_history_oldconnection", type: "javascript" do
+script "js_products_history_oldconnection", type: "javascript" do
   parameters "ds_bill_connections_old", "ds_top_level_bcs", "param_lookback", "rs_org_id", "rs_optima_host"
   result "request"
   code <<-'EOS'
@@ -413,7 +413,7 @@ end
 
 datasource "ds_products_history_newconnection" do
   request do
-    run_script $js_get_products_history_newconnection, $ds_bill_connections_new, $ds_top_level_bcs, $param_lookback, rs_org_id, rs_optima_host
+    run_script $js_products_history_newconnection, $ds_bill_connections_new, $ds_top_level_bcs, $param_lookback, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -429,7 +429,7 @@ datasource "ds_products_history_newconnection" do
   end
 end
 
-script "js_get_products_history_newconnection", type: "javascript" do
+script "js_products_history_newconnection", type: "javascript" do
   parameters "ds_bill_connections_new", "ds_top_level_bcs", "param_lookback", "rs_org_id", "rs_optima_host"
   result "request"
   code <<-'EOS'
@@ -499,7 +499,7 @@ end
 
 datasource "ds_products_history_mcacbiconnection" do
   request do
-    run_script $js_get_products_history_mcacbiconnection, $ds_bill_connections_mcacbi, $ds_top_level_bcs, $param_lookback, rs_org_id, rs_optima_host
+    run_script $js_products_history_mcacbiconnection, $ds_bill_connections_mcacbi, $ds_top_level_bcs, $param_lookback, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
@@ -515,7 +515,7 @@ datasource "ds_products_history_mcacbiconnection" do
   end
 end
 
-script "js_get_products_history_mcacbiconnection", type: "javascript" do
+script "js_products_history_mcacbiconnection", type: "javascript" do
   parameters "ds_bill_connections_mcacbi", "ds_top_level_bcs", "param_lookback", "rs_org_id", "rs_optima_host"
   result "request"
   code <<-'EOS'
@@ -584,10 +584,10 @@ EOS
 end
 
 datasource "ds_products_history" do
-  run_script $js_products_combiner, $ds_products_history_oldconnection, $ds_products_history_newconnection, $ds_products_history_mcacbiconnection
+  run_script $js_products_history, $ds_products_history_oldconnection, $ds_products_history_newconnection, $ds_products_history_mcacbiconnection
 end
 
-script "js_products_combiner", type:"javascript" do
+script "js_products_history", type:"javascript" do
   parameters "oldconnection", "newconnection", "mcacbiconnection"
   result "result"
   code <<-'EOS'

--- a/operational/azure/marketplace_new_products/azure_marketplace_new_products.pt
+++ b/operational/azure/marketplace_new_products/azure_marketplace_new_products.pt
@@ -8,7 +8,7 @@ severity "low"
 category "Operational"
 default_frequency "weekly"
 info(
-  version: "0.6.5",
+  version: "1.0.0",
   provider: "Azure",
   service: "Marketplace",
   policy_set: "New Marketplace Products",
@@ -33,6 +33,7 @@ parameter "param_lookback" do
   label "Look Back Period (Days)"
   description "How far back, in days, to look at Marketplace product purchases to see if new items have been added."
   min_value 4
+  max_value 30
   default 10
 end
 
@@ -317,38 +318,32 @@ script "js_bill_connections_filter", type:"javascript" do
 EOS
 end
 
-datasource "ds_current_products_oldconnection" do
+datasource "ds_products_history_oldconnection" do
   request do
-    run_script $js_get_products_oldconnection, $ds_bill_connections_old, $ds_top_level_bcs, 3, rs_org_id, rs_optima_host
+    run_script $js_get_products_history_oldconnection, $ds_bill_connections_old, $ds_top_level_bcs, $param_lookback, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
     collect jmes_path(response, "rows[*]") do
       field "product", jmes_path(col_item, "dimensions.usage_type")
+      field "bill_source", jmes_path(col_item, "dimensions.bill_source")
+      field "vendor_account", jmes_path(col_item, "dimensions.vendor_account")
+      field "vendor_account_name", jmes_path(col_item, "dimensions.vendor_account_name")
+      field "resource_group", jmes_path(col_item, "dimensions.resource_group")
       field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
+      field "timestamp", jmes_path(col_item, "timestamp")
     end
   end
 end
 
-datasource "ds_previous_products_oldconnection" do
-  request do
-    run_script $js_get_products_oldconnection, $ds_bill_connections_old, $ds_top_level_bcs, $param_lookback, rs_org_id, rs_optima_host
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "rows[*]") do
-      field "product", jmes_path(col_item, "dimensions.usage_type")
-      field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
-    end
-  end
-end
-
-script "js_get_products_oldconnection", type: "javascript" do
+script "js_get_products_history_oldconnection", type: "javascript" do
   parameters "ds_bill_connections_old", "ds_top_level_bcs", "param_lookback", "rs_org_id", "rs_optima_host"
   result "request"
   code <<-'EOS'
+  // End 2 days ago (exclusive) so the range covers every day from the lookback
+  // cutoff through 3 days ago, the most recent day with reliably finalized cost data.
   end_date = new Date()
-  end_date.setDate(end_date.getDate() - (param_lookback - 1))
+  end_date.setDate(end_date.getDate() - 2)
   end_date = end_date.toISOString().split('T')[0]
 
   start_date = new Date()
@@ -398,7 +393,7 @@ script "js_get_products_oldconnection", type: "javascript" do
     verb: "POST",
     path: "/bill-analysis/orgs/" + rs_org_id + "/costs/aggregated",
     body_fields: {
-      dimensions: ["usage_type"],
+      dimensions: ["usage_type", "bill_source", "vendor_account", "vendor_account_name", "resource_group"],
       granularity: "day",
       start_at: start_date,
       end_at: end_date,
@@ -416,38 +411,32 @@ script "js_get_products_oldconnection", type: "javascript" do
 EOS
 end
 
-datasource "ds_current_products_newconnection" do
+datasource "ds_products_history_newconnection" do
   request do
-    run_script $js_get_products_newconnection, $ds_bill_connections_new, $ds_top_level_bcs, 3, rs_org_id, rs_optima_host
+    run_script $js_get_products_history_newconnection, $ds_bill_connections_new, $ds_top_level_bcs, $param_lookback, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
     collect jmes_path(response, "rows[*]") do
       field "product", jmes_path(col_item, "dimensions.resource_type")
+      field "bill_source", jmes_path(col_item, "dimensions.bill_source")
+      field "vendor_account", jmes_path(col_item, "dimensions.vendor_account")
+      field "vendor_account_name", jmes_path(col_item, "dimensions.vendor_account_name")
+      field "resource_group", jmes_path(col_item, "dimensions.resource_group")
       field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
+      field "timestamp", jmes_path(col_item, "timestamp")
     end
   end
 end
 
-datasource "ds_previous_products_newconnection" do
-  request do
-    run_script $js_get_products_newconnection, $ds_bill_connections_new, $ds_top_level_bcs, $param_lookback, rs_org_id, rs_optima_host
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "rows[*]") do
-      field "product", jmes_path(col_item, "dimensions.resource_type")
-      field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
-    end
-  end
-end
-
-script "js_get_products_newconnection", type: "javascript" do
+script "js_get_products_history_newconnection", type: "javascript" do
   parameters "ds_bill_connections_new", "ds_top_level_bcs", "param_lookback", "rs_org_id", "rs_optima_host"
   result "request"
   code <<-'EOS'
+  // End 2 days ago (exclusive) so the range covers every day from the lookback
+  // cutoff through 3 days ago, the most recent day with reliably finalized cost data.
   end_date = new Date()
-  end_date.setDate(end_date.getDate() - (param_lookback - 1))
+  end_date.setDate(end_date.getDate() - 2)
   end_date = end_date.toISOString().split('T')[0]
 
   start_date = new Date()
@@ -490,7 +479,7 @@ script "js_get_products_newconnection", type: "javascript" do
     verb: "POST",
     path: "/bill-analysis/orgs/" + rs_org_id + "/costs/aggregated",
     body_fields: {
-      dimensions: ["resource_type"],
+      dimensions: ["resource_type", "bill_source", "vendor_account", "vendor_account_name", "resource_group"],
       granularity: "day",
       start_at: start_date,
       end_at: end_date,
@@ -508,38 +497,32 @@ script "js_get_products_newconnection", type: "javascript" do
 EOS
 end
 
-datasource "ds_current_products_mcacbiconnection" do
+datasource "ds_products_history_mcacbiconnection" do
   request do
-    run_script $js_get_products_mcacbiconnection, $ds_bill_connections_mcacbi, $ds_top_level_bcs, 3, rs_org_id, rs_optima_host
+    run_script $js_get_products_history_mcacbiconnection, $ds_bill_connections_mcacbi, $ds_top_level_bcs, $param_lookback, rs_org_id, rs_optima_host
   end
   result do
     encoding "json"
     collect jmes_path(response, "rows[*]") do
       field "product", jmes_path(col_item, "dimensions.resource_type")
+      field "bill_source", jmes_path(col_item, "dimensions.bill_source")
+      field "vendor_account", jmes_path(col_item, "dimensions.vendor_account")
+      field "vendor_account_name", jmes_path(col_item, "dimensions.vendor_account_name")
+      field "resource_group", jmes_path(col_item, "dimensions.resource_group")
       field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
+      field "timestamp", jmes_path(col_item, "timestamp")
     end
   end
 end
 
-datasource "ds_previous_products_mcacbiconnection" do
-  request do
-    run_script $js_get_products_mcacbiconnection, $ds_bill_connections_mcacbi, $ds_top_level_bcs, $param_lookback, rs_org_id, rs_optima_host
-  end
-  result do
-    encoding "json"
-    collect jmes_path(response, "rows[*]") do
-      field "product", jmes_path(col_item, "dimensions.resource_type")
-      field "cost", jmes_path(col_item, "metrics.cost_amortized_unblended_adj")
-    end
-  end
-end
-
-script "js_get_products_mcacbiconnection", type: "javascript" do
+script "js_get_products_history_mcacbiconnection", type: "javascript" do
   parameters "ds_bill_connections_mcacbi", "ds_top_level_bcs", "param_lookback", "rs_org_id", "rs_optima_host"
   result "request"
   code <<-'EOS'
+  // End 2 days ago (exclusive) so the range covers every day from the lookback
+  // cutoff through 3 days ago, the most recent day with reliably finalized cost data.
   end_date = new Date()
-  end_date.setDate(end_date.getDate() - (param_lookback - 1))
+  end_date.setDate(end_date.getDate() - 2)
   end_date = end_date.toISOString().split('T')[0]
 
   start_date = new Date()
@@ -582,7 +565,7 @@ script "js_get_products_mcacbiconnection", type: "javascript" do
     verb: "POST",
     path: "/bill-analysis/orgs/" + rs_org_id + "/costs/aggregated",
     body_fields: {
-      dimensions: ["resource_type"],
+      dimensions: ["resource_type", "bill_source", "vendor_account", "vendor_account_name", "resource_group"],
       granularity: "day",
       start_at: start_date,
       end_at: end_date,
@@ -600,12 +583,8 @@ script "js_get_products_mcacbiconnection", type: "javascript" do
 EOS
 end
 
-datasource "ds_current_products" do
-  run_script $js_products_combiner, $ds_current_products_oldconnection, $ds_current_products_newconnection, $ds_current_products_mcacbiconnection
-end
-
-datasource "ds_previous_products" do
-  run_script $js_products_combiner, $ds_previous_products_oldconnection, $ds_previous_products_newconnection, $ds_previous_products_mcacbiconnection
+datasource "ds_products_history" do
+  run_script $js_products_combiner, $ds_products_history_oldconnection, $ds_products_history_newconnection, $ds_products_history_mcacbiconnection
 end
 
 script "js_products_combiner", type:"javascript" do
@@ -617,11 +596,11 @@ EOS
 end
 
 datasource "ds_new_products" do
-  run_script $js_new_products, $ds_current_products, $ds_previous_products, $ds_currency, $ds_applied_policy, $param_min_cost, $param_lookback, $param_incident_csv
+  run_script $js_new_products, $ds_products_history, $ds_currency, $ds_applied_policy, $param_min_cost, $param_lookback, $param_incident_csv
 end
 
 script "js_new_products", type: "javascript" do
-  parameters "ds_current_products", "ds_previous_products", "ds_currency", "ds_applied_policy", "param_min_cost", "param_lookback", "param_incident_csv"
+  parameters "ds_products_history", "ds_currency", "ds_applied_policy", "param_min_cost", "param_lookback", "param_incident_csv"
   result "result"
   code <<-'EOS'
   csv_message = param_incident_csv == "false" ? "" : "Incident table CSV file has been attached to emails for this incident."
@@ -654,21 +633,51 @@ script "js_new_products", type: "javascript" do
   result = []
   total_cost = 0.0
 
-  old_product_list = _.compact(_.uniq(_.pluck(ds_previous_products, "product")))
+  // Build the two comparison snapshot dates from the continuous daily history:
+  // "current" is 3 days ago (buffer for billing data to finalize), "previous" is
+  // the full lookback period ago. A product is new if it has cost in the current
+  // snapshot but had no cost in the previous snapshot.
+  current_date = new Date()
+  current_date.setDate(current_date.getDate() - 3)
+  current_date_str = current_date.toISOString().split('T')[0]
 
-  valid_products = _.filter(ds_current_products, function(item) {
-    return typeof(item['product']) == 'string' && item['product'] != ''
+  previous_date = new Date()
+  previous_date.setDate(previous_date.getDate() - param_lookback)
+  previous_date_str = previous_date.toISOString().split('T')[0]
+
+  function dayOf(item) {
+    return item['timestamp'] ? item['timestamp'].split('T')[0] : ''
+  }
+
+  valid_history = _.filter(ds_products_history, function(item) {
+    return typeof(item['product']) == 'string' && item['product'] != '' && dayOf(item) != ''
   })
 
-  _.each(valid_products, function(item) {
+  current_products = _.filter(valid_history, function(item) { return dayOf(item) == current_date_str })
+  previous_products = _.filter(valid_history, function(item) { return dayOf(item) == previous_date_str })
+
+  old_product_list = _.compact(_.uniq(_.pluck(previous_products, "product")))
+
+  _.each(current_products, function(item) {
     if (_.contains(old_product_list, item['product']) == false) {
       cost = item['cost'] * 365.25 / 12
 
       if (cost >= param_min_cost) {
         total_cost += cost
 
+        // Find the earliest day within the queried history where this product had
+        // any cost, this is the date the product was purchased.
+        product_history = _.filter(valid_history, function(h) { return h['product'] == item['product'] })
+        product_dates = _.sortBy(_.uniq(_.map(product_history, dayOf)), function(date) { return date })
+        date_purchased = product_dates.length > 0 ? product_dates[0] : current_date_str
+
         result.push({
           product: item['product'],
+          bill_source: item['bill_source'],
+          vendor_account: item['vendor_account'],
+          vendor_account_name: item['vendor_account_name'],
+          resource_group: item['resource_group'],
+          date_purchased: date_purchased,
           cost: Number(cost.toFixed(2)),
           currency: ds_currency['symbol'],
           policy_name: ds_applied_policy['name'],
@@ -687,10 +696,6 @@ script "js_new_products", type: "javascript" do
       formatNumber(parseFloat(total_cost).toFixed(2), ds_currency['separator'])
     ].join('')
 
-    start_date = new Date()
-    start_date.setDate(start_date.getDate() - param_lookback)
-    start_date = start_date.toISOString().split('T')[0]
-
     product_noun = "product has"
     product_adj = "This product was"
 
@@ -701,7 +706,7 @@ script "js_new_products", type: "javascript" do
 
     message = [
       result.length, " new Azure Marketplace ", product_noun, " been found. ",
-      product_adj, " not present on ", start_date, " (", param_lookback.toString(), " days ago).\n\n"
+      product_adj, " not present on ", previous_date_str, " (", param_lookback.toString(), " days ago).\n\n"
     ].join('')
 
     disclaimer = "The above settings can be modified by editing the applied policy and changing the appropriate parameters.\n\n"
@@ -729,8 +734,23 @@ policy "pol_new_products" do
     hash_exclude "total_cost", "cost", "currency"
     export do
       resource_level false
+      field "bill_source" do
+        label "Bill Source"
+      end
+      field "vendor_account" do
+        label "Vendor Account"
+      end
+      field "vendor_account_name" do
+        label "Vendor Account Name"
+      end
+      field "resource_group" do
+        label "Resource Group"
+      end
       field "product" do
         label "New Product"
+      end
+      field "date_purchased" do
+        label "Date Purchased"
       end
       field "cost" do
         label "Estimated Monthly Cost"


### PR DESCRIPTION
### Description

Adds additional fields to the incident table for `AWS New Marketplace Products` and `Azure New Marketplace Products` policy templates.

This is a major version change because the new logic to locate the specific date the purchase was made means that there is now a cap of 30 days regarding how far back one can look for new products. This is unlikely to actually affect any users (the default was and remains 10 days) but it is technically a breaking change.

### Link to Example Applied Policy

https://app.flexera.com/orgs/27018/automation/applied-policies/projects/113453?policyId=6aa40fd7b965835902f84f52
https://app.flexera.com/orgs/27018/automation/applied-policies/projects/113453?policyId=6aa410dee121cb96f7187955

### Contribution Check List

- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] New functionality has been documented in CHANGELOG.MD
